### PR TITLE
Ocp4 workload workshop admin storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ ansible/configs/*/roles
 .pre-commit-config.yaml
 .DS_Store
 
+.vscode/settings.json

--- a/ansible/roles/ocp4-workload-workshop-admin-storage/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-workshop-admin-storage/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+become_override: False
+ocp_username: kubeadmin
+silent: False
+
+_infra_node_replicas: 3
+_infra_node_instance_type: m4.4xlarge

--- a/ansible/roles/ocp4-workload-workshop-admin-storage/readme.adoc
+++ b/ansible/roles/ocp4-workload-workshop-admin-storage/readme.adoc
@@ -1,0 +1,129 @@
+= ocp4-workload-workshop-admin-storage - Deploy app for OpenShift and Container Storage for Administrators
+ workshops
+
+== Role overview
+
+* This role deploys the labguide app. It consists of the following playbooks:
+** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+ environment for the workload deployment.
+*** Debug task will print out: `pre_workload Tasks completed successfully.`
+
+** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the app
+*** Debug task will print out: `workload Tasks completed successfully.`
+
+** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+ configure the workload after deployment
+*** This role doesn't do anything here
+*** Debug task will print out: `post_workload Tasks completed successfully.`
+
+** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+ delete the workload
+*** This role removes the logging deployment and project but not the operator configs
+*** Debug task will print out: `remove_workload Tasks completed successfully.`
+
+== Review the defaults variable file
+
+* This file link:./defaults/main.yml[./defaults/main.yml] contains all the variables you need to define to control the deployment of your workload.
+* The variable *ocp_username* is mandatory to assign the workload to the correct OpenShift user.
+* A variable *silent=True* can be passed to suppress debug messages.
+* You can modify any of these default values by adding `-e "variable_name=variable_value"` to the command line
+
+=== Deploy a Workload with the `ocp-workload` playbook [Mostly for testing]
+
+----
+export TARGET_HOST="bastion.cc59.sandbox118.opentlc.com"
+export OCP_USERNAME="kubeadmin"
+export WORKLOAD="ocp4-workload-workshop-admin-storage"
+export GUID=cc59
+export TARGET_HOST_PASSWORD=to_be_changed
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=/home/lab-user/.ssh/id_rsa" \
+    -e"ansible_user=lab-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"silent=False" \
+    -e"guid=${GUID}" \
+    -e"target_host_password=${TARGET_HOST_PASSWORD}" \
+    -e"target_host=${TARGET_HOST}" \
+    -e"ACTION=create"
+----
+
+Wait until workshop is ready
+
+----
+oc rollout status dc/admin -n labguide
+----
+
+To view workshop, go to route. Use ocp_username and its password to go through the http digest authentication
+
+----
+oc get route admin -n labguide
+----
+
+=== To Delete an environment
+
+----
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=/home/lab-user/.ssh/id_rsa" \
+    -e"ansible_user=lab-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"silent=False" \
+    -e"guid=${GUID}" \
+    -e"target_host_password=${TARGET_HOST_PASSWORD}" \
+    -e"target_host=${TARGET_HOST}" \
+    -e"ACTION=remove"
+----
+
+
+== Other related information:
+
+=== Deploy Workload on OpenShift Cluster from an existing playbook:
+
+[source,yaml]
+----
+- name: Deploy a workload role on a master host
+  hosts: all
+  become: true
+  gather_facts: False
+  tags:
+    - step007
+  roles:
+    - { role: "{{ocp_workload}}", when: 'ocp_workload is defined' }
+----
+NOTE: You might want to change `hosts: all` to fit your requirements
+
+
+=== Set up your Ansible inventory file
+
+* You can create an Ansible inventory file to define your connection method to your host (Master/Bastion with `oc` command)
+* You can also use the command line to define the hosts directly if your `ssh` configuration is set to connect to the host correctly
+* You can also use the command line to use localhost or if your cluster is already authenticated and configured in your `oc` configuration
+
+.Example inventory file
+[source, ini]
+----
+[gptehosts:vars]
+ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem
+ansible_user=ec2-user
+
+[gptehosts:children]
+openshift
+
+[openshift]
+bastion.cluster1.openshift.opentlc.com
+bastion.cluster2.openshift.opentlc.com
+bastion.cluster3.openshift.opentlc.com
+bastion.cluster4.openshift.opentlc.com
+
+[dev]
+bastion.cluster1.openshift.opentlc.com
+bastion.cluster2.openshift.opentlc.com
+
+[prod]
+bastion.cluster3.openshift.opentlc.com
+bastion.cluster4.openshift.opentlc.com
+----

--- a/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/main.yml
+++ b/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+
+# Do not modify this file
+
+- name: Running Pre Workload Tasks
+  include_tasks:
+    file: ./pre_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload Tasks
+  include_tasks:
+    file: ./workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  include_tasks:
+    file: ./post_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload removal Tasks
+  include_tasks:
+    file: ./remove_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/post_workload.yml
+++ b/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/post_workload.yml
@@ -1,0 +1,9 @@
+---
+# Implement your Post Workload deployment tasks here
+
+
+# Leave this as the last task in the playbook.
+- name: post_workload tasks complete
+  debug:
+    msg: "Post-Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/pre_workload.yml
@@ -1,0 +1,9 @@
+---
+# Implement your Pre Workload deployment tasks here
+
+
+# Leave this as the last task in the playbook.
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/remove_workload.yml
+++ b/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/remove_workload.yml
@@ -1,0 +1,18 @@
+# vim: set ft=ansible
+---
+
+# Implement your Workload deployment tasks here
+- name: remove the labguide project
+  k8s:
+    state: absent
+    definition:
+      apiVersion: project.openshift.io/v1
+      kind: Project
+      metadata:
+        name: labguide
+
+# Leave this as the last task in the playbook.
+- name: remove_workload tasks complete
+  debug:
+    msg: "Remove Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/workload.yml
@@ -1,0 +1,276 @@
+# vim: set ft=ansible
+---
+
+# Implement your Workload deployment tasks here
+
+## Based on https://github.com/openshift-labs/workshop-dashboard/blob/2.14.4/templates/production.json
+## Parameters according to https://github.com/kaovilai/openshift-cns-testdrive/
+
+- name: create the labguide Project
+  k8s:
+    state: present
+    definition:
+      apiVersion: project.openshift.io/v1
+      kind: Project
+      metadata:
+        name: labguide
+        annotations: 
+          openshift.io/requester: kube:admin
+      status:
+        phase: active
+
+- name: create ServiceAccount
+  k8s:
+    state: present
+    definition:
+      kind: ServiceAccount
+      apiVersion: v1
+      metadata:
+        name: "admin-user"
+        namespace: labguide
+        labels:
+          app: "admin"
+        annotations:
+          serviceaccounts.openshift.io/oauth-redirectreference.first: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"admin"}}'
+          serviceaccounts.openshift.io/oauth-redirecturi.first: oauth_callback
+          serviceaccounts.openshift.io/oauth-want-challenges: 'false'
+
+- name: create RoleBinding
+  k8s:
+    state: present
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        labels:
+          app: admin
+        name: admin-admin
+        namespace: labguide
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: admin
+      subjects:
+      - kind: ServiceAccount
+        name: admin-user
+
+- name: create ImageStream
+  k8s:
+    state: present
+    definition:
+      kind: ImageStream
+      apiVersion: v1
+      metadata:
+        name: "admin"
+        namespace: labguide
+        labels:
+          app: "admin"
+      spec:
+        lookupPolicy:
+          local: true
+        tags:
+        - name: latest
+          referencePolicy:
+            type: Source
+          from:
+            kind: DockerImage
+            name: "quay.io/openshiftlabs/workshop-dashboard:2.14.4"
+
+- name: cat the kubeadmin-password
+  shell: "cat /home/lab-user/cluster-{{ guid }}/auth/kubeadmin-password"
+  register: kubeadmin_password
+
+- name: extract the sandbox id
+  shell: "echo {{ target_host }} | cut -d. -f3"
+  register: sandbox_id
+
+- name: create ConfigMap
+  k8s:
+    state: present
+    definition:
+      kind: ConfigMap
+      apiVersion: v1
+      metadata:
+        name: "admin-env"
+        namespace: labguide
+        labels:
+          app: "admin"
+      data:
+        # terminal.sh: "${TERMINAL_ENVVARS}"
+        workshop.sh: "API_URL=https://api.{{ target_host }}:6443 \
+         MASTER_URL=https://console-openshift-console.apps.cluster-{{ guid }}.{{ sandbox_id.stdout }}.opentlc.com \
+         KUBEADMIN_PASSWORD={{ kubeadmin_password.stdout }} \
+         SSH_PASSWORD={{ target_host_password }} \
+         BASTION_FQDN={{ target_host }} \
+         GUID={{ guid }} \
+         ROUTE_SUBDOMAIN=apps.cluster-{{ guid }}.{{ sandbox_id.stdout }}.opentlc.com \
+         HOME_PATH=/opt/app-root/src"
+        # gateway.sh: "${GATEWAY_ENVVARS}"
+
+- name: create DeploymentConfig
+  k8s:
+    state: present
+    definition:
+      kind: DeploymentConfig
+      apiVersion: v1
+      metadata:
+        name: "admin"
+        namespace: labguide
+        labels:
+          app: "admin"
+      spec:
+        strategy:
+          type: Recreate
+        triggers:
+        - type: ConfigChange
+        - type: ImageChange
+          imageChangeParams:
+            automatic: true
+            containerNames:
+            - terminal
+            from:
+              kind: ImageStreamTag
+              name: "admin:latest"
+        replicas: 1
+        selector:
+          app: "admin"
+          deploymentconfig: "admin"
+        template:
+          metadata:
+            labels:
+              app: "admin"
+              deploymentconfig: "admin"
+          spec:
+            serviceAccountName: "admin-user"
+            initContainers:
+            - name: setup-console
+              image: "quay.io/openshiftlabs/workshop-dashboard:2.14.4"
+              command:
+              - "/opt/workshop/bin/setup-console.sh"
+              env:
+              - name: OPENSHIFT_USERNAME
+                value: "{{ ocp_username }}"
+              - name: OPENSHIFT_PASSWORD
+                value: "{{ kubeadmin_password.stdout }}"
+              # - name: OPENSHIFT_TOKEN
+              #   value: "${OPENSHIFT_TOKEN}"
+              # - name: OC_VERSION
+              #   value: "${OC_VERSION}"
+              # - name: ODO_VERSION
+              #   value: "${ODO_VERSION}"
+              # - name: KUBECTL_VERSION
+              #   value: "${KUBECTL_VERSION}"
+              volumeMounts:
+              - name: shared
+                mountPath: "/var/run/workshop"
+            containers:
+            - name: terminal
+              image: "admin:latest"
+              ports:
+              - containerPort: 10080
+                protocol: TCP
+              env:
+              - name: PROJECT_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+              - name: APPLICATION_NAME
+                value: "admin"
+              - name: AUTH_USERNAME
+                value: "{{ ocp_username }}"
+              - name: AUTH_PASSWORD
+                value: "{{ kubeadmin_password.stdout }}"
+              - name: OAUTH_SERVICE_ACCOUNT
+                value: "admin-user"
+              - name: WORKSHOPPER_URLS
+                value: "https://raw.githubusercontent.com/openshift/openshift-cns-testdrive/ocp4-dev/labguide/_ocp_admin_testdrive.yaml"
+              - name: CONSOLE_URL
+                value: http://0.0.0.0:10083
+              # - name: OC_VERSION
+              #   value: "${OC_VERSION}"
+              # - name: ODO_VERSION
+              #   value: "${ODO_VERSION}"
+              # - name: KUBECTL_VERSION
+              #   value: "${KUBECTL_VERSION}"
+              volumeMounts:
+              - name: envvars
+                mountPath: "/opt/workshop/envvars"
+              - name: shared
+                mountPath: "/var/run/workshop"
+            - name: console
+              image: quay.io/openshift/origin-console:4.2.0
+              command:
+              - "/var/run/workshop/start-console.sh"
+              env:
+              - name: BRIDGE_K8S_MODE
+                value: in-cluster
+              - name: BRIDGE_LISTEN
+                value: http://0.0.0.0:10083
+              - name: BRIDGE_BASE_PATH
+                value: "/console/"
+              - name: BRIDGE_PUBLIC_DIR
+                value: "/opt/bridge/static"
+              - name: BRIDGE_USER_AUTH
+                value: disabled
+              - name: BRIDGE_BRANDING
+                value: "openshift"
+              volumeMounts:
+              - name: shared
+                mountPath: "/var/run/workshop"
+            volumes:
+            - name: envvars
+              configMap:
+                name: "admin-env"
+                defaultMode: 420
+            - name: shared
+              emptyDir: {}
+
+- name: create Service
+  k8s:
+    state: present
+    definition:
+      kind: Service
+      apiVersion: v1
+      metadata:
+        name: "admin"
+        namespace: "labguide"
+        labels:
+          app: "admin"
+      spec:
+        ports:
+        - name: 10080-tcp
+          protocol: TCP
+          port: 10080
+          targetPort: 10080
+        selector:
+          app: "admin"
+          deploymentconfig: "admin"
+
+- name: create Route
+  k8s:
+    state: present
+    definition:
+      kind: Route
+      apiVersion: v1
+      metadata:
+        name: "admin"
+        namespace: labguide
+        labels:
+          app: "admin"
+      spec:
+        to:
+          kind: Service
+          name: "admin"
+          weight: 100
+        port:
+          targetPort: 10080-tcp
+        tls:
+          termination: edge
+          insecureEdgeTerminationPolicy: Redirect
+
+# Leave this as the last task in the playbook.
+- name: workload tasks complete
+  debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent|bool
+


### PR DESCRIPTION
##### SUMMARY
Adds OpenShift and Container Storage for Administrators workshop role

##### ISSUE TYPE
- New role Pull Request

##### COMPONENT NAME
 - roles
    - ocp4-workload-workshop-admin-storage

##### ADDITIONAL INFORMATION
A new role for deploying [OpenShift and Container Storage for Administrators workshop](https://github.com/openshift/openshift-cns-testdrive/tree/ocp4-dev) inside [Homeroom Dashboard](https://github.com/openshift-labs/workshop-dashboard).