### PR TITLE
Remove lookup. uses k8s src, remove yq, workaround fixes

### DIFF
--- a/ansible/roles/ocp4-workload-open-data-hub/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-open-data-hub/tasks/pre_workload.yml
@@ -3,25 +3,27 @@
 
 #Workaround removing osrcp-* delete when https://github.com/openshift/openshift-restclient-python/pull/312 merged and have access to latest python restclient
 #renaming file
-- name: WORKAROUND get file name to delete
-  shell: ls /tmp/osrcp*
-  register: tempFile
-- debug:
-    var: tempFile
-- name: WORKAROUND delete cache
-  file:
-    path: "{{ tempFile.stdout }}"
-    state: absent
-  become: yes
-  register: result
-- debug:
-    var: result
+- name: WORKAROUND checking if potential /tmp/osrcp* exist to conflict with
+  block:
+  - name: WORKAROUND get file name to delete
+    find:
+      paths: /tmp/
+      pattern: "osrcp*"
+    register: tempFile
+  - debug:
+      var: tempFile
+  - name: WORKAROUND delete cache
+    file:
+      path: "{{ tempFile.files[0].path }}"
+      state: absent
+    become: yes
+    register: result
+  - debug:
+      var: result
+  rescue:
+  - debug:
+      msg: "did not delete any osrcp*"
 #End Workaround
-
-- name: go get yq
-  shell: |
-    go get gopkg.in/mikefarah/yq.v2
-    alias yq=$(go env | grep GOPATH | cut -d\= -f2 | cut -d\" -f2)/bin/yq.v2
 
 # Leave this as the last task in the playbook.
 - name: pre_workload tasks complete

--- a/ansible/roles/ocp4-workload-open-data-hub/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-open-data-hub/tasks/workload.yml
@@ -50,7 +50,7 @@
 - name: apply scc.yaml, operator.yaml
   k8s:
     state: present
-    definition: "{{ lookup('file','/tmp/open-data-hub/rook/{{ item }}') }}"
+    src: "/tmp/open-data-hub/rook/{{ item }}"
   loop:
     - scc.yaml
     - operator.yaml
@@ -71,7 +71,7 @@
 - name: Applying cluster.yaml
   k8s:
     state: present
-    definition: "{{ lookup('file','/tmp/open-data-hub/rook/cluster.yaml') }}"
+    src: "/tmp/open-data-hub/rook/cluster.yaml"
   register: result
   retries: 30
 
@@ -91,7 +91,7 @@
 - name: apply toolbox.yaml object.yaml
   k8s:
     state: present
-    definition: "{{ lookup('file','/tmp/open-data-hub/rook/{{ item }}') }}"
+    src: "/tmp/open-data-hub/rook/{{ item }}"
   loop:
     - toolbox.yaml
     - object.yaml
@@ -117,7 +117,7 @@
 - name: Create CephObjectStoreUsers as needed applying object-user.yaml
   k8s:
     state: present
-    definition: "{{ lookup('file','/tmp/open-data-hub/rook/object-user.yaml') }}"
+    src: "/tmp/open-data-hub/rook/object-user.yaml"
 
 ## obtain secrets for each user
 - name: new-obtain my-user secrets - AccessKey
@@ -167,7 +167,7 @@
   k8s:
     state: present
     namespace: open-data-hub
-    definition: "{{ lookup('file','/tmp/open-data-hub/odh/{{ item }}') }}"
+    src: "/tmp/open-data-hub/odh/{{ item }}"
   loop:
     - service_account.yaml
     - role.yaml
@@ -228,8 +228,33 @@
 
 # Modifying https://gitlab.com/opendatahub/opendatahub-operator/raw/v0.3.0/deploy/crds/opendatahub_v1alpha1_opendatahub_cr.yaml
 - name: create ODH Custom Resource object
-  shell: |
-    printf "metadata.namespace: 'open-data-hub'\nspec.monitoring.odh_deploy: 'false'\nspec.aicoe-jupyterhub.s3_endpoint_url: 'http://{{ rookcephrgwip.stdout }}:{{ rookcephrgwport.stdout }}'\nspec.jupyter-on-openshift.jupyterhub_config: c.KubeSpawner.env_keep = ['http://{{ rookcephrgwip.stdout }}:{{ rookcephrgwport.stdout }}', '{{ secret.resources[0].data.AccessKey | b64decode }}', '{{ secret.resources[0].data.SecretKey | b64decode }}']\nspec.jupyter-on-openshift.extra_env_vars.S3_ENDPOINT_URL: http://{{ rookcephrgwip.stdout }}:{{ rookcephrgwport.stdout }}\nspec.jupyter-on-openshift.extra_env_vars.S3_ACCESS_KEY: {{ secret.resources[0].data.AccessKey | b64decode }}\nspec.jupyter-on-openshift.extra_env_vars.S3_SECRET_KEY: {{ secret.resources[0].data.SecretKey | b64decode }}\n" | $(go env | grep GOPATH | cut -d\= -f2 | cut -d\" -f2)/bin/yq.v2 w -s - /tmp/open-data-hub/odh/crds/opendatahub_v1alpha1_opendatahub_cr.yaml | oc apply -f - 
+  k8s:
+    state: present
+    namespace: open-data-hub
+    src: "/tmp/open-data-hub/odh/crds/opendatahub_v1alpha1_opendatahub_cr.yaml"
+- name: apply ODH custom resource object customization
+  k8s:
+    state: present
+    merge_type: merge
+    name: example-opendatahub
+    namespace: open-data-hub
+    api_version: opendatahub.io/v1alpha1
+    kind: OpenDataHub
+    definition:
+      spec:
+        monitoring:
+          odh_deploy: false
+        aicoe-jupyterhub:
+          s3_endpoint_url: "http://{{ rookcephrgwip.stdout }}:{{ rookcephrgwport.stdout }}"
+        jupyter-on-openshift:
+          jupyterhub_config: "c.KubeSpawner.env_keep = ['S3_ENDPOINT_URL', 'S3_ACCESS_KEY', 'S3_SECRET_KEY']"
+          extra_env_vars:
+            S3_ENDPOINT_URL: "http://{{ rookcephrgwip.stdout }}:{{ rookcephrgwport.stdout }}"
+            S3_ACCESS_KEY: "{{ secret.resources[0].data.AccessKey | b64decode }}"
+            S3_SECRET_KEY: "{{ secret.resources[0].data.SecretKey | b64decode }}"
+  register: result
+- debug:
+    var: result
 
 - name: delete temporary ODH custom resource
   file:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Remove use of lookup and use k8s src
Remove yq
If OpenShift rest client cache file do not exist, do not attempt to delete a non-existent file.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4-workload-open-data-hub
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
