### PR TITLE
Move to registry redhat io

### DIFF
--- a/ansible/roles/ocp-workload-dm7-qlb-demo/defaults/main.yml
+++ b/ansible/roles/ocp-workload-dm7-qlb-demo/defaults/main.yml
@@ -33,7 +33,7 @@ kie_server_user: kieserver
 kie_server_pwd: kieserver1!
 pv_capacity: 512Mi
 
-dm_version_tag: 7.1.0.GA
-dm_imagestreams_yml: https://raw.githubusercontent.com/jboss-container-images/rhdm-7-openshift-image/{{dm_version_tag}}/rhdm71-image-streams.yaml
-dm_template_yml: https://raw.githubusercontent.com/jboss-container-images/rhdm-7-openshift-image/{{dm_version_tag}}/templates/rhdm71-authoring.yaml
+dm_version_tag: 7.3.0.GA
+dm_imagestreams_yml: https://raw.githubusercontent.com/jboss-container-images/rhdm-7-openshift-image/{{dm_version_tag}}/rhdm73-image-streams.yaml
+dm_template_yml: https://raw.githubusercontent.com/jboss-container-images/rhdm-7-openshift-image/{{dm_version_tag}}/templates/rhdm73-authoring.yaml
 dm_secrets_template_yml: https://raw.githubusercontent.com/jboss-container-images/rhdm-7-openshift-image/{{dm_version_tag}}/example-app-secret-template.yaml

--- a/ansible/roles/ocp-workload-dm7-qlb-demo/files/rhdm73-kieserver-cors.yaml
+++ b/ansible/roles/ocp-workload-dm7-qlb-demo/files/rhdm73-kieserver-cors.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: v1
+kind: Template
+labels:
+  template: rhdm73-kieserver-cors
+  group: xpaas
+metadata:
+  name: rhdm73-kieserver-cors
+objects:
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: rhdm73-kieserver-cors
+    annotations:
+    labels:
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    name: rhdm73-kieserver-cors
+    annotations:
+      description: Builds Red Hat Decision Manager KIE-Server image with CORS support.
+    labels:
+      name: rhdm73-kieserver-cors
+      app: rhdm73-kieserver-cors
+  spec:
+    resources:
+      requests:
+        cpu: "500m"
+        memory: "256Mi"
+      limits:
+        cpu: "750m"
+        memory: "512Mi"
+    output:
+      to:
+        kind: ImageStreamTag
+        name: rhdm73-kieserver-cors:latest
+    source:
+      contextDir: ${DOCKERFILE_CONTEXT}
+      git:
+        uri: ${DOCKERFILE_REPOSITORY}
+        ref: ${DOCKERFILE_REF}
+      type: Git
+    strategy:
+      dockerStrategy:
+        from:
+          kind: ImageStreamTag
+          name: rhdm73-kieserver-openshift:1.0
+      type: Docker
+    triggers:
+    - type: ConfigChange
+parameters:
+- description: The directory in the git repository containing the Dockerfile.
+  name: DOCKERFILE_CONTEXT
+  required: true
+- description: The git repository containing the Dockerfile
+  name: DOCKERFILE_REPOSITORY
+  required: true
+- description: The ait branchcontaining the Dockerfile
+  name: DOCKERFILE_REF
+  required: true
+  default: master

--- a/ansible/roles/ocp-workload-dm7-qlb-demo/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-dm7-qlb-demo/tasks/workload.yml
@@ -15,8 +15,18 @@
 #- name: Set project limit LimitRange
 #  shell: "oc create -f /tmp/{{guid}}//limit-range.yaml -n {{ocp_project}}"
 
-- name: Import ImageStreams
-  shell: "oc create -f {{dm_imagestreams_yml}} -n {{ocp_project}}"
+# Check whether the required ImageStreams are available in the "openshift" namespace.
+# If they are not, we import them.
+# We need to do this in the "openshift" namespace, in order to have the secret to pull from registry.redhat.io.
+- name: Check if DM ImageStreams exists
+  shell: oc get is/rhdm73-decisioncentral-openshift -n openshift
+  register: rhdm_is_exists_result
+  ignore_errors: true
+
+- name: Import the RHDM73 ImageStreams into the cluster.
+  shell: "oc create -f {{dm_imagestreams_yml}} -n openshift"
+  when: rhdm_is_exists_result is failed
+  ignore_errors: true
 
 - name: "Import templates"
   shell: "oc create -f {{dm_template_yml}} -n {{ocp_project}}"
