### PR TITLE
adding "delegate_to" in order to copy APB source file on the bastion

### DIFF
--- a/ansible/roles/ocp-workload-edge-deployments/tasks/pre_workload.yml
+++ b/ansible/roles/ocp-workload-edge-deployments/tasks/pre_workload.yml
@@ -4,6 +4,7 @@
   copy:
     src: "files/"
     dest: "/tmp/{{guid}}/"
+  delegate_to: bastion.{{ guid }}.internal
 #  with_fileglob:
 #    - files/*
 

--- a/ansible/roles/ocp-workload-edge-deployments/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-edge-deployments/tasks/workload.yml
@@ -41,21 +41,26 @@
 
 - name: Generate a brand new SSH key for connecting to the remote machine
   shell: "cd /tmp/{{guid}}/deploy-containers-apb; ssh-keygen -N '' -f ./id_rsa"
+  delegate_to: bastion.{{ guid }}.internal
 
 - name: Ensure that APB binary is installed
   become: true
   yum:
     name: apb
     state: present
+  delegate_to: bastion.{{ guid }}.internal
 
 - name: Ready to prepare the APB build
   shell: "cd /tmp/{{guid}}/deploy-containers-apb; apb prepare"
+  delegate_to: bastion.{{ guid }}.internal
 
 - name: Create the APB build
   shell: "cd /tmp/{{guid}}/deploy-containers-apb; oc new-build --name deploy-containers-apb --allow-missing-images -n openshift ."
+  delegate_to: bastion.{{ guid }}.internal
 
 - name: Start the APB build and push process
   shell: "cd /tmp/{{guid}}/deploy-containers-apb; oc start-build -n openshift --follow --from-dir . deploy-containers-apb"
+  delegate_to: bastion.{{ guid }}.internal
 
 - name: Annotate the completed iot-development project as requested by user
   shell: "oc annotate namespace iot-development openshift.io/requester={{ocp_username}} --overwrite"
@@ -90,6 +95,7 @@
   slurp:
     src: /tmp/{{guid}}/deploy-containers-apb/id_rsa.pub
   register: publickey
+  delegate_to: bastion.{{ guid }}.internal
 
 - name: Adding SSH public key to the authorized host for the machine
   become: true
@@ -98,18 +104,21 @@
     state: present
     key: "{{ publickey['content'] | b64decode }}"
   #shell: "cat /tmp/{{guid}}/deploy-containers-apb/id_rsa.pub >> /root/.ssh/authorized_keys; chmod 700 /root/.ssh/authorized_keys"
+  delegate_to: bastion.{{ guid }}.internal
 
 - name: Installing Cockpit and Docker (it will be replaced by Podman as soon as Cockpit-Podman will become stable)
   become: true
   yum:
     name: ['docker', 'cockpit', 'cockpit-docker']
     state: present
+  delegate_to: bastion.{{ guid }}.internal  
 
 #!!! We need an admin user that will be able to login in cockpit (w/ password) for monitoring containers deployment !!!
 
 - name: Backing up /etc/containers/registries.conf
   become: true
   shell: cp -rf /etc/containers/registries.conf /etc/containers/registries.conf.bak
+  delegate_to: bastion.{{ guid }}.internal
 
 # Is it right the default route for external registry?
 - name: Inserting the insecure registry
@@ -120,6 +129,7 @@
     replace: 'registries = ["docker-registry-default.apps.{{ guid }}.openshiftworkshop.com"]'
     before: '[registries.block]'
     backup: yes
+  delegate_to: bastion.{{ guid }}.internal  
 
 - name: Starting docker and cockpit service
   become: true
@@ -130,6 +140,7 @@
   with_items:
     - docker
     - cockpit
+  delegate_to: bastion.{{ guid }}.internal  
 
 - name: workload Tasks Complete
   debug:


### PR DESCRIPTION
##### SUMMARY
adding "delegate_to" in order to copy APB source file on the bastion

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
ansible/roles/ocp-workload-edge-deployments/tasks/pre_workload.yml


