### PR TITLE
Switch to ocp4_machineset_config for ocp4-workload-infra-nodes

### DIFF
--- a/ansible/roles/ocp4-workload-infra-nodes/tasks/remove_workload.yml
+++ b/ansible/roles/ocp4-workload-infra-nodes/tasks/remove_workload.yml
@@ -8,7 +8,7 @@
     kind: MachineSet
     namespace: openshift-machine-api
     label_selectors:
-      - machineset = infra
+      - agnosticd.redhat.com/machineset-group = infra
   register: machinesets_out
 
 - name: delete infra machinesets

--- a/ansible/roles/ocp4-workload-infra-nodes/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-infra-nodes/tasks/workload.yml
@@ -1,35 +1,15 @@
 # vim: set ft=ansible
 ---
-# Implement your Workload deployment tasks here
-- name: determine deployed sets
-  k8s_facts:
-    api_version: machine.openshift.io/v1beta1
-    kind: MachineSet
-    namespace: openshift-machine-api
-  register: machinesets_out
-
-- name: register list of machinesets
-  shell: "oc get machineset -n openshift-machine-api -o name"
-  register: infra_machineset_exists
-#
-# stdout will have the word infra if there's already an infra machineset
-# if there is one, we don't create any
-
-# TODO: Fix this! Use ansible instead of shell pipes and jq. Candidate for k8s_facts and k8s modules. ?
-- name: create infra machineset(s)
-  shell: >-
-    oc get machineset -n openshift-machine-api -o json
-    | jq '.items[0]'
-    | jq '.metadata.name=\"infra-{{ machinesets_out.resources[0].spec.template.spec.providerSpec.value.placement.region }}\"'
-    | jq '.spec.selector.matchLabels.\"machine.openshift.io/cluster-api-machineset\"=\"infra-{{ machinesets_out.resources[0].spec.template.spec.providerSpec.value.placement.region }}\"'
-    | jq '.spec.template.metadata.labels.\"machine.openshift.io/cluster-api-machineset\"=\"infra-{{ machinesets_out.resources[0].spec.template.spec.providerSpec.value.placement.region }}\"'
-    | jq '.spec.template.spec.metadata.labels.\"node-role.kubernetes.io/infra\"=\"\"'
-    | jq '.spec.template.spec.providerSpec.value.instanceType=\"{{ _infra_node_instance_type }}\"'
-    | jq 'del (.metadata.annotations)'
-    | jq '.metadata.labels += {\"machineset\":\"infra\"}'
-    | jq '.spec.replicas={{ _infra_node_replicas }}'
-    | oc create -f -
-  when: '"infra" not in infra_machineset_exists.stdout'
+- name: Configure OCP4 infra machinesets
+  include_role:
+    name: ocp4_machineset_config
+  vars:
+    ocp4_machineset_config_groups:
+    - name: infra
+      aws_instance_type: "{{ _infra_node_instance_type }}"
+      total_replicas: "{{ _infra_node_replicas }}"
+      node_labels:
+        node-role.kubernetes.io/infra: ""
 
 # Leave this as the last task in the playbook.
 - name: workload tasks complete

