### PR TITLE
Refactoring cloudformation template usage.

### DIFF
--- a/ansible/roles/infra-ec2-template-create/tasks/main.yml
+++ b/ansible/roles/infra-ec2-template-create/tasks/main.yml
@@ -39,7 +39,21 @@
             - "'images' in amifacts"
             - amifacts.images | d([]) | length > 0
 
-    - name: Launch CloudFormation template (local)
+    - name: Prepare for launch CloudFormation template from local
+      set_fact:
+        cloudform_location: local
+        cloudform_args:
+          template: "{{ cloudformation_template }}"
+      when: stat_template.stat.size <= 51200
+
+    - name: Prepare for launch CloudFormation template from S3 bucket
+      set_fact:
+        cloudform_location: S3
+        cloudform_args:
+          template_url: "https://s3.amazonaws.com/{{bucket_templates}}/{{env_type}}.{{guid}}.{{cloud_provider}}_cloud_template"
+      when: stat_template.stat.size > 51200
+
+    - name: Launch CloudFormation template ({{ cloudform_location }})
       cloudformation:
         aws_access_key: "{{ aws_access_key_id }}"
         aws_secret_key: "{{ aws_secret_access_key }}"
@@ -48,8 +62,8 @@
         region: "{{ aws_region_loop | d(aws_region) | d(region) | d('us-east-1')}}"
         # rollback is unreliable, it can make this task hang forever.
         disable_rollback: true
-        template: "{{ cloudformation_template }}"
         tags: "{{ cf_tags | combine(cloud_tags_final)}}"
+      args: "{{ cloudform_args }}"
       tags:
         - aws_infrastructure_deployment
         - provision_cf_template
@@ -62,42 +76,7 @@
         )
       retries: "{{ cloudformation_retries | default(3) }}"
       delay: "{{ cloudformation_retry_delay | default(30) }}"
-      when: stat_template.stat.size <= 51200
       ignore_errors: yes
-
-    - name: Launch CloudFormation template (from S3)
-      cloudformation:
-        aws_access_key: "{{ aws_access_key_id }}"
-        aws_secret_key: "{{ aws_secret_access_key }}"
-        stack_name: "{{ project_tag }}"
-        state: "present"
-        region: "{{ aws_region_loop | d(aws_region) | d(region) | d('us-east-1')}}"
-        # rollback is unreliable, it can make this task hang forever.
-        disable_rollback: true
-        template_url: "https://s3.amazonaws.com/{{bucket_templates}}/{{env_type}}.{{guid}}.{{cloud_provider}}_cloud_template"
-        tags: "{{ cf_tags | combine(cloud_tags_final)}}"
-      tags:
-        - aws_infrastructure_deployment
-        - provision_cf_template
-      register: cloudformation_out_s3
-      until: >-
-        cloudformation_out_s3 is succeeded
-        and (
-          'output' in cloudformation_out_s3
-          and cloudformation_out_s3.output in ["Stack CREATE complete", "Stack is already up-to-date."]
-        )
-      retries: "{{ cloudformation_retries | default(3) }}"
-      delay: "{{ cloudformation_retry_delay | default(30) }}"
-      when: stat_template.stat.size > 51200
-      ignore_errors: yes
-
-    # We cannot have the same name for the register because the skipped task is always succeeded.
-    # We write back to cloudformation_out if it used the s3 method:
-    - name: Set fact cloudformation_out
-      set_fact:
-        cloudformation_out: "{{ cloudformation_out_s3 }}"
-      when:
-        - stat_template.stat.size > 51200
 
     - name: debug cloudformation
       debug:

--- a/ansible/roles/infra-ec2-template-generate/tasks/main.yml
+++ b/ansible/roles/infra-ec2-template-generate/tasks/main.yml
@@ -62,7 +62,14 @@
 
 ######################### Validate CF Template
 
