### PR TITLE
OCP4: fix version comparison

### DIFF
--- a/ansible/configs/ocp4-ha-lab/software.yml
+++ b/ansible/configs/ocp4-ha-lab/software.yml
@@ -60,7 +60,7 @@
               - unzip
 
         - name: Get the OpenShift Installer (up to Beta3)
-          when: ocp4_installer_version is version_compare('0.17', '<')
+          when: ocp4_installer_version | regex_replace('^v', '') is version_compare('0.17', '<')
           become: yes
           get_url:
             url: "https://github.com/openshift/installer/releases/download/{{ ocp4_installer_version }}/openshift-install-linux-amd64"
@@ -70,7 +70,7 @@
             group: root
 
         - name: Get the OpenShift CLI (up to Beta3)
-          when: ocp4_installer_version is version_compare('0.17', '<')
+          when: ocp4_installer_version | regex_replace('^v', '') is version_compare('0.17', '<')
           become: yes
           unarchive:
             src: "https://mirror.openshift.com/pub/openshift-v3/clients/{{ oc_client_version }}/linux/oc.tar.gz"
@@ -81,7 +81,7 @@
             group: root
 
         - name: Get the OpenShift Installer for Beta4 onwards
-          when: ocp4_installer_version is version_compare('4.0', '>=')
+          when: ocp4_installer_version | regex_replace('^v', '') is version_compare('4.0', '>=')
           become: yes
           unarchive:
             src: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ ocp4_installer_version }}/openshift-install-linux-{{ ocp4_installer_version }}.tar.gz"
@@ -92,7 +92,7 @@
             group: root
 
         - name: Get the OpenShift CLI for Beta4 onwards
-          when: ocp4_installer_version is version_compare('4.0', '>=')
+          when: ocp4_installer_version | regex_replace('^v', '') is version_compare('4.0', '>=')
           become: yes
           unarchive:
             src: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ ocp4_installer_version }}/openshift-client-linux-{{ ocp4_installer_version }}.tar.gz"

--- a/ansible/configs/ocp4-shared/software.yml
+++ b/ansible/configs/ocp4-shared/software.yml
@@ -60,7 +60,7 @@
               - unzip
 
         - name: Get the OpenShift Installer (up to Beta3)
-          when: ocp4_installer_version is version_compare('0.17', '<')
+          when: ocp4_installer_version | regex_replace('^v', '') is version_compare('0.17', '<')
           become: yes
           get_url:
             url: "https://github.com/openshift/installer/releases/download/{{ ocp4_installer_version }}/openshift-install-linux-amd64"
@@ -70,7 +70,7 @@
             group: root
 
         - name: Get the OpenShift CLI (up to Beta3)
-          when: ocp4_installer_version is version_compare('0.17', '<')
+          when: ocp4_installer_version | regex_replace('^v', '') is version_compare('0.17', '<')
           become: yes
           unarchive:
             src: "https://mirror.openshift.com/pub/openshift-v3/clients/{{ oc_client_version }}/linux/oc.tar.gz"
@@ -81,7 +81,7 @@
             group: root
 
         - name: Get the OpenShift Installer for Beta4 onwards
-          when: ocp4_installer_version is version_compare('4.0', '>=')
+          when: ocp4_installer_version | regex_replace('^v', '') is version_compare('4.0', '>=')
           become: yes
           unarchive:
             src: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ ocp4_installer_version }}/openshift-install-linux-{{ ocp4_installer_version }}.tar.gz"
@@ -92,7 +92,7 @@
             group: root
 
         - name: Get the OpenShift CLI for Beta4 onwards
-          when: ocp4_installer_version is version_compare('4.0', '>=')
+          when: ocp4_installer_version | regex_replace('^v', '') is version_compare('4.0', '>=')
           become: yes
           unarchive:
             src: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ ocp4_installer_version }}/openshift-client-linux-{{ ocp4_installer_version }}.tar.gz"

--- a/ansible/configs/ocp4-workshop/software.yml
+++ b/ansible/configs/ocp4-workshop/software.yml
@@ -60,7 +60,7 @@
               - unzip
 
         - name: Get the OpenShift Installer (up to Beta3)
-          when: ocp4_installer_version is version_compare('0.17', '<')
+          when: ocp4_installer_version | regex_replace('^v', '') is version_compare('0.17', '<')
           become: yes
           get_url:
             url: "https://github.com/openshift/installer/releases/download/{{ ocp4_installer_version }}/openshift-install-linux-amd64"
@@ -70,7 +70,7 @@
             group: root
 
         - name: Get the OpenShift CLI (up to Beta3)
-          when: ocp4_installer_version is version_compare('0.17', '<')
+          when: ocp4_installer_version | regex_replace('^v', '') is version_compare('0.17', '<')
           become: yes
           unarchive:
             src: "https://mirror.openshift.com/pub/openshift-v3/clients/{{ oc_client_version }}/linux/oc.tar.gz"
@@ -81,7 +81,7 @@
             group: root
 
         - name: Get the OpenShift Installer for Beta4 onwards
-          when: ocp4_installer_version is version_compare('4.0', '>=')
+          when: ocp4_installer_version | regex_replace('^v', '') is version_compare('4.0', '>=')
           become: yes
           unarchive:
             src: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ ocp4_installer_version }}/openshift-install-linux-{{ ocp4_installer_version }}.tar.gz"
@@ -92,7 +92,7 @@
             group: root
 
         - name: Get the OpenShift CLI for Beta4 onwards
-          when: ocp4_installer_version is version_compare('4.0', '>=')
+          when: ocp4_installer_version | regex_replace('^v', '') is version_compare('4.0', '>=')
           become: yes
           unarchive:
             src: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ ocp4_installer_version }}/openshift-client-linux-{{ ocp4_installer_version }}.tar.gz"


### PR DESCRIPTION
If applied, this commits transforms the ocp4_installer_version before using
version_compare filter.

Indeed, with previous versions the string starts with 'v', and now it's '4.0.0'

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