--- a/ansible/roles/ocp4_machineset_config/README.adoc
+++ b/ansible/roles/ocp4_machineset_config/README.adoc
@@ -1,0 +1,120 @@
+# ocp4_machineset_config
+
+OpenShift 4 MachineSet management to implement custom machinesets such as to
+create dedicated compute and infra nodes.
+
+This Ansible role will query the cluster for the base worker machinesets
+provisioned by the installer and then manage custom machinesets based on the
+discovered worker configuration information.
+
+## Upstream Project
+
+https://github.com/gnuthought/ansible-role-ocp4_machineset_config
+
+## Note
+
+As OpenShift 4 is a fast moving target this Ansible role may become obsolete at
+any time. In particular we hope that the standard OpenShift installer or a
+standard OpenShift 4 operator will manage custom machinesets such as to render
+this Ansible role redundant.
+
+## Example Playbook
+
+```
+- hosts: localhost
+  connection: local
+  gather_facts: no
+  roles:
+  - role: ocp4_machineset_config
+  vars:
+    ocp4_machineset_config_disable_base_worker_machinesets: true
+    ocp4_machineset_config_groups:
+    - name: compute
+      aws_instance_type: m4.large
+      aws_root_volume_size: 80
+      autoscale: true
+      total_replicas_min: 3
+      total_replicas_max: 30
+      node_labels:
+        node-role.kubernetes.io/compute: ""
+    - name: infra
+      aws_instance_type: m4.large
+      total_replicas: 2
+      node_labels:
+        node-role.kubernetes.io/infra: ""
+```
+
+## Configuration
+
+.Top level configuration variables
+[options="header",cols="30%,10%,60%"]
+|===
+| Variable
+| Default
+| Description
+
+| `ocp4_machineset_config_domain`
+| `"ocp4-machineset-config.gnuthought.com"`
+| Domain used for custom group label.
+
+| `ocp4_machineset_config_group_label`
+| `"{{ ocp4_machineset_config_domain }}/machineset-group"`
+| Label applied to machinesets to identify managed machinesets.
+
+| `ocp4_machineset_config_groups`
+| `[]`
+| Listed of machineset groups, described below.
+
+| `ocp4_machineset_config_default_aws_instance_type`
+| `"m4.large"`
+| Default AWS instance type.
+
+| `ocp4_machineset_config_default_aws_root_volume_size`
+| `120`
+| AWS root volume size default in GB
+
+| `ocp4_machineset_config_disable_base_worker_machinesets`
+| `false`
+| Boolean to indicate if base worker machinesets should be scaled to zero.
+
+| `ocp4_cluster_autoscaler_spec`
+| `{"enabled": true}`
+| Value for spec section of ClusterAutoscaler definition, applied if any
+machineset enables autoscaling.
+|===
+
+.`ocp4_machineset_config_groups` item values
+[options="header",cols="30%,10%,60%"]
+|===
+| Variable
+| Default
+| Description
+
+| `name`
+| (required)
+| Name for machineset config group
+
+| `total_replicas`
+| `0`
+| Total number of machineset replicas for non-autoscaling machinesets
+
+| `autoscale`
+| `False`
+| Boolean to indicate if machineautoscaler should be configured for machinesets
+
+| `total_replicas_min`
+| `0`
+| Total minimum number of machineset replicas for non-autoscaling machinesets
+
+| `total_replicas_max`
+| `100`
+| Total maximum number of machineset replicas for non-autoscaling machinesets
+
+| `aws_instance_type`
+| `ocp4_machineset_config_default_aws_instance_type`
+| AWS instance type
+
+| `aws_root_volume_size`
+| `ocp4_machineset_config_default_aws_root_volume_size`
+| Root EBS storage disk size
+|===

--- a/ansible/roles/ocp4_machineset_config/defaults/main.yml
+++ b/ansible/roles/ocp4_machineset_config/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+ocp4_machineset_config_domain: agnosticd.redhat.com
+ocp4_machineset_config_group_label: "{{ ocp4_machineset_config_domain }}/machineset-group"
+ocp4_machineset_config_groups: []
+ocp4_machineset_config_default_aws_instance_type: m4.large
+ocp4_machineset_config_default_aws_root_volume_size: 120
+ocp4_machineset_config_disable_base_worker_machinesets: false
+
+ocp4_cluster_autoscaler_spec:
+  enabled: true

--- a/ansible/roles/ocp4_machineset_config/meta/main.yml
+++ b/ansible/roles/ocp4_machineset_config/meta/main.yml
@@ -1,0 +1,12 @@
+---
+galaxy_info:
+  role_name: ocp4_machineset_config
+  author: Johnathan Kupferer
+  description: Configure OpenShift 4 MachineSets
+  license: MIT
+  min_ansible_version: 2.7
+  platforms: []
+  galaxy_tags:
+  - ocp
+  - openshift
+dependencies: []