@@ -49,7 +59,7 @@
             -p MAVEN_REPO_PASSWORD={{kie_admin_pwd}} \
             -p DECISION_CENTRAL_MEMORY_LIMIT="2Gi" \
             -p DECISION_CENTRAL_VOLUME_CAPACITY={{pv_capacity}} \
-            -p IMAGE_STREAM_NAMESPACE={{ocp_project}} -n {{ocp_project}}
+            -p IMAGE_STREAM_NAMESPACE=openshift -n {{ocp_project}}
 
 - name: "Add ConfigMap as Volume to Decision Central DC"
   shell: oc set volume dc/rhdm7-qlb-rhdmcentr --add --name=config-volume --configmap-name=rhdm-dc-setup-config-map --mount-path=/tmp/config-files

--- a/ansible/roles/ocp-workload-dm7-qlb-demo/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-dm7-qlb-demo/tasks/workload.yml
@@ -18,9 +18,6 @@
 - name: Import ImageStreams
   shell: "oc create -f {{dm_imagestreams_yml}} -n {{ocp_project}}"
 
-- name: Patch KIE-Server Image stream
-  shell: "oc patch is/rhdm71-decisioncentral-openshift --type='json' -p '[{\"op\": \"replace\", \"path\": \"/spec/tags/0/from/name\", \"value\": \"registry.access.redhat.com/rhdm-7/rhdm71-decisioncentral-openshift:1.0\"}]'"
-
 - name: "Import templates"
   shell: "oc create -f {{dm_template_yml}} -n {{ocp_project}}"
 
@@ -31,14 +28,14 @@
   shell: "oc process -f {{dm_secrets_template_yml}} -p SECRET_NAME=kieserver-app-secret | oc create -f - -n {{ocp_project}}"
 
 - name: "Deploy KIE-Server with CORS support."
-  shell: "oc process -f /tmp/{{guid}}/rhdm71-kieserver-cors.yaml -p DOCKERFILE_REPOSITORY=\"http://www.github.com/jbossdemocentral/rhdm7-qlb-loan-demo\" -p DOCKERFILE_REF=master -p DOCKERFILE_CONTEXT=support/openshift/rhdm71-kieserver-cors -n {{ocp_project}} | oc create -n {{ocp_project}} -f -"
+  shell: "oc process -f /tmp/{{guid}}/rhdm73-kieserver-cors.yaml -p DOCKERFILE_REPOSITORY=\"http://www.github.com/jbossdemocentral/rhdm7-qlb-loan-demo\" -p DOCKERFILE_REF=master -p DOCKERFILE_CONTEXT=support/openshift/rhdm73-kieserver-cors -n {{ocp_project}} | oc create -n {{ocp_project}} -f -"
 
 - name: Create ConfigMap Decision Central
   shell: oc create configmap rhdm-dc-setup-config-map --from-file=/tmp/{{guid}}/dc-clone-git-repository.sh,/tmp/{{guid}}/provision-properties-static.sh -n {{ocp_project}}
 
 - name: "Create the Decision Manager application."
   shell: |
-          oc new-app --template=rhdm71-authoring \
+          oc new-app --template=rhdm73-authoring \
             -p APPLICATION_NAME={{application_name}} \
             -p KIE_ADMIN_USER={{kie_admin_user}} \
             -p KIE_ADMIN_PWD={{kie_admin_pwd}} \
@@ -74,7 +71,7 @@
 #  shell: oc rollout latest dc/rhdm7-qlb-rhdmcentr
 
 - name: "Patch the KIE-Server deployment to use CORS"
-  shell: "oc patch dc/rhdm7-qlb-kieserver --type='json' -p=\"[{'op': 'replace', 'path': '/spec/triggers/0/imageChangeParams/from/name', 'value': 'rhdm71-kieserver-cors:latest'}]\""
+  shell: "oc patch dc/rhdm7-qlb-kieserver --type='json' -p=\"[{'op': 'replace', 'path': '/spec/triggers/0/imageChangeParams/from/name', 'value': 'rhdm73-kieserver-cors:latest'}]\""
 
 - name: "Create the QLB client application"
   shell: "oc new-app nodejs:6~https://github.com/jbossdemocentral/rhdm7-qlb-loan-demo#development --name=qlb-client-application --context-dir=support/application-ui -e NODE_ENV=development --build-env NODE_ENV=development"