-- name: validate cloudformation template (local)
+- name: validation cloudformation template
+  assert:
+    that: >
+      lookup('file', cloudformation_template) | from_yaml is succeeded
+      or lookup('file', cloudformation_template) | from_json is succeeded
+    success_msg: Cloudformation template is syntactically valid
+
+- name: validate cloudformation template with validate-template (local)
   environment:
     AWS_ACCESS_KEY_ID: "{{aws_access_key_id}}"
     AWS_SECRET_ACCESS_KEY: "{{aws_secret_access_key}}"
@@ -81,7 +88,7 @@
     - validate_cf_template
   when: stat_template.stat.size <= 51200
 
-- name: validate cloudformation template (S3)
+- name: validate cloudformation template with validate-template (S3)
   environment:
     AWS_ACCESS_KEY_ID: "{{aws_access_key_id}}"
     AWS_SECRET_ACCESS_KEY: "{{aws_secret_access_key}}"


### PR DESCRIPTION
##### SUMMARY
Refers to #466 

Changes:
- Simplification of cloudtemplate validation.
- Merging launch CloudFormation templete task into one.

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
- Launch CloudFormation template ***
- validate cloudformation template (local) + validate cloudformation template (S3) -> validate cloudformation template (local)
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
TASK [infra-ec2-template-generate : AWS Generate CloudFormation Template] ***********************************************************************************
Sunday 23 June 2019  12:00:56 +0200 (0:00:00.035)       0:00:03.122 ***********
ok: [localhost]

...

TASK [infra-ec2-template-generate : validate cloudformation template (local)] *******************************************************************************
Sunday 23 June 2019  12:00:57 +0200 (0:00:00.035)       0:00:04.052 ***********
ok: [localhost]

TASK [infra-ec2-template-generate : validate cloudformation template (S3)] **********************************************************************************
Sunday 23 June 2019  12:00:57 +0200 (0:00:00.916)       0:00:04.969 ***********
skipping: [localhost]

...

TASK [infra-ec2-template-create : Launch CloudFormation template (local)] ***********************************************************************************
Sunday 23 June 2019  12:00:59 +0200 (0:00:00.044)       0:00:06.575 ***********
changed: [localhost]

TASK [infra-ec2-template-create : Launch CloudFormation template (from S3)] *********************************************************************************
Sunday 23 June 2019  12:03:46 +0200 (0:02:46.884)       0:02:53.459 ***********
skipping: [localhost]

TASK [infra-ec2-template-create : Set fact cloudformation_out] **********************************************************************************************
Sunday 23 June 2019  12:03:46 +0200 (0:00:00.039)       0:02:53.499 ***********
skipping: [localhost]
```
After:
```
TASK [infra-ec2-template-generate : AWS Generate CloudFormation Template] ***********************************************************************************
Sunday 23 June 2019  12:00:56 +0200 (0:00:00.035)       0:00:03.122 ***********
ok: [localhost]

TASK [infra-ec2-template-generate : validate cloudformation template (local)] *******************************************************************************
Sunday 23 June 2019  12:00:57 +0200 (0:00:00.035)       0:00:04.052 ***********
ok: [localhost]

...
TASK [infra-ec2-template-create : Prepare for launch CloudFormation template from local] *****************************
Sunday 23 June 2019  11:38:22 +0200 (0:00:00.042)       0:00:06.836 ***********
ok: [localhost]

TASK [infra-ec2-template-create : Prepare for launch CloudFormation template from S3 bucket] *************************
Sunday 23 June 2019  11:38:22 +0200 (0:00:00.034)       0:00:06.871 ***********
skipping: [localhost]

TASK [infra-ec2-template-create : Launch CloudFormation template (local)] ********************************************
Sunday 23 June 2019  11:38:22 +0200 (0:00:00.034)       0:00:06.905 ***********
 [WARNING]: Using a variable for a task's 'args' is unsafe in some situations (see
https://docs.ansible.com/ansible/devel/reference_appendices/faq.html#argsplat-unsafe)

changed: [localhost]
```
