### PR TITLE
Avoid hanging issue on long running deployment tasks.

### DIFF
--- a/ansible/configs/ocp4-ha-lab/software.yml
+++ b/ansible/configs/ocp4-ha-lab/software.yml
@@ -124,6 +124,7 @@
           tags:
           - run_installer
           command: openshift-install create cluster --dir=/home/{{ ansible_user }}/{{ cluster_name }}
+          async: "{{ 2 * 60 * 60 }}"
 
         - name: Fetch kube config
           fetch:

--- a/ansible/configs/ocp4-shared/software.yml
+++ b/ansible/configs/ocp4-shared/software.yml
@@ -124,6 +124,7 @@
           tags:
           - run_installer
           command: openshift-install create cluster --dir=/home/{{ ansible_user }}/{{ cluster_name }}
+          async: "{{ 2 * 60 * 60 }}"
 
         - name: Fetch kube config
           fetch:

--- a/ansible/configs/ocp4-workshop/software.yml
+++ b/ansible/configs/ocp4-workshop/software.yml
@@ -124,6 +124,7 @@
           tags:
           - run_installer
           command: openshift-install create cluster --dir=/home/{{ ansible_user }}/{{ cluster_name }}
+          async: "{{ 2 * 60 * 60 }}"
 
         - name: Fetch kube config
           fetch:

--- a/ansible/roles/host-ocp-installer/tasks/main.yml
+++ b/ansible/roles/host-ocp-installer/tasks/main.yml
@@ -21,6 +21,7 @@
 - name: run openshift-ansible byo/config.yml (from cloned upstream, 3.7 and earlier)
   shell: "ansible-playbook -i /etc/ansible/hosts /root/openshift-ansible/playbooks/byo/config.yml"
   register: openshift_install_log
+  async: "{{ 2 * 60 * 60 }}"
   tags:
     - openshift_installer
   ignore_errors: true
@@ -31,6 +32,7 @@
 - name: run openshift-ansible byo/config.yml (3.7 and earlier)
   shell: "ansible-playbook -i /etc/ansible/hosts /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml"
   register: openshift_install_log
+  async: "{{ 2 * 60 * 60 }}"
   tags:
     - openshift_installer
   ignore_errors: true
@@ -60,6 +62,7 @@
 - name: run openshift-ansible prerequisites.yml (from cloned upstream, 3.9 and later)
   shell: "ansible-playbook -i /etc/ansible/hosts /root/openshift-ansible/playbooks/prerequisites.yml"
   register: openshift_install_log
+  async: "{{ 2 * 60 * 60 }}"
   tags:
     - openshift_installer
   ignore_errors: true
@@ -70,6 +73,7 @@
 - name: run openshift-ansible prerequisites.yml (3.9 and later)
   shell: "ansible-playbook -i /etc/ansible/hosts /usr/share/ansible/openshift-ansible/playbooks/prerequisites.yml"
   register: openshift_install_log
+  async: "{{ 2 * 60 * 60 }}"
   tags:
     - openshift_installer
   ignore_errors: true
@@ -99,6 +103,7 @@
 - name: run openshift-ansible deploy_cluster.yml (from cloned upstream, 3.9 and later)
   shell: "ansible-playbook -i /etc/ansible/hosts /root/openshift-ansible/playbooks/deploy_cluster.yml"
   register: openshift_install_log
+  async: "{{ 2 * 60 * 60 }}"
   tags:
     - openshift_installer
   ignore_errors: true
@@ -109,6 +114,7 @@
 - name: run openshift-ansible deploy_cluster.yml (3.9 and later)
   shell: "ansible-playbook -i /etc/ansible/hosts /usr/share/ansible/openshift-ansible/playbooks/deploy_cluster.yml"
   register: openshift_install_log
+  async: "{{ 2 * 60 * 60 }}"
   tags:
     - openshift_installer
   ignore_errors: true


### PR DESCRIPTION
#### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes redhat-cop#464.

#### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

#### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
- ansible/configs/ocp4-ha-lab/software.yml
- ansible/configs/ocp4-shared/software.yml
- ansible/configs/ocp4-workshop/software.yml
- ansible/roles/host-ocp-installer/tasks/main.yml

#### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Features: Improvement on deployment resiliency, in particular with deployments from a physical host.

Changes:
- Deployment tasks now runs in async mode.
- Every deployment is given a 2h time quantum.
- Similar to https://github.com/redhat-cop/agnosticd/blob/c023f9a8bf92c95141a8bc0023d7b15526ef2cdd/ansible/configs/ocp4-shared/destroy_cluster.yml#L8-L13 (Thanks @fridim with https://github.com/redhat-cop/agnosticd/issues/464#issuecomment-504638671)

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Same as usual.
```