@@ -111,7 +108,7 @@
   vars:
     build_to_wait:
       - qlb-client-application
-      - rhdm71-kieserver-cors
+      - rhdm73-kieserver-cors
 
 #### Wait for the deployment to complete before slapping on the quota ...
 - include_tasks: ./wait_for_deploy.yml

--- a/ansible/roles/ocp-workload-fsi-cc-dispute-demo/defaults/main.yml
+++ b/ansible/roles/ocp-workload-fsi-cc-dispute-demo/defaults/main.yml
@@ -24,9 +24,9 @@ build_status_delay: 30
 deploy_status_retries: 30
 deploy_status_delay: 30
 
-pam_version_tag: 7.1.0.GA
-pam_imagestreams_yml: https://raw.githubusercontent.com/jboss-container-images/rhpam-7-openshift-image/{{pam_version_tag}}/rhpam71-image-streams.yaml
-pam_template_yml: https://raw.githubusercontent.com/jboss-container-images/rhpam-7-openshift-image/{{pam_version_tag}}/templates/rhpam71-authoring.yaml
+pam_version_tag: 7.3.0.GA
+pam_imagestreams_yml: https://raw.githubusercontent.com/jboss-container-images/rhpam-7-openshift-image/{{pam_version_tag}}/rhpam73-image-streams.yaml
+pam_template_yml: https://raw.githubusercontent.com/jboss-container-images/rhpam-7-openshift-image/{{pam_version_tag}}/templates/rhpam73-authoring.yaml
 pam_secrets_template_yml: https://raw.githubusercontent.com/jboss-container-images/rhpam-7-openshift-image/{{pam_version_tag}}/example-app-secret-template.yaml
 pam_app_name: pam
 

--- a/ansible/roles/ocp-workload-fsi-cc-dispute-demo/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-fsi-cc-dispute-demo/tasks/workload.yml
@@ -23,9 +23,18 @@
 #- name: Set project limit LimitRange
 #  shell: "oc create -f /tmp/{{guid}}//limit-range.yaml -n {{ocp_project}}"
 
+# Check whether the required ImageStreams are available in the "openshift" namespace.
+# If they are not, we import them.
+# We need to do this in the "openshift" namespace, in order to have the secret to pull from registry.redhat.io.
+- name: Check if PAM ImageStreams exists
+  shell: oc get is/rhpam73-businesscentral-openshift -n openshift
+  register: rhpam_is_exists_result
+  ignore_errors: true
 
-- name: Import ImageStreams PAM
-  shell: "oc create -f {{pam_imagestreams_yml}} -n {{ocp_project}}"
+- name: Import the RHPAM73 ImageStreams into the cluster.
+  shell: "oc create -f {{pam_imagestreams_yml}} -n openshift"
+  when: rhpam_is_exists_result is failed
+  ignore_errors: true
 
 - name: Import ImageStreams Entando EAP 7.1
   shell: "oc create -f https://raw.githubusercontent.com/entando/entando-ops/credit-card-dispute/Openshift/image-streams/entando-fsi-ccd-demo.json -n {{ocp_project}}"
@@ -62,12 +71,12 @@
 
 - name: Create PAM7 Authoring environment 2
   shell: |
-         oc new-app --template=rhpam71-authoring \
+         oc new-app --template=rhpam73-authoring \
            --name={{pam_app_name}} \
            -p APPLICATION_NAME={{pam_app_name}} \
            -p BUSINESS_CENTRAL_HTTPS_SECRET=businesscentral-app-secret \
            -p KIE_SERVER_HTTPS_SECRET=kieserver-app-secret \
-           -p IMAGE_STREAM_NAMESPACE={{ocp_project}} \
+           -p IMAGE_STREAM_NAMESPACE=openshift \
            -p KIE_ADMIN_USER={{kie_server_username}} \
            -p KIE_ADMIN_PWD={{kie_server_password}} \
            -p KIE_SERVER_USER=kieUser \

--- a/ansible/roles/ocp-workload-fsi-cc-dispute-demo/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-fsi-cc-dispute-demo/tasks/workload.yml
@@ -30,11 +30,6 @@
 - name: Import ImageStreams Entando EAP 7.1
   shell: "oc create -f https://raw.githubusercontent.com/entando/entando-ops/credit-card-dispute/Openshift/image-streams/entando-fsi-ccd-demo.json -n {{ocp_project}}"
 