--- a/ansible/roles/ocp4_machineset_config/tasks/aws-machineset-group.yml
+++ b/ansible/roles/ocp4_machineset_config/tasks/aws-machineset-group.yml
@@ -1,0 +1,58 @@
+---
+- name: Define {{ machineset_group.name }} machinesets
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'aws-machineset.yml.j2') | from_yaml }}"
+  # Iterate through availability zones in reverse order as it makes the math
+  # easier to scale zone "a" before "b" to match expected behavior.
+  loop: "{{ aws_worker_availability_zones[::-1] }}"
+  loop_control:
+    label: "{{ machineset_name }}"
+    loop_var: aws_worker_availability_zone
+    index_var: loop_index
+  vars:
+    availability_zone: "{{ aws_worker_availability_zone.name }}"
+    availability_zone_region: "{{ aws_worker_availability_zone.region }}"
+    availability_zone_subnet: "{{ aws_worker_availability_zone.subnet }}"
+    aws_instance_type: >-
+      {{ machineset_group.aws_instance_type | default(default_aws_instance_type) }}
+    aws_root_volume_size: >-
+      {{ machineset_group.aws_root_volume_size | default(default_aws_root_volume_size) }}
+    machineset_name: >-
+      {{ [cluster_label, machineset_group.name, availability_zone] | join('-') }}
+    machineset_group_total_replicas: >-
+      {{ machineset_group.total_replicas
+       | default(machineset_group.total_replicas_min)
+       | default(0)
+      }}
+    machineset_replicas: >-
+      {{ (
+        (machineset_group_total_replicas|int + loop_index) / aws_worker_availability_zones|count
+      ) | int }}
+
+- name: Define {{ machineset_group.name }} machineautoscalers
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'machineautoscaler.yml.j2') | from_yaml }}"
+  # Iterate through availability zones in reverse order as it makes the math
+  # easier to scale zone "a" before "b" to match expected behavior.
+  loop: "{{ aws_worker_availability_zones[::-1] }}"
+  loop_control:
+    label: "{{ machineset_name }}"
+    loop_var: aws_worker_availability_zone
+    index_var: loop_index
+  vars:
+    availability_zone: "{{ aws_worker_availability_zone.name }}"
+    machineset_name: >-
+      {{ [cluster_label, machineset_group.name, availability_zone] | join('-') }}
+    machineset_min_replicas: >-
+      {{ (
+         (machineset_group.total_replicas_min|default(0) + loop_index) /
+         aws_worker_availability_zones|count
+      ) | int }}
+    machineset_max_replicas: >-
+      {{ (
+         (machineset_group.total_replicas_max|default(100) + loop_index) /
+         aws_worker_availability_zones|count
+      ) | int }}
+  when: machineset_group.autoscale | default(False) | bool

--- a/ansible/roles/ocp4_machineset_config/tasks/aws.yml
+++ b/ansible/roles/ocp4_machineset_config/tasks/aws.yml
@@ -1,0 +1,28 @@
+---
+- name: Define custom machinesets
+  include_tasks: aws-machineset-group.yml
+  loop: "{{ ocp4_machineset_config_groups }}"
+  loop_control:
+    label: "{{ machineset_group.name }}"
+    loop_var: machineset_group
+  vars:
+    aws_coreos_ami_id: >-
+      {{ reference_provider_spec_value.ami.id }}
+    aws_iam_instance_profile_id: >-
+      {{ reference_provider_spec_value.iamInstanceProfile.id }}
+    aws_worker_security_group: >-
+      {{ reference_provider_spec_value.securityGroups[0].filters[0]['values'][0] }}
+    aws_worker_availability_zones: >-
+      {{ ocp4_base_worker_machinesets
+       | json_query(availability_zone_json_query)
+      }}
+    reference_machineset: >-
+      {{ ocp4_base_worker_machinesets[0] }}
+    reference_provider_spec_value: >-
+      {{ reference_machineset.spec.template.spec.providerSpec.value }}
+    availability_zone_json_query: >-
+      [].{
+        "name": spec.template.spec.providerSpec.value.placement.availabilityZone,
+        "region": spec.template.spec.providerSpec.value.placement.region,
+        "subnet": spec.template.spec.providerSpec.value.subnet.filters[0].values[0]
+      }

