### PR TITLE
Improved wait-for-deployment script on ocp4-workload-rhte-kubefed-app-portability

### DIFF
--- a/ansible/roles/ocp4-workload-rhte-kubefed-app-portability/files/wait-for-deployment
+++ b/ansible/roles/ocp4-workload-rhte-kubefed-app-portability/files/wait-for-deployment
@@ -7,6 +7,27 @@ CLUSTER="$1"
 DEPLOYMENT_NAMESPACE="$2"
 DEPLOYMENT_NAME="$3"
 echo "Checking if deployment ${DEPLOYMENT_NAME} from namespace ${DEPLOYMENT_NAMESPACE} on cluster ${CLUSTER} is ready"
+
+while [ $READY -eq 0 ]
+do
+  DEPLOYMENT_EXISTS=$(oc --context=${CLUSTER} -n ${DEPLOYMENT_NAMESPACE} get deployment ${DEPLOYMENT_NAME} -o name | awk -F "/" '{print $2}')
+  if [ "0${DEPLOYMENT_NAME}" == "0${DEPLOYMENT_EXISTS}" ]
+  then
+    READY=1
+  else
+    echo "Deployment still does not exists, waiting for its creation... [$WAIT/$MAX_WAIT]"
+    sleep 5
+    WAIT=$(expr $WAIT + 5)
+  fi
+  if [ $WAIT -ge $MAX_WAIT ]
+  then
+    echo "Timeout while waiting deployment ${DEPLOYMENT_NAME} from namespace ${DEPLOYMENT_NAMESPACE} on cluster ${CLUSTER} to be created"
+    exit 1
+  fi
+done 
+
+READY=0
+WAIT=0
 DESIRED_REPLICAS=$(oc --context=${CLUSTER} -n ${DEPLOYMENT_NAMESPACE} get deployment ${DEPLOYMENT_NAME} -o jsonpath='{ .spec.replicas }')
 while [ $READY -eq 0 ]
 do


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Improved the wait for deployment script so it doesn't fail if the deployment doesn't exist.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4-workload-rhte-kubefed-app-portability
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