-- name: Patch Business Central Image Stream
-  shell: "oc patch is/rhpam71-businesscentral-openshift --type='json' -p '[{\"op\": \"replace\", \"path\": \"/spec/tags/0/from/name\", \"value\": \"registry.access.redhat.com/rhpam-7/rhpam71-businesscentral-openshift:1.0\"}]'"
-
-- name: Patch KIE-Server Image stream
-  shell: "oc patch is/rhpam71-kieserver-openshift --type='json' -p '[{\"op\": \"replace\", \"path\": \"/spec/tags/0/from/name\", \"value\": \"registry.access.redhat.com/rhpam-7/rhpam71-kieserver-openshift:1.0\"}]'"
 #- name: Import ImageStreams Entando Appbuilder
 #  shell: "oc create -f https://raw.githubusercontent.com/entando/entando-ops/master/Openshift/image-streams/appbuilder.json -n {{ocp_project}}"
 

--- a/ansible/roles/ocp-workload-fsi-client-onboarding-demo/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-fsi-client-onboarding-demo/tasks/workload.yml
@@ -21,17 +21,17 @@
 - name: Import ImageStreams
   shell: "oc create -f https://raw.githubusercontent.com/jboss-container-images/jboss-processserver-6-openshift-image/6.4.x/templates/processserver64-image-stream.json -n {{ocp_project}}"
 
-- name: Patch Image Stream
-  shell: |
-          JSONPATCH='[{"op": "replace", "path": "/spec/tags/'{{item}}'/from/name", "value": "registry.access.redhat.com/jboss-processserver-6/processserver64-openshift:1.'{{item}}'"}]'
-          oc patch is/jboss-processserver64-openshift --type='json' -p "$JSONPATCH"
-  loop:
-    - 0
-    - 1
-    - 2
-    - 3
-    - 4
-    - 5
+#- name: Patch Image Stream
+#  shell: |
+#          JSONPATCH='[{"op": "replace", "path": "/spec/tags/'{{item}}'/from/name", "value": "registry.access.redhat.com/jboss-processserver-6/processserver64-openshift:1.'{{item}}'"}]'
+#          oc patch is/jboss-processserver64-openshift --type='json' -p "$JSONPATCH"
+#  loop:
+#    - 0
+#    - 1
+#    - 2
+#    - 3
+#    - 4
+#    - 5
 
 - name: "Import templates"
   shell: "oc create -f https://raw.githubusercontent.com/jboss-container-images/jboss-processserver-6-openshift-image/6.4.x/templates/processserver64-postgresql-s2i.json -n {{ocp_project}}"

--- a/ansible/roles/ocp-workload-pam-order-it-hardware/defaults/main.yml
+++ b/ansible/roles/ocp-workload-pam-order-it-hardware/defaults/main.yml
@@ -27,7 +27,7 @@ deploy_status_delay: 20
 #openjdk_imagestreams_yml: https://raw.githubusercontent.com/jboss-openshift/application-templates/master/openjdk/openjdk18-image-stream.json
 openjdk_imagestreams_yml: https://raw.githubusercontent.com/jboss-openshift/application-templates/ose-v1.4.15/openjdk/openjdk18-image-stream.json
 
-pam_version_tag: 7.1.0.GA
-pam_imagestreams_yml: https://raw.githubusercontent.com/jboss-container-images/rhpam-7-openshift-image/{{pam_version_tag}}/rhpam71-image-streams.yaml
-pam_template_yml: https://raw.githubusercontent.com/jboss-container-images/rhpam-7-openshift-image/{{pam_version_tag}}/templates/rhpam71-authoring.yaml
+pam_version_tag: 7.3.0.GA
+pam_imagestreams_yml: https://raw.githubusercontent.com/jboss-container-images/rhpam-7-openshift-image/{{pam_version_tag}}/rhpam73-image-streams.yaml
+pam_template_yml: https://raw.githubusercontent.com/jboss-container-images/rhpam-7-openshift-image/{{pam_version_tag}}/templates/rhpam73-authoring.yaml
 pam_secrets_template_yml: https://raw.githubusercontent.com/jboss-container-images/rhpam-7-openshift-image/{{pam_version_tag}}/example-app-secret-template.yaml

