### PR TITLE
Fixing CI failures with Ceph workload

### DIFF
--- a/ansible/roles/ocp4-workload-ceph/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-ceph/tasks/pre_workload.yml
@@ -12,9 +12,11 @@
     register: ceph_pvcs
   - set_fact:
       found_scs: "{{ ceph_pvcs | json_query('resources[*].spec.storageClassName') | list | unique }}"
+      csi_rbd: "csi-rbd"
+      csi_cephfs: "csi-cephfs"
   - fail:
       msg: "Ceph provisioned PVCs found. Please remove the PVCs provisioned by Ceph and try removing again..."
-    when: "{{ 'csi-rbd' in found_scs or 'csi-cephfs' in found_scs }}"
+    when: csi_rbd in found_scs or csi_cephfs in found_scs
   when: ceph_workload_destroy | bool
 
 - name: Discovering worker nodes


### PR DESCRIPTION
Signed-off-by: Pranav Gaikwad <pgaikwad@redhat.com>

##### SUMMARY
Fixed issue : CI was failing due to using deprecated jinja2 templating in a when clause.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-workload-ceph