--- a/ansible/roles/ocp4_machineset_config/tasks/disable-base-worker-machinesets.yml
+++ b/ansible/roles/ocp4_machineset_config/tasks/disable-base-worker-machinesets.yml
@@ -1,0 +1,16 @@
+---
+- name: Scale base worker machinesets to zero
+  k8s:
+    state: present
+    definition:
+      apiVersion: machine.openshift.io/v1beta1
+      kind: MachineSet
+      metadata:
+        name: "{{ machineset.metadata.name }}"
+        namespace: openshift-machine-api
+      spec:
+        replicas: 0
+  loop: "{{ ocp4_base_worker_machinesets }}"
+  loop_control:
+    label: "{{ machineset.metadata.name }}"
+    loop_var: machineset

--- a/ansible/roles/ocp4_machineset_config/tasks/enable-cluster-autoscaler.yml
+++ b/ansible/roles/ocp4_machineset_config/tasks/enable-cluster-autoscaler.yml
@@ -1,0 +1,5 @@
+---
+- name: Define clusterautoscaler
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'clusterautoscaler.yml.j2') | from_yaml }}"

--- a/ansible/roles/ocp4_machineset_config/tasks/main.yml
+++ b/ansible/roles/ocp4_machineset_config/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+- name: Set machineset facts
+  include_tasks: set-facts.yml
+
+- name: Disable base worker machinesets
+  include_tasks: disable-base-worker-machinesets.yml
+  when: disable_base_worker_machinesets|bool
+
+- name: Configure machinesets for cloud provider
+  include_tasks: "{{ cloud_provider_platform }}.yml"
+
+- name: Enable cluster autoscaler
+  include_tasks: enable-cluster-autoscaler.yml
+  when: >-
+    ocp4_machineset_config_groups | json_query('[?autoscale]')

--- a/ansible/roles/ocp4_machineset_config/tasks/set-facts.yml
+++ b/ansible/roles/ocp4_machineset_config/tasks/set-facts.yml
@@ -1,0 +1,42 @@
+---
+- name: Get machinesets
+  k8s_facts:
+    api_version: machine.openshift.io/v1beta1
+    kind: MachineSet
+    namespace: openshift-machine-api
+  register: r_get_machinesets
+
+- name: Set ocp4_base_worker_machinesets
+  set_fact:
+    ocp4_current_machinesets: >-
+      {{ r_get_machinesets.resources }}
+    ocp4_current_machineset_names: >-
+      {{ r_get_machinesets.resources
+       | json_query('[].metadata.name')
+      }}
+    ocp4_base_worker_machinesets: >-
+      {{ r_get_machinesets.resources
+       | json_query(base_worker_machineset_json_query)
+      }}
+  vars:
+    # Base worker machinesets will lack machineset group label
+    base_worker_machineset_json_query: >-
+      [?!contains(keys(metadata.labels), '{{ machineset_group_label }}')]
+
+- debug: var=ocp4_current_machineset_names
+
+- name: Set cluster facts
+  set_fact:
+    cluster_label: >-
+      {{ reference_machineset.metadata.labels['machine.openshift.io/cluster-api-cluster'] }}
+    cloud_provider_api_version: >-
+      {{ reference_provider_spec_value.apiVersion }}
+    cloud_provider_platform: >-
+      {{ reference_provider_spec_value.apiVersion
+       | regex_replace('providerconfig\.openshift\.io/v1beta1', '')
+      }}
+  vars:
+    reference_machineset: >-
+      {{ ocp4_base_worker_machinesets[0] }}
+    reference_provider_spec_value: >-
+      {{ reference_machineset.spec.template.spec.providerSpec.value }}

