### PR TITLE
Ocp4 workload workshop admin storage - .stdout fixes

### DIFF
--- a/ansible/roles/ocp4-workload-workshop-admin-storage/readme.adoc
+++ b/ansible/roles/ocp4-workload-workshop-admin-storage/readme.adoc
@@ -43,13 +43,14 @@
 TARGET_HOST=$(dig @resolver1.opendns.com A myip.opendns.com +short)
 TARGET_HOST_PASSWORD=to_be_changed
 GUID=$(oc whoami --show-server | awk -F '[-.]' '{ print $3 }')
+SUBDOMAIN_BASE=guid.xxxx.xxxx.com
 
 # a TARGET_HOST is specified in the command line, without using an inventory file
 ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
     -e"ansible_ssh_private_key_file=/home/$(whoami)/.ssh/id_rsa" \
     -e"ansible_user=$(whoami)" \
     -e"guid=${GUID}" \
-    -e"subdomain_base_suffix=bastion.$(oc whoami --show-server | awk -F '[-:]' '{ print $3 }')" \
+    -e"subdomain_base=${SUBDOMAIN_BASE}" \
     -e"ocp_workload=ocp4-workload-workshop-admin-storage" \
     -e"silent=False" \
     -e"target_host_password=${TARGET_HOST_PASSWORD}" \
@@ -76,7 +77,7 @@ ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
     -e"ansible_ssh_private_key_file=/home/$(whoami)/.ssh/id_rsa" \
     -e"ansible_user=$(whoami)" \
     -e"guid=${GUID}" \
-    -e"subdomain_base_suffix=bastion.$(oc whoami --show-server | awk -F '[-:]' '{ print $3 }')" \
+    -e"subdomain_base=${SUBDOMAIN_BASE}" \
     -e"ocp_workload=ocp4-workload-workshop-admin-storage" \
     -e"silent=False" \
     -e"target_host_password=${TARGET_HOST_PASSWORD}" \

--- a/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/pre_workload.yml
@@ -7,30 +7,55 @@
 
 - name: extract api_url
   command: oc whoami --show-server
-  register: api_url
+  register: api_url_r
+
+- set_fact:
+    api_url: "{{ api_url_r.stdout | trim }}"
 
 - name: extract master_url
-  command: oc get route console -o jsonpath='{.spec.host}' -n openshift-console
+  k8s_facts:
+    kind: Route # required. Use to specify an object model. Use in conjunction with I(api_version), I(name), and I(namespace) to identify a specific object.
+    name: console # not required. Use to specify an object name.  Use in conjunction with I(api_version), I(kind) and I(namespace) to identify a specific object.
+    namespace: openshift-console # not required. Use to specify an object namespace. Use in conjunction with I(api_version), I(kind), and I(name) to identify a specfic object.
   register: master_url_r
 
 - set_fact:
-    master_url: "https://{{ master_url_r.stdout | trim }}"
+    master_url: "https://{{ master_url_r.resources[0].spec.host | trim }}"
 
 - name: extract route_subdomain
-  command: oc get ingresses.config.openshift.io cluster -o jsonpath='{.spec.domain}'
-  register: route_subdomain
+  k8s_facts:
+    kind: Ingress
+  register: route_subdomain_r
+
+- set_fact:
+    route_subdomain: "{{ route_subdomain_r.resources[0].spec.domain | trim }}"
 
 - name: extract ocp_username
   command: oc whoami
-  register: ocp_username
+  register: ocp_username_r
+
+- set_fact:
+    ocp_username: "{{ ocp_username_r.stdout | trim }}"
 
 - name: cat the kubeadmin-password
   command: "cat /home/{{ ansible_user }}/cluster-{{ guid }}/auth/kubeadmin-password"
-  register: kubeadmin_password
+  register: kubeadmin_password_r
+
+- set_fact:
+    kubeadmin_password: "{{ kubeadmin_password_r.stdout | trim }}"
 
 - name: set bastion_fqdn
   set_fact:
-    bastion_fqdn: bastion.{{ guid }}{{ subdomain_base_suffix }}
+    bastion_fqdn: bastion.{{ subdomain_base }}
+
+- debug:
+    msg:
+    - "{{ api_url }}"
+    - "{{ master_url }}"
+    - "{{ route_subdomain }}"
+    - "{{ ocp_username }}"
+    - "{{ bastion_fqdn }}"
+    - "{{ kubeadmin_password }}"
 
 # Leave this as the last task in the playbook.
 - name: pre_workload tasks complete

--- a/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/workload.yml
@@ -18,14 +18,14 @@
     project_name: labguide
     app_name: admin #don't forget to replace this value under ServiceAccount.metadata.annotations.
     terminal_image: quay.io/openshiftlabs/workshop-dashboard:3.3.2
-    workshop_env: "API_URL={{ api_url.stdout }} \
-          MASTER_URL={{ master_url.stdout }} \
-          KUBEADMIN_PASSWORD={{ kubeadmin_password.stdout }} \
+    workshop_env: "API_URL={{ api_url }} \
+          MASTER_URL={{ master_url }} \
+          KUBEADMIN_PASSWORD={{ kubeadmin_password }} \
           SSH_USERNAME={{ ansible_user }} \
           SSH_PASSWORD={{ target_host_password }} \
           BASTION_FQDN={{ bastion_fqdn }} \
           GUID={{ guid }} \
-          ROUTE_SUBDOMAIN={{ route_subdomain.stdout }} \
+          ROUTE_SUBDOMAIN={{ route_subdomain }} \
           HOME_PATH=/opt/app-root/src"
     serviceaccounts_oauth_redirectref_first: "'{\"kind\":\"OAuthRedirectReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"Route\",\"name\":\"admin\"}}'"
     download_url: https://raw.githubusercontent.com/openshift/openshift-cns-testdrive/ocp4-prod/labguide
@@ -276,7 +276,7 @@
 - debug:
     msg:
     - "Your route is '{{ Route.result.spec.host }}'"
-    - "Login with '{{ ocp_username.stdout }}' and '{{ kubeadmin_password.stdout }}'"
+    - "Login with '{{ ocp_username }}' and '{{ kubeadmin_password }}'"
     - "Login may not be available until rollout finishes shortly. See 'oc rollout status dc/admin -n labguide'"
   when: not silent|bool
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix .stdout references in workload.yml
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4-workload-workshop-admin-storage

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Please ensure the email notify users to access the workshop at "{{ Route.result.spec.host }}"
Something like admin-labguide.apps.cluster-32e4.sandbox483.opentlc.com

