### PR TITLE
Fixed copy task to get root's kube/config

### DIFF
--- a/ansible/roles/ocp-workload-odo-workshop/tasks/pre_remove_workload.yml
+++ b/ansible/roles/ocp-workload-odo-workshop/tasks/pre_remove_workload.yml
@@ -3,6 +3,7 @@
   copy:
     src: ~/.kube/config
     dest: "{{ tmp_kubeconfig }}"
+    remote_src: yes
 
 - name: pre_workload Removal Tasks Complete
   debug:

--- a/ansible/roles/ocp-workload-odo-workshop/tasks/pre_workload.yml
+++ b/ansible/roles/ocp-workload-odo-workshop/tasks/pre_workload.yml
@@ -3,6 +3,7 @@
   copy:
     src: ~/.kube/config
     dest: "{{ tmp_kubeconfig }}"
+    remote_src: yes
 
 - name: pre_workload Tasks Complete
   debug:


### PR DESCRIPTION
##### SUMMARY
When running the role, the copy task was trying to copy to the target host and not to the same host where the playbook was run.
This role needs to copy the .kube/config file from a location in the bastion server to a different location ALSO on the bastion server (where the playbook is run).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp-workload-odo-workshop

##### ADDITIONAL INFORMATION
Copy task was not run from-to bastion server. With this change, we make the copy task happen on the bastion server.