--- a/ansible/roles/ocp4_machineset_config/templates/aws-machineset.yml.j2
+++ b/ansible/roles/ocp4_machineset_config/templates/aws-machineset.yml.j2
@@ -1,0 +1,74 @@
+---
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  name: {{ machineset_name }}
+  namespace: openshift-machine-api
+  labels:
+    {{ machineset_group_label }}: {{ machineset_group.name }}
+    machine.openshift.io/cluster-api-cluster: {{ cluster_label }}
+    machine.openshift.io/cluster-api-machine-role: worker
+    machine.openshift.io/cluster-api-machine-type: worker
+spec:
+{% if machineset_name not in ocp4_current_machineset_names
+   or not machineset_group.autoscale|default(False)
+%}
+  replicas: {{ machineset_replicas }}
+{% endif %}
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: {{ cluster_label }}
+      machine.openshift.io/cluster-api-machineset: {{ machineset_name }}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        {{ machineset_group_label }}: {{ machineset_group.name }}
+        machine.openshift.io/cluster-api-cluster: {{ cluster_label }}
+        machine.openshift.io/cluster-api-machine-role: worker
+        machine.openshift.io/cluster-api-machine-type: worker
+        machine.openshift.io/cluster-api-machineset: {{ machineset_name }}
+    spec:
+      metadata:
+        creationTimestamp: null
+        labels: {{ machineset_group.node_labels | default({}) | to_json }}
+      providerSpec:
+        value:
+          ami:
+            id: {{ aws_coreos_ami_id }}
+          apiVersion: awsproviderconfig.openshift.io/v1beta1
+          blockDevices:
+          - ebs:
+              iops: 0
+              volumeSize: {{ aws_root_volume_size }}
+              volumeType: gp2
+          credentialsSecret:
+            name: aws-cloud-credentials
+          deviceIndex: 0
+          iamInstanceProfile:
+            id: {{ aws_iam_instance_profile_id }}
+          instanceType: {{ aws_instance_type }}
+          kind: AWSMachineProviderConfig
+          metadata:
+            creationTimestamp: null
+          placement:
+            availabilityZone: {{ availability_zone }}
+            region: {{ availability_zone_region }}
+          publicIp: null
+          securityGroups:
+          - filters:
+            - name: tag:Name
+              values:
+              - {{ aws_worker_security_group }}
+          subnet:
+            filters:
+            - name: tag:Name
+              values:
+              - {{ availability_zone_subnet }}
+          tags:
+          - name: kubernetes.io/cluster/{{ cluster_label }}
+            value: owned
+          userDataSecret:
+            name: worker-user-data
+      versions:
+        kubelet: ""

--- a/ansible/roles/ocp4_machineset_config/templates/clusterautoscaler.yml.j2
+++ b/ansible/roles/ocp4_machineset_config/templates/clusterautoscaler.yml.j2
@@ -1,0 +1,6 @@
+---
+apiVersion: autoscaling.openshift.io/v1alpha1
+kind: ClusterAutoscaler
+metadata:
+  name: default
+spec: {{ ocp4_cluster_autoscaler_spec | to_json }}

--- a/ansible/roles/ocp4_machineset_config/templates/machineautoscaler.yml.j2
+++ b/ansible/roles/ocp4_machineset_config/templates/machineautoscaler.yml.j2
@@ -1,0 +1,13 @@
+---
+apiVersion: autoscaling.openshift.io/v1alpha1
+kind: MachineAutoscaler
+metadata:
+  name: {{ machineset_name }}
+  namespace: openshift-machine-api
+spec:
+  minReplicas: {{ machineset_min_replicas }}
+  maxReplicas: {{ machineset_max_replicas }}
+  scaleTargetRef:
+    apiVersion: machine.openshift.io/v1beta1
+    kind: MachineSet
+    name: {{ machineset_name }}

--- a/ansible/roles/ocp4_machineset_config/vars/main.yml
+++ b/ansible/roles/ocp4_machineset_config/vars/main.yml
@@ -1,0 +1,10 @@
+---
+config_domain: "{{ ocp4_machineset_config_annotation_domain }}"
+machineset_group_label: "{{ ocp4_machineset_config_group_label }}"
+machineset_groups: "{{ ocp4_machineset_config_groups }}"
+default_aws_instance_type: >-
+  {{ ocp4_machineset_config_default_aws_instance_type }}
+default_aws_root_volume_size: >-
+  {{ ocp4_machineset_config_default_aws_root_volume_size }}
+disable_base_worker_machinesets: >-
+  {{ ocp4_machineset_config_disable_base_worker_machinesets | bool }}


### PR DESCRIPTION
##### SUMMARY

Switch to cleaner ansible role for machineset management. Also fixes quoting issue in jq by eliminating use of jq in machineset creation.

##### ISSUE TYPE

- Bugfix Pull Request
- New role Pull Request

##### COMPONENT NAME

ocp4_machineset_config
ocp4-workload-infra-nodes

##### ADDITIONAL INFORMATION

Adds ocp4_machineset_config