### PR TITLE
adds kubeadmin password to workshopper

### DIFF
--- a/ansible/roles/ocp4-workload-workshopper/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-workshopper/tasks/workload.yml
@@ -27,6 +27,10 @@
     namespace: openshift-ingress-operator
   register: cluster_domain
 
+- name: cat the kubeadmin-password
+  shell: "cat /home/ec2-user/cluster-{{ guid }}/auth/kubeadmin-password"
+  register: kubeadmin_password
+
 - name: set cluster route domain as fact
   set_fact:
     apps_base_domain: "{{ cluster_domain.resources[0].status.domain }}"
@@ -47,7 +51,8 @@
   shell: |
     oc new-app -n labguide --name {{ _deployed_guide_name }} \
     {{ newapp_string.content }} -e API_URL=https://api.{{ base_domain }}:6443 \
-    -e MASTER_URL=https://console-openshift-console.{{ apps_base_domain }}
+    -e MASTER_URL=https://console-openshift-console.{{ apps_base_domain }} \
+    -e KUBEADMIN_PASSWORD={{ kubeadmin_password.stdout }}
   when:
     - guide_exists.resources | list | length < 1
 


### PR DESCRIPTION
modification to the ocp4-workload-workshopper role to add the kubeadmin password to the environment variables 