### PR TITLE
changes the configuration of the deployed istio controlplane

### DIFF
--- a/ansible/roles/ocp4-workload-istio-controlplane/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-istio-controlplane/tasks/workload.yml
@@ -523,6 +523,7 @@
                 limits:
                   cpu: 500m
                   memory: 128Mi
+            disablePolicyChecks: false
           gateways:
             istio-egressgateway:
               autoscaleEnabled: false
@@ -545,9 +546,12 @@
             autoscaleEnabled: false
             traceSampling: 100.0
           kiali:
-           dashboard:
+            enabled: true
+            dashboard:
               user: admin
               passphrase: admin
+          tracing:
+            enabled: true
 
 - name: wait up to 5 minutes for istio operator pod to be ready
   shell: "oc get deployment -n istio-operator istio-operator -o jsonpath='{.status.readyReplicas}'"


### PR DESCRIPTION
This updates the `ocp4-workload-istio-controlplane` role to use a slightly different configuration. It was tested against an existing cluster.