--- a/ansible/roles/ocp-workload-pam-order-it-hardware/files/rhpam73-businesscentral-openshift-with-users.yaml
+++ b/ansible/roles/ocp-workload-pam-order-it-hardware/files/rhpam73-businesscentral-openshift-with-users.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: v1
+kind: Template
+labels:
+  template: rhpam73-businesscental-openshift-with-users
+  group: xpaas
+metadata:
+  name: rhpam73-businesscentral-openshift-with-users
+objects:
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: rhpam73-businesscentral-openshift-with-users
+    annotations:
+    labels:
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    name: rhpam73-businesscentral-openshift-with-users
+    annotations:
+      description: Builds Red Hat Process Automation Manager Business Central OpenShift image with additional users.
+    labels:
+      name: rhpam73-businesscentral-openshift-with-users
+      app: rhpam73-businesscentral-openshift-with-users
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: rhpam73-businesscentral-openshift-with-users:latest
+    source:
+      contextDir: ${DOCKERFILE_CONTEXT}
+      git:
+        uri: ${DOCKERFILE_REPOSITORY}
+        ref: ${DOCKERFILE_REF}
+      type: Git
+    strategy:
+      dockerStrategy:
+        from:
+          kind: ImageStreamTag
+          name: rhpam73-businesscentral-openshift:1.0
+      type: Docker
+    triggers:
+    - type: ConfigChange
+parameters:
+- description: The directory in the git repository containing the Dockerfile.
+  name: DOCKERFILE_CONTEXT
+  required: true
+- description: The git repository containing the Dockerfile
+  name: DOCKERFILE_REPOSITORY
+  required: true
+- description: The ait branchcontaining the Dockerfile
+  name: DOCKERFILE_REF
+  required: true
+  default: master

--- a/ansible/roles/ocp-workload-pam-order-it-hardware/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-pam-order-it-hardware/tasks/workload.yml
@@ -24,9 +24,6 @@
 - name: Import ImageStreams PAM
   shell: "oc create -f {{pam_imagestreams_yml}} -n {{ocp_project}}"
 
-- name: Patch KIE-Server Image stream
-  shell: "oc patch is/rhpam71-kieserver-openshift --type='json' -p '[{\"op\": \"replace\", \"path\": \"/spec/tags/0/from/name\", \"value\": \"registry.access.redhat.com/rhpam-7/rhpam71-kieserver-openshift:1.0\"}]'"
-
 - name: Import PAM Authoring template
   shell: "oc create -f {{pam_template_yml}} -n {{ocp_project}}"
 
@@ -52,11 +49,11 @@
   shell: oc create configmap rhpam-bc-setup-config-map --from-file=/tmp/{{guid}}/bc-clone-git-repository.sh,/tmp/{{guid}}/provision-properties-static.sh -n {{ocp_project}}
 
 - name: Create custom RHPAM 7 Business Central build with users.
-  shell: oc process -f /tmp/{{guid}}/rhpam71-businesscentral-openshift-with-users.yaml -p DOCKERFILE_REPOSITORY="https://github.com/jbossdemocentral/rhpam7-order-it-hw-demo-rhpamcentr" -p DOCKERFILE_REF="master" -p DOCKERFILE_CONTEXT="." -n {{ocp_project}} | oc create -n {{ocp_project}} -f -
+  shell: oc process -f /tmp/{{guid}}/rhpam73-businesscentral-openshift-with-users.yaml -p DOCKERFILE_REPOSITORY="https://github.com/jbossdemocentral/rhpam7-order-it-hw-demo-rhpamcentr" -p DOCKERFILE_REF="master" -p DOCKERFILE_CONTEXT="." -n {{ocp_project}} | oc create -n {{ocp_project}} -f -
 
 - name: Create PAM7 Authoring environment
   shell: |
-          oc new-app --template=rhpam71-authoring \
+          oc new-app --template=rhpam73-authoring \
             -p APPLICATION_NAME="rhpam7-oih" \
             -p KIE_ADMIN_USER="adminUser" \
             -p KIE_ADMIN_PWD="test1234!" \
@@ -78,7 +75,7 @@
   shell: oc set deployment-hook dc/rhpam7-oih-rhpamcentr --post -c rhpam7-oih-rhpamcentr -e BC_URL="http://rhpam7-oih-rhpamcentr:8080" -v config-volume --failure-policy=abort -- /bin/bash /tmp/config-files/bc-clone-git-repository.sh
 
 - name: "Configure Business Central ImageStream"
