### PR TITLE
New operator integration: Project Reaper

### DIFF
--- a/ansible/roles/ocp4-workload-projectreaper-operator/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-projectreaper-operator/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+become_override: False
+ocp_username: system:admin
+silent: False
+
+_operator_project: rht-project-reaper-operator
+_operator_project_display: "RHT Operators"

--- a/ansible/roles/ocp4-workload-projectreaper-operator/readme.adoc
+++ b/ansible/roles/ocp4-workload-projectreaper-operator/readme.adoc
@@ -1,0 +1,7 @@
+= ocp-workload-projectreaper-operator - Enable and edit the Project Reaper Operator on OCP4
+
+== Role overview
+
+* This role enables the Project Reaper Operator on an OpenShift 4 Cluster.
+
+To be documented...

--- a/ansible/roles/ocp4-workload-projectreaper-operator/tasks/main.yml
+++ b/ansible/roles/ocp4-workload-projectreaper-operator/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+
+# Do not modify this file
+
+- name: Running Pre Workload Tasks
+  include_tasks:
+    file: ./pre_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload Tasks
+  include_tasks:
+    file: ./workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  include_tasks:
+    file: ./post_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload removal Tasks
+  include_tasks:
+    file: ./remove_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles/ocp4-workload-projectreaper-operator/tasks/post_workload.yml
+++ b/ansible/roles/ocp4-workload-projectreaper-operator/tasks/post_workload.yml
@@ -1,0 +1,9 @@
+---
+# Implement your Post Workload deployment tasks here
+
+
+# Leave this as the last task in the playbook.
+- name: post_workload tasks complete
+  debug:
+    msg: "Post-Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp4-workload-projectreaper-operator/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-projectreaper-operator/tasks/pre_workload.yml
@@ -1,0 +1,9 @@
+---
+# Implement your Pre Workload deployment tasks here
+
+
+# Leave this as the last task in the playbook.
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp4-workload-projectreaper-operator/tasks/remove_workload.yml
+++ b/ansible/roles/ocp4-workload-projectreaper-operator/tasks/remove_workload.yml
@@ -1,0 +1,29 @@
+---
+# Implement your Workload removal tasks here
+
+- name: Delete the UserQuota (which deletes all ClusterResourceQuotas)
+  k8s:
+    state: absent
+    definition: "{{ lookup('template', './templates/project_tracker.j2' ) | from_yaml }}"
+
+- name: Wait 15 seconds (the Operator reconciles every 5 seconds)
+  wait_for: timeout=15
+  delegate_to: localhost
+
+- name: Delete OpenShift Objects for User Quota Operator
+  k8s:
+    state: absent
+    definition: "{{ lookup('template', item ) | from_yaml }}"
+  loop:
+  - ./templates/operator.j2
+  - ./templates/role_binding.j2
+  - ./templates/role.j2
+  - ./templates/service_account.j2
+  - ./templates/crd.j2
+  - ./templates/project.j2
+
+# Leave this as the last task in the playbook.
+- name: remove_workload tasks complete
+  debug:
+    msg: "Remove Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp4-workload-projectreaper-operator/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-projectreaper-operator/tasks/workload.yml
@@ -1,0 +1,28 @@
+---
+# Implement your Workload deployment tasks here
+
+- name: Setting up workload for user
+  debug:
+    msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
+
+- name: Create OpenShift Objects for User Quota Operator
+  k8s:
+    state: present
+    merge_type:
+    - strategic-merge
+    - merge
+    definition: "{{ lookup('template', item ) | from_yaml }}"
+  loop:
+  - ./templates/project.j2
+  - ./templates/crd.j2
+  - ./templates/service_account.j2
+  - ./templates/role.j2
+  - ./templates/role_binding.j2
+  - ./templates/operator.j2
+  - ./templates/project_tracker.j2
+
+# Leave this as the last task in the playbook.
+- name: workload tasks complete
+  debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp4-workload-projectreaper-operator/templates/crd.j2
+++ b/ansible/roles/ocp4-workload-projectreaper-operator/templates/crd.j2
@@ -1,0 +1,19 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: projecttrackers.redhattraining.com
+spec:
+  group: redhattraining.com
+  names:
+    kind: ProjectTracker
+    listKind: ProjectTrackerList
+    plural: projecttrackers
+    singular: projecttracker
+  scope: Cluster
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/ansible/roles/ocp4-workload-projectreaper-operator/templates/operator.j2
+++ b/ansible/roles/ocp4-workload-projectreaper-operator/templates/operator.j2
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rht-project-reaper-operator
+  namespace: "{{ _operator_project }}"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: rht-project-reaper-operator
+  template:
+    metadata:
+      labels:
+        name: rht-project-reaper-operator
+    spec:
+      serviceAccountName: rht-project-reaper-operator
+      containers:
+        - name: ansible
+          command:
+          - /usr/local/bin/ao-logs
+          - /tmp/ansible-operator/runner
+          - stdout
+          # Replace this with the built image name
+          image: quay.io/redhattraining/rht-project-reaper-operator:v0.0.1
+          imagePullPolicy: Always
+          volumeMounts:
+          - mountPath: /tmp/ansible-operator/runner
+            name: runner
+            readOnly: true
+        - name: operator
+          # Replace this with the built image name
+          image: quay.io/redhattraining/rht-project-reaper-operator:v0.0.1
+          imagePullPolicy: Always
+          volumeMounts:
+          - mountPath: /tmp/ansible-operator/runner
+            name: runner
+          env:
+            - name: WATCH_NAMESPACE
+              value: ""
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "rht-project-reaper-operator"
+      volumes:
+        - name: runner
+          emptyDir: {}

