### PR TITLE
Add a workload that upgrades ocp 4 cluster to newer version

### DIFF
--- a/ansible/roles/ocp4-workload-upgrade-cluster/README.adoc
+++ b/ansible/roles/ocp4-workload-upgrade-cluster/README.adoc
@@ -1,0 +1,72 @@
+= ocp4-workload-upgrade-cluster - Upgrade an OCP cluster to a newer release version.
+
+== Role overview
+
+* This role checks if the ocp user is cluster admin and upgrades the cluster to a newer OCP release version through Openshift OTA updates. 
+** Playbook: link:./tasks/workload.yml[workload.yml] - Used to upgrade the ocp 4 cluster.
+
+=== Deploy a Workload with the `ocp-workload` playbook [Mostly for testing]
+
+----
+TARGET_HOST="bastion.na311.openshift.opentlc.com"
+OCP_USERNAME="rorai-redhat.com"
+WORKLOAD="ocp4-workload-upgrade-cluster"
+GUID=1001
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=ec2-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"silent=False" \
+    -e"guid=${GUID}" \
+    -e"ACTION=create"
+----
+
+=== Deploy Workload on OpenShift Cluster from an existing playbook:
+
+[source,yaml]
+----
+- name: Deploy a workload role on a master host
+  hosts: all
+  become: true
+  gather_facts: False
+  tags:
+    - step007
+  roles:
+    - { role: "{{ocp_workload}}", when: 'ocp_workload is defined' }
+----
+NOTE: You might want to change `hosts: all` to fit your requirements
+
+
+=== Set up your Ansible inventory file
+
+* You can create an Ansible inventory file to define your connection method to your host (Master/Bastion with `oc` command)
+* You can also use the command line to define the hosts directly if your `ssh` configuration is set to connect to the host correctly
+* You can also use the command line to use localhost or if your cluster is already authenticated and configured in your `oc` configuration
+
+.Example inventory file
+[source, ini]
+----
+[gptehosts:vars]
+ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem
+ansible_user=ec2-user
+
+[gptehosts:children]
+openshift
+
+[openshift]
+bastion.cluster1.openshift.opentlc.com
+bastion.cluster2.openshift.opentlc.com
+bastion.cluster3.openshift.opentlc.com
+bastion.cluster4.openshift.opentlc.com
+
+[dev]
+bastion.cluster1.openshift.opentlc.com
+bastion.cluster2.openshift.opentlc.com
+
+[prod]
+bastion.cluster3.openshift.opentlc.com
+bastion.cluster4.openshift.opentlc.com
+----

--- a/ansible/roles/ocp4-workload-upgrade-cluster/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-upgrade-cluster/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+become_override: False
+ocp_username: opentlc-mgr
+silent: False
+
+_ocp_release_version: "4.2"

--- a/ansible/roles/ocp4-workload-upgrade-cluster/tasks/main.yml
+++ b/ansible/roles/ocp4-workload-upgrade-cluster/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+
+# Do not modify this file
+
+- name: Running Pre Workload Tasks
+  include_tasks:
+    file: ./pre_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload Tasks
+  include_tasks:
+    file: ./workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  include_tasks:
+    file: ./post_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload removal Tasks
+  include_tasks:
+    file: ./remove_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles/ocp4-workload-upgrade-cluster/tasks/post_workload.yml
+++ b/ansible/roles/ocp4-workload-upgrade-cluster/tasks/post_workload.yml
@@ -1,0 +1,8 @@
+---
+# Implement your Post Workload deployment tasks here
+
+# Leave this as the last task in the playbook.
+- name: post_workload tasks complete
+  debug:
+    msg: "Post-Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp4-workload-upgrade-cluster/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-upgrade-cluster/tasks/pre_workload.yml
@@ -1,0 +1,8 @@
+---
+# Implement your Pre Workload deployment tasks here
+
+# Leave this as the last task in the playbook.
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp4-workload-upgrade-cluster/tasks/remove_workload.yml
+++ b/ansible/roles/ocp4-workload-upgrade-cluster/tasks/remove_workload.yml
@@ -1,0 +1,5 @@
+# Leave this as the last task in the playbook.
+- name: remove_workload tasks complete
+  debug:
+    msg: "Remove Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp4-workload-upgrade-cluster/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-upgrade-cluster/tasks/workload.yml
@@ -1,0 +1,21 @@
+---
+# Implement your Workload deployment tasks here
+
+- name: check if user is cluster admin
+  command: "oc get project default"
+  register: default_project_result
+  ignore_errors: true
+  changed_when: false
+
+- fail:
+    msg: "User does not have cluster-admin rights to upgrade the cluster"
+  when: default_project_result is failed
+
+- name: upgrade ocp 4 cluster to {{ _ocp_release_version }}
+  command: "oc adm upgrade --to-image=registry.svc.ci.openshift.org/origin/release:{{ _ocp_release_version }} --force"
+
+# Leave this as the last task in the playbook.
+- name: workload tasks complete
+  debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent|bool


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Adding a role that upgrades a existing ocp 4 cluster to newer version. 
- This workload is needed for hands-on lab on Openshift Developer Console in RHTE 2019 since Developer Console has not been released yet and we need a way to upgrade the cluster to latest 4.2.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4-workload-upgrade-cluster

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
