### PR TITLE
#375: Fixed deployment of ImageStreams and Templates. IS locations ar…

### DIFF
--- a/ansible/roles/ocp-workload-fsi-client-onboarding-demo/defaults/main.yml
+++ b/ansible/roles/ocp-workload-fsi-client-onboarding-demo/defaults/main.yml
@@ -18,7 +18,7 @@ quota_services: 15
 quota_secrets: 50
 quota_requests_storage: 0Gi
 
-build_status_retries: 20
+build_status_retries: 25
 build_status_delay: 20
 
 deploy_status_retries: 15

--- a/ansible/roles/ocp-workload-fsi-client-onboarding-demo/files/client-onboarding-process.yaml
+++ b/ansible/roles/ocp-workload-fsi-client-onboarding-demo/files/client-onboarding-process.yaml
@@ -61,7 +61,7 @@ objects:
         from:
           kind: ImageStreamTag
           name: jboss-processserver64-openshift:1.0
-          namespace: openshift
+          namespace: ${IMAGE_STREAM_NAMESPACE}
       type: Source
     successfulBuildsHistoryLimit: 5
     triggers:
@@ -160,7 +160,7 @@ objects:
           - name: HORNETQ_QUEUES
           - name: HORNETQ_TOPICS
           - name: ENTANDO_BASE_URL
-            value: ${ENTANDO_BASE_URL} 
+            value: ${ENTANDO_BASE_URL}
           image: co
           imagePullPolicy: Always
           livenessProbe:
@@ -520,3 +520,7 @@ parameters:
   displayName: Entando base URL
   name: ENTANDO_BASE_URL
   value: http://fsi-customer.serv.run/fsi-customer/
+- description: ImageStream namespace
+  displayName: ImageStream namespace
+  name: IMAGE_STREAM_NAMESPACE
+  value: openshift

--- a/ansible/roles/ocp-workload-fsi-client-onboarding-demo/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-fsi-client-onboarding-demo/tasks/workload.yml
@@ -19,10 +19,18 @@
 #  shell: "oc create -f /tmp/{{guid}}//limit-range.yaml -n {{ocp_project}}"
 
 - name: Import ImageStreams
-  shell: "oc create -f https://raw.githubusercontent.com/jboss-openshift/application-templates/master/processserver/processserver64-image-stream.json -n {{ocp_project}}"
+  shell: "oc create -f https://raw.githubusercontent.com/jboss-container-images/jboss-processserver-6-openshift-image/6.4.x/templates/processserver64-image-stream.json -n {{ocp_project}}"
+
+- name: Patch Image Stream
+  shell: |
+        for i in {0..5}
+        do
+          JSONPATCH='[{"op": "replace", "path": "/spec/tags/'$i'/from/name", "value": "registry.access.redhat.com/jboss-processserver-6/processserver64-openshift:1.'$i'"}]'
+          oc patch is/jboss-processserver64-openshift --type='json' -p "$JSONPATCH"
+        done
 
 - name: "Import templates"
-  shell: "oc create -f https://raw.githubusercontent.com/jboss-openshift/application-templates/master/processserver/processserver64-postgresql-s2i.json -n {{ocp_project}}"
+  shell: "oc create -f https://raw.githubusercontent.com/jboss-container-images/jboss-processserver-6-openshift-image/6.4.x/templates/processserver64-postgresql-s2i.json -n {{ocp_project}}"
 
 - name: "Create secrets and service accounts"
   shell: "oc process -f /tmp/{{guid}}/secrets-and-accounts.yaml | oc create -n {{ocp_project}} -f  -"
@@ -63,12 +71,13 @@
           -p GIT_URI="https://github.com/entando/fsi-onboarding-bpm" \
           -p GIT_REF="master" \
           -p ENTANDO_BASE_URL="http://{{fsi_customer_route}}/fsi-customer/" \
+          -p IMAGE_STREAM_NAMESPACE="{{ocp_project}}" \
           -n {{ocp_project}} | oc create -f - -n {{ocp_project}}
 
-- name: "Patch the ImageSteam location"
-  shell: |
-          oc patch bc/co --type="json" \
-          -p="[{'op': 'replace', 'path': '/spec/strategy/sourceStrategy/from/namespace', 'value': '{{ocp_project}}'}]"
+#- name: "Patch the ImageSteam location"
+#  shell: |
+#          oc patch bc/co --type="json" \
+#          -p="[{'op': 'replace', 'path': '/spec/strategy/sourceStrategy/from/namespace', 'value': '{{ocp_project}}'}]"
 
 
 #### Wait for the build to complete before slapping on the quota ....

--- a/ansible/roles/ocp-workload-fsi-client-onboarding-demo/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-fsi-client-onboarding-demo/tasks/workload.yml
@@ -23,11 +23,15 @@
 
 - name: Patch Image Stream
   shell: |
-        for i in {0..5}
-        do
-          JSONPATCH='[{"op": "replace", "path": "/spec/tags/'$i'/from/name", "value": "registry.access.redhat.com/jboss-processserver-6/processserver64-openshift:1.'$i'"}]'
+          JSONPATCH='[{"op": "replace", "path": "/spec/tags/'{{item}}'/from/name", "value": "registry.access.redhat.com/jboss-processserver-6/processserver64-openshift:1.'{{item}}'"}]'
           oc patch is/jboss-processserver64-openshift --type='json' -p "$JSONPATCH"
-        done
+  loop:
+    - 0
+    - 1
+    - 2
+    - 3
+    - 4
+    - 5
 
 - name: "Import templates"
   shell: "oc create -f https://raw.githubusercontent.com/jboss-container-images/jboss-processserver-6-openshift-image/6.4.x/templates/processserver64-postgresql-s2i.json -n {{ocp_project}}"


### PR DESCRIPTION
…e also patched to point to the old registry so we don't require a login. Added a bit bigger buffer in the build phase so we don't time out.

##### SUMMARY
Fixes #375 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp-workload-fsi-client-onboarding-demo

##### ADDITIONAL INFORMATION
n.a.

<!--- Paste verbatim command output below, e.g. before and after your change -->
n.a.