### PR TITLE
Added a pause to wait for the actual builds to be created before we c…

### DIFF
--- a/ansible/roles/ocp-workload-optaweb-vrp/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-optaweb-vrp/tasks/workload.yml
@@ -47,6 +47,9 @@
             -p SOURCE_REPOSITORY_REF=RHPDS \
             -p SOURCE_REPOSITORY_DIR=optaweb-vehicle-routing-frontend -n {{ocp_project}}"
 
+- name: Wait 10 seconds for the builds to be defined
+  pause:
+    seconds: 10
 
 #### Wait for the build to complete before slapping on the quota ....
 - include_tasks: ./wait_for_build.yml


### PR DESCRIPTION
…heck whether they're finished.

##### SUMMARY
Bugfix ocp-workloap-optaweb-vrp deployment. The task that checks for the builds to be finished was executed before the system had the time to actually create the builds, which caused the deployment to continue and fail on the "wait for deployment".

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp-workload-optaweb-vrp

##### ADDITIONAL INFORMATION
n.a.