### PR TITLE
Add integreatly operator params

### DIFF
--- a/ansible/roles/ocp-workload-integreatly/defaults/main.yml
+++ b/ansible/roles/ocp-workload-integreatly/defaults/main.yml
@@ -7,6 +7,7 @@ inventory_hosts_file: inventories/hosts.template
 release_tag: "release-{{ ig_version }}"
 webapp_namespace: webapp
 self_signed_certs_enabled: True
+amq_streams: True
 openshift_master_config_path: /etc/origin/master/master-config.yaml
 admin_username: admin@example.com
 admin_password: Password1

--- a/ansible/roles/ocp-workload-integreatly/tasks/remove_workload.yml
+++ b/ansible/roles/ocp-workload-integreatly/tasks/remove_workload.yml
@@ -3,7 +3,7 @@
 - name: Uninstall Integreatly
   shell: |
           ansible-playbook -i "{{ inventory_hosts_file }}" \
-          playbooks/uninstall.yml
+          playbooks/uninstall.yml -e amq_streams="{{ amq_streams }}"
   args:
     chdir: "{{ install_dir }}"
 

--- a/ansible/roles/ocp-workload-integreatly/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-integreatly/tasks/workload.yml
@@ -9,7 +9,7 @@
 - name: Run Integreatly installer
   shell: |
           ansible-playbook -i "{{ inventory_hosts_file }}" \
-          playbooks/install.yml -e eval_self_signed_certs="{{ self_signed_certs_enabled }} -e rhsso_identity_provider_ca_cert_path={{ rhsso_identity_provider_ca_cert_path }}"
+          playbooks/install.yml -e eval_self_signed_certs="{{ self_signed_certs_enabled }} -e rhsso_identity_provider_ca_cert_path={{ rhsso_identity_provider_ca_cert_path }} -e amq_streams={{ amq_streams }}"
   args:
     chdir: "{{ install_dir }}"
 


### PR DESCRIPTION
##### SUMMARY
Integreatly installation does not install AMQ Streams by default but RHPDS should install AMQ Streams.
These changes sets the required flag to install AMQ Streams.

Fixes: https://issues.jboss.org/browse/INTLY-1914

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
integreatly
