### PR TITLE
Cicd lab fixes

### DIFF
--- a/ansible/configs/ansible-cicd-lab/env_vars.yml
+++ b/ansible/configs/ansible-cicd-lab/env_vars.yml
@@ -73,7 +73,7 @@ az_resource_group: "{{ project_tag }}"
 #az_destroy_method: deployment
 #az_resource_group: my-shared-resource-group
 
-# use --insecure flag when adding teh tower license
+# use --insecure flag when adding the tower license
 tower_license_use_insecure: True
 
 ### AWS EC2 Environment settings

--- a/ansible/configs/ansible-cicd-lab/env_vars.yml
+++ b/ansible/configs/ansible-cicd-lab/env_vars.yml
@@ -73,8 +73,8 @@ az_resource_group: "{{ project_tag }}"
 #az_destroy_method: deployment
 #az_resource_group: my-shared-resource-group
 
-# use --insecure flag when adding the tower license
-tower_license_use_insecure: True
+# use --insecure flag when adding the tower license; leave empty or undefined if the flag is not needed
+tower_cli_insecure_flag: "--insecure"
 
 ### AWS EC2 Environment settings
 

--- a/ansible/configs/ansible-cicd-lab/env_vars.yml
+++ b/ansible/configs/ansible-cicd-lab/env_vars.yml
@@ -73,6 +73,9 @@ az_resource_group: "{{ project_tag }}"
 #az_destroy_method: deployment
 #az_resource_group: my-shared-resource-group
 
+# use --insecure flag when adding teh tower license
+tower_license_use_insecure: True
+
 ### AWS EC2 Environment settings
 
 ### Route 53 Zone ID (AWS)

--- a/ansible/software_playbooks/tower.yml
+++ b/ansible/software_playbooks/tower.yml
@@ -127,9 +127,4 @@
 
     - name: Add the tower license
       command: |
-        tower-cli setting modify LICENSE @/root/license.txt
-      when: not tower_license_use_insecure | default('False') | bool
-    - name: Add the tower license (with --insecure)
-      command: |
-        tower-cli setting modify LICENSE @/root/license.txt --insecure
-      when: tower_license_use_insecure | default('False') | bool
+        tower-cli setting modify LICENSE @/root/license.txt {{ tower_cli_insecure_flag | d() }}

--- a/ansible/software_playbooks/tower.yml
+++ b/ansible/software_playbooks/tower.yml
@@ -127,4 +127,9 @@
 
     - name: Add the tower license
       command: |
+        tower-cli setting modify LICENSE @/root/license.txt
+      when: not tower_license_use_insecure | default('False') | bool
+    - name: Add the tower license (with --insecure)
+      command: |
         tower-cli setting modify LICENSE @/root/license.txt --insecure
+      when: tower_license_use_insecure | default('False') | bool

--- a/ansible/software_playbooks/tower.yml
+++ b/ansible/software_playbooks/tower.yml
@@ -127,4 +127,4 @@
 
     - name: Add the tower license
       command: |
-        tower-cli setting modify LICENSE @/root/license.txt
+        tower-cli --insecure setting modify LICENSE @/root/license.txt

--- a/ansible/software_playbooks/tower.yml
+++ b/ansible/software_playbooks/tower.yml
@@ -127,4 +127,4 @@
 
     - name: Add the tower license
       command: |
-        tower-cli --insecure setting modify LICENSE @/root/license.txt
+        tower-cli setting modify LICENSE @/root/license.txt --insecure


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The Ansible CI/CD lab didn't deploy because the task to add the Tower license in the Tower software playbook failed. I added a variable to the Ansible CI/CD lab environment and a check for that variable in the playbook
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- New config Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
-  `ansible/configs/ansible-cicd-lab/env_vars.yml`
-  `ansible/software_playbooks/tower.yml`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
I could only test that the deployment of the Ansible CI/CD lab works if `tower_license_use_insecure` is defined _and_ set to `True`.

```
TASK [Add the tower license] ***************************************************
Monday 25 February 2019  10:50:58 -0500 (0:00:02.012)       0:20:09.733 ******* 
skipping: [tower1.90d9.internal]

TASK [Add the tower license (with --insecure)] *********************************
Monday 25 February 2019  10:50:58 -0500 (0:00:00.022)       0:20:09.755 ******* 
changed: [tower1.90d9.internal]
 [WARNING]: Could not match supplied host pattern, ignoring: support
```

I have not confirmed that other labs using `ansible/software_playbooks/tower.yml` are still deploying, i.e., if the playbook works if `tower_license_use_insecure` is either undefined or set to `False`.

