### PR TITLE
Added new username var to linklight foundations vars to allow linklight to be updated to more recent version

### DIFF
--- a/ansible/configs/linklight-foundations/lab_vars/foundations_all_vars.yml
+++ b/ansible/configs/linklight-foundations/lab_vars/foundations_all_vars.yml
@@ -7,7 +7,8 @@
 admin_password:         ansible                 # password used for student account on control node
 create_login_page:      false                   # Don't create an S3 bucket
 email:                  no
-student_total:          1                       # Can be
+student_total:          1                       # 
+username:               student1
 
 # vars sourced from elsewhere (CloudForms + Deployer Script)
 # should not need to be set - here for completeness


### PR DESCRIPTION
##### SUMMARY
Ansible Foundations labs are deployed by an older version of linklight which often leaves artifacts around on AWS, such as undeleted ec2 instances.

To enable it to be updated to a much more recent version of linklight a new var `username` needed to be added to the foundations_all_vars.yml

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
config/linklight-foundations

##### ADDITIONAL INFORMATION
All other fixes related to this are external to agnosticd e.g. OPEN_ADMIN deployer scripts and linklight
