### PR TITLE
Ocp4 workload build your own operator (replaces PR 416)

### DIFF
--- a/ansible/roles/ocp4-workload-build-your-own-operator/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-build-your-own-operator/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+become_override: false
+tmp_kubeconfig: /tmp/{{ guid }}
+tmp_git_location: /tmp/{{ guid }}-lab-build-your-own-operator
+ocp_username: opentlc-mgr
+
+user_project_name: demo-workshop
+user_application_name: demo
+
+

--- a/ansible/roles/ocp4-workload-build-your-own-operator/readme.adoc
+++ b/ansible/roles/ocp4-workload-build-your-own-operator/readme.adoc
@@ -1,0 +1,165 @@
+= ocp4-workload-build-your-own-operator - summit lab environment
+
+== Role overview
+
+* This is a simple role that does the following:
+** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+ environment for the workload deployment
+*** Copies ~/.kube/config to a temp directory and sets the KUBECONFIG env variable.
+*** Debug task will print out: `pre_workload Tasks Complete`
+
+** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the 
+ lab environment.
+*** Creates a new project and a deployment for the learning portal.
+*** Debug task will print out: `workload Tasks Complete`
+
+** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+ configure the workload after deployment
+*** Removes the temp .kube/config file.
+*** Debug task will print out: `post_workload Tasks Complete`
+
+** Playbook: link:./tasks/pre_remove_workload.yml[pre_remove_workload.yml] - Sets up an
+ environment for the workload removal
+*** Copies ~/.kube/config to a temp directory and sets the KUBECONFIG env variable.
+*** Debug task will print out: `pre_workload Removal Tasks Complete`
+
+** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to clean up the environment and delete all resources.
+*** Deletes resources and projects that were created.
+*** Debug task will print out: `workload Removal Tasks Complete`
+
+** Playbook: link:./tasks/post_remove_workload.yml[post_remove_workload.yml] - Used to
+ configure the workload after deployment
+*** Removes the temp .kube/config file.
+*** Debug task will print out: `post_workload Removal Tasks Complete`
+
+== Set up your Ansible inventory file
+
+* You will need to create an Ansible inventory file to define your connection
+ method to your host (Master/Bastion with OC command)
+
+* You can also use the command line to define the hosts directly if your `ssh`
+ configuration is set to connect to the host correctly
+
+* You can also use the command line to use localhost or if your cluster is
+ already authenticated and configured in your `oc` configuration
+[source, ini]
+
+.example inventory file
+----
+[gptehosts:vars]
+ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem
+ansible_user=ec2-user
+
+[gptehosts:children]
+openshift
+
+[openshift]
+bastion.cluster1.openshift.opentlc.com
+bastion.cluster2.openshift.opentlc.com
+bastion.cluster3.openshift.opentlc.com ansible_ssh_host=ec2-11-111-111-11.us-west-2.compute.amazonaws.com
+bastion.cluster4.openshift.opentlc.com
+
+
+[dev]
+bastion.cluster1.openshift.opentlc.com
+bastion.cluster2.openshift.opentlc.com
+
+
+[prod]
+bastion.cluster3.openshift.opentlc.com
+bastion.cluster4.openshift.opentlc.com
+----
+
+
+== Review the defaults variable file
+
+* This file link:./defaults/main.yml[./defaults/main.yml] contains all the variables you
+ need to define to control the deployment of your workload.
+
+* You can modify any of these default values by adding
+`-e"variable_name=variable_value"` to the command line
+
+=== Deploy Workload on OpenShift Cluster from an existing playbook:
+
+[source,yaml]
+----
+- name: Deploy a workload role on a master host
+  hosts: all
+  become: true
+  gather_facts: False
+  tags:
+    - step007
+  roles:
+    - { role: "{{ocp_workload}}", when: 'ocp_workload is defined' }
+
+----
+NOTE: You might want to change `hosts: all` to fit your requirements
+
+=== Common configuration to run these playbooks
+You should have these environment variables defined/exported in your system in order
+to run these playbooks.
+
+----
+HOST_GUID=rjarvine-099m
+DOMAIN="$HOST_GUID.openshiftworkshop.com"
+TARGET_HOST="bastion.$DOMAIN"
+MASTER_HOSTNAME="master.$DOMAIN"
+APPS_DOMAIN="apps.$DOMAIN"
+OCP_USERNAME="opentlc-mgr"
+SSH_USER="ec2-user"
+SSH_PRIVATE_KEY="ocp-workshop.pem"
+GUID=rjarvine-099m
+# WORKLOAD SPECIFICS
+WORKSHOP_PROJECT="workshop"
+WORKLOAD="ocp4-workload-build-your-own-operator"
+----
+
+=== Deploy a Workload with the `ocp-workload` playbook [Mostly for testing]
+----
+WORKLOAD="ocp4-workload-build-your-own-operator"
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp4-workshop/ocp-workloads.yml \
+                -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
+                -e"ansible_ssh_user=${SSH_USER}" \
+                -e"ANSIBLE_REPO_PATH=`pwd`" \
+                -e"ocp_username=${OCP_USERNAME}" \
+                -e"ocp_workload=${WORKLOAD}" \
+                -e"guid=${GUID}" \
+                -e"user_project_name=${WORKSHOP_PROJECT}" \
+                -e"ACTION=create"
+----
+
+=== To Delete an environment
+----
+WORKLOAD="ocp4-workload-build-your-own-operator"
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp4-workshop/ocp-workloads.yml \
+                -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
+                -e"ansible_ssh_user=${SSH_USER}" \
+                -e"ANSIBLE_REPO_PATH=`pwd`" \
+                -e"ocp_username=${OCP_USERNAME}" \
+                -e"ocp_workload=${WORKLOAD}" \
+                -e"guid=${GUID}" \
+                -e"user_project_name=${WORKSHOP_PROJECT}" \
+                -e"ACTION=remove"
+----
+
+=== Additional information
+
+== Additional configuration
+You can alter the defaults provided when running your ansible role by
+providing the name of the variable via *ENV* variable (with -e).
+
+The values that can be set (and the defaults) are:
+
+----
+become_override: false # set to true if your SSH_USER is something other than opentlc-mgr, e.g. ec2-user 
+ocp_username: opentlc-mgr
+
+user_project_name: workshop
+user_application_name: demo
+
+
+----

