### PR TITLE
Add branch variable for mig-operator repo in migration workload

### DIFF
--- a/ansible/roles/ocp-workload-migration/defaults/main.yml
+++ b/ansible/roles/ocp-workload-migration/defaults/main.yml
@@ -1,4 +1,5 @@
 mig_operator_repo: https://github.com/fusor/mig-operator
+mig_operator_repo_branch: master
 
 mig_operator_deploy_velero: true
 mig_operator_deploy_controller: true
@@ -13,4 +14,4 @@ migration_workload_title: "{{ 'Creating' if not migration_workload_destroy else 
 migration_workload_state: "{{ 'present' if not migration_workload_destroy else 'absent' }}"     # state of k8s resources
 
 # undefined variables 
-# mig_operator_ui_cluster_api_endpoint: 
+# mig_operator_ui_cluster_api_endpoint:

--- a/ansible/roles/ocp-workload-migration/tasks/pre_workload.yml
+++ b/ansible/roles/ocp-workload-migration/tasks/pre_workload.yml
@@ -9,6 +9,7 @@
   git:
     repo: "{{ mig_operator_repo }}"
     dest: "{{ repodir.path }}"
+    version: "{{ mig_operator_repo_branch }}"
     
 - name: "Applying variables"
   replace:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Exposes a new variable for the migration workload that allows a user to specify a branch of the migration operator repo.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New config Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp-workload-migration