### PR TITLE
Bumping Integreatly release version v 1.2.1

### DIFF
--- a/ansible/roles/ocp-workload-integreatly/defaults/main.yml
+++ b/ansible/roles/ocp-workload-integreatly/defaults/main.yml
@@ -4,7 +4,7 @@ become_override: True
 silent: False
 install_dir: /tmp/integreatly
 inventory_hosts_file: inventories/hosts.template
-release_tag: release-1.2.0
+release_tag: release-1.2.1
 webapp_namespace: webapp
 self_signed_certs_enabled: True
 openshift_master_config_path: /etc/origin/master/master-config.yaml


### PR DESCRIPTION
##### SUMMARY
Updating Integreatly release version to v1.2.0

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New config Pull Request

##### COMPONENT NAME
Integreatly

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

There is a PR (https://github.com/redhat-cop/agnosticd/pull/332) for bumping to 1.2.0, but we decided to update to 1.2.1 directly.