--- a/ansible/roles/ocp4-workload-projectreaper-operator/templates/project.j2
+++ b/ansible/roles/ocp4-workload-projectreaper-operator/templates/project.j2
@@ -1,0 +1,10 @@
+apiVersion: project.openshift.io/v1
+kind: Project
+metadata:
+  annotations:
+    openshift.io/description: ""
+    openshift.io/display-name: "{{ _operator_project_display }}"
+  name: "{{ _operator_project }}"
+spec:
+  finalizers:
+  - kubernetes

--- a/ansible/roles/ocp4-workload-projectreaper-operator/templates/project_tracker.j2
+++ b/ansible/roles/ocp4-workload-projectreaper-operator/templates/project_tracker.j2
@@ -1,0 +1,11 @@
+apiVersion: redhattraining.com/v1alpha1
+kind: ProjectTracker
+metadata:
+  name: default
+spec:
+  ignore_project_prefix:
+  - default
+  - kube-
+  - openshift-
+  - rht-
+  - gpte-

--- a/ansible/roles/ocp4-workload-projectreaper-operator/templates/role.j2
+++ b/ansible/roles/ocp4-workload-projectreaper-operator/templates/role.j2
@@ -1,0 +1,71 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rht-project-reaper-operator
+rules:
+- apiGroups:
+  - user.openshift.io
+  resources:
+  - users
+  - users/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - project.openshift.io
+  resources:
+  - projects
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resourceNames:
+  - rht-project-reaper-operator
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - configmaps
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - redhattraining.com
+  resources:
+  - projecttrackers
+  - projecttrackers/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/ansible/roles/ocp4-workload-projectreaper-operator/templates/role_binding.j2
+++ b/ansible/roles/ocp4-workload-projectreaper-operator/templates/role_binding.j2
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rht-project-reaper-operator
+subjects:
+- kind: ServiceAccount
+  name: rht-project-reaper-operator
+  namespace: "{{ _operator_project }}"
+roleRef:
+  kind: ClusterRole
+  name: rht-project-reaper-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/ansible/roles/ocp4-workload-projectreaper-operator/templates/service_account.j2
+++ b/ansible/roles/ocp4-workload-projectreaper-operator/templates/service_account.j2
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rht-project-reaper-operator
+  namespace: "{{ _operator_project }}"


### PR DESCRIPTION
##### SUMMARY
Introduce a project reaper that will delete any projects created by a user that is no longer defined to the cluster based on the USER resource. The operator has been integrated as ocp4-workload-projectreaper-operator.


##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
New role: ocp4-workload-projectreaper-operator
Operator Image: quay.io/redhattraining/rht-project-reaper-operator:v0.0.1
Source code for this operator is in a private repository https://github.com/redhattraining/do999.git

##### ADDITIONAL INFORMATION
Recommend use in env_vars.yml:
```
default_workloads:
...omitted...
- ocp4-workload-projectreaper-operator
...omitted...
```
