### PR TITLE
Remove evals user from email text

### DIFF
--- a/ansible/roles/ocp-workload-integreatly/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-integreatly/tasks/workload.yml
@@ -33,7 +33,6 @@
     - "user.info: Openshift Master Console: {{ openshift_master_url }}"
     - "user.info: Web App URL: https://{{ webapp_route.stdout }}"
     - "user.info: Cluster Admin User: {{ admin_username }} / {{ admin_password }}"
-    - "user.info: Evaluation User: {{ evals_username }} / {{ evals_password }}"
     - "user.info: Pre-seeded Evaluation Users: evals{01..50} / {{ evals_password }}"
     - "user.info: Getting Started Guide: https://docs.google.com/document/d/1lSb481fCiec0aTlJAw8cRLn_AiQjNgbCZsqq6wWfdWE"
 


### PR DESCRIPTION
##### SUMMARY

Fixes https://issues.jboss.org/browse/INTLY-1316

The evals user has been removed from the Integreatly environment. This PR removes the reference to that user in the ready notification email

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Integreatly
