### PR TITLE
adds missing curl deployment

### DIFF
--- a/ansible/roles/ocp4-workload-istio-tutorial/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-istio-tutorial/tasks/workload.yml
@@ -315,6 +315,39 @@
                 name: http
                 protocol: TCP
 
+- name: create the curl deployment
+  k8s:
+    state: present
+    definition:
+      apiVersion: extensions/v1beta1
+      kind: Deployment
+      metadata:
+        namespace: istio-tutorial
+        labels:
+          app: curl
+          version: v1
+        name: curl
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app: curl
+            version: v1
+        template:
+          metadata:
+            labels:
+              app: curl
+              version: v1
+            annotations:
+              sidecar.istio.io/proxyCPU: "500m"
+              sidecar.istio.io/proxyMemory: 400Mi
+          spec:
+            containers:
+            - image: quay.io/maistra_demos/curl:latest
+              command: ["/bin/sleep", "3650d"]
+              imagePullPolicy: Always
+              name: curl
+
 # Leave this as the last task in the playbook.
 - name: workload tasks complete
   debug:


### PR DESCRIPTION
The ocp4-workload-istio-tutorial was missing a deployment which this PR adds.