### PR TITLE
Removed copy-files task as there are no files to be copied.

### DIFF
--- a/ansible/roles/ocp-workload-optaweb-vrp/tasks/pre_workload.yml
+++ b/ansible/roles/ocp-workload-optaweb-vrp/tasks/pre_workload.yml
@@ -31,14 +31,6 @@
         --hard requests.storage="{{quota_requests_storage}}"
   ignore_errors: true
 
-- name: Copy the files used in this role
-  synchronize:
-    src: "files/"
-    dest: "/tmp/{{guid}}/"
-    rsync_opts:
-      - "--no-motd"
-      - "--exclude=.git,*.qcow2"
-
 - name: pre_workload Tasks Complete
   debug:
     msg: "Pre-Software checks completed successfully"


### PR DESCRIPTION
##### SUMMARY
Fixes failing rsync on optaweb-vrp deployment.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ocp-workload-optaweb-vrp

##### ADDITIONAL INFORMATION
n.a.