### PR TITLE
Update ocp4-workload-workshop-admin-storage

### DIFF
--- a/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/workload.yml
@@ -77,7 +77,7 @@
             name: "quay.io/openshiftlabs/workshop-dashboard:2.14.4"
 
 - name: cat the kubeadmin-password
-  shell: "cat /home/lab-user/cluster-{{ guid }}/auth/kubeadmin-password"
+  shell: "cat /home/{{ ansible_user }}/cluster-{{ guid }}/auth/kubeadmin-password"
   register: kubeadmin_password
 
 - name: extract the sandbox id


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix for ocp4-workload-workshop-admin-storage to pull kubeadmin from correct location

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
