### PR TITLE
Update ocp4_machineset_config role

### DIFF
--- a/ansible/roles/ocp4-workload-infra-nodes/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-infra-nodes/tasks/workload.yml
@@ -6,10 +6,9 @@
   vars:
     ocp4_machineset_config_groups:
     - name: infra
+      role: infra
       aws_instance_type: "{{ _infra_node_instance_type }}"
       total_replicas: "{{ _infra_node_replicas }}"
-      node_labels:
-        node-role.kubernetes.io/infra: ""
 
 # Leave this as the last task in the playbook.
 - name: workload tasks complete

--- a/ansible/roles/ocp4_machineset_config/README.adoc
+++ b/ansible/roles/ocp4_machineset_config/README.adoc
@@ -30,18 +30,16 @@ this Ansible role redundant.
     ocp4_machineset_config_disable_base_worker_machinesets: true
     ocp4_machineset_config_groups:
     - name: compute
+      role: compute
       aws_instance_type: m4.large
       aws_root_volume_size: 80
       autoscale: true
       total_replicas_min: 3
       total_replicas_max: 30
-      node_labels:
-        node-role.kubernetes.io/compute: ""
     - name: infra
+      role: infra
       aws_instance_type: m4.large
       total_replicas: 2
-      node_labels:
-        node-role.kubernetes.io/infra: ""
 ```
 
 ## Configuration
@@ -93,6 +91,10 @@ machineset enables autoscaling.
 | `name`
 | (required)
 | Name for machineset config group
+
+| `role`
+| (optional)
+| Value used for default machine and node labels
 
 | `total_replicas`
 | `0`

--- a/ansible/roles/ocp4_machineset_config/tasks/aws-machineset-group.yml
+++ b/ansible/roles/ocp4_machineset_config/tasks/aws-machineset-group.yml
@@ -20,6 +20,11 @@
       {{ machineset_group.aws_root_volume_size | default(default_aws_root_volume_size) }}
     machineset_name: >-
       {{ [cluster_label, machineset_group.name, availability_zone] | join('-') }}
+    machineset_group_node_labels: >-
+      {{ machineset_group.node_labels
+       | default({'node-role.kubernetes.io/' + machineset_group.role: ''}
+           if machineset_group.role|default(False) else {})
+      }}
     machineset_group_total_replicas: >-
       {{ machineset_group.total_replicas
        | default(machineset_group.total_replicas_min)

--- a/ansible/roles/ocp4_machineset_config/tasks/aws.yml
+++ b/ansible/roles/ocp4_machineset_config/tasks/aws.yml
@@ -10,8 +10,10 @@
       {{ reference_provider_spec_value.ami.id }}
     aws_iam_instance_profile_id: >-
       {{ reference_provider_spec_value.iamInstanceProfile.id }}
-    aws_worker_security_group: >-
-      {{ reference_provider_spec_value.securityGroups[0].filters[0]['values'][0] }}
+    aws_worker_security_groups: >-
+      {{ reference_provider_spec_value.securityGroups }}
+    aws_worker_tags: >-
+      {{ reference_provider_spec_value.tags }}
     aws_worker_availability_zones: >-
       {{ ocp4_base_worker_machinesets
        | json_query(availability_zone_json_query)

--- a/ansible/roles/ocp4_machineset_config/templates/aws-machineset.yml.j2
+++ b/ansible/roles/ocp4_machineset_config/templates/aws-machineset.yml.j2
@@ -16,6 +16,10 @@ spec:
   selector:
     matchLabels:
       machine.openshift.io/cluster-api-cluster: {{ cluster_label }}
+{% if 'role' in machineset_group %}
+      machine.openshift.io/cluster-api-machine-role: {{ machineset_group.role }}
+      machine.openshift.io/cluster-api-machine-type: {{ machineset_group.role }}
+{% endif %}
       machine.openshift.io/cluster-api-machineset: {{ machineset_name }}
   template:
     metadata:
@@ -23,11 +27,15 @@ spec:
       labels:
         {{ machineset_group_label }}: {{ machineset_group.name }}
         machine.openshift.io/cluster-api-cluster: {{ cluster_label }}
+{% if 'role' in machineset_group %}
+        machine.openshift.io/cluster-api-machine-role: {{ machineset_group.role }}
+        machine.openshift.io/cluster-api-machine-type: {{ machineset_group.role }}
+{% endif %}
         machine.openshift.io/cluster-api-machineset: {{ machineset_name }}
     spec:
       metadata:
         creationTimestamp: null
-        labels: {{ machineset_group.node_labels | default({}) | to_json }}
+        labels: {{ machineset_group_node_labels | to_json }}
       providerSpec:
         value:
           ami:
@@ -51,19 +59,13 @@ spec:
             availabilityZone: {{ availability_zone }}
             region: {{ availability_zone_region }}
           publicIp: null
-          securityGroups:
-          - filters:
-            - name: tag:Name
-              values:
-              - {{ aws_worker_security_group }}
+          securityGroups: {{ aws_worker_security_groups | to_json }}
           subnet:
             filters:
             - name: tag:Name
               values:
               - {{ availability_zone_subnet }}
-          tags:
-          - name: kubernetes.io/cluster/{{ cluster_label }}
-            value: owned
+          tags: {{ aws_worker_tags | to_json }}
           userDataSecret:
             name: worker-user-data
       versions:


### PR DESCRIPTION
##### SUMMARY

* Preserve worker AWS tags

* Add role setting to default node role labels

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Ansible role ocp4_machineset_config

##### ADDITIONAL INFORMATION

Previous version did not preserve AWS instance tags in the worker machineset configs. This version keeps the user tags. This is needed so that jobs that suspend ec2 instances by tag will find ec2 instances created because of configuration generated by this role.