### PR TITLE
OCP4 Workshop: mount bind ReadOnly cluster dir to lab-user

### DIFF
--- a/ansible/configs/ocp4-workshop/post_software.yml
+++ b/ansible/configs/ocp4-workshop/post_software.yml
@@ -67,6 +67,15 @@
                   owner: "{{ student_name }}"
                   mode: 0600
 
+              - name: Setup mount bind for cluster directory
+                become: yes
+                mount:
+                  path: /home/{{ student_name }}/{{ cluster_name }}
+                  src: /home/{{ remote_user }}/{{ cluster_name }}
+                  fstype: none
+                  opts: defaults,bind,ro
+                  state: mounted
+
           - name: Create OpenShift Bash completion file
             shell: oc completion bash >/etc/bash_completion.d/openshift
 


### PR DESCRIPTION
This commit, if applied will mount and update /etc/fstab for:

/home/ec2-user/cluster-GUID to /home/lab-user/cluster-GUID as bind ReadOnly

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
