### PR TITLE
Add lifecycle.yml for start/stop/status action

### DIFF
--- a/ansible/lifecycle.yml
+++ b/ansible/lifecycle.yml
@@ -1,0 +1,42 @@
+---
+# This file is the default playbook for common actions.
+# You should implement those actions in your config if you
+# need a specific process.
+
+- import_playbook: setup_runtime.yml
+
+- name: Run stop/start/status/... actions
+  hosts: localhost
+  connection: local
+  gather_facts: False
+  become: no
+  tasks:
+    - fail:
+        msg: "project_tag is not defined"
+      when: project_tag is not defined or project_tag == ''
+
+    - fail:
+        msg: "ACTION is not defined"
+      when: ACTION is not defined
+
+    - when: cloud_provider == 'ec2'
+      environment:
+        AWS_ACCESS_KEY_ID: "{{aws_access_key_id}}"
+        AWS_SECRET_ACCESS_KEY: "{{aws_secret_access_key}}"
+        AWS_DEFAULT_REGION: "{{aws_region_final|d(aws_region)}}"
+      block:
+        - when: ACTION == 'stop'
+          name: Stop instances
+          ec2_instance:
+            state: stopped
+            wait: no
+            filters:
+              "tag:Project": "{{project_tag}}"
+
+        - when: ACTION == 'start'
+          name: Start instances
+          ec2_instance:
+            state: started
+            wait: no
+            filters:
+              "tag:Project": "{{project_tag}}"


### PR DESCRIPTION
Start using agnosticd for idleing / start environments.

##### SUMMARY
With agnosticv coming, i need to use agnosticd not only for deploying and destroying, but also for stopping and starting environments.

We would pass the same args to `ansible-playbook` as we do for `main.yml` or `destroy.yml` playbooks.

When cloudforms 'stop' or 'start' an environment, in OPEN_Admin scripts (or in tower in the future) i suggest we look for those files:

- `ansible/configs/$ENVTYPE/lifecycle.yml`
- `ansible/configs/$ENVTYPE/start.yml`
- `ansible/configs/$ENVTYPE/stop.yml`

If they exist, they will be used. If not, the default is the file present in this PR, `ansible/lifecycle.yml`.

This logic cannot be implemented in agnosticd, since playbook can only be *imported* and not dynamically *included*.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
`lifecycle.yml`


used like:

```shell
ansible-playbook lifecycle.yml -e @~/myenvs/just-some-nodes.yml -e @~/secrets/gpte.yml -e ACTION=stop
ansible-playbook lifecycle.yml -e @~/myenvs/just-some-nodes.yml -e @~/secrets/mysecrets.yml -e ACTION=start
```

