### PR TITLE
Fix customer image name for istio tutorial

### DIFF
--- a/ansible/roles/ocp4-workload-istio-tutorial/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-istio-tutorial/tasks/workload.yml
@@ -126,7 +126,7 @@
         labels:
           app: customer
           version: v1
-        name: customer
+        name: customer-v1
       spec:
         replicas: 1
         selector:
@@ -147,7 +147,7 @@
             - env:
               - name: JAVA_OPTIONS
                 value: -Xms128m -Xmx256m -Djava.net.preferIPv4Stack=true -Djava.security.egd=file:///dev/./urandom
-              image: quay.io/maistra_demos/customer:latest
+              image: quay.io/maistra_demos/customer:v1
               imagePullPolicy: Always
               name: customer
               ports:


### PR DESCRIPTION
##### SUMMARY
The istio tutorial customer image reference is wrong, it currently references customer:latest and not customer:v1

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-workload-istio-tutorial

##### ADDITIONAL INFORMATION

@thoraxe FYI