### PR TITLE
default to self signed certs unless le is production

### DIFF
--- a/ansible/roles/ocp-workload-integreatly/defaults/main.yml
+++ b/ansible/roles/ocp-workload-integreatly/defaults/main.yml
@@ -6,7 +6,7 @@ install_dir: /tmp/integreatly
 inventory_hosts_file: inventories/hosts.template
 release_tag: release-1.2.0
 webapp_namespace: webapp
-self_signed_certs_enabled: false
+self_signed_certs_enabled: True
 openshift_master_config_path: /etc/origin/master/master-config.yaml
 admin_username: admin@example.com
 admin_password: Password1

--- a/ansible/roles/ocp-workload-integreatly/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-integreatly/tasks/workload.yml
@@ -3,6 +3,7 @@
 - name: Set Identity Provider CA Cert Path
   set_fact:
     rhsso_identity_provider_ca_cert_path: ""
+    self_signed_certs_enabled: False
   when: lets_encrypt_production|bool
 
 - name: Run Integreatly installer


### PR DESCRIPTION
##### SUMMARY
We want to have the variable eval_self_signed_certs default to true unless we are in an environment where lets encrypt production is being used.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- New config Pull Request


##### COMPONENT NAME
Integreatly Workshop


