### PR TITLE
Change limits and quotas

### DIFF
--- a/ansible/configs/ocp-workshop/files/project-template.j2
+++ b/ansible/configs/ocp-workshop/files/project-template.j2
@@ -36,7 +36,7 @@ objects:
           max:
             memory: 6Gi
           min:
-            memory: 10Mi
+            memory: 6Mi
           default:
             cpu: 500m
             memory: 1.5Gi

--- a/ansible/roles/ocp4-workload-project-request-template/templates/project_request_template.j2
+++ b/ansible/roles/ocp4-workload-project-request-template/templates/project_request_template.j2
@@ -16,7 +16,7 @@ objects:
           max:
             memory: 6Gi
           min:
-            memory: 10Mi
+            memory: 6Mi
           default:
             cpu: 500m
             memory: 1.5Gi


### PR DESCRIPTION
##### SUMMARY
a) changed minimal requested memory to allow Launcher deployment ([it's currently requesting 8M](https://github.com/fabric8-launcher/launcher-operator/blob/d0124534296c3d1239fb0110ce70876bfe9dd3fa/templates/fabric8-launcher.yaml#L225-L229)). I picked "6Mi" value to match min requested memory for a pod.

b) **dropped**, see discussion below ~~bumped UserQuota for OCP4 workshop. This will enable opentlc-mgr user to utilize all available resources (I calculated CPU and memory based on 3x m4.2xlarge worker nodes available).~~
~~This is mainly motivated by the problems discovered during Integreatly installation. We are starting to test new MW products on OpenShift 4.~~

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp-workshop, ocp4-workshop

##### ADDITIONAL INFORMATION
**dropped**, see discussion below ~~P.S: This change is motivated by 3Scale Redis deployment -~~`requests.memory: 32Gi`