--- a/ansible/roles/ocp4-workload-build-your-own-operator/tasks/main.yml
+++ b/ansible/roles/ocp4-workload-build-your-own-operator/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+- name: Running Pre Workload Tasks
+  import_tasks: pre_workload.yml
+  become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload Tasks
+  import_tasks: workload.yml
+  become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  import_tasks: post_workload.yml
+  become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Pre Workload removal Tasks
+  import_tasks: pre_remove_workload.yml
+  become: "{{ become_override | bool }}"
+  when: ACTION == "destroy" or ACTION == "remove"
+
+- name: Running Workload removal Tasks
+  import_tasks: remove_workload.yml
+  become: "{{ become_override | bool }}"
+  when: ACTION == "destroy" or ACTION == "remove"
+
+- name: Running Post Workload removal Tasks
+  import_tasks: post_remove_workload.yml
+  become: "{{ become_override | bool }}"
+  when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles/ocp4-workload-build-your-own-operator/tasks/post_remove_workload.yml
+++ b/ansible/roles/ocp4-workload-build-your-own-operator/tasks/post_remove_workload.yml
@@ -1,0 +1,10 @@
+---
+- name: Remove temp kube config
+  command: "rm {{ tmp_kubeconfig }}"
+
+- name: Remove temp git repo
+  command: "rm -rf {{ tmp_git_location }}"
+
+- name: post_workload Removal Tasks Complete
+  debug:
+    msg: "Post-Software removal checks completed successfully"

--- a/ansible/roles/ocp4-workload-build-your-own-operator/tasks/post_workload.yml
+++ b/ansible/roles/ocp4-workload-build-your-own-operator/tasks/post_workload.yml
@@ -1,0 +1,10 @@
+---
+- name: Remove temp kube config
+  command: "rm {{ tmp_kubeconfig }}"
+
+- name: Remove temp git repo
+  command: "rm -rf {{ tmp_git_location }}"
+
+- name: post_workload Tasks Complete
+  debug:
+    msg: "Post-Software checks completed successfully"

--- a/ansible/roles/ocp4-workload-build-your-own-operator/tasks/pre_remove_workload.yml
+++ b/ansible/roles/ocp4-workload-build-your-own-operator/tasks/pre_remove_workload.yml
@@ -1,0 +1,10 @@
+---
+- name: Copy .kube/config and set env var
+  copy:
+    src: ~/.kube/config
+    dest: "{{ tmp_kubeconfig }}"
+    remote_src: yes
+
+- name: pre_workload Removal Tasks Complete
+  debug:
+    msg: "Pre-Software removal checks completed successfully"

--- a/ansible/roles/ocp4-workload-build-your-own-operator/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-build-your-own-operator/tasks/pre_workload.yml
@@ -1,0 +1,10 @@
+---
+- name: Copy .kube/config and set env var
+  copy:
+    src: ~/.kube/config
+    dest: "{{ tmp_kubeconfig }}"
+    remote_src: yes
+
+- name: pre_workload Tasks Complete
+  debug:
+    msg: "Pre-Software checks completed successfully"

