### PR TITLE
workshopper role that deploys a labguide into a project

### DIFF
--- a/ansible/roles/ocp4-workload-workshopper/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-workshopper/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+become_override: False
+ocp_username: opentlc-mgr
+silent: False
+
+_deployed_guide_name: istio
+_deployed_guide_string_url: https://gist.githubusercontent.com/thoraxe/5c57fb5a7107ea5337ebdec710635118/raw/16ef6ea41412f3bf66de6fd462f12496de645e65/istio-summit-lab-2019-workshopper

--- a/ansible/roles/ocp4-workload-workshopper/readme.adoc
+++ b/ansible/roles/ocp4-workload-workshopper/readme.adoc
@@ -1,0 +1,121 @@
+= ocp4-workload-workshopper - Deploy the workshopper lab guide app
+
+== Role overview
+
+* This role deploys the Istio control plane. It consists of the following playbooks:
+** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+ environment for the workload deployment.
+*** Debug task will print out: `pre_workload Tasks completed successfully.`
+
+** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy workshopper
+*** Debug task will print out: `workload Tasks completed successfully.`
+
+** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+ configure the workload after deployment
+*** This role doesn't do anything here
+*** Debug task will print out: `post_workload Tasks completed successfully.`
+
+** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+ delete the workload
+*** This role removes the logging deployment and project but not the operator configs
+*** Debug task will print out: `remove_workload Tasks completed successfully.`
+
+== Review the defaults variable file
+
+* This file link:./defaults/main.yml[./defaults/main.yml] contains all the variables you need to define to control the deployment of your workload.
+* The variable *ocp_username* is mandatory to assign the workload to the correct OpenShift user.
+* A variable *silent=True* can be passed to suppress debug messages.
+* You can modify any of these default values by adding `-e "variable_name=variable_value"` to the command line
+* `_deployed_guide_name` is the name that will be passed to `new-app` and will be used for the route. 
+* `_deployed_guide_string_url` is a public URL that will return a string that contains everything that should be passed to `new-app`. The expectation is that this will be the path to `workshopper` (eg:`quay.io/osevg/workshopper`), the required Workshopper args (`CONTENT_URL_PREFIX` and `WORKSHOPS_URLS`), and any extra vars you want to pass into workshopper (eg: `-e OPENSHIFT_MASTER="http://127.0.0.1:8443"`). An example string is below:
+
+```
+quay.io/osevg/workshopper -e CONTENT_URL_PREFIX=https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/instructions WORKSHOPS_URLS="https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/instructions/_rhsummit18.yml" -e JAVA_APP=false -e OPENSHIFT_MASTER="http://127.0.0.1:8443" -e APPS_SUFFIX="apps.127.0.0.1.nip.io" -e ISTIO_LAB_HOSTNAME="127.0.0.1"
+```
+
+=== Deploy a Workload with the `ocp-workload` playbook [Mostly for testing]
+
+----
+TARGET_HOST="bastion.na311.openshift.opentlc.com"
+OCP_USERNAME="shacharb-redhat.com"
+WORKLOAD="ocp-workload-enable-service-broker"
+GUID=1001
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=ec2-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"silent=False" \
+    -e"guid=${GUID}" \
+    -e"ACTION=create"
+----
+
+=== To Delete an environment
+
+----
+TARGET_HOST="bastion.na311.openshift.opentlc.com"
+OCP_USERNAME="opentlc-mgr"
+WORKLOAD="ocp4-workload-infra-nodes"
+GUID=1002
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=ec2-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"guid=${GUID}" \
+    -e"ACTION=remove"
+----
+
+
+== Other related information:
+
+=== Deploy Workload on OpenShift Cluster from an existing playbook:
+
+[source,yaml]
+----
+- name: Deploy a workload role on a master host
+  hosts: all
+  become: true
+  gather_facts: False
+  tags:
+    - step007
+  roles:
+    - { role: "{{ocp_workload}}", when: 'ocp_workload is defined' }
+----
+NOTE: You might want to change `hosts: all` to fit your requirements
+
+
+=== Set up your Ansible inventory file
+
+* You can create an Ansible inventory file to define your connection method to your host (Master/Bastion with `oc` command)
+* You can also use the command line to define the hosts directly if your `ssh` configuration is set to connect to the host correctly
+* You can also use the command line to use localhost or if your cluster is already authenticated and configured in your `oc` configuration
+
+.Example inventory file
+[source, ini]
+----
+[gptehosts:vars]
+ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem
+ansible_user=ec2-user
+
+[gptehosts:children]
+openshift
+
+[openshift]
+bastion.cluster1.openshift.opentlc.com
+bastion.cluster2.openshift.opentlc.com
+bastion.cluster3.openshift.opentlc.com
+bastion.cluster4.openshift.opentlc.com
+
+[dev]
+bastion.cluster1.openshift.opentlc.com
+bastion.cluster2.openshift.opentlc.com
+
+[prod]
+bastion.cluster3.openshift.opentlc.com
+bastion.cluster4.openshift.opentlc.com
+----

