### PR TITLE
add ansible_user to subject of rolebinding enabling route access

### DIFF
--- a/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/pre_workload.yml
@@ -30,13 +30,6 @@
 - set_fact:
     route_subdomain: "{{ route_subdomain_r.resources[0].spec.domain | trim }}"
 
-- name: extract ocp_username
-  command: oc whoami
-  register: ocp_username_r
-
-- set_fact:
-    ocp_username: "{{ ocp_username_r.stdout | trim }}"
-
 - name: cat the kubeadmin-password
   command: "cat /home/{{ ansible_user }}/cluster-{{ guid }}/auth/kubeadmin-password"
   register: kubeadmin_password_r

--- a/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/workload.yml
@@ -65,7 +65,7 @@
     var: ServiceAccount
   when: not silent|bool
 
-- name: create the RoleBinding
+- name: "create the RoleBinding {{ app_name }}-admin"
   k8s:
     namespace: "{{ project_name }}"
     state: present
@@ -273,10 +273,34 @@
           insecureEdgeTerminationPolicy: Redirect
   register: Route
 
+- name: add kubeadmin to RoleBinding admin enabling route access
+  k8s:
+    namespace: "{{ project_name }}"
+    state: present
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: "{{ app_name }}"
+        labels:
+          app: "{{ app_name }}"
+      subjects:
+      - kind: User
+        apiGroup: rbac.authorization.k8s.io
+        name: 'kube:admin'
+      roleRef:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        name: admin
+  register: RoleBinding
+- debug:
+    var: RoleBinding
+  when: not silent|bool
+
 - debug:
     msg:
     - "user.info: Access the workshop at '{{ Route.result.spec.host }}'"
-    - "user.info: Login with '{{ ocp_username }}' and '{{ kubeadmin_password }}'"
+    - "user.info: Login with 'kubeadmin' and '{{ kubeadmin_password }}'"
     - "user.info: Workshop may not be accessible until rollout finishes shortly."
   when: not silent|bool
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Enable route access for `kubeadmin` user
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes access forbidden issues that doesn't come up if user logged-in was kubeadmin and not system:admin.
Systems requested on cloudforms default oc user to system:admin preventing access.
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4-workload-workshop-admin-storage