-  shell: "oc patch dc/rhpam7-oih-rhpamcentr --type='json' -p '[{\"op\": \"replace\", \"path\": \"/spec/triggers/0/imageChangeParams/from/name\", \"value\": \"rhpam71-businesscentral-openshift-with-users:latest\"}]'"
+  shell: "oc patch dc/rhpam7-oih-rhpamcentr --type='json' -p '[{\"op\": \"replace\", \"path\": \"/spec/triggers/0/imageChangeParams/from/name\", \"value\": \"rhpam73-businesscentral-openshift-with-users:latest\"}]'"
 
 #- name: "Create secrets and service accounts"
 #  shell: "oc process -f /tmp/{{guid}}/secrets-and-accounts.yaml | oc create -n {{ocp_project}} -f  -"
@@ -149,7 +146,7 @@
     build_to_wait:
       - rhpam7-oih-order-app
       - rhpam7-oih-order-mgmt-app
-      - rhpam71-businesscentral-openshift-with-users
+      - rhpam73-businesscentral-openshift-with-users
 
 #### Wait for the deployment to complete before slapping on the quota ...
 - include_tasks: ./wait_for_deploy.yml

--- a/ansible/roles/ocp-workload-pam-order-it-hardware/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-pam-order-it-hardware/tasks/workload.yml
@@ -18,11 +18,28 @@
 #- name: Set project limit LimitRange
 #  shell: "oc create -f /tmp/{{guid}}//limit-range.yaml -n {{ocp_project}}"
 
-- name: Import ImageStreams OpenJDK
-  shell: "oc create -f {{openjdk_imagestreams_yml}} -n {{ocp_project}}"
+# Check whether the required ImageStreams are available in the "openshift" namespace.
+# If they are not, we import them.
+# We need to do this in the "openshift" namespace, in order to have the secret to pull from registry.redhat.io.
+- name: Check if PAM ImageStreams exists
+  shell: oc get is/rhpam73-businesscentral-openshift -n openshift
+  register: rhpam_is_exists_result
+  ignore_errors: true
 
-- name: Import ImageStreams PAM
-  shell: "oc create -f {{pam_imagestreams_yml}} -n {{ocp_project}}"
+- name: Import the RHPAM73 ImageStreams into the cluster.
+  shell: "oc create -f {{pam_imagestreams_yml}} -n openshift"
+  when: rhpam_is_exists_result is failed
+  ignore_errors: true
+
+- name: Check if OpenJDK ImageStreams exists
+  shell: oc get is/redhat-openjdk18-openshift -n openshift
+  register: openjdk_is_exists_result
+  ignore_errors: true
+
+- name: Import OpenJDK Image Streams into the cluster.
+  shell: "oc create -f {{openjdk_imagestreams_yml}} -n openshift"
+  when: openjdk_is_exists_result is failed
+  ignore_errors: true
 
 - name: Import PAM Authoring template
   shell: "oc create -f {{pam_template_yml}} -n {{ocp_project}}"
@@ -66,7 +83,7 @@
             -p BUSINESS_CENTRAL_MAVEN_USERNAME="mavenUser" \
             -p BUSINESS_CENTRAL_MAVEN_PASSWORD="test1234!" \
             -p BUSINESS_CENTRAL_MEMORY_LIMIT="2Gi" \
-            -p IMAGE_STREAM_NAMESPACE={{ocp_project}} -n {{ocp_project}}
+            -p IMAGE_STREAM_NAMESPACE=openshift -n {{ocp_project}}
 
 - name: "Add ConfigMap as Volume to Business Central DC"
   shell: oc set volume dc/rhpam7-oih-rhpamcentr --add --name=config-volume --configmap-name=rhpam-bc-setup-config-map --mount-path=/tmp/config-files


### PR DESCRIPTION
##### SUMMARY
Due to the shutdown of registry.access.redhat.com, all the RHPAM and RHDM demos started to fail. This PR fixes this by:
- Checking whether the required ImageStreams are in the "openshift" namespace
- If not present, provision the ImageStreams in the "openshift" namespace

I need to use the "openshift" namespace instead of the project namespace, as I need the credentials to pull from "registry.redhat.io", which are present in the "openshift" namespace, but not in the project namespace.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- rhpam-order-it-hw
- rhdm-qlb-loan
- fsi-cc-dispute

##### ADDITIONAL INFORMATION
Talked to Sha to discuss possible fixes, and this seemed the best option (unitil we move to a dedicated Quay instance).