--- a/ansible/roles/ocp4-workload-build-your-own-operator/tasks/remove_workload.yml
+++ b/ansible/roles/ocp4-workload-build-your-own-operator/tasks/remove_workload.yml
@@ -1,0 +1,31 @@
+---
+- environment:
+    KUBECONFIG: "{{ tmp_kubeconfig }}"
+  block:
+    - name: post_workload Tasks Complete
+      debug:
+       msg: "Pre-Software checks completed successfully - Removed"
+  
+    - name: Git clone the repo if it doesn't exist
+      command: git clone --branch v1.0 https://github.com/openshift-labs/lab-build-your-own-operator {{ tmp_git_location }}
+      args:
+        creates: "{{ tmp_git_location }}"
+
+    - name: Delete spawner
+      command: "{{ tmp_git_location }}/.workshop/scripts/delete-spawner.sh"
+
+    - name: Delete workshop
+      command: "{{ tmp_git_location }}/.workshop/scripts/delete-workshop.sh"
+
+    - name: Check if user workshop project exists
+      shell: "oc get project {{user_project_name}}"
+      register: workshop_project
+      ignore_errors: true
+
+    - name: Remove user workshop project if it exists
+      shell: "oc delete project {{user_project_name}}"
+      when: workshop_project is succeeded
+
+    - name: post_workload Tasks Complete
+      debug:
+        msg: "Post-Software checks completed successfully - Removed"

--- a/ansible/roles/ocp4-workload-build-your-own-operator/tasks/remove_workload.yml
+++ b/ansible/roles/ocp4-workload-build-your-own-operator/tasks/remove_workload.yml
@@ -7,15 +7,19 @@
        msg: "Pre-Software checks completed successfully - Removed"
   
     - name: Git clone the repo if it doesn't exist
-      command: git clone --branch v1.0 https://github.com/openshift-labs/lab-build-your-own-operator {{ tmp_git_location }}
+      command: git clone --branch v1.1 https://github.com/openshift-labs/lab-build-your-own-operator {{ tmp_git_location }}
       args:
         creates: "{{ tmp_git_location }}"
 
     - name: Delete spawner
       command: "{{ tmp_git_location }}/.workshop/scripts/delete-spawner.sh"
+      args:
+        chdir: "{{ tmp_git_location }}"
 
     - name: Delete workshop
       command: "{{ tmp_git_location }}/.workshop/scripts/delete-workshop.sh"
+      args:
+        chdir: "{{ tmp_git_location }}"
 
     - name: Check if user workshop project exists
       shell: "oc get project {{user_project_name}}"

--- a/ansible/roles/ocp4-workload-build-your-own-operator/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-build-your-own-operator/tasks/workload.yml
@@ -1,0 +1,29 @@
+---
+- environment:
+    KUBECONFIG: "{{ tmp_kubeconfig }}"
+  block:
+    - name: Verify user can create projects
+      command: "oc auth can-i create project"
+      register: canicreateprojects
+      failed_when: canicreateprojects.stdout != 'yes'
+
+    - name: Check if user workshop project exists
+      shell: "oc get project {{user_project_name}}"
+      register: workshop_project
+      ignore_errors: true
+
+    - name: Create project for user workshop if it doesn't exist
+      shell: "oc new-project {{user_project_name}} --display-name='user workshop'"
+      when: workshop_project is failed
+
+    - name: Git clone the repo if it doesn't exist
+      command: git clone --branch v1.0 https://github.com/openshift-labs/lab-build-your-own-operator {{ tmp_git_location }}
+      args:
+        creates: "{{ tmp_git_location }}"
+
+    - name: Create deployment
+      command: "{{ tmp_git_location }}/.workshop/scripts/deploy-spawner.sh"
+      
+    - name: workload Tasks Complete
+      debug:
+        msg: workload Tasks Complete

--- a/ansible/roles/ocp4-workload-build-your-own-operator/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-build-your-own-operator/tasks/workload.yml
@@ -17,13 +17,15 @@
       when: workshop_project is failed
 
     - name: Git clone the repo if it doesn't exist
-      command: git clone --branch v1.0 https://github.com/openshift-labs/lab-build-your-own-operator {{ tmp_git_location }}
+      command: git clone --branch v1.1 https://github.com/openshift-labs/lab-build-your-own-operator {{ tmp_git_location }}
       args:
         creates: "{{ tmp_git_location }}"
 
-    - name: Create deployment
+    - name: Create deployment, chdir first
       command: "{{ tmp_git_location }}/.workshop/scripts/deploy-spawner.sh"
-      
+      args:
+        chdir: "{{ tmp_git_location }}"
+        
     - name: workload Tasks Complete
       debug:
         msg: workload Tasks Complete


### PR DESCRIPTION
This is a replacement for https://github.com/redhat-cop/agnosticd/pull/416, which addresses the issues raised there. 

The workload is now referencing a tagged release rather than just a branch https://github.com/openshift-labs/lab-build-your-own-operator/releases/tag/v1.1

Also fixed another task that needed chdir added to it.