--- a/ansible/roles/ocp4-workload-workshopper/tasks/main.yml
+++ b/ansible/roles/ocp4-workload-workshopper/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+
+# Do not modify this file
+
+- name: Running Pre Workload Tasks
+  import_tasks: ./pre_workload.yml
+  become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload Tasks
+  import_tasks: ./workload.yml
+  become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  import_tasks: ./post_workload.yml
+  become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload removal Tasks
+  import_tasks: ./remove_workload.yml
+  become: "{{ become_override | bool }}"
+  when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles/ocp4-workload-workshopper/tasks/post_workload.yml
+++ b/ansible/roles/ocp4-workload-workshopper/tasks/post_workload.yml
@@ -1,0 +1,9 @@
+---
+# Implement your Post Workload deployment tasks here
+
+
+# Leave this as the last task in the playbook.
+- name: post_workload tasks complete
+  debug:
+    msg: "Post-Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp4-workload-workshopper/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-workshopper/tasks/pre_workload.yml
@@ -1,0 +1,9 @@
+---
+# Implement your Pre Workload deployment tasks here
+
+
+# Leave this as the last task in the playbook.
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp4-workload-workshopper/tasks/remove_workload.yml
+++ b/ansible/roles/ocp4-workload-workshopper/tasks/remove_workload.yml
@@ -1,0 +1,17 @@
+# vim: set ft=ansible
+---
+# Implement your Workload removal tasks here
+- name: create labguide project
+  k8s:
+    state: absent
+    definition:
+      apiVersion: project.openshift.io/v1
+      kind: Project
+      metadata:
+        name: labguide
+
+# Leave this as the last task in the playbook.
+- name: remove_workload tasks complete
+  debug:
+    msg: "Remove Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp4-workload-workshopper/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-workshopper/tasks/workload.yml
@@ -1,0 +1,60 @@
+# vim: set ft=ansible
+---
+# Implement your Workload deployment tasks here
+
+- name: create labguide project
+  k8s:
+    state: present
+    definition:
+      apiVersion: project.openshift.io/v1
+      kind: Project
+      metadata:
+        name: labguide
+
+- name: check if guide is deployed
+  k8s_facts:
+    api_version: apps.openshift.io/v1
+    kind: DeploymentConfig
+    name: "{{ _deployed_guide_name }}"
+    namespace: labguide
+  register: guide_exists
+
+- name: fetch the string for passing to new-app
+  uri: 
+    url: "{{ _deployed_guide_string_url }}"
+    return_content: true
+  register: newapp_string
+  when:
+    - guide_exists.resources | list | length < 1
+
+- name: deploy workshopper using the fetched string
+  shell: "oc new-app -n labguide --name {{ _deployed_guide_name }} {{ newapp_string.content }}"
+  when:
+    - guide_exists.resources | list | length < 1
+
+- name: lab guide route
+  k8s:
+    state: present
+    definition:
+      apiVersion: route.openshift.io/v1
+      kind: Route
+      metadata:
+        labels:
+          app: "{{ _deployed_guide_name }}"
+        name: "{{ _deployed_guide_name }}"
+        namespace: labguide
+      spec:
+        port:
+          targetPort: 8080-tcp
+        to:
+          kind: Service
+          name: "{{ _deployed_guide_name }}"
+          weight: 100
+        wildcardPolicy: None
+
+# Leave this as the last task in the playbook.
+- name: workload tasks complete
+  debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent|bool
+


### PR DESCRIPTION
##### SUMMARY
a role for deploying the workshopper app, which generates lab guides from markdown/adoc.

##### ISSUE TYPE
- New role Pull Request

##### COMPONENT NAME
ocp4-workload-workshopper

##### ADDITIONAL INFORMATION
* `_deployed_guide_name` is the name that will be passed to `new-app` and will be used for the route. 
* `_deployed_guide_string_url` is a public URL that will return a string that contains everything that should be passed to `new-app`. The expectation is that this will be the path to `workshopper` (eg:`quay.io/osevg/workshopper`), the required Workshopper args (`CONTENT_URL_PREFIX` and `WORKSHOPS_URLS`), and any extra vars you want to pass into workshopper (eg: `-e OPENSHIFT_MASTER="http://127.0.0.1:8443"`). An example string is below:

```
quay.io/osevg/workshopper -e CONTENT_URL_PREFIX=https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/instructions WORKSHOPS_URLS="https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/instructions/_rhsummit18.yml" -e JAVA_APP=false -e OPENSHIFT_MASTER="http://127.0.0.1:8443" -e APPS_SUFFIX="apps.127.0.0.1.nip.io" -e ISTIO_LAB_HOSTNAME="127.0.0.1"
```