### PR TITLE
Add wait for metering CRD to ocp4-workload-metering

### DIFF
--- a/ansible/roles/ocp4-workload-metering/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-metering/tasks/pre_workload.yml
@@ -1,5 +1,14 @@
 ---
 # Implement your Pre Workload deployment tasks here
+- name: Wait for metering crd creation
+  k8s_facts:
+    api_version: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    name: meterings.metering.openshift.ioo
+  until: 0 < r_get_meterings.resources|length
+  register: r_get_meterings
+  retries: 20
+  delay: 5
 
 # Leave this as the last task in the playbook.
 - name: pre_workload tasks complete


### PR DESCRIPTION
##### SUMMARY

Fix race condition where the workload can run before the meterings.metering.openshift.io CRD is created by the operator.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-workload-metering

##### ADDITIONAL INFORMATION

Failure addressed by this PR:

```
TASK [ocp4-workload-metering : Create Metering Custom Resource with Route and Resource Limits] ***
Tuesday 25 June 2019  18:16:07 +0000 (0:00:17.178)       0:57:13.177 ********** 
failed: [clientvm.95ca.internal] (item=./templates/metering.j2) => {"changed": false, "item": "./templates/metering.j2", "msg": "Failed to find exact match for metering.openshift.io/v1alpha1.Metering by [kind, name, singularName, shortNames]"}
```