### PR TITLE
Use the summit version of the quay operator

### DIFF
--- a/ansible/roles/ocp4-workload-security-compliance-lab/tasks/quay.yml
+++ b/ansible/roles/ocp4-workload-security-compliance-lab/tasks/quay.yml
@@ -7,7 +7,7 @@
   git:
     repo: https://github.com/sabre1041/quay-operator.git
     dest: "{{ tmp_dir }}/quay-operator"
-    version: "master"
+    version: "4ba1d1620e92776dd40decad9e8d2cc5ac49df7f"
 
 - name: Create openshift quay objects
   command: "{{ openshift_cli }} create -f {{ item }}"


### PR DESCRIPTION
##### SUMMARY
Changed quay operator version to summit version

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-workload-security-compliance-lab

##### ADDITIONAL INFORMATION
The workload was using the latest quay operator, which is not currently working for the version of quay used by this lab. Update to use the last known working operator version.