### PR TITLE
Add role for Analytics and Data Engineering on OpenShift workshop

### DIFF
--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+# Default variables that are defined by the playbook that will be deploying these roles
+become_override: False
+ocp_username: opentlc-mgr
+silent: False
+
+# These variables will be set by the role at runtime
+# The Rook Ceph RGW service ClusterIP in the rook-ceph namespace
+rgw_service_ip: "{{ rgw_service.resources[0].spec.clusterIP }}"
+# The Rook Ceph RGW service port in the rook-ceph namespace
+rgw_service_port: "{{ rgw_service.resources[0].spec.ports[0].port }}"

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/cluster.yaml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/cluster.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/cluster.yaml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/cluster.yaml
@@ -1,0 +1,264 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rook-ceph
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rook-ceph-osd
+  namespace: rook-ceph
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rook-ceph-mgr
+  namespace: rook-ceph
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-osd
+  namespace: rook-ceph
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: [ "get", "list", "watch", "create", "update", "delete" ]
+---
+# Aspects of ceph-mgr that require access to the system namespace
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-mgr-system
+  namespace: rook-ceph
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Aspects of ceph-mgr that operate within the cluster's namespace
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-mgr
+  namespace: rook-ceph
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ceph.rook.io
+  resources:
+  - "*"
+  verbs:
+  - "*"
+---
+# Allow the operator to create resources in this cluster's namespace
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-cluster-mgmt
+  namespace: rook-ceph
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rook-ceph-cluster-mgmt
+subjects:
+- kind: ServiceAccount
+  name: rook-ceph-system
+  namespace: rook-ceph-system
+---
+# Allow the osd pods in this namespace to work with configmaps
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-osd
+  namespace: rook-ceph
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-osd
+subjects:
+- kind: ServiceAccount
+  name: rook-ceph-osd
+  namespace: rook-ceph
+---
+# Allow the ceph mgr to access the cluster-specific resources necessary for the mgr modules
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-mgr
+  namespace: rook-ceph
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-mgr
+subjects:
+- kind: ServiceAccount
+  name: rook-ceph-mgr
+  namespace: rook-ceph
+---
+# Allow the ceph mgr to access the rook system resources necessary for the mgr modules
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-mgr-system
+  namespace: rook-ceph-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-mgr-system
+subjects:
+- kind: ServiceAccount
+  name: rook-ceph-mgr
+  namespace: rook-ceph
+---
+# Allow the ceph mgr to access cluster-wide resources necessary for the mgr modules
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-mgr-cluster
+  namespace: rook-ceph
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rook-ceph-mgr-cluster
+subjects:
+- kind: ServiceAccount
+  name: rook-ceph-mgr
+  namespace: rook-ceph
+---
+apiVersion: ceph.rook.io/v1
+kind: CephCluster
+metadata:
+  name: rook-ceph
+  namespace: rook-ceph
+spec:
+  cephVersion:
+    # The container image used to launch the Ceph daemon pods (mon, mgr, osd, mds, rgw).
+    # v12 is luminous, v13 is mimic, and v14 is nautilus.
+    # RECOMMENDATION: In production, use a specific version tag instead of the general v13 flag, which pulls the latest release and could result in different
+    # versions running within the cluster. See tags available at https://hub.docker.com/r/ceph/ceph/tags/.
+    image: ceph/ceph:v13.2.4-20190109
+    # Whether to allow unsupported versions of Ceph. Currently only luminous and mimic are supported.
+    # After nautilus is released, Rook will be updated to support nautilus.
+    # Do not set to true in production.
+    allowUnsupported: false
+  # The path on the host where configuration files will be persisted. If not specified, a kubernetes emptyDir will be created (not recommended).
+  # Important: if you reinstall the cluster, make sure you delete this directory from each host or else the mons will fail to start on the new cluster.
+  # In Minikube, the '/data' directory is configured to persist across reboots. Use "/data/rook" in Minikube environment.
+  dataDirHostPath: /var/lib/rook
+  # set the amount of mons to be started
+  mon:
+    count: 3
+    allowMultiplePerNode: true
+  # enable the ceph dashboard for viewing cluster status
+  dashboard:
+    enabled: true
+    # serve the dashboard under a subpath (useful when you are accessing the dashboard via a reverse proxy)
+    # urlPrefix: /ceph-dashboard
+    # serve the dashboard at the given port.
+    # port: 8443
+    # serve the dashboard using SSL
+    # ssl: true
+  network:
+    # toggle to use hostNetwork
+    hostNetwork: false
+  rbdMirroring:
+    # The number of daemons that will perform the rbd mirroring.
+    # rbd mirroring must be configured with "rbd mirror" from the rook toolbox.
+    workers: 0
+  # To control where various services will be scheduled by kubernetes, use the placement configuration sections below.
+  # The example under 'all' would have all services scheduled on kubernetes nodes labeled with 'role=storage-node' and
+  # tolerate taints with a key of 'storage-node'.
+#  placement:
+#    all:
+#      nodeAffinity:
+#        requiredDuringSchedulingIgnoredDuringExecution:
+#          nodeSelectorTerms:
+#          - matchExpressions:
+#            - key: role
+#              operator: In
+#              values:
+#              - storage-node
+#      podAffinity:
+#      podAntiAffinity:
+#      tolerations:
+#      - key: storage-node
+#        operator: Exists
+# The above placement information can also be specified for mon, osd, and mgr components
+#    mon:
+#    osd:
+#    mgr:
+  resources:
+# The requests and limits set here, allow the mgr pod to use half of one CPU core and 1 gigabyte of memory
+#    mgr:
+#      limits:
+#        cpu: "500m"
+#        memory: "1024Mi"
+#      requests:
+#        cpu: "500m"
+#        memory: "1024Mi"
+# The above example requests/limits can also be added to the mon and osd components
+#    mon:
+#    osd:
+  storage: # cluster level storage configuration and selection
+    useAllNodes: true
+    useAllDevices: false
+    deviceFilter:
+    location:
+    config:
+      # The default and recommended storeType is dynamically set to bluestore for devices and filestore for directories.
+      # Set the storeType explicitly only if it is required not to use the default.
+      # storeType: bluestore
+      databaseSizeMB: "1024" # this value can be removed for environments with normal sized disks (100 GB or larger)
+      journalSizeMB: "1024"  # this value can be removed for environments with normal sized disks (20 GB or larger)
+      osdsPerDevice: "1" # this value can be overridden at the node or device level
+# Cluster level list of directories to use for storage. These values will be set for all nodes that have no `directories` set.
+#    directories:
+#    - path: /rook/storage-dir
+# Individual nodes and their config can be specified as well, but 'useAllNodes' above must be set to false. Then, only the named
+# nodes below will be used as storage resources.  Each node's 'name' field should match their 'kubernetes.io/hostname' label.
+#    nodes:
+#    - name: "172.17.4.101"
+#      directories: # specific directories to use for storage can be specified for each node
+#      - path: "/rook/storage-dir"
+#      resources:
+#        limits:
+#          cpu: "500m"
+#          memory: "1024Mi"
+#        requests:
+#          cpu: "500m"
+#          memory: "1024Mi"
+#    - name: "172.17.4.201"
+#      devices: # specific devices to use for storage can be specified for each node
+#      - name: "sdb"
+#      - name: "nvme01" # multiple osds can be created on high performance devices
+#        config:
+#          osdsPerDevice: "5"
+#      config: # configuration can be specified at the node level which overrides the cluster level config
+#        storeType: filestore
+#    - name: "172.17.4.301"
+#      deviceFilter: "^sd."

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/kafka/kafka.clusterrole.yaml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/kafka/kafka.clusterrole.yaml
@@ -1,0 +1,384 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: StrimziAdmin
+rules:
+- apiGroups:
+  - "kafka.strimzi.io"
+  resources:
+  - kafkas
+  - kafkaconnects
+  - kafkaconnects2is
+  - kafkausers
+  - kafkatopics
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: strimzi-cluster-operator-namespaced
+  labels:
+    app: strimzi
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - get
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - kafka.strimzi.io
+  resources:
+  - kafkas
+  - kafkaconnects
+  - kafkaconnects2is
+  - kafkamirrormakers
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - deployments
+  - deployments/scale
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - deployments/scale
+  - deployments/status
+  - statefulsets
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - extensions
+  resources:
+  - replicationcontrollers
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs
+  - deploymentconfigs/scale
+  - deploymentconfigs/status
+  - deploymentconfigs/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - build.openshift.io
+  resources:
+  - buildconfigs
+  - builds
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+  - update
+- apiGroups:
+  - image.openshift.io
+  resources:
+  - imagestreams
+  - imagestreams/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - replicationcontrollers
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  - routes/custom-host
+  verbs:
+  - get
+  - list
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: strimzi-cluster-operator-global
+  labels:
+    app: strimzi
+rules:
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  verbs:
+  - get
+  - create
+  - delete
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: strimzi-kafka-broker
+  labels:
+    app: strimzi
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: strimzi-entity-operator
+  labels:
+    app: strimzi
+rules:
+- apiGroups:
+  - kafka.strimzi.io
+  resources:
+  - kafkatopics
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - kafka.strimzi.io
+  resources:
+  - kafkausers
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - create
+  - patch
+  - update
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: strimzi-topic-operator
+  labels:
+    app: strimzi
+rules:
+- apiGroups:
+  - kafka.strimzi.io
+  resources:
+  - kafkatopics
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/kafka/kafka.crd.yaml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/kafka/kafka.crd.yaml
@@ -1,0 +1,3877 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkas.kafka.strimzi.io
+  labels:
+    app: strimzi
+spec:
+  group: kafka.strimzi.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: Kafka
+    listKind: KafkaList
+    singular: kafka
+    plural: kafkas
+    shortNames:
+    - k
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            kafka:
+              type: object
+              properties:
+                replicas:
+                  type: integer
+                  minimum: 1
+                image:
+                  type: string
+                storage:
+                  type: object
+                  properties:
+                    class:
+                      type: string
+                    deleteClaim:
+                      type: boolean
+                    id:
+                      type: integer
+                      minimum: 0
+                    selector:
+                      type: object
+                    size:
+                      type: string
+                    type:
+                      type: string
+                      enum:
+                      - ephemeral
+                      - persistent-claim
+                      - jbod
+                    volumes:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          class:
+                            type: string
+                          deleteClaim:
+                            type: boolean
+                          id:
+                            type: integer
+                            minimum: 0
+                          selector:
+                            type: object
+                          size:
+                            type: string
+                          type:
+                            type: string
+                            enum:
+                            - ephemeral
+                            - persistent-claim
+                        required:
+                        - type
+                  required:
+                  - type
+                listeners:
+                  type: object
+                  properties:
+                    plain:
+                      type: object
+                      properties:
+                        authentication:
+                          type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                              - tls
+                              - scram-sha-512
+                          required:
+                          - type
+                        networkPolicyPeers:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              ipBlock:
+                                type: object
+                                properties:
+                                  cidr:
+                                    type: string
+                                  except:
+                                    type: array
+                                    items:
+                                      type: string
+                              namespaceSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              podSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                    tls:
+                      type: object
+                      properties:
+                        authentication:
+                          type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                              - tls
+                              - scram-sha-512
+                          required:
+                          - type
+                        networkPolicyPeers:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              ipBlock:
+                                type: object
+                                properties:
+                                  cidr:
+                                    type: string
+                                  except:
+                                    type: array
+                                    items:
+                                      type: string
+                              namespaceSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              podSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                    external:
+                      type: object
+                      properties:
+                        authentication:
+                          type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                              - tls
+                              - scram-sha-512
+                          required:
+                          - type
+                        networkPolicyPeers:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              ipBlock:
+                                type: object
+                                properties:
+                                  cidr:
+                                    type: string
+                                  except:
+                                    type: array
+                                    items:
+                                      type: string
+                              namespaceSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              podSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                        overrides:
+                          type: object
+                          properties:
+                            bootstrap:
+                              type: object
+                              properties:
+                                address:
+                                  type: string
+                                nodePort:
+                                  type: integer
+                            brokers:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  broker:
+                                    type: integer
+                                  advertisedHost:
+                                    type: string
+                                  advertisedPort:
+                                    type: integer
+                                  nodePort:
+                                    type: integer
+                        tls:
+                          type: boolean
+                        type:
+                          type: string
+                          enum:
+                          - route
+                          - loadbalancer
+                          - nodeport
+                      required:
+                      - type
+                authorization:
+                  type: object
+                  properties:
+                    superUsers:
+                      type: array
+                      items:
+                        type: string
+                    type:
+                      type: string
+                      enum:
+                      - simple
+                  required:
+                  - type
+                config:
+                  type: object
+                rack:
+                  type: object
+                  properties:
+                    topologyKey:
+                      type: string
+                      example: failure-domain.beta.kubernetes.io/zone
+                  required:
+                  - topologyKey
+                brokerRackInitImage:
+                  type: string
+                affinity:
+                  type: object
+                  properties:
+                    nodeAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              preference:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchFields:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: object
+                          properties:
+                            nodeSelectorTerms:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchFields:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                    podAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              podAffinityTerm:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                    podAntiAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              podAffinityTerm:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                tolerations:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      tolerationSeconds:
+                        type: integer
+                      value:
+                        type: string
+                livenessProbe:
+                  type: object
+                  properties:
+                    initialDelaySeconds:
+                      type: integer
+                      minimum: 0
+                    timeoutSeconds:
+                      type: integer
+                      minimum: 0
+                readinessProbe:
+                  type: object
+                  properties:
+                    initialDelaySeconds:
+                      type: integer
+                      minimum: 0
+                    timeoutSeconds:
+                      type: integer
+                      minimum: 0
+                jvmOptions:
+                  type: object
+                  properties:
+                    -XX:
+                      type: object
+                    -Xms:
+                      type: string
+                      pattern: '[0-9]+[mMgG]?'
+                    -Xmx:
+                      type: string
+                      pattern: '[0-9]+[mMgG]?'
+                    gcLoggingEnabled:
+                      type: boolean
+                resources:
+                  type: object
+                  properties:
+                    limits:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                          pattern: '[0-9]+m?$'
+                        memory:
+                          type: string
+                          pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                    requests:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                          pattern: '[0-9]+m?$'
+                        memory:
+                          type: string
+                          pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                metrics:
+                  type: object
+                logging:
+                  type: object
+                  properties:
+                    loggers:
+                      type: object
+                    name:
+                      type: string
+                    type:
+                      type: string
+                      enum:
+                      - inline
+                      - external
+                  required:
+                  - type
+                tlsSidecar:
+                  type: object
+                  properties:
+                    image:
+                      type: string
+                    livenessProbe:
+                      type: object
+                      properties:
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
+                    logLevel:
+                      type: string
+                      enum:
+                      - emerg
+                      - alert
+                      - crit
+                      - err
+                      - warning
+                      - notice
+                      - info
+                      - debug
+                    readinessProbe:
+                      type: object
+                      properties:
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
+                    resources:
+                      type: object
+                      properties:
+                        limits:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                        requests:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                template:
+                  type: object
+                  properties:
+                    statefulset:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
+                    pod:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
+                        imagePullSecrets:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                        securityContext:
+                          type: object
+                          properties:
+                            fsGroup:
+                              type: integer
+                            runAsGroup:
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              type: integer
+                            seLinuxOptions:
+                              type: object
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                            supplementalGroups:
+                              type: array
+                              items:
+                                type: integer
+                            sysctls:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                        terminationGracePeriodSeconds:
+                          type: integer
+                          minimum: 0
+                    bootstrapService:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
+                    brokersService:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
+                    externalBootstrapRoute:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
+                    externalBootstrapService:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
+                    perPodRoute:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
+                    perPodService:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
+                    podDisruptionBudget:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
+                        maxUnavailable:
+                          type: integer
+                          minimum: 0
+                version:
+                  type: string
+              required:
+              - replicas
+              - storage
+              - listeners
+            zookeeper:
+              type: object
+              properties:
+                replicas:
+                  type: integer
+                  minimum: 1
+                image:
+                  type: string
+                storage:
+                  type: object
+                  properties:
+                    class:
+                      type: string
+                    deleteClaim:
+                      type: boolean
+                    id:
+                      type: integer
+                      minimum: 0
+                    selector:
+                      type: object
+                    size:
+                      type: string
+                    type:
+                      type: string
+                      enum:
+                      - ephemeral
+                      - persistent-claim
+                  required:
+                  - type
+                config:
+                  type: object
+                affinity:
+                  type: object
+                  properties:
+                    nodeAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              preference:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchFields:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: object
+                          properties:
+                            nodeSelectorTerms:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchFields:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                    podAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              podAffinityTerm:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                    podAntiAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              podAffinityTerm:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                tolerations:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      tolerationSeconds:
+                        type: integer
+                      value:
+                        type: string
+                livenessProbe:
+                  type: object
+                  properties:
+                    initialDelaySeconds:
+                      type: integer
+                      minimum: 0
+                    timeoutSeconds:
+                      type: integer
+                      minimum: 0
+                readinessProbe:
+                  type: object
+                  properties:
+                    initialDelaySeconds:
+                      type: integer
+                      minimum: 0
+                    timeoutSeconds:
+                      type: integer
+                      minimum: 0
+                jvmOptions:
+                  type: object
+                  properties:
+                    -XX:
+                      type: object
+                    -Xms:
+                      type: string
+                      pattern: '[0-9]+[mMgG]?'
+                    -Xmx:
+                      type: string
+                      pattern: '[0-9]+[mMgG]?'
+                    gcLoggingEnabled:
+                      type: boolean
+                resources:
+                  type: object
+                  properties:
+                    limits:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                          pattern: '[0-9]+m?$'
+                        memory:
+                          type: string
+                          pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                    requests:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                          pattern: '[0-9]+m?$'
+                        memory:
+                          type: string
+                          pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                metrics:
+                  type: object
+                logging:
+                  type: object
+                  properties:
+                    loggers:
+                      type: object
+                    name:
+                      type: string
+                    type:
+                      type: string
+                      enum:
+                      - inline
+                      - external
+                  required:
+                  - type
+                tlsSidecar:
+                  type: object
+                  properties:
+                    image:
+                      type: string
+                    livenessProbe:
+                      type: object
+                      properties:
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
+                    logLevel:
+                      type: string
+                      enum:
+                      - emerg
+                      - alert
+                      - crit
+                      - err
+                      - warning
+                      - notice
+                      - info
+                      - debug
+                    readinessProbe:
+                      type: object
+                      properties:
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
+                    resources:
+                      type: object
+                      properties:
+                        limits:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                        requests:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                template:
+                  type: object
+                  properties:
+                    statefulset:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
+                    pod:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
+                        imagePullSecrets:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                        securityContext:
+                          type: object
+                          properties:
+                            fsGroup:
+                              type: integer
+                            runAsGroup:
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              type: integer
+                            seLinuxOptions:
+                              type: object
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                            supplementalGroups:
+                              type: array
+                              items:
+                                type: integer
+                            sysctls:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                        terminationGracePeriodSeconds:
+                          type: integer
+                          minimum: 0
+                    clientService:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
+                    nodesService:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
+                    podDisruptionBudget:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
+                        maxUnavailable:
+                          type: integer
+                          minimum: 0
+              required:
+              - replicas
+              - storage
+            topicOperator:
+              type: object
+              properties:
+                watchedNamespace:
+                  type: string
+                image:
+                  type: string
+                reconciliationIntervalSeconds:
+                  type: integer
+                  minimum: 0
+                zookeeperSessionTimeoutSeconds:
+                  type: integer
+                  minimum: 0
+                affinity:
+                  type: object
+                  properties:
+                    nodeAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              preference:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchFields:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: object
+                          properties:
+                            nodeSelectorTerms:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchFields:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                    podAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              podAffinityTerm:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                    podAntiAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              podAffinityTerm:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                resources:
+                  type: object
+                  properties:
+                    limits:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                          pattern: '[0-9]+m?$'
+                        memory:
+                          type: string
+                          pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                    requests:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                          pattern: '[0-9]+m?$'
+                        memory:
+                          type: string
+                          pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                topicMetadataMaxAttempts:
+                  type: integer
+                  minimum: 0
+                tlsSidecar:
+                  type: object
+                  properties:
+                    image:
+                      type: string
+                    livenessProbe:
+                      type: object
+                      properties:
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
+                    logLevel:
+                      type: string
+                      enum:
+                      - emerg
+                      - alert
+                      - crit
+                      - err
+                      - warning
+                      - notice
+                      - info
+                      - debug
+                    readinessProbe:
+                      type: object
+                      properties:
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
+                    resources:
+                      type: object
+                      properties:
+                        limits:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                        requests:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                logging:
+                  type: object
+                  properties:
+                    loggers:
+                      type: object
+                    name:
+                      type: string
+                    type:
+                      type: string
+                      enum:
+                      - inline
+                      - external
+                  required:
+                  - type
+                jvmOptions:
+                  type: object
+                  properties:
+                    gcLoggingEnabled:
+                      type: boolean
+            entityOperator:
+              type: object
+              properties:
+                topicOperator:
+                  type: object
+                  properties:
+                    watchedNamespace:
+                      type: string
+                    image:
+                      type: string
+                    reconciliationIntervalSeconds:
+                      type: integer
+                      minimum: 0
+                    zookeeperSessionTimeoutSeconds:
+                      type: integer
+                      minimum: 0
+                    resources:
+                      type: object
+                      properties:
+                        limits:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                        requests:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                    topicMetadataMaxAttempts:
+                      type: integer
+                      minimum: 0
+                    logging:
+                      type: object
+                      properties:
+                        loggers:
+                          type: object
+                        name:
+                          type: string
+                        type:
+                          type: string
+                          enum:
+                          - inline
+                          - external
+                      required:
+                      - type
+                    jvmOptions:
+                      type: object
+                      properties:
+                        gcLoggingEnabled:
+                          type: boolean
+                userOperator:
+                  type: object
+                  properties:
+                    watchedNamespace:
+                      type: string
+                    image:
+                      type: string
+                    reconciliationIntervalSeconds:
+                      type: integer
+                      minimum: 0
+                    zookeeperSessionTimeoutSeconds:
+                      type: integer
+                      minimum: 0
+                    resources:
+                      type: object
+                      properties:
+                        limits:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                        requests:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                    logging:
+                      type: object
+                      properties:
+                        loggers:
+                          type: object
+                        name:
+                          type: string
+                        type:
+                          type: string
+                          enum:
+                          - inline
+                          - external
+                      required:
+                      - type
+                    jvmOptions:
+                      type: object
+                      properties:
+                        gcLoggingEnabled:
+                          type: boolean
+                affinity:
+                  type: object
+                  properties:
+                    nodeAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              preference:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchFields:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: object
+                          properties:
+                            nodeSelectorTerms:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchFields:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                    podAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              podAffinityTerm:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                    podAntiAffinity:
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              podAffinityTerm:
+                                type: object
+                                properties:
+                                  labelSelector:
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        type: object
+                                  namespaces:
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    type: string
+                              weight:
+                                type: integer
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                tolerations:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      tolerationSeconds:
+                        type: integer
+                      value:
+                        type: string
+                tlsSidecar:
+                  type: object
+                  properties:
+                    image:
+                      type: string
+                    livenessProbe:
+                      type: object
+                      properties:
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
+                    logLevel:
+                      type: string
+                      enum:
+                      - emerg
+                      - alert
+                      - crit
+                      - err
+                      - warning
+                      - notice
+                      - info
+                      - debug
+                    readinessProbe:
+                      type: object
+                      properties:
+                        initialDelaySeconds:
+                          type: integer
+                          minimum: 0
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 0
+                    resources:
+                      type: object
+                      properties:
+                        limits:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                        requests:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '[0-9]+m?$'
+                            memory:
+                              type: string
+                              pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                template:
+                  type: object
+                  properties:
+                    deployment:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
+                    pod:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                            annotations:
+                              type: object
+                        imagePullSecrets:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                        securityContext:
+                          type: object
+                          properties:
+                            fsGroup:
+                              type: integer
+                            runAsGroup:
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              type: integer
+                            seLinuxOptions:
+                              type: object
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                            supplementalGroups:
+                              type: array
+                              items:
+                                type: integer
+                            sysctls:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                        terminationGracePeriodSeconds:
+                          type: integer
+                          minimum: 0
+            clusterCa:
+              type: object
+              properties:
+                generateCertificateAuthority:
+                  type: boolean
+                validityDays:
+                  type: integer
+                  minimum: 1
+                renewalDays:
+                  type: integer
+                  minimum: 1
+                certificateExpirationPolicy:
+                  type: string
+                  enum:
+                  - renew-certificate
+                  - replace-key
+            clientsCa:
+              type: object
+              properties:
+                generateCertificateAuthority:
+                  type: boolean
+                validityDays:
+                  type: integer
+                  minimum: 1
+                renewalDays:
+                  type: integer
+                  minimum: 1
+                certificateExpirationPolicy:
+                  type: string
+                  enum:
+                  - renew-certificate
+                  - replace-key
+            maintenanceTimeWindows:
+              type: array
+              items:
+                type: string
+          required:
+          - kafka
+          - zookeeper
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkaconnects.kafka.strimzi.io
+  labels:
+    app: strimzi
+spec:
+  group: kafka.strimzi.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: KafkaConnect
+    listKind: KafkaConnectList
+    singular: kafkaconnect
+    plural: kafkaconnects
+    shortNames:
+    - kc
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            replicas:
+              type: integer
+            image:
+              type: string
+            livenessProbe:
+              type: object
+              properties:
+                initialDelaySeconds:
+                  type: integer
+                  minimum: 0
+                timeoutSeconds:
+                  type: integer
+                  minimum: 0
+            readinessProbe:
+              type: object
+              properties:
+                initialDelaySeconds:
+                  type: integer
+                  minimum: 0
+                timeoutSeconds:
+                  type: integer
+                  minimum: 0
+            jvmOptions:
+              type: object
+              properties:
+                -XX:
+                  type: object
+                -Xms:
+                  type: string
+                  pattern: '[0-9]+[mMgG]?'
+                -Xmx:
+                  type: string
+                  pattern: '[0-9]+[mMgG]?'
+                gcLoggingEnabled:
+                  type: boolean
+            affinity:
+              type: object
+              properties:
+                nodeAffinity:
+                  type: object
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          preference:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchFields:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                          weight:
+                            type: integer
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      type: object
+                      properties:
+                        nodeSelectorTerms:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchFields:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                podAffinity:
+                  type: object
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          podAffinityTerm:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                          weight:
+                            type: integer
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          labelSelector:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchLabels:
+                                type: object
+                          namespaces:
+                            type: array
+                            items:
+                              type: string
+                          topologyKey:
+                            type: string
+                podAntiAffinity:
+                  type: object
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          podAffinityTerm:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                          weight:
+                            type: integer
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          labelSelector:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchLabels:
+                                type: object
+                          namespaces:
+                            type: array
+                            items:
+                              type: string
+                          topologyKey:
+                            type: string
+            tolerations:
+              type: array
+              items:
+                type: object
+                properties:
+                  effect:
+                    type: string
+                  key:
+                    type: string
+                  operator:
+                    type: string
+                  tolerationSeconds:
+                    type: integer
+                  value:
+                    type: string
+            logging:
+              type: object
+              properties:
+                loggers:
+                  type: object
+                name:
+                  type: string
+                type:
+                  type: string
+                  enum:
+                  - inline
+                  - external
+              required:
+              - type
+            metrics:
+              type: object
+            template:
+              type: object
+              properties:
+                deployment:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                        annotations:
+                          type: object
+                pod:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                        annotations:
+                          type: object
+                    imagePullSecrets:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                    securityContext:
+                      type: object
+                      properties:
+                        fsGroup:
+                          type: integer
+                        runAsGroup:
+                          type: integer
+                        runAsNonRoot:
+                          type: boolean
+                        runAsUser:
+                          type: integer
+                        seLinuxOptions:
+                          type: object
+                          properties:
+                            level:
+                              type: string
+                            role:
+                              type: string
+                            type:
+                              type: string
+                            user:
+                              type: string
+                        supplementalGroups:
+                          type: array
+                          items:
+                            type: integer
+                        sysctls:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                    terminationGracePeriodSeconds:
+                      type: integer
+                      minimum: 0
+                apiService:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                        annotations:
+                          type: object
+                podDisruptionBudget:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                        annotations:
+                          type: object
+                    maxUnavailable:
+                      type: integer
+                      minimum: 0
+            authentication:
+              type: object
+              properties:
+                certificateAndKey:
+                  type: object
+                  properties:
+                    certificate:
+                      type: string
+                    key:
+                      type: string
+                    secretName:
+                      type: string
+                  required:
+                  - certificate
+                  - key
+                  - secretName
+                passwordSecret:
+                  type: object
+                  properties:
+                    password:
+                      type: string
+                    secretName:
+                      type: string
+                  required:
+                  - password
+                  - secretName
+                type:
+                  type: string
+                  enum:
+                  - tls
+                  - scram-sha-512
+                username:
+                  type: string
+              required:
+              - type
+            bootstrapServers:
+              type: string
+            config:
+              type: object
+            externalConfiguration:
+              type: object
+              properties:
+                env:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      valueFrom:
+                        type: object
+                        properties:
+                          configMapKeyRef:
+                            type: object
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                          secretKeyRef:
+                            type: object
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                    required:
+                    - name
+                    - valueFrom
+                volumes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      configMap:
+                        type: object
+                        properties:
+                          defaultMode:
+                            type: integer
+                          items:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                mode:
+                                  type: integer
+                                path:
+                                  type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                      name:
+                        type: string
+                      secret:
+                        type: object
+                        properties:
+                          defaultMode:
+                            type: integer
+                          items:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                mode:
+                                  type: integer
+                                path:
+                                  type: string
+                          optional:
+                            type: boolean
+                          secretName:
+                            type: string
+                    required:
+                    - name
+            resources:
+              type: object
+              properties:
+                limits:
+                  type: object
+                  properties:
+                    cpu:
+                      type: string
+                      pattern: '[0-9]+m?$'
+                    memory:
+                      type: string
+                      pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                requests:
+                  type: object
+                  properties:
+                    cpu:
+                      type: string
+                      pattern: '[0-9]+m?$'
+                    memory:
+                      type: string
+                      pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+            tls:
+              type: object
+              properties:
+                trustedCertificates:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      certificate:
+                        type: string
+                      secretName:
+                        type: string
+                    required:
+                    - certificate
+                    - secretName
+              required:
+              - trustedCertificates
+            version:
+              type: string
+          required:
+          - bootstrapServers
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkaconnects2is.kafka.strimzi.io
+  labels:
+    app: strimzi
+spec:
+  group: kafka.strimzi.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: KafkaConnectS2I
+    listKind: KafkaConnectS2IList
+    singular: kafkaconnects2i
+    plural: kafkaconnects2is
+    shortNames:
+    - kcs2i
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            replicas:
+              type: integer
+            image:
+              type: string
+            livenessProbe:
+              type: object
+              properties:
+                initialDelaySeconds:
+                  type: integer
+                  minimum: 0
+                timeoutSeconds:
+                  type: integer
+                  minimum: 0
+            readinessProbe:
+              type: object
+              properties:
+                initialDelaySeconds:
+                  type: integer
+                  minimum: 0
+                timeoutSeconds:
+                  type: integer
+                  minimum: 0
+            jvmOptions:
+              type: object
+              properties:
+                -XX:
+                  type: object
+                -Xms:
+                  type: string
+                  pattern: '[0-9]+[mMgG]?'
+                -Xmx:
+                  type: string
+                  pattern: '[0-9]+[mMgG]?'
+                gcLoggingEnabled:
+                  type: boolean
+            affinity:
+              type: object
+              properties:
+                nodeAffinity:
+                  type: object
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          preference:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchFields:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                          weight:
+                            type: integer
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      type: object
+                      properties:
+                        nodeSelectorTerms:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchFields:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                podAffinity:
+                  type: object
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          podAffinityTerm:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                          weight:
+                            type: integer
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          labelSelector:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchLabels:
+                                type: object
+                          namespaces:
+                            type: array
+                            items:
+                              type: string
+                          topologyKey:
+                            type: string
+                podAntiAffinity:
+                  type: object
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          podAffinityTerm:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                          weight:
+                            type: integer
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          labelSelector:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchLabels:
+                                type: object
+                          namespaces:
+                            type: array
+                            items:
+                              type: string
+                          topologyKey:
+                            type: string
+            logging:
+              type: object
+              properties:
+                loggers:
+                  type: object
+                name:
+                  type: string
+                type:
+                  type: string
+                  enum:
+                  - inline
+                  - external
+              required:
+              - type
+            metrics:
+              type: object
+            template:
+              type: object
+              properties:
+                deployment:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                        annotations:
+                          type: object
+                pod:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                        annotations:
+                          type: object
+                    imagePullSecrets:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                    securityContext:
+                      type: object
+                      properties:
+                        fsGroup:
+                          type: integer
+                        runAsGroup:
+                          type: integer
+                        runAsNonRoot:
+                          type: boolean
+                        runAsUser:
+                          type: integer
+                        seLinuxOptions:
+                          type: object
+                          properties:
+                            level:
+                              type: string
+                            role:
+                              type: string
+                            type:
+                              type: string
+                            user:
+                              type: string
+                        supplementalGroups:
+                          type: array
+                          items:
+                            type: integer
+                        sysctls:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                    terminationGracePeriodSeconds:
+                      type: integer
+                      minimum: 0
+                apiService:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                        annotations:
+                          type: object
+                podDisruptionBudget:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                        annotations:
+                          type: object
+                    maxUnavailable:
+                      type: integer
+                      minimum: 0
+            authentication:
+              type: object
+              properties:
+                certificateAndKey:
+                  type: object
+                  properties:
+                    certificate:
+                      type: string
+                    key:
+                      type: string
+                    secretName:
+                      type: string
+                  required:
+                  - certificate
+                  - key
+                  - secretName
+                passwordSecret:
+                  type: object
+                  properties:
+                    password:
+                      type: string
+                    secretName:
+                      type: string
+                  required:
+                  - password
+                  - secretName
+                type:
+                  type: string
+                  enum:
+                  - tls
+                  - scram-sha-512
+                username:
+                  type: string
+              required:
+              - type
+            bootstrapServers:
+              type: string
+            config:
+              type: object
+            externalConfiguration:
+              type: object
+              properties:
+                env:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      valueFrom:
+                        type: object
+                        properties:
+                          configMapKeyRef:
+                            type: object
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                          secretKeyRef:
+                            type: object
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                    required:
+                    - name
+                    - valueFrom
+                volumes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      configMap:
+                        type: object
+                        properties:
+                          defaultMode:
+                            type: integer
+                          items:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                mode:
+                                  type: integer
+                                path:
+                                  type: string
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                      name:
+                        type: string
+                      secret:
+                        type: object
+                        properties:
+                          defaultMode:
+                            type: integer
+                          items:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                mode:
+                                  type: integer
+                                path:
+                                  type: string
+                          optional:
+                            type: boolean
+                          secretName:
+                            type: string
+                    required:
+                    - name
+            insecureSourceRepository:
+              type: boolean
+            resources:
+              type: object
+              properties:
+                limits:
+                  type: object
+                  properties:
+                    cpu:
+                      type: string
+                      pattern: '[0-9]+m?$'
+                    memory:
+                      type: string
+                      pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                requests:
+                  type: object
+                  properties:
+                    cpu:
+                      type: string
+                      pattern: '[0-9]+m?$'
+                    memory:
+                      type: string
+                      pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+            tls:
+              type: object
+              properties:
+                trustedCertificates:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      certificate:
+                        type: string
+                      secretName:
+                        type: string
+                    required:
+                    - certificate
+                    - secretName
+              required:
+              - trustedCertificates
+            tolerations:
+              type: array
+              items:
+                type: object
+                properties:
+                  effect:
+                    type: string
+                  key:
+                    type: string
+                  operator:
+                    type: string
+                  tolerationSeconds:
+                    type: integer
+                  value:
+                    type: string
+            version:
+              type: string
+          required:
+          - bootstrapServers
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkatopics.kafka.strimzi.io
+  labels:
+    app: strimzi
+spec:
+  group: kafka.strimzi.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: KafkaTopic
+    listKind: KafkaTopicList
+    singular: kafkatopic
+    plural: kafkatopics
+    shortNames:
+    - kt
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            partitions:
+              type: integer
+              minimum: 1
+            replicas:
+              type: integer
+              minimum: 1
+              maximum: 32767
+            config:
+              type: object
+            topicName:
+              type: string
+          required:
+          - partitions
+          - replicas
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkausers.kafka.strimzi.io
+  labels:
+    app: strimzi
+spec:
+  group: kafka.strimzi.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: KafkaUser
+    listKind: KafkaUserList
+    singular: kafkauser
+    plural: kafkausers
+    shortNames:
+    - ku
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            authentication:
+              type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                  - tls
+                  - scram-sha-512
+              required:
+              - type
+            authorization:
+              type: object
+              properties:
+                acls:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      host:
+                        type: string
+                      operation:
+                        type: string
+                        enum:
+                        - Read
+                        - Write
+                        - Create
+                        - Delete
+                        - Alter
+                        - Describe
+                        - ClusterAction
+                        - AlterConfigs
+                        - DescribeConfigs
+                        - IdempotentWrite
+                        - All
+                      resource:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          patternType:
+                            type: string
+                            enum:
+                            - literal
+                            - prefix
+                          type:
+                            type: string
+                            enum:
+                            - topic
+                            - group
+                            - cluster
+                            - transactionalId
+                        required:
+                        - type
+                      type:
+                        type: string
+                        enum:
+                        - allow
+                        - deny
+                    required:
+                    - operation
+                    - resource
+                type:
+                  type: string
+                  enum:
+                  - simple
+              required:
+              - acls
+              - type
+          required:
+          - authentication
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkamirrormakers.kafka.strimzi.io
+  labels:
+    app: strimzi
+spec:
+  group: kafka.strimzi.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: KafkaMirrorMaker
+    listKind: KafkaMirrorMakerList
+    singular: kafkamirrormaker
+    plural: kafkamirrormakers
+    shortNames:
+    - kmm
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            replicas:
+              type: integer
+              minimum: 1
+            image:
+              type: string
+            whitelist:
+              type: string
+            consumer:
+              type: object
+              properties:
+                numStreams:
+                  type: integer
+                  minimum: 1
+                groupId:
+                  type: string
+                bootstrapServers:
+                  type: string
+                authentication:
+                  type: object
+                  properties:
+                    certificateAndKey:
+                      type: object
+                      properties:
+                        certificate:
+                          type: string
+                        key:
+                          type: string
+                        secretName:
+                          type: string
+                      required:
+                      - certificate
+                      - key
+                      - secretName
+                    passwordSecret:
+                      type: object
+                      properties:
+                        password:
+                          type: string
+                        secretName:
+                          type: string
+                      required:
+                      - password
+                      - secretName
+                    type:
+                      type: string
+                      enum:
+                      - tls
+                      - scram-sha-512
+                    username:
+                      type: string
+                  required:
+                  - type
+                config:
+                  type: object
+                tls:
+                  type: object
+                  properties:
+                    trustedCertificates:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          certificate:
+                            type: string
+                          secretName:
+                            type: string
+                        required:
+                        - certificate
+                        - secretName
+                  required:
+                  - trustedCertificates
+              required:
+              - groupId
+              - bootstrapServers
+            producer:
+              type: object
+              properties:
+                bootstrapServers:
+                  type: string
+                authentication:
+                  type: object
+                  properties:
+                    certificateAndKey:
+                      type: object
+                      properties:
+                        certificate:
+                          type: string
+                        key:
+                          type: string
+                        secretName:
+                          type: string
+                      required:
+                      - certificate
+                      - key
+                      - secretName
+                    passwordSecret:
+                      type: object
+                      properties:
+                        password:
+                          type: string
+                        secretName:
+                          type: string
+                      required:
+                      - password
+                      - secretName
+                    type:
+                      type: string
+                      enum:
+                      - tls
+                      - scram-sha-512
+                    username:
+                      type: string
+                  required:
+                  - type
+                config:
+                  type: object
+                tls:
+                  type: object
+                  properties:
+                    trustedCertificates:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          certificate:
+                            type: string
+                          secretName:
+                            type: string
+                        required:
+                        - certificate
+                        - secretName
+                  required:
+                  - trustedCertificates
+              required:
+              - bootstrapServers
+            resources:
+              type: object
+              properties:
+                limits:
+                  type: object
+                  properties:
+                    cpu:
+                      type: string
+                      pattern: '[0-9]+m?$'
+                    memory:
+                      type: string
+                      pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+                requests:
+                  type: object
+                  properties:
+                    cpu:
+                      type: string
+                      pattern: '[0-9]+m?$'
+                    memory:
+                      type: string
+                      pattern: '[0-9]+([kKmMgGtTpPeE]i?)?$'
+            affinity:
+              type: object
+              properties:
+                nodeAffinity:
+                  type: object
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          preference:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchFields:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                          weight:
+                            type: integer
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      type: object
+                      properties:
+                        nodeSelectorTerms:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchFields:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                podAffinity:
+                  type: object
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          podAffinityTerm:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                          weight:
+                            type: integer
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          labelSelector:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchLabels:
+                                type: object
+                          namespaces:
+                            type: array
+                            items:
+                              type: string
+                          topologyKey:
+                            type: string
+                podAntiAffinity:
+                  type: object
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          podAffinityTerm:
+                            type: object
+                            properties:
+                              labelSelector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                              namespaces:
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                type: string
+                          weight:
+                            type: integer
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          labelSelector:
+                            type: object
+                            properties:
+                              matchExpressions:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      type: array
+                                      items:
+                                        type: string
+                              matchLabels:
+                                type: object
+                          namespaces:
+                            type: array
+                            items:
+                              type: string
+                          topologyKey:
+                            type: string
+            tolerations:
+              type: array
+              items:
+                type: object
+                properties:
+                  effect:
+                    type: string
+                  key:
+                    type: string
+                  operator:
+                    type: string
+                  tolerationSeconds:
+                    type: integer
+                  value:
+                    type: string
+            jvmOptions:
+              type: object
+              properties:
+                -XX:
+                  type: object
+                -Xms:
+                  type: string
+                  pattern: '[0-9]+[mMgG]?'
+                -Xmx:
+                  type: string
+                  pattern: '[0-9]+[mMgG]?'
+                gcLoggingEnabled:
+                  type: boolean
+            logging:
+              type: object
+              properties:
+                loggers:
+                  type: object
+                name:
+                  type: string
+                type:
+                  type: string
+                  enum:
+                  - inline
+                  - external
+              required:
+              - type
+            metrics:
+              type: object
+            template:
+              type: object
+              properties:
+                deployment:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                        annotations:
+                          type: object
+                pod:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                        annotations:
+                          type: object
+                    imagePullSecrets:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                    securityContext:
+                      type: object
+                      properties:
+                        fsGroup:
+                          type: integer
+                        runAsGroup:
+                          type: integer
+                        runAsNonRoot:
+                          type: boolean
+                        runAsUser:
+                          type: integer
+                        seLinuxOptions:
+                          type: object
+                          properties:
+                            level:
+                              type: string
+                            role:
+                              type: string
+                            type:
+                              type: string
+                            user:
+                              type: string
+                        supplementalGroups:
+                          type: array
+                          items:
+                            type: integer
+                        sysctls:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                    terminationGracePeriodSeconds:
+                      type: integer
+                      minimum: 0
+                podDisruptionBudget:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                        annotations:
+                          type: object
+                    maxUnavailable:
+                      type: integer
+                      minimum: 0
+            version:
+              type: string
+          required:
+          - replicas
+          - whitelist
+          - consumer
+          - producer

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/object-user.yaml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/object-user.yaml
@@ -1,0 +1,8 @@
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: rhte-admin
+  namespace: rook-ceph
+spec:
+  store: my-store
+  displayName: "rhte-admin"

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/object-user.yaml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/object-user.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: ceph.rook.io/v1
 kind: CephObjectStoreUser
 metadata:

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/object.yaml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/object.yaml
@@ -1,0 +1,58 @@
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStore
+metadata:
+  name: my-store
+  namespace: rook-ceph
+spec:
+  # The pool spec used to create the metadata pools
+  metadataPool:
+    failureDomain: host
+    replicated:
+      # Increase the replication size if you have more than one osd
+      size: 1
+  # The pool spec used to create the data pool
+  dataPool:
+    failureDomain: osd
+    replicated:
+      size: 1
+    # If you have at least three osds, erasure coding can be specified
+    # erasureCoded:
+    #   dataChunks: 2
+    #   codingChunks: 1
+  # The gaeteway service configuration
+  gateway:
+    # type of the gateway (s3)
+    type: s3
+    # A reference to the secret in the rook namespace where the ssl certificate is stored
+    sslCertificateRef:
+    # The port that RGW pods will listen on (http)
+    port: 8000
+    # The port that RGW pods will listen on (https). An ssl certificate is required.
+    securePort:
+    # The number of pods in the rgw deployment (ignored if allNodes=true)
+    instances: 1
+    # Whether the rgw pods should be deployed on all nodes as a daemonset
+    allNodes: false
+    # The affinity rules to apply to the rgw deployment or daemonset.
+    placement:
+    #  nodeAffinity:
+    #    requiredDuringSchedulingIgnoredDuringExecution:
+    #      nodeSelectorTerms:
+    #      - matchExpressions:
+    #        - key: role
+    #          operator: In
+    #          values:
+    #          - rgw-node
+    #  tolerations:
+    #  - key: rgw-node
+    #    operator: Exists
+    #  podAffinity:
+    #  podAntiAffinity:
+    resources:
+    # The requests and limits set here, allow the object store gateway Pod(s) to use half of one CPU core and 1 gigabyte of memory
+    #  limits:
+    #    cpu: "500m"
+    #    memory: "1024Mi"
+    #  requests:
+    #    cpu: "500m"
+    #    memory: "1024Mi"

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/object.yaml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/object.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: ceph.rook.io/v1
 kind: CephObjectStore
 metadata:

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/opendatahub_v1alpha1_opendatahub_crd.yaml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/opendatahub_v1alpha1_opendatahub_crd.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/opendatahub_v1alpha1_opendatahub_crd.yaml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/opendatahub_v1alpha1_opendatahub_crd.yaml
@@ -1,0 +1,21 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: opendatahubs.opendatahub.io
+spec:
+  group: opendatahub.io
+  names:
+    kind: OpenDataHub
+    listKind: OpenDataHubList
+    plural: opendatahubs
+    singular: opendatahub
+    shortNames:
+    - odh
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/operator.yaml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/operator.yaml
@@ -1,0 +1,487 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rook-ceph-system
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cephclusters.ceph.rook.io
+spec:
+  group: ceph.rook.io
+  names:
+    kind: CephCluster
+    listKind: CephClusterList
+    plural: cephclusters
+    singular: cephcluster
+  scope: Namespaced
+  version: v1
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            cephVersion:
+              properties:
+                allowUnsupported:
+                  type: boolean
+                image:
+                  type: string
+                name:
+                  pattern: ^(luminous|mimic|nautilus)$
+                  type: string
+            dashboard:
+              properties:
+                enabled:
+                  type: boolean
+                urlPrefix:
+                  type: string
+                port:
+                  type: integer
+            dataDirHostPath:
+              pattern: ^/(\S+)
+              type: string
+            mon:
+              properties:
+                allowMultiplePerNode:
+                  type: boolean
+                count:
+                  maximum: 9
+                  minimum: 1
+                  type: integer
+              required:
+              - count
+            network:
+              properties:
+                hostNetwork:
+                  type: boolean
+            storage:
+              properties:
+                nodes:
+                  items: {}
+                  type: array
+                useAllDevices: {}
+                useAllNodes:
+                  type: boolean
+          required:
+          - mon
+  additionalPrinterColumns:
+    - name: DataDirHostPath
+      type: string
+      description: Directory used on the K8s nodes
+      JSONPath: .spec.dataDirHostPath
+    - name: MonCount
+      type: string
+      description: Number of MONs
+      JSONPath: .spec.mon.count
+    - name: Age
+      type: date
+      JSONPath: .metadata.creationTimestamp
+    - name: State
+      type: string
+      description: Current State
+      JSONPath: .status.state
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cephfilesystems.ceph.rook.io
+spec:
+  group: ceph.rook.io
+  names:
+    kind: CephFilesystem
+    listKind: CephFilesystemList
+    plural: cephfilesystems
+    singular: cephfilesystem
+  scope: Namespaced
+  version: v1
+  additionalPrinterColumns:
+    - name: MdsCount
+      type: string
+      description: Number of MDSs
+      JSONPath: .spec.metadataServer.activeCount
+    - name: Age
+      type: date
+      JSONPath: .metadata.creationTimestamp
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cephobjectstores.ceph.rook.io
+spec:
+  group: ceph.rook.io
+  names:
+    kind: CephObjectStore
+    listKind: CephObjectStoreList
+    plural: cephobjectstores
+    singular: cephobjectstore
+  scope: Namespaced
+  version: v1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cephobjectstoreusers.ceph.rook.io
+spec:
+  group: ceph.rook.io
+  names:
+    kind: CephObjectStoreUser
+    listKind: CephObjectStoreUserList
+    plural: cephobjectstoreusers
+    singular: cephobjectstoreuser
+  scope: Namespaced
+  version: v1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cephblockpools.ceph.rook.io
+spec:
+  group: ceph.rook.io
+  names:
+    kind: CephBlockPool
+    listKind: CephBlockPoolList
+    plural: cephblockpools
+    singular: cephblockpool
+  scope: Namespaced
+  version: v1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: volumes.rook.io
+spec:
+  group: rook.io
+  names:
+    kind: Volume
+    listKind: VolumeList
+    plural: volumes
+    singular: volume
+    shortNames:
+    - rv
+  scope: Namespaced
+  version: v1alpha2
+---
+# The cluster role for managing all the cluster-specific resources in a namespace
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: rook-ceph-cluster-mgmt
+  labels:
+    operator: rook
+    storage-backend: ceph
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - pods
+  - pods/log
+  - services
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - extensions
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+---
+# The role for the operator to manage resources in the system namespace
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: rook-ceph-system
+  namespace: rook-ceph-system
+  labels:
+    operator: rook
+    storage-backend: ceph
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+---
+# The cluster role for managing the Rook CRDs
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: rook-ceph-global
+  labels:
+    operator: rook
+    storage-backend: ceph
+rules:
+- apiGroups:
+  - ""
+  resources:
+  # Pod access is needed for fencing
+  - pods
+  # Node access is needed for determining nodes where mons should run
+  - nodes
+  - nodes/proxy
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+    # PVs and PVCs are managed by the Rook provisioner
+  - persistentvolumes
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ceph.rook.io
+  resources:
+  - "*"
+  verbs:
+  - "*"
+- apiGroups:
+  - rook.io
+  resources:
+  - "*"
+  verbs:
+  - "*"
+---
+# Aspects of ceph-mgr that require cluster-wide access
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-mgr-cluster
+  labels:
+    operator: rook
+    storage-backend: ceph
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - nodes
+  - nodes/proxy
+  verbs:
+  - get
+  - list
+  - watch
+---
+# The rook system service account used by the operator, agent, and discovery pods
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rook-ceph-system
+  namespace: rook-ceph-system
+  labels:
+    operator: rook
+    storage-backend: ceph
+---
+# Grant the operator, agent, and discovery agents access to resources in the rook-ceph-system namespace
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-system
+  namespace: rook-ceph-system
+  labels:
+    operator: rook
+    storage-backend: ceph
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-system
+subjects:
+- kind: ServiceAccount
+  name: rook-ceph-system
+  namespace: rook-ceph-system
+---
+# Grant the rook system daemons cluster-wide access to manage the Rook CRDs, PVCs, and storage classes
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-global
+  namespace: rook-ceph-system
+  labels:
+    operator: rook
+    storage-backend: ceph
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rook-ceph-global
+subjects:
+- kind: ServiceAccount
+  name: rook-ceph-system
+  namespace: rook-ceph-system
+---
+# The deployment for the rook operator
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: rook-ceph-operator
+  namespace: rook-ceph-system
+  labels:
+    operator: rook
+    storage-backend: ceph
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: rook-ceph-operator
+    spec:
+      serviceAccountName: rook-ceph-system
+      containers:
+      - name: rook-ceph-operator
+        image: rook/ceph:v0.9.3
+        args: ["ceph", "operator"]
+        volumeMounts:
+        - mountPath: /var/lib/rook
+          name: rook-config
+        - mountPath: /etc/ceph
+          name: default-config-dir
+        env:
+        # To disable RBAC, uncomment the following:
+        # - name: RBAC_ENABLED
+        #  value: "false"
+        # Rook Agent toleration. Will tolerate all taints with all keys.
+        # Choose between NoSchedule, PreferNoSchedule and NoExecute:
+        # - name: AGENT_TOLERATION
+        #   value: "NoSchedule"
+        # (Optional) Rook Agent toleration key. Set this to the key of the taint you want to tolerate
+        # - name: AGENT_TOLERATION_KEY
+        #   value: "<KeyOfTheTaintToTolerate>"
+        # (Optional) Rook Agent mount security mode. Can by `Any` or `Restricted`.
+        # `Any` uses Ceph admin credentials by default/fallback.
+        # For using `Restricted` you must have a Ceph secret in each namespace storage should be consumed from and
+        # set `mountUser` to the Ceph user, `mountSecret` to the Kubernetes secret name.
+        # to the namespace in which the `mountSecret` Kubernetes secret namespace.
+        # - name: AGENT_MOUNT_SECURITY_MODE
+        #   value: "Any"
+        # Set the path where the Rook agent can find the flex volumes
+        # - name: FLEXVOLUME_DIR_PATH
+        #  value: "<PathToFlexVolumes>"
+        - name: FLEXVOLUME_DIR_PATH
+          value: "/etc/kubernetes/kubelet-plugins/volume/exec"
+        # Set the path where kernel modules can be found
+        # - name: LIB_MODULES_DIR_PATH
+        #  value: "<PathToLibModules>"
+        # Mount any extra directories into the agent container
+        # - name: AGENT_MOUNTS
+        #  value: "somemount=/host/path:/container/path,someothermount=/host/path2:/container/path2"
+        # Rook Discover toleration. Will tolerate all taints with all keys.
+        # Choose between NoSchedule, PreferNoSchedule and NoExecute:
+        # - name: DISCOVER_TOLERATION
+        #   value: "NoSchedule"
+        # (Optional) Rook Discover toleration key. Set this to the key of the taint you want to tolerate
+        # - name: DISCOVER_TOLERATION_KEY
+        #  value: "<KeyOfTheTaintToTolerate>"
+        # Allow rook to create multiple file systems. Note: This is considered
+        # an experimental feature in Ceph as described at
+        # http://docs.ceph.com/docs/master/cephfs/experimental-features/#multiple-filesystems-within-a-ceph-cluster
+        # which might cause mons to crash as seen in https://github.com/rook/rook/issues/1027
+        - name: ROOK_ALLOW_MULTIPLE_FILESYSTEMS
+          value: "false"
+        # The logging level for the operator: INFO | DEBUG
+        - name: ROOK_LOG_LEVEL
+          value: "INFO"
+        # The interval to check if every mon is in the quorum.
+        - name: ROOK_MON_HEALTHCHECK_INTERVAL
+          value: "45s"
+        # The duration to wait before trying to failover or remove/replace the
+        # current mon with a new mon (useful for compensating flapping network).
+        - name: ROOK_MON_OUT_TIMEOUT
+          value: "600s"
+        # The duration between discovering devices in the rook-discover daemonset.
+        - name: ROOK_DISCOVER_DEVICES_INTERVAL
+          value: "60m"
+        # Whether to start pods as privileged that mount a host path, which includes the Ceph mon and osd pods.
+        # This is necessary to workaround the anyuid issues when running on OpenShift.
+        # For more details see https://github.com/rook/rook/issues/1314#issuecomment-355799641
+        - name: ROOK_HOSTPATH_REQUIRES_PRIVILEGED
+          value: "true"
+        # In some situations SELinux relabelling breaks (times out) on large filesystems, and doesn't work with cephfs ReadWriteMany volumes (last relabel wins).
+        # Disable it here if you have similiar issues.
+        # For more details see https://github.com/rook/rook/issues/2417
+        - name: ROOK_ENABLE_SELINUX_RELABELING
+          value: "true"
+        # In large volumes it will take some time to chown all the files. Disable it here if you have performance issues.
+        # For more details see https://github.com/rook/rook/issues/2254
+        - name: ROOK_ENABLE_FSGROUP
+          value: "true"
+        # The name of the node to pass with the downward API
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        # The pod name to pass with the downward API
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        # The pod namespace to pass with the downward API
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+      volumes:
+      - name: rook-config
+        emptyDir: {}
+      - name: default-config-dir
+        emptyDir: {}

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/operator.yaml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/operator.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -66,21 +67,21 @@ spec:
           required:
           - mon
   additionalPrinterColumns:
-    - name: DataDirHostPath
-      type: string
-      description: Directory used on the K8s nodes
-      JSONPath: .spec.dataDirHostPath
-    - name: MonCount
-      type: string
-      description: Number of MONs
-      JSONPath: .spec.mon.count
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
-    - name: State
-      type: string
-      description: Current State
-      JSONPath: .status.state
+  - name: DataDirHostPath
+    type: string
+    description: Directory used on the K8s nodes
+    JSONPath: .spec.dataDirHostPath
+  - name: MonCount
+    type: string
+    description: Number of MONs
+    JSONPath: .spec.mon.count
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  - name: State
+    type: string
+    description: Current State
+    JSONPath: .status.state
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -96,13 +97,13 @@ spec:
   scope: Namespaced
   version: v1
   additionalPrinterColumns:
-    - name: MdsCount
-      type: string
-      description: Number of MDSs
-      JSONPath: .spec.metadataServer.activeCount
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
+  - name: MdsCount
+    type: string
+    description: Number of MDSs
+    JSONPath: .spec.metadataServer.activeCount
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -261,7 +262,7 @@ rules:
   - ""
   resources:
   - events
-    # PVs and PVCs are managed by the Rook provisioner
+  # PVs and PVCs are managed by the Rook provisioner
   - persistentvolumes
   - persistentvolumeclaims
   verbs:

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/scc.yaml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/scc.yaml
@@ -1,0 +1,44 @@
+kind: SecurityContextConstraints
+# older versions of openshift have "apiVersion: v1"
+apiVersion: security.openshift.io/v1
+metadata:
+  name: rook-ceph
+allowPrivilegedContainer: true
+allowHostNetwork: true
+allowHostDirVolumePlugin: true
+priority:
+allowedCapabilities: []
+allowHostPorts: false
+allowHostPID: true
+allowHostIPC: true
+readOnlyRootFilesystem: false
+requiredDropCapabilities: []
+defaultAddCapabilities: []
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+fsGroup:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+allowedFlexVolumes:
+  - driver: "ceph.rook.io/rook"
+  - driver: "ceph.rook.io/rook-ceph"
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - flexVolume
+  - hostPath
+  - persistentVolumeClaim
+  - projected
+  - secret
+users:
+  # A user needs to be added for each rook service account.
+  # This assumes running in the default sample "rook-ceph" and "rook-ceph-system" namespaces.
+  # If other namespaces or service accounts are configured, they need to be updated here.
+  - system:serviceaccount:rook-ceph-system:rook-ceph-system
+  - system:serviceaccount:rook-ceph:default
+  - system:serviceaccount:rook-ceph:rook-ceph-mgr
+  - system:serviceaccount:rook-ceph:rook-ceph-osd

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/scc.yaml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/scc.yaml
@@ -1,3 +1,4 @@
+---
 kind: SecurityContextConstraints
 # older versions of openshift have "apiVersion: v1"
 apiVersion: security.openshift.io/v1

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/seldon/seldon-deployment.crd.json
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/seldon/seldon-deployment.crd.json
@@ -1,0 +1,4126 @@
+---
+# Source: seldon-core-crd/templates/seldon-deployment-crd.json
+{
+  "apiVersion": "apiextensions.k8s.io/v1beta1",
+  "kind": "CustomResourceDefinition",
+  "metadata": {
+    "name": "seldondeployments.machinelearning.seldon.io"
+  },
+  "spec": {
+    "group": "machinelearning.seldon.io",
+    "names": {
+      "kind": "SeldonDeployment",
+      "plural": "seldondeployments",
+      "shortNames": [
+        "sdep"
+      ],
+      "singular": "seldondeployment"
+    },
+    "scope": "Namespaced",
+    "validation": {
+      "openAPIV3Schema": {
+        "properties": {
+          "spec": {
+            "properties": {
+              "annotations": {
+                "description": "The annotations to be updated to a deployment",
+                "type": "object"
+              },
+              "name": {
+                "type": "string"
+              },
+              "oauth_key": {
+                "type": "string"
+              },
+              "oauth_secret": {
+                "type": "string"
+              },
+              "predictors": {
+                "description": "List of predictors belonging to the deployment",
+                "items": {
+                  "properties": {
+                    "annotations": {
+                      "description": "The annotations to be updated to a predictor",
+                      "type": "object"
+                    },
+                    "graph": {
+                      "properties": {
+                        "children": {
+                          "items": {
+                            "properties": {
+                              "children": {
+                                "items": {
+                                  "properties": {
+                                    "children": {
+                                      "items": {},
+                                      "type": "array"
+                                    },
+                                    "endpoint": {
+                                      "properties": {
+                                        "service_host": {
+                                          "type": "string"
+                                        },
+                                        "service_port": {
+                                          "type": "integer"
+                                        },
+                                        "type": {
+                                          "enum": [
+                                            "REST",
+                                            "GRPC"
+                                          ],
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "implementation": {
+                                      "enum": [
+                                        "UNKNOWN_IMPLEMENTATION",
+                                        "SIMPLE_MODEL",
+                                        "SIMPLE_ROUTER",
+                                        "RANDOM_ABTEST",
+                                        "AVERAGE_COMBINER"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "enum": [
+                                        "UNKNOWN_TYPE",
+                                        "ROUTER",
+                                        "COMBINER",
+                                        "MODEL",
+                                        "TRANSFORMER",
+                                        "OUTPUT_TRANSFORMER"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "methods": {
+                                      "type": "array",
+                                      "items": {
+                                        "enum": [
+                                          "TRANSFORM_INPUT",
+                                          "TRANSFORM_OUTPUT",
+                                          "ROUTE",
+                                          "AGGREGATE",
+                                          "SEND_FEEDBACK"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "type": "array"
+                              },
+                              "endpoint": {
+                                "properties": {
+                                  "service_host": {
+                                    "type": "string"
+                                  },
+                                  "service_port": {
+                                    "type": "integer"
+                                  },
+                                  "type": {
+                                    "enum": [
+                                      "REST",
+                                      "GRPC"
+                                    ],
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "implementation": {
+                                "enum": [
+                                  "UNKNOWN_IMPLEMENTATION",
+                                  "SIMPLE_MODEL",
+                                  "SIMPLE_ROUTER",
+                                  "RANDOM_ABTEST",
+                                  "AVERAGE_COMBINER"
+                                ],
+                                "type": "string"
+                              },
+                              "type": {
+                                "enum": [
+                                  "UNKNOWN_TYPE",
+                                  "ROUTER",
+                                  "COMBINER",
+                                  "MODEL",
+                                  "TRANSFORMER",
+                                  "OUTPUT_TRANSFORMER"
+                                ],
+                                "type": "string"
+                              },
+                              "methods": {
+                                "type": "array",
+                                "items": {
+                                  "enum": [
+                                    "TRANSFORM_INPUT",
+                                    "TRANSFORM_OUTPUT",
+                                    "ROUTE",
+                                    "AGGREGATE",
+                                    "SEND_FEEDBACK"
+                                  ],
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "type": "array"
+                        },
+                        "endpoint": {
+                          "properties": {
+                            "service_host": {
+                              "type": "string"
+                            },
+                            "service_port": {
+                              "type": "integer"
+                            },
+                            "type": {
+                              "enum": [
+                                "REST",
+                                "GRPC"
+                              ],
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "implementation": {
+                          "enum": [
+                            "UNKNOWN_IMPLEMENTATION",
+                            "SIMPLE_MODEL",
+                            "SIMPLE_ROUTER",
+                            "RANDOM_ABTEST",
+                            "AVERAGE_COMBINER"
+                          ],
+                          "type": "string"
+                        },
+                        "type": {
+                          "enum": [
+                            "UNKNOWN_TYPE",
+                            "ROUTER",
+                            "COMBINER",
+                            "MODEL",
+                            "TRANSFORMER",
+                            "OUTPUT_TRANSFORMER"
+                          ],
+                          "type": "string"
+                        },
+                        "methods": {
+                          "type": "array",
+                          "items": {
+                            "enum": [
+                              "TRANSFORM_INPUT",
+                              "TRANSFORM_OUTPUT",
+                              "ROUTE",
+                              "AGGREGATE",
+                              "SEND_FEEDBACK"
+                            ],
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "componentSpecs": {
+                      "description": "List of pods belonging to the predictor",
+                      "type": "array",
+                      "items": {
+                        "description": "Pod spec with optional HPA spec",
+                        "type": "object",
+                        "properties": {
+                          "metadata": {
+                            "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
+                            "properties": {
+                              "annotations": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                                "type": "object"
+                              },
+                              "clusterName": {
+                                "description": "The name of the cluster which the object belongs to. This is used to distinguish resources with same name and namespace in different clusters. This field is not set anywhere right now and apiserver is going to ignore it if set in create or update request.",
+                                "type": "string"
+                              },
+                              "creationTimestamp": {
+                                "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+                                "format": "date-time",
+                                "type": "string"
+                              },
+                              "deletionGracePeriodSeconds": {
+                                "description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "deletionTimestamp": {
+                                "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+                                "format": "date-time",
+                                "type": "string"
+                              },
+                              "finalizers": {
+                                "description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-patch-strategy": "merge"
+                              },
+                              "generateName": {
+                                "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency",
+                                "type": "string"
+                              },
+                              "generation": {
+                                "description": "A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.",
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "initializers": {
+                                "description": "Initializers tracks the progress of initialization.",
+                                "properties": {
+                                  "pending": {
+                                    "description": "Pending is a list of initializers that must execute in order before this object is visible. When the last pending initializer is removed, and no failing result is set, the initializers struct will be set to nil and the object is considered as initialized and visible to all clients.",
+                                    "items": {
+                                      "description": "Initializer is information about an initializer that has not yet completed.",
+                                      "properties": {
+                                        "name": {
+                                          "description": "name of the process that is responsible for initializing this object.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-patch-merge-key": "name",
+                                    "x-kubernetes-patch-strategy": "merge"
+                                  },
+                                  "result": {
+                                    "description": "Status is a return value for calls that don't return other objects.",
+                                    "properties": {
+                                      "apiVersion": {
+                                        "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+                                        "type": "string"
+                                      },
+                                      "code": {
+                                        "description": "Suggested HTTP return code for this status, 0 if not set.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "details": {
+                                        "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+                                        "properties": {
+                                          "causes": {
+                                            "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes.",
+                                            "items": {
+                                              "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+                                              "properties": {
+                                                "field": {
+                                                  "description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.\n\nExamples:\n  \"name\" - the field \"name\" on the current resource\n  \"items[0].name\" - the field \"name\" on the first array entry in \"items\"",
+                                                  "type": "string"
+                                                },
+                                                "message": {
+                                                  "description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader.",
+                                                  "type": "string"
+                                                },
+                                                "reason": {
+                                                  "description": "A machine-readable description of the cause of the error. If this value is empty there is no information available.",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "group": {
+                                            "description": "The group attribute of the resource associated with the status StatusReason.",
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described).",
+                                            "type": "string"
+                                          },
+                                          "retryAfterSeconds": {
+                                            "description": "If specified, the time in seconds before the operation should be retried. Some errors may indicate the client must take an alternate action - for those errors this field may indicate how long to wait before taking the alternate action.",
+                                            "format": "int32",
+                                            "type": "integer"
+                                          },
+                                          "uid": {
+                                            "description": "UID of the resource. (when there is a single resource which can be described). More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "kind": {
+                                        "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+                                        "type": "string"
+                                      },
+                                      "message": {
+                                        "description": "A human-readable description of the status of this operation.",
+                                        "type": "string"
+                                      },
+                                      "metadata": {
+                                        "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+                                        "properties": {
+                                          "continue": {
+                                            "description": "continue may be set if the user set a limit on the number of items returned, and indicates that the server has more data available. The value is opaque and may be used to issue another request to the endpoint that served this list to retrieve the next set of available objects. Continuing a consistent list may not be possible if the server configuration has changed or more than a few minutes have passed. The resourceVersion field returned when using this continue value will be identical to the value in the first response, unless you have received this token from an error message.",
+                                            "type": "string"
+                                          },
+                                          "resourceVersion": {
+                                            "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency",
+                                            "type": "string"
+                                          },
+                                          "selfLink": {
+                                            "description": "selfLink is a URL representing this object. Populated by the system. Read-only.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "reason": {
+                                        "description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.",
+                                        "type": "string"
+                                      },
+                                      "status": {
+                                        "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-group-version-kind": [
+                                      {
+                                        "group": "",
+                                        "kind": "Status",
+                                        "version": "v1"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "pending"
+                                ],
+                                "type": "object"
+                              },
+                              "labels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                                "type": "object"
+                              },
+                              "managedFields": {
+                                "description": "ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like \"ci-cd\". The set of fields is always in the version that the workflow used when modifying the object.\n\nThis field is alpha and can be changed or removed without notice.",
+                                "items": {
+                                  "description": "ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.",
+                                  "properties": {
+                                    "apiVersion": {
+                                      "description": "APIVersion defines the version of this resource that this field set applies to. The format is \"group/version\" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.",
+                                      "type": "string"
+                                    },
+                                    "fields": {
+                                      "description": "Fields stores a set of fields in a data structure like a Trie. To understand how this is used, see: https://github.com/kubernetes-sigs/structured-merge-diff",
+                                      "type": "object"
+                                    },
+                                    "manager": {
+                                      "description": "Manager is an identifier of the workflow managing these fields.",
+                                      "type": "string"
+                                    },
+                                    "operation": {
+                                      "description": "Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.",
+                                      "type": "string"
+                                    },
+                                    "time": {
+                                      "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+                                      "format": "date-time",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "name": {
+                                "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces",
+                                "type": "string"
+                              },
+                              "ownerReferences": {
+                                "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+                                "items": {
+                                  "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+                                  "properties": {
+                                    "apiVersion": {
+                                      "description": "API version of the referent.",
+                                      "type": "string"
+                                    },
+                                    "blockOwnerDeletion": {
+                                      "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+                                      "type": "boolean"
+                                    },
+                                    "controller": {
+                                      "description": "If true, this reference points to the managing controller.",
+                                      "type": "boolean"
+                                    },
+                                    "kind": {
+                                      "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+                                      "type": "string"
+                                    },
+                                    "uid": {
+                                      "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "apiVersion",
+                                    "kind",
+                                    "name",
+                                    "uid"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array",
+                                "x-kubernetes-patch-merge-key": "uid",
+                                "x-kubernetes-patch-strategy": "merge"
+                              },
+                              "resourceVersion": {
+                                "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency",
+                                "type": "string"
+                              },
+                              "selfLink": {
+                                "description": "SelfLink is a URL representing this object. Populated by the system. Read-only.",
+                                "type": "string"
+                              },
+                              "uid": {
+                                "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "spec": {
+                            "description": "PodSpec is a description of a pod.",
+                            "properties": {
+                              "activeDeadlineSeconds": {
+                                "description": "Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.",
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "affinity": {
+                                "description": "Affinity is a group of affinity scheduling rules.",
+                                "properties": {
+                                  "nodeAffinity": {
+                                    "description": "Node affinity is a group of node affinity scheduling rules.",
+                                    "properties": {
+                                      "preferredDuringSchedulingIgnoredDuringExecution": {
+                                        "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                                        "items": {
+                                          "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                                          "properties": {
+                                            "preference": {
+                                              "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                              "properties": {
+                                                "matchExpressions": {
+                                                  "description": "A list of node selector requirements by node's labels.",
+                                                  "items": {
+                                                    "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                    "properties": {
+                                                      "key": {
+                                                        "description": "The label key that the selector applies to.",
+                                                        "type": "string"
+                                                      },
+                                                      "operator": {
+                                                        "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                        "type": "string"
+                                                      },
+                                                      "values": {
+                                                        "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key",
+                                                      "operator"
+                                                    ],
+                                                    "type": "object"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "matchFields": {
+                                                  "description": "A list of node selector requirements by node's fields.",
+                                                  "items": {
+                                                    "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                    "properties": {
+                                                      "key": {
+                                                        "description": "The label key that the selector applies to.",
+                                                        "type": "string"
+                                                      },
+                                                      "operator": {
+                                                        "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                        "type": "string"
+                                                      },
+                                                      "values": {
+                                                        "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key",
+                                                      "operator"
+                                                    ],
+                                                    "type": "object"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "weight": {
+                                              "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                              "format": "int32",
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "required": [
+                                            "weight",
+                                            "preference"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "requiredDuringSchedulingIgnoredDuringExecution": {
+                                        "description": "A node selector represents the union of the results of one or more label queries over a set of nodes; that is, it represents the OR of the selectors represented by the node selector terms.",
+                                        "properties": {
+                                          "nodeSelectorTerms": {
+                                            "description": "Required. A list of node selector terms. The terms are ORed.",
+                                            "items": {
+                                              "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                              "properties": {
+                                                "matchExpressions": {
+                                                  "description": "A list of node selector requirements by node's labels.",
+                                                  "items": {
+                                                    "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                    "properties": {
+                                                      "key": {
+                                                        "description": "The label key that the selector applies to.",
+                                                        "type": "string"
+                                                      },
+                                                      "operator": {
+                                                        "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                        "type": "string"
+                                                      },
+                                                      "values": {
+                                                        "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key",
+                                                      "operator"
+                                                    ],
+                                                    "type": "object"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "matchFields": {
+                                                  "description": "A list of node selector requirements by node's fields.",
+                                                  "items": {
+                                                    "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                    "properties": {
+                                                      "key": {
+                                                        "description": "The label key that the selector applies to.",
+                                                        "type": "string"
+                                                      },
+                                                      "operator": {
+                                                        "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                        "type": "string"
+                                                      },
+                                                      "values": {
+                                                        "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key",
+                                                      "operator"
+                                                    ],
+                                                    "type": "object"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "required": [
+                                          "nodeSelectorTerms"
+                                        ],
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "podAffinity": {
+                                    "description": "Pod affinity is a group of inter pod affinity scheduling rules.",
+                                    "properties": {
+                                      "preferredDuringSchedulingIgnoredDuringExecution": {
+                                        "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                        "items": {
+                                          "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                          "properties": {
+                                            "podAffinityTerm": {
+                                              "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                              "properties": {
+                                                "labelSelector": {
+                                                  "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                                  "properties": {
+                                                    "matchExpressions": {
+                                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                      "items": {
+                                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                        "properties": {
+                                                          "key": {
+                                                            "description": "key is the label key that the selector applies to.",
+                                                            "type": "string",
+                                                            "x-kubernetes-patch-merge-key": "key",
+                                                            "x-kubernetes-patch-strategy": "merge"
+                                                          },
+                                                          "operator": {
+                                                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                            "type": "string"
+                                                          },
+                                                          "values": {
+                                                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key",
+                                                          "operator"
+                                                        ],
+                                                        "type": "object"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "matchLabels": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                      "type": "object"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "namespaces": {
+                                                  "description": "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "topologyKey": {
+                                                  "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "topologyKey"
+                                              ],
+                                              "type": "object"
+                                            },
+                                            "weight": {
+                                              "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                              "format": "int32",
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "required": [
+                                            "weight",
+                                            "podAffinityTerm"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "requiredDuringSchedulingIgnoredDuringExecution": {
+                                        "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                        "items": {
+                                          "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                          "properties": {
+                                            "labelSelector": {
+                                              "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                              "properties": {
+                                                "matchExpressions": {
+                                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                  "items": {
+                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                    "properties": {
+                                                      "key": {
+                                                        "description": "key is the label key that the selector applies to.",
+                                                        "type": "string",
+                                                        "x-kubernetes-patch-merge-key": "key",
+                                                        "x-kubernetes-patch-strategy": "merge"
+                                                      },
+                                                      "operator": {
+                                                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                        "type": "string"
+                                                      },
+                                                      "values": {
+                                                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key",
+                                                      "operator"
+                                                    ],
+                                                    "type": "object"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "matchLabels": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "namespaces": {
+                                              "description": "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "topologyKey": {
+                                              "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "topologyKey"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "podAntiAffinity": {
+                                    "description": "Pod anti affinity is a group of inter pod anti affinity scheduling rules.",
+                                    "properties": {
+                                      "preferredDuringSchedulingIgnoredDuringExecution": {
+                                        "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                        "items": {
+                                          "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                          "properties": {
+                                            "podAffinityTerm": {
+                                              "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                              "properties": {
+                                                "labelSelector": {
+                                                  "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                                  "properties": {
+                                                    "matchExpressions": {
+                                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                      "items": {
+                                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                        "properties": {
+                                                          "key": {
+                                                            "description": "key is the label key that the selector applies to.",
+                                                            "type": "string",
+                                                            "x-kubernetes-patch-merge-key": "key",
+                                                            "x-kubernetes-patch-strategy": "merge"
+                                                          },
+                                                          "operator": {
+                                                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                            "type": "string"
+                                                          },
+                                                          "values": {
+                                                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "key",
+                                                          "operator"
+                                                        ],
+                                                        "type": "object"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "matchLabels": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                      "type": "object"
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "namespaces": {
+                                                  "description": "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "topologyKey": {
+                                                  "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "topologyKey"
+                                              ],
+                                              "type": "object"
+                                            },
+                                            "weight": {
+                                              "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                              "format": "int32",
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "required": [
+                                            "weight",
+                                            "podAffinityTerm"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "requiredDuringSchedulingIgnoredDuringExecution": {
+                                        "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                        "items": {
+                                          "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                          "properties": {
+                                            "labelSelector": {
+                                              "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                              "properties": {
+                                                "matchExpressions": {
+                                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                  "items": {
+                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                    "properties": {
+                                                      "key": {
+                                                        "description": "key is the label key that the selector applies to.",
+                                                        "type": "string",
+                                                        "x-kubernetes-patch-merge-key": "key",
+                                                        "x-kubernetes-patch-strategy": "merge"
+                                                      },
+                                                      "operator": {
+                                                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                        "type": "string"
+                                                      },
+                                                      "values": {
+                                                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key",
+                                                      "operator"
+                                                    ],
+                                                    "type": "object"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "matchLabels": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "namespaces": {
+                                              "description": "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "topologyKey": {
+                                              "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "topologyKey"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "automountServiceAccountToken": {
+                                "description": "AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.",
+                                "type": "boolean"
+                              },
+                              "containers": {
+                                "description": "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.",
+                                "items": {
+                                  "description": "A single application container that you want to run within a pod.",
+                                  "properties": {
+                                    "args": {
+                                      "description": "Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "command": {
+                                      "description": "Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "env": {
+                                      "description": "List of environment variables to set in the container. Cannot be updated.",
+                                      "items": {
+                                        "description": "EnvVar represents an environment variable present in a Container.",
+                                        "properties": {
+                                          "name": {
+                                            "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "description": "Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                            "type": "string"
+                                          },
+                                          "valueFrom": {
+                                            "description": "EnvVarSource represents a source for the value of an EnvVar.",
+                                            "properties": {
+                                              "configMapKeyRef": {
+                                                "description": "Selects a key from a ConfigMap.",
+                                                "properties": {
+                                                  "key": {
+                                                    "description": "The key to select.",
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "description": "Specify whether the ConfigMap or it's key must be defined",
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object"
+                                              },
+                                              "fieldRef": {
+                                                "description": "ObjectFieldSelector selects an APIVersioned field of an object.",
+                                                "properties": {
+                                                  "apiVersion": {
+                                                    "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                    "type": "string"
+                                                  },
+                                                  "fieldPath": {
+                                                    "description": "Path of the field to select in the specified API version.",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "fieldPath"
+                                                ],
+                                                "type": "object"
+                                              },
+                                              "resourceFieldRef": {
+                                                "description": "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
+                                                "properties": {
+                                                  "containerName": {
+                                                    "description": "Container name: required for volumes, optional for env vars",
+                                                    "type": "string"
+                                                  },
+                                                  "divisor": {
+                                                    "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and Int64() accessors.\n\nThe serialization format is:\n\n<quantity>        ::= <signedNumber><suffix>\n  (Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber>\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n  a. No precision is lost\n  b. No fractional digits will be emitted\n  c. The exponent (or suffix) is as large as possible.\nThe sign will be omitted unless the number is negative.\n\nExamples:\n  1.5 will be serialized as \"1500m\"\n  1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+                                                    "type": "string"
+                                                  },
+                                                  "resource": {
+                                                    "description": "Required: resource to select",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "resource"
+                                                ],
+                                                "type": "object"
+                                              },
+                                              "secretKeyRef": {
+                                                "description": "SecretKeySelector selects a key of a Secret.",
+                                                "properties": {
+                                                  "key": {
+                                                    "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "description": "Specify whether the Secret or it's key must be defined",
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-patch-merge-key": "name",
+                                      "x-kubernetes-patch-strategy": "merge"
+                                    },
+                                    "envFrom": {
+                                      "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
+                                      "items": {
+                                        "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                                        "properties": {
+                                          "configMapRef": {
+                                            "description": "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.",
+                                            "properties": {
+                                              "name": {
+                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "description": "Specify whether the ConfigMap must be defined",
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "prefix": {
+                                            "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                                            "type": "string"
+                                          },
+                                          "secretRef": {
+                                            "description": "SecretEnvSource selects a Secret to populate the environment variables with.\n\nThe contents of the target Secret's Data field will represent the key-value pairs as environment variables.",
+                                            "properties": {
+                                              "name": {
+                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "description": "Specify whether the Secret must be defined",
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "image": {
+                                      "description": "Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.",
+                                      "type": "string"
+                                    },
+                                    "imagePullPolicy": {
+                                      "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                                      "type": "string"
+                                    },
+                                    "lifecycle": {
+                                      "description": "Lifecycle describes actions that the management system should take in response to container lifecycle events. For the PostStart and PreStop lifecycle handlers, management of the container blocks until the action is complete, unless the container process fails, in which case the handler is aborted.",
+                                      "properties": {
+                                        "postStart": {
+                                          "description": "Handler defines a specific action that should be taken",
+                                          "properties": {
+                                            "exec": {
+                                              "description": "ExecAction describes a \"run in container\" action.",
+                                              "properties": {
+                                                "command": {
+                                                  "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "httpGet": {
+                                              "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                                              "properties": {
+                                                "host": {
+                                                  "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                                  "type": "string"
+                                                },
+                                                "httpHeaders": {
+                                                  "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                                  "items": {
+                                                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                    "properties": {
+                                                      "name": {
+                                                        "description": "The header field name",
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "description": "The header field value",
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "type": "object"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "path": {
+                                                  "description": "Path to access on the HTTP server.",
+                                                  "type": "string"
+                                                },
+                                                "port": {
+                                                  "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                                  "format": "int-or-string",
+                                                  "type": "string"
+                                                },
+                                                "scheme": {
+                                                  "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "port"
+                                              ],
+                                              "type": "object"
+                                            },
+                                            "tcpSocket": {
+                                              "description": "TCPSocketAction describes an action based on opening a socket",
+                                              "properties": {
+                                                "host": {
+                                                  "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                                  "type": "string"
+                                                },
+                                                "port": {
+                                                  "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                                  "format": "int-or-string",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "port"
+                                              ],
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "preStop": {
+                                          "description": "Handler defines a specific action that should be taken",
+                                          "properties": {
+                                            "exec": {
+                                              "description": "ExecAction describes a \"run in container\" action.",
+                                              "properties": {
+                                                "command": {
+                                                  "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "httpGet": {
+                                              "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                                              "properties": {
+                                                "host": {
+                                                  "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                                  "type": "string"
+                                                },
+                                                "httpHeaders": {
+                                                  "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                                  "items": {
+                                                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                    "properties": {
+                                                      "name": {
+                                                        "description": "The header field name",
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "description": "The header field value",
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "type": "object"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "path": {
+                                                  "description": "Path to access on the HTTP server.",
+                                                  "type": "string"
+                                                },
+                                                "port": {
+                                                  "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                                  "format": "int-or-string",
+                                                  "type": "string"
+                                                },
+                                                "scheme": {
+                                                  "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "port"
+                                              ],
+                                              "type": "object"
+                                            },
+                                            "tcpSocket": {
+                                              "description": "TCPSocketAction describes an action based on opening a socket",
+                                              "properties": {
+                                                "host": {
+                                                  "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                                  "type": "string"
+                                                },
+                                                "port": {
+                                                  "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                                  "format": "int-or-string",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "port"
+                                              ],
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "livenessProbe": {
+                                      "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
+                                      "properties": {
+                                        "exec": {
+                                          "description": "ExecAction describes a \"run in container\" action.",
+                                          "properties": {
+                                            "command": {
+                                              "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "failureThreshold": {
+                                          "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "httpGet": {
+                                          "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                                          "properties": {
+                                            "host": {
+                                              "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                              "type": "string"
+                                            },
+                                            "httpHeaders": {
+                                              "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                              "items": {
+                                                "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                "properties": {
+                                                  "name": {
+                                                    "description": "The header field name",
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "description": "The header field value",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name",
+                                                  "value"
+                                                ],
+                                                "type": "object"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "path": {
+                                              "description": "Path to access on the HTTP server.",
+                                              "type": "string"
+                                            },
+                                            "port": {
+                                              "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                              "format": "int-or-string",
+                                              "type": "string"
+                                            },
+                                            "scheme": {
+                                              "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "port"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "initialDelaySeconds": {
+                                          "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "periodSeconds": {
+                                          "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "successThreshold": {
+                                          "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.",
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "tcpSocket": {
+                                          "description": "TCPSocketAction describes an action based on opening a socket",
+                                          "properties": {
+                                            "host": {
+                                              "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                              "type": "string"
+                                            },
+                                            "port": {
+                                              "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                              "format": "int-or-string",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "port"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "timeoutSeconds": {
+                                          "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                          "format": "int32",
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "name": {
+                                      "description": "Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.",
+                                      "type": "string"
+                                    },
+                                    "ports": {
+                                      "description": "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.",
+                                      "items": {
+                                        "description": "ContainerPort represents a network port in a single container.",
+                                        "properties": {
+                                          "containerPort": {
+                                            "description": "Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.",
+                                            "format": "int32",
+                                            "type": "integer"
+                                          },
+                                          "hostIP": {
+                                            "description": "What host IP to bind the external port to.",
+                                            "type": "string"
+                                          },
+                                          "hostPort": {
+                                            "description": "Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
+                                            "format": "int32",
+                                            "type": "integer"
+                                          },
+                                          "name": {
+                                            "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
+                                            "type": "string"
+                                          },
+                                          "protocol": {
+                                            "description": "Protocol for port. Must be UDP, TCP, or SCTP. Defaults to \"TCP\".",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "containerPort"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-map-keys": [
+                                        "containerPort",
+                                        "protocol"
+                                      ],
+                                      "x-kubernetes-list-type": "map",
+                                      "x-kubernetes-patch-merge-key": "containerPort",
+                                      "x-kubernetes-patch-strategy": "merge"
+                                    },
+                                    "readinessProbe": {
+                                      "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
+                                      "properties": {
+                                        "exec": {
+                                          "description": "ExecAction describes a \"run in container\" action.",
+                                          "properties": {
+                                            "command": {
+                                              "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "failureThreshold": {
+                                          "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "httpGet": {
+                                          "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                                          "properties": {
+                                            "host": {
+                                              "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                              "type": "string"
+                                            },
+                                            "httpHeaders": {
+                                              "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                              "items": {
+                                                "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                "properties": {
+                                                  "name": {
+                                                    "description": "The header field name",
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "description": "The header field value",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name",
+                                                  "value"
+                                                ],
+                                                "type": "object"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "path": {
+                                              "description": "Path to access on the HTTP server.",
+                                              "type": "string"
+                                            },
+                                            "port": {
+                                              "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                              "format": "int-or-string",
+                                              "type": "string"
+                                            },
+                                            "scheme": {
+                                              "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "port"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "initialDelaySeconds": {
+                                          "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "periodSeconds": {
+                                          "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "successThreshold": {
+                                          "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.",
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "tcpSocket": {
+                                          "description": "TCPSocketAction describes an action based on opening a socket",
+                                          "properties": {
+                                            "host": {
+                                              "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                              "type": "string"
+                                            },
+                                            "port": {
+                                              "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                              "format": "int-or-string",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "port"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "timeoutSeconds": {
+                                          "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                          "format": "int32",
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "resources": {
+                                      "description": "ResourceRequirements describes the compute resource requirements.",
+                                      "properties": {
+                                        "limits": {
+                                          "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                                          "type": "object"
+                                        },
+                                        "requests": {
+                                          "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "securityContext": {
+                                      "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
+                                      "properties": {
+                                        "allowPrivilegeEscalation": {
+                                          "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN",
+                                          "type": "boolean"
+                                        },
+                                        "capabilities": {
+                                          "description": "Adds and removes POSIX capabilities from running containers.",
+                                          "properties": {
+                                            "add": {
+                                              "description": "Added capabilities",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "drop": {
+                                              "description": "Removed capabilities",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "privileged": {
+                                          "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.",
+                                          "type": "boolean"
+                                        },
+                                        "procMount": {
+                                          "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.",
+                                          "type": "string"
+                                        },
+                                        "readOnlyRootFilesystem": {
+                                          "description": "Whether this container has a read-only root filesystem. Default is false.",
+                                          "type": "boolean"
+                                        },
+                                        "runAsGroup": {
+                                          "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                          "format": "int64",
+                                          "type": "integer"
+                                        },
+                                        "runAsNonRoot": {
+                                          "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                          "type": "boolean"
+                                        },
+                                        "runAsUser": {
+                                          "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                          "format": "int64",
+                                          "type": "integer"
+                                        },
+                                        "seLinuxOptions": {
+                                          "description": "SELinuxOptions are the labels to be applied to the container",
+                                          "properties": {
+                                            "level": {
+                                              "description": "Level is SELinux level label that applies to the container.",
+                                              "type": "string"
+                                            },
+                                            "role": {
+                                              "description": "Role is a SELinux role label that applies to the container.",
+                                              "type": "string"
+                                            },
+                                            "type": {
+                                              "description": "Type is a SELinux type label that applies to the container.",
+                                              "type": "string"
+                                            },
+                                            "user": {
+                                              "description": "User is a SELinux user label that applies to the container.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "stdin": {
+                                      "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
+                                      "type": "boolean"
+                                    },
+                                    "stdinOnce": {
+                                      "description": "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false",
+                                      "type": "boolean"
+                                    },
+                                    "terminationMessagePath": {
+                                      "description": "Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.",
+                                      "type": "string"
+                                    },
+                                    "terminationMessagePolicy": {
+                                      "description": "Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.",
+                                      "type": "string"
+                                    },
+                                    "tty": {
+                                      "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.",
+                                      "type": "boolean"
+                                    },
+                                    "volumeDevices": {
+                                      "description": "volumeDevices is the list of block devices to be used by the container. This is a beta feature.",
+                                      "items": {
+                                        "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                                        "properties": {
+                                          "devicePath": {
+                                            "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "name must match the name of a persistentVolumeClaim in the pod",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "devicePath"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-patch-merge-key": "devicePath",
+                                      "x-kubernetes-patch-strategy": "merge"
+                                    },
+                                    "volumeMounts": {
+                                      "description": "Pod volumes to mount into the container's filesystem. Cannot be updated.",
+                                      "items": {
+                                        "description": "VolumeMount describes a mounting of a Volume within a container.",
+                                        "properties": {
+                                          "mountPath": {
+                                            "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                                            "type": "string"
+                                          },
+                                          "mountPropagation": {
+                                            "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "This must match the Name of a Volume.",
+                                            "type": "string"
+                                          },
+                                          "readOnly": {
+                                            "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+                                            "type": "boolean"
+                                          },
+                                          "subPath": {
+                                            "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+                                            "type": "string"
+                                          },
+                                          "subPathExpr": {
+                                            "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive. This field is alpha in 1.14.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "mountPath"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-patch-merge-key": "mountPath",
+                                      "x-kubernetes-patch-strategy": "merge"
+                                    },
+                                    "workingDir": {
+                                      "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array",
+                                "x-kubernetes-patch-merge-key": "name",
+                                "x-kubernetes-patch-strategy": "merge"
+                              },
+                              "dnsConfig": {
+                                "description": "PodDNSConfig defines the DNS parameters of a pod in addition to those generated from DNSPolicy.",
+                                "properties": {
+                                  "nameservers": {
+                                    "description": "A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "options": {
+                                    "description": "A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.",
+                                    "items": {
+                                      "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
+                                      "properties": {
+                                        "name": {
+                                          "description": "Required.",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "searches": {
+                                    "description": "A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "dnsPolicy": {
+                                "description": "Set DNS policy for the pod. Defaults to \"ClusterFirst\". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.",
+                                "type": "string"
+                              },
+                              "enableServiceLinks": {
+                                "description": "EnableServiceLinks indicates whether information about services should be injected into pod's environment variables, matching the syntax of Docker links. Optional: Defaults to true.",
+                                "type": "boolean"
+                              },
+                              "hostAliases": {
+                                "description": "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.",
+                                "items": {
+                                  "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.",
+                                  "properties": {
+                                    "hostnames": {
+                                      "description": "Hostnames for the above IP address.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "ip": {
+                                      "description": "IP address of the host file entry.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array",
+                                "x-kubernetes-patch-merge-key": "ip",
+                                "x-kubernetes-patch-strategy": "merge"
+                              },
+                              "hostIPC": {
+                                "description": "Use the host's ipc namespace. Optional: Default to false.",
+                                "type": "boolean"
+                              },
+                              "hostNetwork": {
+                                "description": "Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.",
+                                "type": "boolean"
+                              },
+                              "hostPID": {
+                                "description": "Use the host's pid namespace. Optional: Default to false.",
+                                "type": "boolean"
+                              },
+                              "hostname": {
+                                "description": "Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.",
+                                "type": "string"
+                              },
+                              "imagePullSecrets": {
+                                "description": "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod",
+                                "items": {
+                                  "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array",
+                                "x-kubernetes-patch-merge-key": "name",
+                                "x-kubernetes-patch-strategy": "merge"
+                              },
+                              "initContainers": {
+                                "description": "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, or Liveness probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/",
+                                "items": {
+                                  "description": "A single application container that you want to run within a pod.",
+                                  "properties": {
+                                    "args": {
+                                      "description": "Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "command": {
+                                      "description": "Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "env": {
+                                      "description": "List of environment variables to set in the container. Cannot be updated.",
+                                      "items": {
+                                        "description": "EnvVar represents an environment variable present in a Container.",
+                                        "properties": {
+                                          "name": {
+                                            "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "description": "Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                            "type": "string"
+                                          },
+                                          "valueFrom": {
+                                            "description": "EnvVarSource represents a source for the value of an EnvVar.",
+                                            "properties": {
+                                              "configMapKeyRef": {
+                                                "description": "Selects a key from a ConfigMap.",
+                                                "properties": {
+                                                  "key": {
+                                                    "description": "The key to select.",
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "description": "Specify whether the ConfigMap or it's key must be defined",
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object"
+                                              },
+                                              "fieldRef": {
+                                                "description": "ObjectFieldSelector selects an APIVersioned field of an object.",
+                                                "properties": {
+                                                  "apiVersion": {
+                                                    "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                    "type": "string"
+                                                  },
+                                                  "fieldPath": {
+                                                    "description": "Path of the field to select in the specified API version.",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "fieldPath"
+                                                ],
+                                                "type": "object"
+                                              },
+                                              "resourceFieldRef": {
+                                                "description": "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
+                                                "properties": {
+                                                  "containerName": {
+                                                    "description": "Container name: required for volumes, optional for env vars",
+                                                    "type": "string"
+                                                  },
+                                                  "divisor": {
+                                                    "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and Int64() accessors.\n\nThe serialization format is:\n\n<quantity>        ::= <signedNumber><suffix>\n  (Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber>\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n  a. No precision is lost\n  b. No fractional digits will be emitted\n  c. The exponent (or suffix) is as large as possible.\nThe sign will be omitted unless the number is negative.\n\nExamples:\n  1.5 will be serialized as \"1500m\"\n  1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+                                                    "type": "string"
+                                                  },
+                                                  "resource": {
+                                                    "description": "Required: resource to select",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "resource"
+                                                ],
+                                                "type": "object"
+                                              },
+                                              "secretKeyRef": {
+                                                "description": "SecretKeySelector selects a key of a Secret.",
+                                                "properties": {
+                                                  "key": {
+                                                    "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "description": "Specify whether the Secret or it's key must be defined",
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key"
+                                                ],
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-patch-merge-key": "name",
+                                      "x-kubernetes-patch-strategy": "merge"
+                                    },
+                                    "envFrom": {
+                                      "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
+                                      "items": {
+                                        "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                                        "properties": {
+                                          "configMapRef": {
+                                            "description": "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.",
+                                            "properties": {
+                                              "name": {
+                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "description": "Specify whether the ConfigMap must be defined",
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "prefix": {
+                                            "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                                            "type": "string"
+                                          },
+                                          "secretRef": {
+                                            "description": "SecretEnvSource selects a Secret to populate the environment variables with.\n\nThe contents of the target Secret's Data field will represent the key-value pairs as environment variables.",
+                                            "properties": {
+                                              "name": {
+                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "description": "Specify whether the Secret must be defined",
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "image": {
+                                      "description": "Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.",
+                                      "type": "string"
+                                    },
+                                    "imagePullPolicy": {
+                                      "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                                      "type": "string"
+                                    },
+                                    "lifecycle": {
+                                      "description": "Lifecycle describes actions that the management system should take in response to container lifecycle events. For the PostStart and PreStop lifecycle handlers, management of the container blocks until the action is complete, unless the container process fails, in which case the handler is aborted.",
+                                      "properties": {
+                                        "postStart": {
+                                          "description": "Handler defines a specific action that should be taken",
+                                          "properties": {
+                                            "exec": {
+                                              "description": "ExecAction describes a \"run in container\" action.",
+                                              "properties": {
+                                                "command": {
+                                                  "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "httpGet": {
+                                              "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                                              "properties": {
+                                                "host": {
+                                                  "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                                  "type": "string"
+                                                },
+                                                "httpHeaders": {
+                                                  "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                                  "items": {
+                                                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                    "properties": {
+                                                      "name": {
+                                                        "description": "The header field name",
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "description": "The header field value",
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "type": "object"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "path": {
+                                                  "description": "Path to access on the HTTP server.",
+                                                  "type": "string"
+                                                },
+                                                "port": {
+                                                  "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                                  "format": "int-or-string",
+                                                  "type": "string"
+                                                },
+                                                "scheme": {
+                                                  "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "port"
+                                              ],
+                                              "type": "object"
+                                            },
+                                            "tcpSocket": {
+                                              "description": "TCPSocketAction describes an action based on opening a socket",
+                                              "properties": {
+                                                "host": {
+                                                  "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                                  "type": "string"
+                                                },
+                                                "port": {
+                                                  "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                                  "format": "int-or-string",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "port"
+                                              ],
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "preStop": {
+                                          "description": "Handler defines a specific action that should be taken",
+                                          "properties": {
+                                            "exec": {
+                                              "description": "ExecAction describes a \"run in container\" action.",
+                                              "properties": {
+                                                "command": {
+                                                  "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "httpGet": {
+                                              "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                                              "properties": {
+                                                "host": {
+                                                  "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                                  "type": "string"
+                                                },
+                                                "httpHeaders": {
+                                                  "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                                  "items": {
+                                                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                    "properties": {
+                                                      "name": {
+                                                        "description": "The header field name",
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "description": "The header field value",
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "type": "object"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "path": {
+                                                  "description": "Path to access on the HTTP server.",
+                                                  "type": "string"
+                                                },
+                                                "port": {
+                                                  "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                                  "format": "int-or-string",
+                                                  "type": "string"
+                                                },
+                                                "scheme": {
+                                                  "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "port"
+                                              ],
+                                              "type": "object"
+                                            },
+                                            "tcpSocket": {
+                                              "description": "TCPSocketAction describes an action based on opening a socket",
+                                              "properties": {
+                                                "host": {
+                                                  "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                                  "type": "string"
+                                                },
+                                                "port": {
+                                                  "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                                  "format": "int-or-string",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "port"
+                                              ],
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "livenessProbe": {
+                                      "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
+                                      "properties": {
+                                        "exec": {
+                                          "description": "ExecAction describes a \"run in container\" action.",
+                                          "properties": {
+                                            "command": {
+                                              "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "failureThreshold": {
+                                          "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "httpGet": {
+                                          "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                                          "properties": {
+                                            "host": {
+                                              "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                              "type": "string"
+                                            },
+                                            "httpHeaders": {
+                                              "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                              "items": {
+                                                "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                "properties": {
+                                                  "name": {
+                                                    "description": "The header field name",
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "description": "The header field value",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name",
+                                                  "value"
+                                                ],
+                                                "type": "object"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "path": {
+                                              "description": "Path to access on the HTTP server.",
+                                              "type": "string"
+                                            },
+                                            "port": {
+                                              "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                              "format": "int-or-string",
+                                              "type": "string"
+                                            },
+                                            "scheme": {
+                                              "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "port"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "initialDelaySeconds": {
+                                          "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "periodSeconds": {
+                                          "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "successThreshold": {
+                                          "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.",
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "tcpSocket": {
+                                          "description": "TCPSocketAction describes an action based on opening a socket",
+                                          "properties": {
+                                            "host": {
+                                              "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                              "type": "string"
+                                            },
+                                            "port": {
+                                              "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                              "format": "int-or-string",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "port"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "timeoutSeconds": {
+                                          "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                          "format": "int32",
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "name": {
+                                      "description": "Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.",
+                                      "type": "string"
+                                    },
+                                    "ports": {
+                                      "description": "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.",
+                                      "items": {
+                                        "description": "ContainerPort represents a network port in a single container.",
+                                        "properties": {
+                                          "containerPort": {
+                                            "description": "Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.",
+                                            "format": "int32",
+                                            "type": "integer"
+                                          },
+                                          "hostIP": {
+                                            "description": "What host IP to bind the external port to.",
+                                            "type": "string"
+                                          },
+                                          "hostPort": {
+                                            "description": "Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
+                                            "format": "int32",
+                                            "type": "integer"
+                                          },
+                                          "name": {
+                                            "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
+                                            "type": "string"
+                                          },
+                                          "protocol": {
+                                            "description": "Protocol for port. Must be UDP, TCP, or SCTP. Defaults to \"TCP\".",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "containerPort"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-map-keys": [
+                                        "containerPort",
+                                        "protocol"
+                                      ],
+                                      "x-kubernetes-list-type": "map",
+                                      "x-kubernetes-patch-merge-key": "containerPort",
+                                      "x-kubernetes-patch-strategy": "merge"
+                                    },
+                                    "readinessProbe": {
+                                      "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
+                                      "properties": {
+                                        "exec": {
+                                          "description": "ExecAction describes a \"run in container\" action.",
+                                          "properties": {
+                                            "command": {
+                                              "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "failureThreshold": {
+                                          "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "httpGet": {
+                                          "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                                          "properties": {
+                                            "host": {
+                                              "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                              "type": "string"
+                                            },
+                                            "httpHeaders": {
+                                              "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                              "items": {
+                                                "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                "properties": {
+                                                  "name": {
+                                                    "description": "The header field name",
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "description": "The header field value",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name",
+                                                  "value"
+                                                ],
+                                                "type": "object"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "path": {
+                                              "description": "Path to access on the HTTP server.",
+                                              "type": "string"
+                                            },
+                                            "port": {
+                                              "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                              "format": "int-or-string",
+                                              "type": "string"
+                                            },
+                                            "scheme": {
+                                              "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "port"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "initialDelaySeconds": {
+                                          "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "periodSeconds": {
+                                          "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "successThreshold": {
+                                          "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.",
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "tcpSocket": {
+                                          "description": "TCPSocketAction describes an action based on opening a socket",
+                                          "properties": {
+                                            "host": {
+                                              "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                              "type": "string"
+                                            },
+                                            "port": {
+                                              "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                              "format": "int-or-string",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "port"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "timeoutSeconds": {
+                                          "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                          "format": "int32",
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "resources": {
+                                      "description": "ResourceRequirements describes the compute resource requirements.",
+                                      "properties": {
+                                        "limits": {
+                                          "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                                          "type": "object"
+                                        },
+                                        "requests": {
+                                          "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "securityContext": {
+                                      "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
+                                      "properties": {
+                                        "allowPrivilegeEscalation": {
+                                          "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN",
+                                          "type": "boolean"
+                                        },
+                                        "capabilities": {
+                                          "description": "Adds and removes POSIX capabilities from running containers.",
+                                          "properties": {
+                                            "add": {
+                                              "description": "Added capabilities",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "drop": {
+                                              "description": "Removed capabilities",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "privileged": {
+                                          "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.",
+                                          "type": "boolean"
+                                        },
+                                        "procMount": {
+                                          "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.",
+                                          "type": "string"
+                                        },
+                                        "readOnlyRootFilesystem": {
+                                          "description": "Whether this container has a read-only root filesystem. Default is false.",
+                                          "type": "boolean"
+                                        },
+                                        "runAsGroup": {
+                                          "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                          "format": "int64",
+                                          "type": "integer"
+                                        },
+                                        "runAsNonRoot": {
+                                          "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                          "type": "boolean"
+                                        },
+                                        "runAsUser": {
+                                          "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                          "format": "int64",
+                                          "type": "integer"
+                                        },
+                                        "seLinuxOptions": {
+                                          "description": "SELinuxOptions are the labels to be applied to the container",
+                                          "properties": {
+                                            "level": {
+                                              "description": "Level is SELinux level label that applies to the container.",
+                                              "type": "string"
+                                            },
+                                            "role": {
+                                              "description": "Role is a SELinux role label that applies to the container.",
+                                              "type": "string"
+                                            },
+                                            "type": {
+                                              "description": "Type is a SELinux type label that applies to the container.",
+                                              "type": "string"
+                                            },
+                                            "user": {
+                                              "description": "User is a SELinux user label that applies to the container.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "stdin": {
+                                      "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
+                                      "type": "boolean"
+                                    },
+                                    "stdinOnce": {
+                                      "description": "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false",
+                                      "type": "boolean"
+                                    },
+                                    "terminationMessagePath": {
+                                      "description": "Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.",
+                                      "type": "string"
+                                    },
+                                    "terminationMessagePolicy": {
+                                      "description": "Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.",
+                                      "type": "string"
+                                    },
+                                    "tty": {
+                                      "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.",
+                                      "type": "boolean"
+                                    },
+                                    "volumeDevices": {
+                                      "description": "volumeDevices is the list of block devices to be used by the container. This is a beta feature.",
+                                      "items": {
+                                        "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                                        "properties": {
+                                          "devicePath": {
+                                            "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "name must match the name of a persistentVolumeClaim in the pod",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "devicePath"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-patch-merge-key": "devicePath",
+                                      "x-kubernetes-patch-strategy": "merge"
+                                    },
+                                    "volumeMounts": {
+                                      "description": "Pod volumes to mount into the container's filesystem. Cannot be updated.",
+                                      "items": {
+                                        "description": "VolumeMount describes a mounting of a Volume within a container.",
+                                        "properties": {
+                                          "mountPath": {
+                                            "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                                            "type": "string"
+                                          },
+                                          "mountPropagation": {
+                                            "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "This must match the Name of a Volume.",
+                                            "type": "string"
+                                          },
+                                          "readOnly": {
+                                            "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+                                            "type": "boolean"
+                                          },
+                                          "subPath": {
+                                            "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+                                            "type": "string"
+                                          },
+                                          "subPathExpr": {
+                                            "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive. This field is alpha in 1.14.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "mountPath"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-patch-merge-key": "mountPath",
+                                      "x-kubernetes-patch-strategy": "merge"
+                                    },
+                                    "workingDir": {
+                                      "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array",
+                                "x-kubernetes-patch-merge-key": "name",
+                                "x-kubernetes-patch-strategy": "merge"
+                              },
+                              "nodeName": {
+                                "description": "NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.",
+                                "type": "string"
+                              },
+                              "nodeSelector": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
+                                "type": "object"
+                              },
+                              "priority": {
+                                "description": "The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "priorityClassName": {
+                                "description": "If specified, indicates the pod's priority. \"system-node-critical\" and \"system-cluster-critical\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.",
+                                "type": "string"
+                              },
+                              "readinessGates": {
+                                "description": "If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to \"True\" More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md",
+                                "items": {
+                                  "description": "PodReadinessGate contains the reference to a pod condition",
+                                  "properties": {
+                                    "conditionType": {
+                                      "description": "ConditionType refers to a condition in the pod's condition list with matching type.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "conditionType"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "restartPolicy": {
+                                "description": "Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy",
+                                "type": "string"
+                              },
+                              "runtimeClassName": {
+                                "description": "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the \"legacy\" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md This is an alpha feature and may change in the future.",
+                                "type": "string"
+                              },
+                              "schedulerName": {
+                                "description": "If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.",
+                                "type": "string"
+                              },
+                              "securityContext": {
+                                "description": "PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.",
+                                "properties": {
+                                  "fsGroup": {
+                                    "description": "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:\n\n1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----\n\nIf unset, the Kubelet will not modify the ownership and permissions of any volume.",
+                                    "format": "int64",
+                                    "type": "integer"
+                                  },
+                                  "runAsGroup": {
+                                    "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.",
+                                    "format": "int64",
+                                    "type": "integer"
+                                  },
+                                  "runAsNonRoot": {
+                                    "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                    "type": "boolean"
+                                  },
+                                  "runAsUser": {
+                                    "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.",
+                                    "format": "int64",
+                                    "type": "integer"
+                                  },
+                                  "seLinuxOptions": {
+                                    "description": "SELinuxOptions are the labels to be applied to the container",
+                                    "properties": {
+                                      "level": {
+                                        "description": "Level is SELinux level label that applies to the container.",
+                                        "type": "string"
+                                      },
+                                      "role": {
+                                        "description": "Role is a SELinux role label that applies to the container.",
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "description": "Type is a SELinux type label that applies to the container.",
+                                        "type": "string"
+                                      },
+                                      "user": {
+                                        "description": "User is a SELinux user label that applies to the container.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "supplementalGroups": {
+                                    "description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container.",
+                                    "items": {
+                                      "format": "int64",
+                                      "type": "integer"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "sysctls": {
+                                    "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch.",
+                                    "items": {
+                                      "description": "Sysctl defines a kernel parameter to be set",
+                                      "properties": {
+                                        "name": {
+                                          "description": "Name of a property to set",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "Value of a property to set",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "serviceAccount": {
+                                "description": "DeprecatedServiceAccount is a depreciated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead.",
+                                "type": "string"
+                              },
+                              "serviceAccountName": {
+                                "description": "ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/",
+                                "type": "string"
+                              },
+                              "shareProcessNamespace": {
+                                "description": "Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Default to false. This field is beta-level and may be disabled with the PodShareProcessNamespace feature.",
+                                "type": "boolean"
+                              },
+                              "subdomain": {
+                                "description": "If specified, the fully qualified Pod hostname will be \"<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>\". If not specified, the pod will not have a domainname at all.",
+                                "type": "string"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "description": "Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds.",
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "tolerations": {
+                                "description": "If specified, the pod's tolerations.",
+                                "items": {
+                                  "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+                                  "properties": {
+                                    "effect": {
+                                      "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                                      "type": "string"
+                                    },
+                                    "key": {
+                                      "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                                      "type": "string"
+                                    },
+                                    "tolerationSeconds": {
+                                      "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                                      "format": "int64",
+                                      "type": "integer"
+                                    },
+                                    "value": {
+                                      "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "volumes": {
+                                "description": "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes",
+                                "items": {
+                                  "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+                                  "properties": {
+                                    "awsElasticBlockStore": {
+                                      "description": "Represents a Persistent Disk resource in AWS.\n\nAn AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership management and SELinux relabeling.",
+                                      "properties": {
+                                        "fsType": {
+                                          "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                                          "type": "string"
+                                        },
+                                        "partition": {
+                                          "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "readOnly": {
+                                          "description": "Specify \"true\" to force and set the ReadOnly property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                                          "type": "boolean"
+                                        },
+                                        "volumeID": {
+                                          "description": "Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "volumeID"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "azureDisk": {
+                                      "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
+                                      "properties": {
+                                        "cachingMode": {
+                                          "description": "Host Caching mode: None, Read Only, Read Write.",
+                                          "type": "string"
+                                        },
+                                        "diskName": {
+                                          "description": "The Name of the data disk in the blob storage",
+                                          "type": "string"
+                                        },
+                                        "diskURI": {
+                                          "description": "The URI the data disk in the blob storage",
+                                          "type": "string"
+                                        },
+                                        "fsType": {
+                                          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                          "type": "string"
+                                        },
+                                        "kind": {
+                                          "description": "Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "diskName",
+                                        "diskURI"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "azureFile": {
+                                      "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
+                                      "properties": {
+                                        "readOnly": {
+                                          "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                          "type": "boolean"
+                                        },
+                                        "secretName": {
+                                          "description": "the name of secret that contains Azure Storage Account Name and Key",
+                                          "type": "string"
+                                        },
+                                        "shareName": {
+                                          "description": "Share Name",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "secretName",
+                                        "shareName"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "cephfs": {
+                                      "description": "Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.",
+                                      "properties": {
+                                        "monitors": {
+                                          "description": "Required: Monitors is a collection of Ceph monitors More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "path": {
+                                          "description": "Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
+                                          "type": "boolean"
+                                        },
+                                        "secretFile": {
+                                          "description": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
+                                          "type": "string"
+                                        },
+                                        "secretRef": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "user": {
+                                          "description": "Optional: User is the rados user name, default is admin More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "monitors"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "cinder": {
+                                      "description": "Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.",
+                                      "properties": {
+                                        "fsType": {
+                                          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md",
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md",
+                                          "type": "boolean"
+                                        },
+                                        "secretRef": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "volumeID": {
+                                          "description": "volume id used to identify the volume in cinder More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "volumeID"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "csi": {
+                                      "description": "Represents a source location of a volume to mount, managed by an external CSI driver",
+                                      "properties": {
+                                        "driver": {
+                                          "description": "Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
+                                          "type": "string"
+                                        },
+                                        "fsType": {
+                                          "description": "Filesystem type to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
+                                          "type": "string"
+                                        },
+                                        "nodePublishSecretRef": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "readOnly": {
+                                          "description": "Specifies a read-only configuration for the volume. Defaults to false (read/write).",
+                                          "type": "boolean"
+                                        },
+                                        "volumeAttributes": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "description": "VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
+                                          "type": "object"
+                                        }
+                                      },
+                                      "required": [
+                                        "driver"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "emptyDir": {
+                                      "description": "Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux relabeling.",
+                                      "properties": {
+                                        "medium": {
+                                          "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                                          "type": "string"
+                                        },
+                                        "sizeLimit": {
+                                          "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and Int64() accessors.\n\nThe serialization format is:\n\n<quantity>        ::= <signedNumber><suffix>\n  (Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber>\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n  a. No precision is lost\n  b. No fractional digits will be emitted\n  c. The exponent (or suffix) is as large as possible.\nThe sign will be omitted unless the number is negative.\n\nExamples:\n  1.5 will be serialized as \"1500m\"\n  1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "fc": {
+                                      "description": "Represents a Fibre Channel volume. Fibre Channel volumes can only be mounted as read/write once. Fibre Channel volumes support ownership management and SELinux relabeling.",
+                                      "properties": {
+                                        "fsType": {
+                                          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                          "type": "string"
+                                        },
+                                        "lun": {
+                                          "description": "Optional: FC target lun number",
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "readOnly": {
+                                          "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                          "type": "boolean"
+                                        },
+                                        "targetWWNs": {
+                                          "description": "Optional: FC target worldwide names (WWNs)",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "wwids": {
+                                          "description": "Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "flexVolume": {
+                                      "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.",
+                                      "properties": {
+                                        "driver": {
+                                          "description": "Driver is the name of the driver to use for this volume.",
+                                          "type": "string"
+                                        },
+                                        "fsType": {
+                                          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+                                          "type": "string"
+                                        },
+                                        "options": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "description": "Optional: Extra command options if any.",
+                                          "type": "object"
+                                        },
+                                        "readOnly": {
+                                          "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                          "type": "boolean"
+                                        },
+                                        "secretRef": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "required": [
+                                        "driver"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "flocker": {
+                                      "description": "Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID should be set. Flocker volumes do not support ownership management or SELinux relabeling.",
+                                      "properties": {
+                                        "datasetName": {
+                                          "description": "Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
+                                          "type": "string"
+                                        },
+                                        "datasetUUID": {
+                                          "description": "UUID of the dataset. This is unique identifier of a Flocker dataset",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "gcePersistentDisk": {
+                                      "description": "Represents a Persistent Disk resource in Google Compute Engine.\n\nA GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.",
+                                      "properties": {
+                                        "fsType": {
+                                          "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                          "type": "string"
+                                        },
+                                        "partition": {
+                                          "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "pdName": {
+                                          "description": "Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "pdName"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "gitRepo": {
+                                      "description": "Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.\n\nDEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
+                                      "properties": {
+                                        "directory": {
+                                          "description": "Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
+                                          "type": "string"
+                                        },
+                                        "repository": {
+                                          "description": "Repository URL",
+                                          "type": "string"
+                                        },
+                                        "revision": {
+                                          "description": "Commit hash for the specified revision.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "repository"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "glusterfs": {
+                                      "description": "Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.",
+                                      "properties": {
+                                        "endpoints": {
+                                          "description": "EndpointsName is the endpoint name that details Glusterfs topology. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod",
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "description": "Path is the Glusterfs volume path. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod",
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "description": "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod",
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "endpoints",
+                                        "path"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "hostPath": {
+                                      "description": "Represents a host path mapped into a pod. Host path volumes do not support ownership management or SELinux relabeling.",
+                                      "properties": {
+                                        "path": {
+                                          "description": "Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                                          "type": "string"
+                                        },
+                                        "type": {
+                                          "description": "Type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "path"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "iscsi": {
+                                      "description": "Represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.",
+                                      "properties": {
+                                        "chapAuthDiscovery": {
+                                          "description": "whether support iSCSI Discovery CHAP authentication",
+                                          "type": "boolean"
+                                        },
+                                        "chapAuthSession": {
+                                          "description": "whether support iSCSI Session CHAP authentication",
+                                          "type": "boolean"
+                                        },
+                                        "fsType": {
+                                          "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
+                                          "type": "string"
+                                        },
+                                        "initiatorName": {
+                                          "description": "Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
+                                          "type": "string"
+                                        },
+                                        "iqn": {
+                                          "description": "Target iSCSI Qualified Name.",
+                                          "type": "string"
+                                        },
+                                        "iscsiInterface": {
+                                          "description": "iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
+                                          "type": "string"
+                                        },
+                                        "lun": {
+                                          "description": "iSCSI Target Lun number.",
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "portals": {
+                                          "description": "iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "readOnly": {
+                                          "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
+                                          "type": "boolean"
+                                        },
+                                        "secretRef": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "targetPortal": {
+                                          "description": "iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "targetPortal",
+                                        "iqn",
+                                        "lun"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "name": {
+                                      "description": "Volume's name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                      "type": "string"
+                                    },
+                                    "nfs": {
+                                      "description": "Represents an NFS mount that lasts the lifetime of a pod. NFS volumes do not support ownership management or SELinux relabeling.",
+                                      "properties": {
+                                        "path": {
+                                          "description": "Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "description": "ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                                          "type": "boolean"
+                                        },
+                                        "server": {
+                                          "description": "Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "server",
+                                        "path"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "persistentVolumeClaim": {
+                                      "description": "PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a wrapper around another type of volume that is owned by someone else (the system).",
+                                      "properties": {
+                                        "claimName": {
+                                          "description": "ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "description": "Will force the ReadOnly setting in VolumeMounts. Default false.",
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "claimName"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "photonPersistentDisk": {
+                                      "description": "Represents a Photon Controller persistent disk resource.",
+                                      "properties": {
+                                        "fsType": {
+                                          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                          "type": "string"
+                                        },
+                                        "pdID": {
+                                          "description": "ID that identifies Photon Controller persistent disk",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "pdID"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "portworxVolume": {
+                                      "description": "PortworxVolumeSource represents a Portworx volume resource.",
+                                      "properties": {
+                                        "fsType": {
+                                          "description": "FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                          "type": "boolean"
+                                        },
+                                        "volumeID": {
+                                          "description": "VolumeID uniquely identifies a Portworx volume",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "volumeID"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "projected": {
+                                      "description": "Represents a projected volume source",
+                                      "properties": {
+                                        "defaultMode": {
+                                          "description": "Mode bits to use on created files by default. Must be a value between 0 and 0777. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "sources": {
+                                          "description": "list of volume projections",
+                                          "items": {
+                                            "description": "Projection that may be projected along with other supported volume types",
+                                            "properties": {
+                                              "serviceAccountToken": {
+                                                "description": "ServiceAccountTokenProjection represents a projected service account token volume. This projection can be used to insert a service account token into the pods runtime filesystem for use against APIs (Kubernetes API Server or otherwise).",
+                                                "properties": {
+                                                  "audience": {
+                                                    "description": "Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
+                                                    "type": "string"
+                                                  },
+                                                  "expirationSeconds": {
+                                                    "description": "ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
+                                                    "format": "int64",
+                                                    "type": "integer"
+                                                  },
+                                                  "path": {
+                                                    "description": "Path is the path relative to the mount point of the file to project the token into.",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "path"
+                                                ],
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "sources"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "quobyte": {
+                                      "description": "Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership management or SELinux relabeling.",
+                                      "properties": {
+                                        "group": {
+                                          "description": "Group to map volume access to Default is no group",
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "description": "ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
+                                          "type": "boolean"
+                                        },
+                                        "registry": {
+                                          "description": "Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
+                                          "type": "string"
+                                        },
+                                        "tenant": {
+                                          "description": "Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
+                                          "type": "string"
+                                        },
+                                        "user": {
+                                          "description": "User to map volume access to Defaults to serivceaccount user",
+                                          "type": "string"
+                                        },
+                                        "volume": {
+                                          "description": "Volume is a string that references an already created Quobyte volume by name.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "registry",
+                                        "volume"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "rbd": {
+                                      "description": "Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.",
+                                      "properties": {
+                                        "fsType": {
+                                          "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
+                                          "type": "string"
+                                        },
+                                        "image": {
+                                          "description": "The rados image name. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
+                                          "type": "string"
+                                        },
+                                        "keyring": {
+                                          "description": "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
+                                          "type": "string"
+                                        },
+                                        "monitors": {
+                                          "description": "A collection of Ceph monitors. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "pool": {
+                                          "description": "The rados pool name. Default is rbd. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
+                                          "type": "boolean"
+                                        },
+                                        "secretRef": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "user": {
+                                          "description": "The rados user name. Default is admin. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "monitors",
+                                        "image"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "scaleIO": {
+                                      "description": "ScaleIOVolumeSource represents a persistent ScaleIO volume",
+                                      "properties": {
+                                        "fsType": {
+                                          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
+                                          "type": "string"
+                                        },
+                                        "gateway": {
+                                          "description": "The host address of the ScaleIO API Gateway.",
+                                          "type": "string"
+                                        },
+                                        "protectionDomain": {
+                                          "description": "The name of the ScaleIO Protection Domain for the configured storage.",
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                          "type": "boolean"
+                                        },
+                                        "secretRef": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "sslEnabled": {
+                                          "description": "Flag to enable/disable SSL communication with Gateway, default false",
+                                          "type": "boolean"
+                                        },
+                                        "storageMode": {
+                                          "description": "Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
+                                          "type": "string"
+                                        },
+                                        "storagePool": {
+                                          "description": "The ScaleIO Storage Pool associated with the protection domain.",
+                                          "type": "string"
+                                        },
+                                        "system": {
+                                          "description": "The name of the storage system as configured in ScaleIO.",
+                                          "type": "string"
+                                        },
+                                        "volumeName": {
+                                          "description": "The name of a volume already created in the ScaleIO system that is associated with this volume source.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "gateway",
+                                        "system",
+                                        "secretRef"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "storageos": {
+                                      "description": "Represents a StorageOS persistent volume resource.",
+                                      "properties": {
+                                        "fsType": {
+                                          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                          "type": "boolean"
+                                        },
+                                        "secretRef": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "volumeName": {
+                                          "description": "VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
+                                          "type": "string"
+                                        },
+                                        "volumeNamespace": {
+                                          "description": "VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "vsphereVolume": {
+                                      "description": "Represents a vSphere volume resource.",
+                                      "properties": {
+                                        "fsType": {
+                                          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                          "type": "string"
+                                        },
+                                        "storagePolicyID": {
+                                          "description": "Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+                                          "type": "string"
+                                        },
+                                        "storagePolicyName": {
+                                          "description": "Storage Policy Based Management (SPBM) profile name.",
+                                          "type": "string"
+                                        },
+                                        "volumePath": {
+                                          "description": "Path that identifies vSphere volume vmdk",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "volumePath"
+                                      ],
+                                      "type": "object"
+                                    }
+                                  },
+                                  "required": [
+                                    "name"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array",
+                                "x-kubernetes-patch-merge-key": "name",
+                                "x-kubernetes-patch-strategy": "merge,retainKeys"
+                              }
+                            },
+                            "required": [
+                              "containers"
+                            ],
+                            "type": "object"
+                          },
+                          "hpaSpec": {
+                            "description": "Horizontal Pod Autoscaler Spec",
+                            "type": "object",
+                            "properties": {
+                              "maxReplicas": {
+                                "description": "maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up. It cannot be less that minReplicas.",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "minReplicas": {
+                                "description": "minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down. It defaults to 1 pod.",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "metrics": {
+                                "description": "List of HPA Specs",
+                                "type": "array",
+                                "items": {
+                                  "description": "MetricSpec specifies how to scale based on a single metric (only `type` and one other matching field should be set at once).",
+                                  "properties": {
+                                    "external": {
+                                      "description": "ExternalMetricSource indicates how to scale on a metric not associated with any Kubernetes object (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster). Exactly one \"target\" type should be set.",
+                                      "properties": {
+                                        "metricName": {
+                                          "description": "metricName is the name of the metric in question.",
+                                          "type": "string"
+                                        },
+                                        "metricSelector": {
+                                          "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                          "properties": {
+                                            "matchExpressions": {
+                                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                              "items": {
+                                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                "properties": {
+                                                  "key": {
+                                                    "description": "key is the label key that the selector applies to.",
+                                                    "type": "string",
+                                                    "x-kubernetes-patch-merge-key": "key",
+                                                    "x-kubernetes-patch-strategy": "merge"
+                                                  },
+                                                  "operator": {
+                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                    "type": "string"
+                                                  },
+                                                  "values": {
+                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key",
+                                                  "operator"
+                                                ],
+                                                "type": "object"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "matchLabels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "targetAverageValue": {
+                                          "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and Int64() accessors.\n\nThe serialization format is:\n\n<quantity>        ::= <signedNumber><suffix>\n  (Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber>\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n  a. No precision is lost\n  b. No fractional digits will be emitted\n  c. The exponent (or suffix) is as large as possible.\nThe sign will be omitted unless the number is negative.\n\nExamples:\n  1.5 will be serialized as \"1500m\"\n  1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+                                          "type": "string"
+                                        },
+                                        "targetValue": {
+                                          "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and Int64() accessors.\n\nThe serialization format is:\n\n<quantity>        ::= <signedNumber><suffix>\n  (Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber>\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n  a. No precision is lost\n  b. No fractional digits will be emitted\n  c. The exponent (or suffix) is as large as possible.\nThe sign will be omitted unless the number is negative.\n\nExamples:\n  1.5 will be serialized as \"1500m\"\n  1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "metricName"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "object": {
+                                      "description": "ObjectMetricSource indicates how to scale on a metric describing a kubernetes object (for example, hits-per-second on an Ingress object).",
+                                      "properties": {
+                                        "averageValue": {
+                                          "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and Int64() accessors.\n\nThe serialization format is:\n\n<quantity>        ::= <signedNumber><suffix>\n  (Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber>\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n  a. No precision is lost\n  b. No fractional digits will be emitted\n  c. The exponent (or suffix) is as large as possible.\nThe sign will be omitted unless the number is negative.\n\nExamples:\n  1.5 will be serialized as \"1500m\"\n  1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+                                          "type": "string"
+                                        },
+                                        "metricName": {
+                                          "description": "metricName is the name of the metric in question.",
+                                          "type": "string"
+                                        },
+                                        "selector": {
+                                          "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                          "properties": {
+                                            "matchExpressions": {
+                                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                              "items": {
+                                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                "properties": {
+                                                  "key": {
+                                                    "description": "key is the label key that the selector applies to.",
+                                                    "type": "string",
+                                                    "x-kubernetes-patch-merge-key": "key",
+                                                    "x-kubernetes-patch-strategy": "merge"
+                                                  },
+                                                  "operator": {
+                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                    "type": "string"
+                                                  },
+                                                  "values": {
+                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key",
+                                                  "operator"
+                                                ],
+                                                "type": "object"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "matchLabels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "target": {
+                                          "description": "CrossVersionObjectReference contains enough information to let you identify the referred resource.",
+                                          "properties": {
+                                            "apiVersion": {
+                                              "description": "API version of the referent",
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "description": "Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds\"",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "kind",
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "targetValue": {
+                                          "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and Int64() accessors.\n\nThe serialization format is:\n\n<quantity>        ::= <signedNumber><suffix>\n  (Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber>\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n  a. No precision is lost\n  b. No fractional digits will be emitted\n  c. The exponent (or suffix) is as large as possible.\nThe sign will be omitted unless the number is negative.\n\nExamples:\n  1.5 will be serialized as \"1500m\"\n  1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "target",
+                                        "metricName",
+                                        "targetValue"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "pods": {
+                                      "description": "PodsMetricSource indicates how to scale on a metric describing each pod in the current scale target (for example, transactions-processed-per-second). The values will be averaged together before being compared to the target value.",
+                                      "properties": {
+                                        "metricName": {
+                                          "description": "metricName is the name of the metric in question",
+                                          "type": "string"
+                                        },
+                                        "selector": {
+                                          "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                          "properties": {
+                                            "matchExpressions": {
+                                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                              "items": {
+                                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                "properties": {
+                                                  "key": {
+                                                    "description": "key is the label key that the selector applies to.",
+                                                    "type": "string",
+                                                    "x-kubernetes-patch-merge-key": "key",
+                                                    "x-kubernetes-patch-strategy": "merge"
+                                                  },
+                                                  "operator": {
+                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                    "type": "string"
+                                                  },
+                                                  "values": {
+                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "key",
+                                                  "operator"
+                                                ],
+                                                "type": "object"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "matchLabels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "targetAverageValue": {
+                                          "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and Int64() accessors.\n\nThe serialization format is:\n\n<quantity>        ::= <signedNumber><suffix>\n  (Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber>\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n  a. No precision is lost\n  b. No fractional digits will be emitted\n  c. The exponent (or suffix) is as large as possible.\nThe sign will be omitted unless the number is negative.\n\nExamples:\n  1.5 will be serialized as \"1500m\"\n  1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "metricName",
+                                        "targetAverageValue"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "resource": {
+                                      "description": "ResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.  Only one \"target\" type should be set.",
+                                      "properties": {
+                                        "name": {
+                                          "description": "name is the name of the resource in question.",
+                                          "type": "string"
+                                        },
+                                        "targetAverageUtilization": {
+                                          "description": "targetAverageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.",
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "targetAverageValue": {
+                                          "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and Int64() accessors.\n\nThe serialization format is:\n\n<quantity>        ::= <signedNumber><suffix>\n  (Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber>\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n  a. No precision is lost\n  b. No fractional digits will be emitted\n  c. The exponent (or suffix) is as large as possible.\nThe sign will be omitted unless the number is negative.\n\nExamples:\n  1.5 will be serialized as \"1500m\"\n  1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "type": {
+                                      "description": "type is the type of metric source.  It should be one of \"Object\", \"Pods\" or \"Resource\", each mapping to a matching field in the object.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "type": "object"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "replicas": {
+                      "type": "integer"
+                    },
+                    "labels": {
+                      "description": "labels to be attached to entry deplyment for this predictor",
+                      "type": "object"
+                    },
+                    "svcOrchSpec": {
+                      "description": "Configuration for the service orchestrator",
+                      "type": "object",
+                      "properties": {
+                        "resources": {
+                          "description": "ResourceRequirements describes the compute resource requirements.",
+                          "properties": {
+                            "requests": {
+                              "additionalProperties": true,
+                              "type": "object",
+                              "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/"
+                            },
+                            "limits": {
+                              "additionalProperties": true,
+                              "type": "object",
+                              "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/"
+                            }
+                          }
+                        },
+                        "env": {
+                          "items": {
+                            "required": [
+                              "name"
+                            ],
+                            "description": "EnvVar represents an environment variable present in a Container.",
+                            "properties": {
+                              "valueFrom": {
+                                "description": "EnvVarSource represents a source for the value of an EnvVar.",
+                                "properties": {
+                                  "secretKeyRef": {
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "description": "SecretKeySelector selects a key of a Secret.",
+                                    "properties": {
+                                      "optional": {
+                                        "type": "boolean",
+                                        "description": "Specify whether the Secret or it's key must be defined"
+                                      },
+                                      "name": {
+                                        "type": "string",
+                                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names"
+                                      },
+                                      "key": {
+                                        "type": "string",
+                                        "description": "The key of the secret to select from.  Must be a valid secret key."
+                                      }
+                                    }
+                                  },
+                                  "fieldRef": {
+                                    "required": [
+                                      "fieldPath"
+                                    ],
+                                    "description": "ObjectFieldSelector selects an APIVersioned field of an object.",
+                                    "properties": {
+                                      "fieldPath": {
+                                        "type": "string",
+                                        "description": "Path of the field to select in the specified API version."
+                                      },
+                                      "apiVersion": {
+                                        "type": "string",
+                                        "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\"."
+                                      }
+                                    }
+                                  },
+                                  "resourceFieldRef": {
+                                    "required": [
+                                      "resource"
+                                    ],
+                                    "description": "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
+                                    "properties": {
+                                      "containerName": {
+                                        "type": "string",
+                                        "description": "Container name: required for volumes, optional for env vars"
+                                      },
+                                      "resource": {
+                                        "type": "string",
+                                        "description": "Required: resource to select"
+                                      },
+                                      "divisor": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "configMapKeyRef": {
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "description": "Selects a key from a ConfigMap.",
+                                    "properties": {
+                                      "optional": {
+                                        "type": "boolean",
+                                        "description": "Specify whether the ConfigMap or it's key must be defined"
+                                      },
+                                      "name": {
+                                        "type": "string",
+                                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names"
+                                      },
+                                      "key": {
+                                        "type": "string",
+                                        "description": "The key to select."
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "Name of the environment variable. Must be a C_IDENTIFIER."
+                              },
+                              "value": {
+                                "type": "string",
+                                "description": "Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\"."
+                              }
+                            }
+                          },
+                          "type": "array",
+                          "description": "List of environment variables to set in the container. Cannot be updated.",
+                          "x-kubernetes-patch-strategy": "merge",
+                          "x-kubernetes-patch-merge-key": "name"
+                        }
+                      }
+                    }
+                  }
+                },
+                "type": "array"
+              }
+            }
+          }
+        }
+      }
+    },
+    "version": "v1alpha2",
+    "subresources": {
+      "status": {}
+    }
+  }
+}

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/seldon/seldon-user.clusterrole.yaml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/seldon/seldon-user.clusterrole.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/seldon/seldon-user.clusterrole.yaml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/seldon/seldon-user.clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: seldon-user
+  namespace: odh
+rules:
+- apiGroups:
+  - machinelearning.seldon.io
+  resources: ["*"]
+  verbs: ["*"]

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/toolbox.yaml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/toolbox.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rook-ceph-tools
+  namespace: rook-ceph
+  labels:
+    app: rook-ceph-tools
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rook-ceph-tools
+  template:
+    metadata:
+      labels:
+        app: rook-ceph-tools
+    spec:
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+      - name: rook-ceph-tools
+        image: rook/ceph:v0.9.3
+        command: ["/tini"]
+        args: ["-g", "--", "/usr/local/bin/toolbox.sh"]
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: ROOK_ADMIN_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: rook-ceph-mon
+                key: admin-secret
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - mountPath: /dev
+            name: dev
+          - mountPath: /sys/bus
+            name: sysbus
+          - mountPath: /lib/modules
+            name: libmodules
+          - name: mon-endpoint-volume
+            mountPath: /etc/rook
+      # if hostNetwork: false, the "rbd map" command hangs, see https://github.com/rook/rook/issues/2021
+      hostNetwork: true
+      volumes:
+        - name: dev
+          hostPath:
+            path: /dev
+        - name: sysbus
+          hostPath:
+            path: /sys/bus
+        - name: libmodules
+          hostPath:
+            path: /lib/modules
+        - name: mon-endpoint-volume
+          configMap:
+            name: rook-ceph-mon-endpoints
+            items:
+            - key: data
+              path: mon-endpoints

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/toolbox.yaml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/toolbox.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -23,37 +24,37 @@ spec:
         args: ["-g", "--", "/usr/local/bin/toolbox.sh"]
         imagePullPolicy: IfNotPresent
         env:
-          - name: ROOK_ADMIN_SECRET
-            valueFrom:
-              secretKeyRef:
-                name: rook-ceph-mon
-                key: admin-secret
+        - name: ROOK_ADMIN_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: rook-ceph-mon
+              key: admin-secret
         securityContext:
           privileged: true
         volumeMounts:
-          - mountPath: /dev
-            name: dev
-          - mountPath: /sys/bus
-            name: sysbus
-          - mountPath: /lib/modules
-            name: libmodules
-          - name: mon-endpoint-volume
-            mountPath: /etc/rook
+        - mountPath: /dev
+          name: dev
+        - mountPath: /sys/bus
+          name: sysbus
+        - mountPath: /lib/modules
+          name: libmodules
+        - name: mon-endpoint-volume
+          mountPath: /etc/rook
       # if hostNetwork: false, the "rbd map" command hangs, see https://github.com/rook/rook/issues/2021
       hostNetwork: true
       volumes:
-        - name: dev
-          hostPath:
-            path: /dev
-        - name: sysbus
-          hostPath:
-            path: /sys/bus
-        - name: libmodules
-          hostPath:
-            path: /lib/modules
-        - name: mon-endpoint-volume
-          configMap:
-            name: rook-ceph-mon-endpoints
-            items:
-            - key: data
-              path: mon-endpoints
+      - name: dev
+        hostPath:
+          path: /dev
+      - name: sysbus
+        hostPath:
+          path: /sys/bus
+      - name: libmodules
+        hostPath:
+          path: /lib/modules
+      - name: mon-endpoint-volume
+        configMap:
+          name: rook-ceph-mon-endpoints
+          items:
+          - key: data
+            path: mon-endpoints

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/readme.adoc
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/readme.adoc
@@ -1,0 +1,122 @@
+= ocp4-workload-rhte-analytics_data_ocp_infra - Infrastructure workload for the Red Hat Tech Exchange Analytics and Data Engineering on OpenShift workshop
+
+This infrastructure workload will setup the cluster for an link:http://opendatahub.io[Open Data Hub] v0.4.0 deployment.
+
+Infrastructure tasks include:
+
+* Deployment of Ceph using the link:http://rook.io[Rook] operator v0.9.3
+* Adding CRDs and ClusterRoles for Open Data Hub and it's components: Kafka, Seldon
+
+== Role overview
+
+* This is an infrastructure role to deploy the dependencies required for Open Data Hub infrastructure: Rook Ceph Object Storage, dependent CRDs, ClusterRoles. It consists of the following playbooks:
+** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment
+*** This role doesn't do anything here
+*** Debug task will print out: `pre_workload Tasks completed successfully.`
+
+** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy Rook Ceph Object Storage and required CRDs for ODH deployment
+*** This role only prints the current username for which this role is provisioning.
+*** Debug task will print out: `workload Tasks completed successfully.`
+
+** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
+*** This role doesn't do anything here
+*** Debug task will print out: `post_workload Tasks completed successfully.`
+
+** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Attempts to remove the Rook Ceph deployment
+*** Debug task will print out: `remove_workload Tasks completed successfully.`
+
+== Review the defaults variable file
+
+* This file link:./defaults/main.yml[./defaults/main.yml] contains all the variables you need to define to control the deployment of your workload.
+* The variable *ocp_username* is mandatory to assign the workload to the correct OpenShift user.
+* A variable *silent=True* can be passed to suppress debug messages.
+* You can modify any of these default values by adding `-e "variable_name=variable_value"` to the command line
+
+=== Deploy a Workload with the `ocp-workload` playbook [Mostly for testing]
+
+----
+TARGET_HOST="bastion.na39.openshift.opentlc.com"
+ANSIBLE_USER=<User with SSH access to bastion host>
+OCP_USERNAME=opentlc-mgr
+WORKLOAD="ocp4-workload-rhte-analytics_data_ocp_infra"
+GUID=<GUID assigned by RHPDS>
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=${ANSIBLE_USER}" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"silent=False" \
+    -e"guid=${GUID}" \
+    -e"ACTION=create"
+----
+
+=== To Delete an environment
+
+----
+TARGET_HOST="bastion.na39.openshift.opentlc.com"
+ANSIBLE_USER=<User with SSH access to bastion host>
+OCP_USERNAME=opentlc-mgr
+WORKLOAD="ocp4-workload-rhte-analytics_data_ocp_infra"
+GUID=<GUID assigned by RHPDS>
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=${ANSIBLE_USER}" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"guid=${GUID}" \
+    -e"ACTION=remove"
+----
+
+
+== Other related information:
+
+=== Deploy Workload on OpenShift Cluster from an existing playbook:
+
+[source,yaml]
+----
+- name: Deploy a workload role on a master host
+  hosts: all
+  become: true
+  gather_facts: False
+  tags:
+    - step007
+  roles:
+    - { role: "{{ocp_workload}}", when: 'ocp_workload is defined' }
+----
+NOTE: You might want to change `hosts: all` to fit your requirements
+
+
+=== Set up your Ansible inventory file
+
+* You can create an Ansible inventory file to define your connection method to your host (Master/Bastion with `oc` command)
+* You can also use the command line to define the hosts directly if your `ssh` configuration is set to connect to the host correctly
+* You can also use the command line to use localhost or if your cluster is already authenticated and configured in your `oc` configuration
+
+.Example inventory file
+[source, ini]
+----
+[gptehosts:vars]
+ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem
+ansible_user=ec2-user
+
+[gptehosts:children]
+openshift
+
+[openshift]
+bastion.cluster1.openshift.opentlc.com
+bastion.cluster2.openshift.opentlc.com
+bastion.cluster3.openshift.opentlc.com
+bastion.cluster4.openshift.opentlc.com
+
+[dev]
+bastion.cluster1.openshift.opentlc.com
+bastion.cluster2.openshift.opentlc.com
+
+[prod]
+bastion.cluster3.openshift.opentlc.com
+bastion.cluster4.openshift.opentlc.com
+----

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/tasks/main.yml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+
+# Do not modify this file
+
+- name: Running Pre Workload Tasks
+  include_tasks:
+    file: ./pre_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload Tasks
+  include_tasks:
+    file: ./workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  include_tasks:
+    file: ./post_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload removal Tasks
+  include_tasks:
+    file: ./remove_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/tasks/post_workload.yml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/tasks/post_workload.yml
@@ -1,0 +1,8 @@
+---
+# Implement your Post Workload deployment tasks here
+
+# Leave this as the last task in the playbook.
+- name: post_workload tasks complete
+  debug:
+    msg: "Post-Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/tasks/pre_workload.yml
@@ -1,0 +1,8 @@
+---
+# Implement your Pre Workload deployment tasks here
+
+# Leave this as the last task in the playbook.
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/tasks/remove_workload.yml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/tasks/remove_workload.yml
@@ -1,0 +1,101 @@
+# vim: set ft=ansible
+---
+
+# Implement your Workload deployment tasks here
+
+- name: remove rook-ceph cluster finalizers
+  k8s:
+    state: present
+    name: rook-ceph
+    namespace: rook-ceph
+    api_version: ceph.rook.io/v1
+    kind: CephCluster
+    definition:
+      metadata:
+        finalizers: null
+    merge_type: merge
+  ignore_errors: yes
+
+- name: remove rook-ceph cluster
+  k8s:
+    state: absent
+    name: rook-ceph
+    namespace: rook-ceph
+    api_version: ceph.rook.io/v1
+    kind: CephCluster
+  ignore_errors: yes
+
+- name: Ensure rook-ceph cluster is done removing if it was being terminated
+  k8s_facts:
+    api_version: ceph.rook.io/v1
+    kind: CephCluster
+    name: rook-ceph
+    namespace: rook-ceph
+  register: result
+  failed_when: result.resources | length > 0
+  delay: 15
+  retries: 60
+  until: result.resources | length == 0
+
+- name: remove rook operator
+  k8s:
+    state: absent
+    name: rook-ceph-operator
+    namespace: rook-ceph
+    kind: Deployment
+  ignore_errors: yes
+
+- name: remove daemonsets discover, agent
+  k8s:
+    state: absent
+    name: "{{ item }}"
+    namespace: rook-ceph
+    kind: daemonset
+    api_version: apps/v1
+  ignore_errors: yes
+  loop:
+  - rook-ceph-agent
+  - rook-discover
+
+- name: remove the rook-ceph rook-ceph-system project
+  ignore_errors: yes
+  k8s:
+    state: absent
+    definition:
+      apiVersion: project.openshift.io/v1
+      kind: Project
+      metadata:
+        name: "{{ item }}"
+  loop:
+    - rook-ceph
+    - rook-ceph-system
+
+- name: remove SCC.yaml
+  ignore_errors: yes
+  k8s:
+    state: absent
+    definition:
+      kind: SecurityContextConstraints
+      apiVersion: security.openshift.io/v1
+      metadata:
+        name: rook-ceph
+
+- name: Ensure project is done terminating if it was being terminated
+  k8s_facts:
+    api_version: project.openshift.io/v1
+    kind: Project
+    name: "{{ item }}"
+  register: result
+  failed_when: result.resources | length > 0
+  delay: 15
+  retries: 60
+  until: result.resources | length == 0
+  loop:
+    - rook-ceph
+    - rook-ceph-system
+
+# Leave this as the last task in the playbook.
+- name: remove_workload tasks complete
+  debug:
+    msg: "Remove Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/tasks/remove_workload.yml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/tasks/remove_workload.yml
@@ -67,8 +67,8 @@
       metadata:
         name: "{{ item }}"
   loop:
-    - rook-ceph
-    - rook-ceph-system
+  - rook-ceph
+  - rook-ceph-system
 
 - name: remove SCC.yaml
   ignore_errors: yes
@@ -91,8 +91,8 @@
   retries: 60
   until: result.resources | length == 0
   loop:
-    - rook-ceph
-    - rook-ceph-system
+  - rook-ceph
+  - rook-ceph-system
 
 # Leave this as the last task in the playbook.
 - name: remove_workload tasks complete

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/tasks/workload.yml
@@ -1,0 +1,121 @@
+# vim: set ft=ansible
+---
+
+# Implement your Workload deployment tasks here
+
+### all following based on files at https://github.com/rook/rook/blob/0.9.3/cluster/examples/kubernetes/ceph/
+
+- name: Verify user can create projects
+  command: "oc auth can-i create project"
+  register: canicreateprojects
+  failed_when: canicreateprojects.stdout != 'yes'
+
+- name: Apply rook scc.yaml
+  k8s:
+    state: present
+    definition: "{{ lookup('file', 'scc.yaml') }}"
+
+- name: Apply rook operator.yaml
+  k8s:
+    state: present
+    definition: "{{ lookup('file', 'operator.yaml') }}"
+
+- name: wait for deploy
+  command: "oc rollout status {{ item }} -n rook-ceph-system -w"
+  register: result
+  until: result.stderr.find("Error from server (NotFound)") != 0
+  retries: 60
+  loop:
+    - daemonset rook-ceph-agent
+    - daemonset rook-discover
+    - deployment rook-ceph-operator
+
+- name: Apply rook cluster.yaml
+  k8s:
+    state: present
+    definition: "{{ lookup('file', 'cluster.yaml') }}"
+  register: result
+  retries: 30
+
+- name: wait for rook-ceph-mon/osd a to get to status of running
+  shell: |
+    for i in $(oc get deployment -l app={{ item }} --no-headers | cut -d\  -f1); \
+    do \
+        oc rollout status deployment "$i" -n rook-ceph -w
+    done
+  loop:
+    - rook-ceph-mon
+    - rook-ceph-osd
+
+- name: Apply rook toolbox.yaml
+  k8s:
+    state: present
+    definition: "{{ lookup('file', 'toolbox.yaml') }}"
+
+- name: Apply rook object.yaml
+  k8s:
+    state: present
+    definition: "{{ lookup('file', 'object.yaml') }}"
+
+- name: wait for deploy rook-ceph-rgw-my-store
+  command: "oc rollout status deployment rook-ceph-rgw-my-store -n rook-ceph -w"
+  register: result
+  until: result.stderr.find("Error from server (NotFound)") != 0
+  retries: 120
+
+- name: Get Rook Ceph RGW Service
+  k8s_facts:
+    kind: Service
+    namespace: rook-ceph
+    name: rook-ceph-rgw-my-store
+  register: rgw_service
+  until: rgw_service.resources
+  retries: 60
+
+- name: Set the Rook Ceph RGW IP and Port
+  set_fact:
+    rgw_service_ip: "{{ rgw_service.resources[0].spec.clusterIP }}"
+    rgw_service_port: "{{ rgw_service.resources[0].spec.ports[0].port }}"
+
+- name: Confirm Open Data Hub CRD is present
+  k8s:
+    state: present
+    definition: "{{ lookup('file', 'opendatahub_v1alpha1_opendatahub_crd.yaml') }}"
+
+- name: Create an opendatahub-admin cluster role
+  k8s:
+    state: present
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: opendatahub-admin
+      rules:
+        - apiGroups:
+          - opendatahub.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+
+- name: Confirm Seldon CRD and ClusterRole are present
+  k8s:
+    state: present
+    definition: "{{ item }}"
+  with_items:
+    - "{{ lookup('file', 'seldon/seldon-deployment.crd.json') }}"
+    - "{{ lookup('file', 'seldon/seldon-user.clusterrole.yaml') }}"
+
+- name: Confirm Kafka CRDs and ClusterRoles are present
+  k8s:
+    state: present
+    definition: "{{ item }}"
+  with_items:
+    - "{{ lookup('file', 'kafka/kafka.crd.yaml') }}"
+    - "{{ lookup('file', 'kafka/kafka.clusterrole.yaml') }}"
+
+# Leave this as the last task in the playbook.
+- name: workload tasks complete
+  debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/tasks/workload.yml
@@ -92,11 +92,11 @@
         name: opendatahub-admin
       rules:
         - apiGroups:
-          - opendatahub.io
+            - opendatahub.io
           resources:
-          - '*'
+            - '*'
           verbs:
-          - '*'
+            - '*'
 
 - name: Confirm Seldon CRD and ClusterRole are present
   k8s:

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/defaults/main.yml
@@ -1,0 +1,69 @@
+---
+# Default variables that are defined by the playbook that will be deploying these roles
+become_override: False
+ocp_username: opentlc-mgr
+silent: False
+
+# This workshop requires per user 10-12 CPU and 16GB of Memory
+# For a 50 person workshop, you'll need ~40 OCP worker nodes running on with m4.4xlarge instances
+_infra_node_replicas: 40
+_infra_node_instance_type: m4.4xlarge
+
+user_name: null
+project_name: null
+
+# The first user number to start with when creating projects
+user_count_start: 1
+# The last user number to start with when creating projects
+user_count_end: "{{user_count_start|int + user_count|int}}"
+
+# Rook Ceph Info
+# These variables will be initialized by the role ocp4-workload-rhte-analytics_data_ocp_infra
+# The Rook Ceph RGW service ClusterIP in the rook-ceph namespace
+rgw_service_ip: null
+# The Rook Ceph RGW service port in the rook-ceph namespace
+rgw_service_port: null
+# Full RGW endpoint url that can be used as the S3 endpoint
+rgw_endpoint_url: "http://{{ rgw_service_ip }}:{{ rgw_service_port }}"
+
+# Open Data Hub
+# Deploy the Open Data Hub CustomResource in the user project space,
+#   after the project is setup and ODH ClusterServiceVersion has finished
+deploy_odh_cr: false
+# Open Data Hub operator image
+odh_operator_image_repo: "quay.io/opendatahub/opendatahub-operator:v0.4.0"
+# Registry and repistory for AICoE-JupyterHub images
+# EXAMPLE: podman pull {{ jupyterhub_image_registry }}/{{ jupyterhub_image_repository }}:IMAGE:TAG
+jupyterhub_image_registry: 'quay.io'
+jupyterhub_image_repository: 'odh-jupyterhub'
+
+# Custom notebook image source that will be used for the workshop
+workshop_jupyter_notebook_imagestream_image: "quay.io/llasmith/spark-notebook:spark-2.3.2_hadoop-2.8.5"
+# Imagestream name for the custom workshop image
+workshop_jupyter_notebook_imagestream_name: s2i-spark-scipy-notebook
+# Imagestream tag for the custom workshop image
+workshop_jupyter_notebook_imagestream_tag: "3.6"
+
+# Command separated string list each git repo url to preload on the notebook pod when it spawns
+workshop_preload_repos: "https://github.com/anishasthana/odh-hybrid-data-workshop"
+
+# Amount of memory for the JupyterHub server
+jupyterhub_memory: "1Gi"
+# Amount of memory for the spawned Jupyter Notebook pods
+jupyter_notebook_memory: "2Gi"
+
+# Image to use for the Spark Cluster
+spark_node_image: "quay.io/llasmith/openshift-spark:spark-2.3.2_hadoop-2.8.5"
+# Number of Spark master nodes
+spark_master_count: 1
+# Number of Spark worker nodes
+spark_worker_count: 2
+# Amount of memory to allocate to each Spark node. This amount will be used for master AND worker nodes
+spark_node_memory: "4Gi"
+# Amount of cpu to allocate to each Spark node. This amount will be used for master AND worker nodes
+spark_node_cpu: 1
+
+# Path to append to env var PYTHONPATH for pyspark module
+spark_pythonpath: "/opt/app-root/lib/python3.6/site-packages/pyspark/python/:/opt/app-root/lib/python3.6/site-packages/pyspark/python/lib/py4j-0.10.7-src.zip"
+# PySpark submit args to be set as the env var SPARK_SUBMIT_ARGS
+spark_submit_args: "--conf spark.cores.max=1 --conf spark.executor.instances=1 --conf spark.executor.memory=4G --conf spark.executor.cores=1 --conf spark.driver.memory=2G --packages com.amazonaws:aws-java-sdk:1.8.0,org.apache.hadoop:hadoop-aws:2.8.5 pyspark-shell"

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/files/opendatahub_v1alpha1_opendatahub_cr.yaml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/files/opendatahub_v1alpha1_opendatahub_cr.yaml
@@ -1,0 +1,77 @@
+apiVersion: opendatahub.io/v1alpha1
+kind: OpenDataHub
+metadata:
+  name: example-opendatahub
+spec:
+  # JupyterHub deployment developed by Graham Dumpleton - https://github.com/aicoe/jupyterhub-ocp-oauth
+  aicoe-jupyterhub:
+    # Deploy the ODH aicoe-jupyterhub role if True
+    odh_deploy: true
+    notebook_memory: 2Gi
+    deploy_all_notebooks: False
+    registry: ''
+    repository: ''
+    storage_class: ''
+    db_memory: 1Gi
+    jupyterhub_memory: 1Gi
+    notebook_image: 's2i-minimal-notebook:3.6'
+    notebook_memory: 1Gi
+    s3_endpoint_url: ''
+
+    # Name of the configmap that will be used when spawning a notebook for the single user
+    spark_configmap_template: 'jupyterhub-spark-operator-configmap'
+    # PYSPARK args to use in the notebook pod
+    # These submit args should be customized for the values passed for spark_memory and spark_cpu. You'll need to account for the available memory on the spark work nodes
+    spark_pyspark_submit_args: "--conf spark.cores.max=6 --conf spark.executor.instances=2 --conf spark.executor.memory=3G --conf spark.executor.cores=3 --conf spark.driver.memory=4G --packages com.amazonaws:aws-java-sdk:1.7.4,org.apache.hadoop:hadoop-aws:2.7.3 pyspark-shell"
+    spark_pyspark_driver_python: "jupyter"
+    spark_pyspark_driver_python_opts: "notebook"
+    spark_home: "/opt/app-root/lib/python3.6/site-packages/pyspark/"
+    spark_pythonpath: "$PYTHONPATH:/opt/app-root/lib/python3.6/site-packages/:/opt/app-root/lib/python3.6/site-packages/pyspark/python/:/opt/app-root/lib/python3.6/site-packages/pyspark/python/lib/py4j-0.8.2.1-src.zip"
+
+    # Number of master and worker nodes for the spark cluster
+    spark_worker_nodes: 2
+    spark_master_nodes: 1
+
+    # Amount of cpu & memory to allocate to the each node in the cluster.
+    # This value will be applied to all worker and master nodes
+    spark_memory: 4Gi
+    spark_cpu: 3
+    # Spark image to use in the cluster
+    spark_image: "quay.io/opendatahub/spark-cluster-image:spark22python36"
+
+  # Spark operator developed by radanalyticsio - https://github.com/radanalyticsio/spark-operator
+  spark-operator:
+    # Deploy the ODH spark-operator role if True
+    odh_deploy: true
+    master_node_count: 0
+    master_memory: 1Gi
+    master_cpu: 1
+    worker_node_count: 0
+    worker_memory: 2Gi
+    worker_cpu: 2
+
+  # Seldon Delployment
+  seldon:
+    odh_deploy: false
+
+  # JupyterHub deployment developed by Graham Dumpleton - https://github.com/jupyter-on-openshift/jupyterhub-quickstart
+  jupyter-on-openshift:
+    # Deploy the ODH jupyter-on-openshift role if True
+    odh_deploy: false
+    notebook_memory: 2Gi
+    # Add these whitelisted environment variables from JupyterHub to the user's notebook pod
+    jupyterhub_config: |
+      c.KubeSpawner.env_keep = ['S3_ENDPOINT_URL', 'S3_ACCESS_KEY', 'S3_SECRET_KEY']
+    # Environment variables that will be set on the JupyterHub pod
+    extra_env_vars:
+      S3_ENDPOINT_URL: "http://s3.foo.com:8000"
+      S3_ACCESS_KEY: "YOURS3ACCESSKEYHERE"
+      S3_SECRET_KEY: "this1is2just3gibberish"
+
+  # Deployment of Prometheus and Grafana for Monitoring of ODH
+  monitoring:
+    odh_deploy: true
+
+  # Deployment of Two Sigma's BeakerX Jupyter notebook
+  beakerx:
+    odh_deploy: false

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/files/opendatahub_v1alpha1_opendatahub_cr.yaml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/files/opendatahub_v1alpha1_opendatahub_cr.yaml
@@ -15,7 +15,6 @@ spec:
     db_memory: 1Gi
     jupyterhub_memory: 1Gi
     notebook_image: 's2i-minimal-notebook:3.6'
-    notebook_memory: 1Gi
     s3_endpoint_url: ''
 
     # Name of the configmap that will be used when spawning a notebook for the single user

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/files/operator.yaml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/files/operator.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opendatahub-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: opendatahub-operator
+  template:
+    metadata:
+      labels:
+        name: opendatahub-operator
+    spec:
+      serviceAccountName: opendatahub-operator
+      containers:
+        - name: opendatahub-operator
+          image: "quay.io/opendatahub/opendatahub-operator:master"
+          imagePullPolicy: "Always"
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "opendatahub-operator"

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/files/role.yaml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/files/role.yaml
@@ -1,0 +1,815 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: opendatahub-operator
+rules:
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - clusterserviceversions
+  - catalogsources
+  - installplans
+  - subscriptions
+  - packagemanifests
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - clusterserviceversions
+  - catalogsources
+  - installplans
+  - subscriptions
+  - packagemanifests
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - automationbroker.io
+  resources:
+  - ansible-service-broker-openshift-automation-broker-user-auth
+  verbs:
+  - create
+- apiGroups:
+  - logging.openshift.io
+  resources:
+  - elasticsearches
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  - image.openshift.io
+  resources:
+  - imagestreamimages
+  - imagestreammappings
+  - imagestreams
+  - imagestreams/secrets
+  - imagestreamtags
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  - image.openshift.io
+  resources:
+  - imagestreamimports
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  - image.openshift.io
+  resources:
+  - imagestreams/layers
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  - project.openshift.io
+  resources:
+  - projects
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - pods/attach
+  - pods/exec
+  - pods/portforward
+  - pods/proxy
+  - secrets
+  - services/proxy
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/attach
+  - pods/exec
+  - pods/portforward
+  - pods/proxy
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - persistentvolumeclaims
+  - replicationcontrollers
+  - replicationcontrollers/scale
+  - secrets
+  - serviceaccounts
+  - services
+  - services/proxy
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - deployments/rollback
+  - deployments/scale
+  - replicasets
+  - replicasets/scale
+  - statefulsets
+  - statefulsets/scale
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - deployments/rollback
+  - deployments/scale
+  - ingresses
+  - networkpolicies
+  - replicasets
+  - replicasets/scale
+  - replicationcontrollers/scale
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+  - get
+  - list
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - ""
+  - image.openshift.io
+  resources:
+  - imagestreams
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  - build.openshift.io
+  resources:
+  - builds/details
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  - build.openshift.io
+  resources:
+  - builds
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  - build.openshift.io
+  resources:
+  - buildconfigs
+  - buildconfigs/webhooks
+  - builds
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  - build.openshift.io
+  resources:
+  - builds/log
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - build.openshift.io
+  resources:
+  - buildconfigs/instantiate
+  - buildconfigs/instantiatebinary
+  - builds/clone
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs
+  - deploymentconfigs/scale
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  - apps.openshift.io
+  resources:
+  - deploymentconfigrollbacks
+  - deploymentconfigs/instantiate
+  - deploymentconfigs/rollback
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs/log
+  - deploymentconfigs/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - image.openshift.io
+  resources:
+  - imagestreams/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - quota.openshift.io
+  resources:
+  - appliedclusterresourcequotas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  - route.openshift.io
+  resources:
+  - routes/custom-host
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  - route.openshift.io
+  resources:
+  - routes/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - template.openshift.io
+  resources:
+  - processedtemplates
+  - templateconfigs
+  - templateinstances
+  - templates
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - extensions
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  - build.openshift.io
+  resources:
+  - buildlogs
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - resourcequotausages
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - servicecatalog.k8s.io
+  resources:
+  - servicebrokers
+  - serviceclasses
+  - serviceplans
+  - serviceinstances
+  - servicebindings
+  verbs:
+  - create
+  - update
+  - delete
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - settings.k8s.io
+  resources:
+  - podpresets
+  verbs:
+  - create
+  - update
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resourceNames:
+  - elasticsearches.logging.openshift.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+- apiGroups:
+  - logging.openshift.io
+  resources:
+  - elasticsearches
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - image.openshift.io
+  resources:
+  - imagestreamimages
+  - imagestreammappings
+  - imagestreams
+  - imagestreamtags
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - image.openshift.io
+  resources:
+  - imagestreams/layers
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - events
+  - nodes
+  - persistentvolumeclaims
+  - pods
+  - replicationcontrollers
+  - replicationcontrollers/scale
+  - serviceaccounts
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - bindings
+  - events
+  - limitranges
+  - namespaces/status
+  - pods/log
+  - pods/status
+  - replicationcontrollers/status
+  - resourcequotas
+  - resourcequotas/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - controllerrevisions
+  - daemonsets
+  - deployments
+  - deployments/scale
+  - replicasets
+  - replicasets/scale
+  - statefulsets
+  - statefulsets/scale
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - deployments/scale
+  - ingresses
+  - networkpolicies
+  - replicasets
+  - replicasets/scale
+  - replicationcontrollers/scale
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - build.openshift.io
+  resources:
+  - buildconfigs
+  - buildconfigs/webhooks
+  - builds
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs
+  - deploymentconfigs/scale
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - template.openshift.io
+  resources:
+  - processedtemplates
+  - templateconfigs
+  - templateinstances
+  - templates
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - build.openshift.io
+  resources:
+  - buildlogs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - servicecatalog.k8s.io
+  resources:
+  - servicebrokers
+  - serviceclasses
+  - serviceplans
+  - serviceinstances
+  - servicebindings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - logging.openshift.io
+  resources:
+  - elasticsearches
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  - authorization.openshift.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  - authorization.openshift.io
+  resources:
+  - localresourceaccessreviews
+  - localsubjectaccessreviews
+  - subjectrulesreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - localsubjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  - project.openshift.io
+  resources:
+  - projects
+  verbs:
+  - delete
+  - get
+- apiGroups:
+  - ""
+  - authorization.openshift.io
+  resources:
+  - resourceaccessreviews
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  - security.openshift.io
+  resources:
+  - podsecuritypolicyreviews
+  - podsecuritypolicyselfsubjectreviews
+  - podsecuritypolicysubjectreviews
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  - authorization.openshift.io
+  resources:
+  - rolebindingrestrictions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - project.openshift.io
+  resources:
+  - projects
+  verbs:
+  - delete
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  - route.openshift.io
+  resources:
+  - routes/status
+  verbs:
+  - update
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - apiextensions.k8s.io
+  resourceNames:
+  - opendatahubs.opendatahub.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resourceNames:
+  - opendatahub-operator
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - opendatahub.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - machinelearning.seldon.io
+  resources:
+  - seldondeployments
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - machinelearning.seldon.io
+  resources:
+  - seldondeployments/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/files/role_binding.yaml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/files/role_binding.yaml
@@ -1,0 +1,11 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: opendatahub-operator
+subjects:
+- kind: ServiceAccount
+  name: opendatahub-operator
+roleRef:
+  kind: Role
+  name: opendatahub-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/files/service_account.yaml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/files/service_account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: opendatahub-operator

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/readme.adoc
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/readme.adoc
@@ -1,0 +1,134 @@
+= ocp4-workload-rhte-analytics_data_ocp_workshop - Workshop workload for the Red Hat Tech Exchange Analytics and Data Engineering on OpenShift workshop
+
+This workshop workoad will create user(s) project to deploy link:http://opendatahub.io[Open Data Hub] v0.4.0.
+
+The individual workload task includes
+
+* Creation of the project and project RBAC for the user
+* Add the Open Data Hub to the project's Catalog of `Installed Operators`
+* Deploy the Open Data Hub and Strimzi Operator
+* OPTIONAL: Create an Open Data Hub deployment for the user
+
+== Role overview
+
+* This is a workshop role to setup the Open Data Hub project for a specific user. This role requires that the infrastructure has all Open Data Hub required and dependent CRDS loaded and Rook Ceph Object storage has been installed. This role must be run after the link:../ocp4-workload-rhte-analytics_data_ocp_infra[ocp4-workload-rhte-analytics_data_ocp_infra] role. It consists of the following playbooks:
+** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment
+*** This role doesn't do anything here
+*** Debug task will print out: `pre_workload Tasks completed successfully.`
+
+** Playbook: link:./tasks/workload.yml[workload.yml] - Creates the each user's project space, adds the ODH ClusterServiceVersion to the project, deploys the opendatahub-operator and *OPTIONAL* deploys Open Data Hub
+*** This role only prints the current username for which this role is provisioning.
+*** Debug task will print out: `workload Tasks completed successfully.`
+
+** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
+*** This role doesn't do anything here
+*** Debug task will print out: `post_workload Tasks completed successfully.`
+
+** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Deletes the project created for each user
+*** Debug task will print out: `remove_workload Tasks completed successfully.`
+
+== Review the defaults variable file
+
+* This file link:./defaults/main.yml[./defaults/main.yml] contains all the variables you need to define to control the deployment of your workload.
+* The variable *ocp_username* is mandatory to assign the workload to the correct OpenShift user.
+* A variable *silent=True* can be passed to suppress debug messages.
+* You can modify any of these default values by adding `-e "variable_name=variable_value"` to the command line
+
+=== Deploy a Workload with the `ocp-workload` playbook [Mostly for testing]
+
+----
+TARGET_HOST="bastion.na39.openshift.opentlc.com"
+ANSIBLE_USER=<User with SSH access to bastion host>
+OCP_USERNAME=opentlc-mgr
+WORKLOAD="ocp4-workload-rhte-analytics_data_ocp_workshop"
+GUID=<GUID assigned by RHPDS>
+# ROOK CEPH RGW info would be provided by role ocp4-workload-rhte-analytics_data_ocp_infra
+ROOK_CEPH_RGW_SERVICE_IP=XX.YY.ZZ.WW
+ROOK_CEPH_RGW_SERVICE_PORT=8000
+WORKSHOP_USER_COUNT=50
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=${ANSIBLE_USER}" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"silent=False" \
+    -e"guid=${GUID}" \
+    -e"rgw_service_ip=${ROOK_CEPH_RGW_SERVICE_IP}"
+    -e"rgw_service_port=${ROOK_CEPH_RGW_SERVICE_PORT}"
+    -e"user_count=${WORKSHOP_USER_COUNT}" \
+    -e"ACTION=create"
+----
+
+=== To Delete an environment
+
+----
+TARGET_HOST="bastion.na39.openshift.opentlc.com"
+ANSIBLE_USER=<User with SSH access to bastion host>
+OCP_USERNAME=opentlc-mgr
+WORKLOAD="ocp4-workload-rhte-analytics_data_ocp_workshop"
+GUID=<GUID assigned by RHPDS>
+WORKSHOP_USER_COUNT=50
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=${ANSIBLE_USER}" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"guid=${GUID}" \
+    -e"user_count=${WORKSHOP_USER_COUNT}" \
+    -e"ACTION=remove"
+----
+
+
+== Other related information:
+
+=== Deploy Workload on OpenShift Cluster from an existing playbook:
+
+[source,yaml]
+----
+- name: Deploy a workload role on a master host
+  hosts: all
+  become: true
+  gather_facts: False
+  tags:
+    - step007
+  roles:
+    - { role: "ocp4-workload-rhte-analytics_data_ocp_infra", when: 'ocp_workload is defined' }
+    - { role: "ocp4-workload-rhte-analytics_data_ocp_workshop", when: 'ocp_workload is defined' }
+----
+NOTE: You might want to change `hosts: all` to fit your requirements
+
+
+=== Set up your Ansible inventory file
+
+* You can create an Ansible inventory file to define your connection method to your host (Master/Bastion with `oc` command)
+* You can also use the command line to define the hosts directly if your `ssh` configuration is set to connect to the host correctly
+* You can also use the command line to use localhost or if your cluster is already authenticated and configured in your `oc` configuration
+
+.Example inventory file
+[source, ini]
+----
+[gptehosts:vars]
+ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem
+ansible_user=ec2-user
+
+[gptehosts:children]
+openshift
+
+[openshift]
+bastion.cluster1.openshift.opentlc.com
+bastion.cluster2.openshift.opentlc.com
+bastion.cluster3.openshift.opentlc.com
+bastion.cluster4.openshift.opentlc.com
+
+[dev]
+bastion.cluster1.openshift.opentlc.com
+bastion.cluster2.openshift.opentlc.com
+
+[prod]
+bastion.cluster3.openshift.opentlc.com
+bastion.cluster4.openshift.opentlc.com
+----

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/tasks/main.yml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+
+# Do not modify this file
+
+- name: Running Pre Workload Tasks
+  include_tasks:
+    file: ./pre_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload Tasks
+  include_tasks:
+    file: ./workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  include_tasks:
+    file: ./post_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload removal Tasks
+  include_tasks:
+    file: ./remove_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/tasks/per_user_remove_workload.yml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/tasks/per_user_remove_workload.yml
@@ -1,0 +1,48 @@
+# vim: set ft=ansible
+---
+- set_fact:
+    user_name: "user{{ user_num }}"
+
+- set_fact:
+    project_name: "opendatahub-{{ user_name }}"
+
+# Implement your Workload deployment tasks here
+- name: Delete the Strimzi ClusterRoleBinding
+  k8s:
+    state: absent
+    namespace: "{{ project_name }}"
+    definition: "{{ item }}"
+  with_items:
+    - "{{ lookup('template', 'kafka/strimzi.clusterrolebinding.yaml.j2') }}"
+    - "{{ lookup('template', 'kafka/strimzi.serviceaccount.yaml.j2') }}"
+
+- name: "Remove the Project {{ project_name }}"
+  ignore_errors: yes
+  k8s:
+    state: absent
+    definition:
+      apiVersion: project.openshift.io/v1
+      kind: Project
+      metadata:
+        name: "{{ item }}"
+  loop:
+    - "{{ project_name }}"
+
+- name: Ensure project is done terminating if it was being terminated
+  k8s_facts:
+    api_version: project.openshift.io/v1
+    kind: Project
+    name: "{{ item }}"
+  register: result
+  failed_when: result.resources | length > 0
+  delay: 15
+  retries: 60
+  until: result.resources | length == 0
+  loop:
+    - "{{ project_name }}"
+
+# Leave this as the last task in the playbook.
+- name: remove_workload tasks complete
+  debug:
+    msg: "Remove Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/tasks/per_user_workload.yml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/tasks/per_user_workload.yml
@@ -1,0 +1,195 @@
+# vim: set ft=ansible
+---
+# Implement your Workload deployment tasks here
+- set_fact:
+    user_name: "user{{ user_num }}"
+
+- set_fact:
+    project_name: "opendatahub-{{ user_name }}"
+
+- debug:
+    msg: "Deploying Open Data Hub to project {{ project_name }} and adding {{ user_name }}"
+
+- name: Verify user can create projects
+  command: "oc auth can-i create project"
+  register: canicreateprojects
+  failed_when: canicreateprojects.stdout != 'yes'
+
+- name: "Create CephObjectStoreUser for {{ user_name }}"
+  k8s:
+    state: present
+    definition:
+      apiVersion: ceph.rook.io/v1
+      kind: CephObjectStoreUser
+      metadata:
+        name: "{{ user_name }}"
+        namespace: rook-ceph
+      spec:
+        store: my-store
+        displayName: "{{ user_name }}"
+
+## obtain secrets for each user
+- name: Get Ceph Access and Secret Key
+  k8s_facts:
+    name: "rook-ceph-object-user-my-store-{{ user_name }}"
+    namespace: rook-ceph
+    kind: Secret
+  register: secret
+
+- name: Set the user S3 secrets
+  set_fact:
+    s3_access_key: "{{ secret.resources[0].data.AccessKey | b64decode }}"
+    s3_secret_key: "{{ secret.resources[0].data.SecretKey | b64decode }}"
+
+####################################################################################################
+## OPEN DATA HUB
+####################################################################################################
+- name: "Make sure project {{ project_name }} is not there"
+  k8s:
+    state: absent
+    name: "{{ project_name }}"
+    kind: Project
+    api_version: project.openshift.io/v1
+
+- name: Ensure project is done terminating if it was being terminated
+  k8s_facts:
+    api_version: project.openshift.io/v1
+    kind: Project
+    name: "{{ project_name }}"
+  register: result
+  failed_when: result.resources | length > 0
+  retries: 60
+  until: result.resources | length == 0
+
+- name: "Creating project {{ project_name }}"
+  k8s:
+    state: present
+    name: "{{ project_name }}"
+    kind: ProjectRequest
+    api_version: project.openshift.io/v1
+
+- name: Create Open Data Hub operator RBAC
+  k8s:
+    state: present
+    definition: "{{ item }}"
+    namespace: "{{ project_name }}"
+  loop:
+    - "{{ lookup('file', 'service_account.yaml') }}"
+    - "{{ lookup('file', 'role.yaml') }}"
+    - "{{ lookup('file', 'role_binding.yaml') }}"
+
+- name: Make '{{ user_name }}' project admin
+  k8s:
+    state: present
+    definition:
+      kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: "admin-{{ user_name }}"
+        namespace: "{{ project_name }}"
+      subjects:
+      - kind: User
+        name: "{{ user_name }}"
+      roleRef:
+        kind: ClusterRole
+        name: admin
+        apiGroup: rbac.authorization.k8s.io
+
+- name: Make '{{ user_name }}' ODH admin
+  k8s:
+    state: present
+    definition:
+      kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: "opendatahub-admin-{{ user_name }}"
+        namespace: "{{ project_name }}"
+      subjects:
+      - kind: User
+        name: "{{ user_name }}"
+      roleRef:
+        kind: ClusterRole
+        name: opendatahub-admin
+        apiGroup: rbac.authorization.k8s.io
+
+####################################################################################################
+# STRIMZI SETUP
+####################################################################################################
+- name: Create the Strimzi ServiceAccount, RoleBinding and ClusterRoleBinding
+  k8s:
+    state: present
+    namespace: "{{ project_name }}"
+    definition: "{{ item }}"
+  with_items:
+    - "{{ lookup('template', 'kafka/strimzi.serviceaccount.yaml.j2') }}"
+    - "{{ lookup('template', 'kafka/strimzi.rolebinding.yaml.j2') }}"
+    - "{{ lookup('template', 'kafka/strimzi.clusterrolebinding.yaml.j2') }}"
+####################################################################################################
+# END STRIMZI
+####################################################################################################
+
+- name: 'Add Open Data Hub to the project "Installed Operators"'
+  k8s:
+    state: present
+    namespace: "{{ project_name }}"
+    definition: "{{ item }}"
+  loop:
+    - "{{ lookup('template', 'opendatahub-operator.operatorgroup.yaml.j2') }}"
+    - "{{ lookup('template', 'opendatahub-operator.v0.4.0.clusterserviceversion.yaml.j2') }}"
+
+- name: Wait for Open Data Hub ClusterServiceVersion to finish installing
+  k8s_facts:
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    namespace: "{{ project_name }}"
+    name: opendatahub-operator.v0.4.0
+    field_selectors:
+      - status.phase=Succeeded
+  register: odh_csv
+  until:  odh_csv.resources
+  retries: 10
+  delay: 10
+
+- name: Wait for Open Data Hub operator to finish deploying
+  k8s_facts:
+    kind: Pod
+    namespace: "{{ project_name }}"
+    label_selectors:
+      - name = opendatahub-operator
+    field_selectors:
+      - status.phase=Running
+  register: odh_operator
+  until:  odh_operator.resources
+  retries: 10
+  delay: 10
+
+- name: "Create the JupyterHub Single User ConfigMap for {{ user_name }}"
+  k8s:
+    namespace: "{{ project_name }}"
+    definition: "{{ lookup('template', 'jupyterhub-single-user-profile-user.configmap.yaml.j2') }}"
+
+- name: "Create the ImageStream for the notebook used in this workshop"
+  k8s:
+    state: present
+    namespace: "{{ project_name }}"
+    definition: "{{ lookup('template', 'workshop-notebook.imagestream.yaml.j2') }}"
+
+- name: Deploy the Strimzi Cluster Operator
+  k8s:
+    state: present
+    namespace: "{{ project_name }}"
+    definition: "{{ lookup('template', 'kafka/strimzi-cluster-operator.deployment.yaml.j2') }}"
+
+- name: Create the ODH Custom Resource
+  k8s:
+    state: present
+    namespace: "{{ project_name }}"
+    definition: "{{ lookup('template', 'opendatahub_v1alpha1_opendatahub_cr.yaml.j2') }}"
+  when: deploy_odh_cr
+
+# Leave this as the last task in the playbook.
+- name: "{{ user_name }} tasks complete"
+  debug:
+    msg: "{{ user_name }} Tasks completed successfully."
+  when: not silent|bool
+

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/tasks/per_user_workload.yml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/tasks/per_user_workload.yml
@@ -88,8 +88,8 @@
         name: "admin-{{ user_name }}"
         namespace: "{{ project_name }}"
       subjects:
-      - kind: User
-        name: "{{ user_name }}"
+        - kind: User
+          name: "{{ user_name }}"
       roleRef:
         kind: ClusterRole
         name: admin
@@ -105,8 +105,8 @@
         name: "opendatahub-admin-{{ user_name }}"
         namespace: "{{ project_name }}"
       subjects:
-      - kind: User
-        name: "{{ user_name }}"
+        - kind: User
+          name: "{{ user_name }}"
       roleRef:
         kind: ClusterRole
         name: opendatahub-admin
@@ -146,7 +146,7 @@
     field_selectors:
       - status.phase=Succeeded
   register: odh_csv
-  until:  odh_csv.resources[0] and odh_csv.resources[0].get('status') and odh_csv.resources[0].status.phase == 'Succeeded'
+  until: odh_csv.resources[0] and odh_csv.resources[0].get('status') and odh_csv.resources[0].status.phase == 'Succeeded'
   retries: 36
   delay: 10
 
@@ -159,7 +159,7 @@
     field_selectors:
       - status.phase=Running
   register: odh_operator
-  until:  odh_operator.resources
+  until: odh_operator.resources
   retries: 12
   delay: 10
 
@@ -192,4 +192,3 @@
   debug:
     msg: "{{ user_name }} Tasks completed successfully."
   when: not silent|bool
-

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/tasks/per_user_workload.yml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/tasks/per_user_workload.yml
@@ -128,7 +128,7 @@
 # END STRIMZI
 ####################################################################################################
 
-- name: 'Add Open Data Hub to the project "Installed Operators"'
+- name: 'Add Open Data Hub to the project "Installed Operators" in {{ project_name }}'
   k8s:
     state: present
     namespace: "{{ project_name }}"
@@ -137,7 +137,7 @@
     - "{{ lookup('template', 'opendatahub-operator.operatorgroup.yaml.j2') }}"
     - "{{ lookup('template', 'opendatahub-operator.v0.4.0.clusterserviceversion.yaml.j2') }}"
 
-- name: Wait for Open Data Hub ClusterServiceVersion to finish installing
+- name: "Wait for Open Data Hub ClusterServiceVersion to finish installing in {{ project_name }}"
   k8s_facts:
     api_version: operators.coreos.com/v1alpha1
     kind: ClusterServiceVersion
@@ -146,11 +146,11 @@
     field_selectors:
       - status.phase=Succeeded
   register: odh_csv
-  until:  odh_csv.resources
-  retries: 10
+  until:  odh_csv.resources[0] and odh_csv.resources[0].get('status') and odh_csv.resources[0].status.phase == 'Succeeded'
+  retries: 36
   delay: 10
 
-- name: Wait for Open Data Hub operator to finish deploying
+- name: "Wait for Open Data Hub operator to finish deploying in {{ project_name }}"
   k8s_facts:
     kind: Pod
     namespace: "{{ project_name }}"
@@ -160,7 +160,7 @@
       - status.phase=Running
   register: odh_operator
   until:  odh_operator.resources
-  retries: 10
+  retries: 12
   delay: 10
 
 - name: "Create the JupyterHub Single User ConfigMap for {{ user_name }}"

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/tasks/post_workload.yml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/tasks/post_workload.yml
@@ -1,0 +1,8 @@
+---
+# Implement your Post Workload deployment tasks here
+
+# Leave this as the last task in the playbook.
+- name: post_workload tasks complete
+  debug:
+    msg: "Post-Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/tasks/pre_workload.yml
@@ -1,0 +1,8 @@
+---
+# Implement your Pre Workload deployment tasks here
+
+# Leave this as the last task in the playbook.
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/tasks/remove_workload.yml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/tasks/remove_workload.yml
@@ -1,0 +1,18 @@
+# vim: set ft=ansible
+---
+
+# Implement your Workload deployment tasks here
+- fail:
+    msg: User count end({{ user_count_end }}) < user count start ({{ user_count_start }})
+  when: user_count_end|int < user_count_start|int
+
+- include_tasks: per_user_remove_workload.yml
+  loop: "{{ range(user_count_start|int, user_count_end|int)|list }}"
+  loop_control:
+    loop_var: user_num
+
+# Leave this as the last task in the playbook.
+- name: remove_workload tasks complete
+  debug:
+    msg: "Remove Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/tasks/workload.yml
@@ -1,0 +1,20 @@
+---
+# Implement your Workload deployment tasks here
+- fail:
+    msg: User count end({{ user_count_end }}) < user count start ({{ user_count_start }})
+  when: user_count_end|int < user_count_start|int
+
+- name: Setting up workload for user
+  debug:
+    msg: "Setting up workload for {{ user_count }} users"
+
+- include_tasks: per_user_workload.yml
+  loop: "{{ range(user_count_start|int, user_count_end|int)|list }}"
+  loop_control:
+    loop_var: user_num
+
+# Leave this as the last task in the playbook.
+- name: workload tasks complete
+  debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/templates/jupyterhub-single-user-profile-user.configmap.yaml.j2
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/templates/jupyterhub-single-user-profile-user.configmap.yaml.j2
@@ -1,0 +1,16 @@
+apiVersion: v1
+data:
+  profile: |
+    env:
+      AWS_ACCESS_KEY_ID: {{ s3_access_key }}
+      AWS_SECRET_ACCESS_KEY: {{ s3_secret_key }}
+      JUPYTER_PRELOAD_REPOS: "{{ workshop_preload_repos }}"
+    gpu: '0'
+    last_selected_image: s2i-spark-scipy-notebook:3.6
+    last_selected_size: None
+kind: ConfigMap
+metadata:
+  labels:
+    app: jupyterhub
+  name: jupyterhub-singleuser-profile-{{ user_name }}
+  namespace: {{ project_name }}

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/templates/kafka/strimzi-cluster-operator.deployment.yaml.j2
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/templates/kafka/strimzi-cluster-operator.deployment.yaml.j2
@@ -1,0 +1,85 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: strimzi-cluster-operator
+  labels:
+    app: strimzi
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: strimzi-cluster-operator
+        strimzi.io/kind: cluster-operator
+    spec:
+      serviceAccountName: strimzi-cluster-operator
+      containers:
+      - name: strimzi-cluster-operator
+        image: strimzi/cluster-operator:0.11.1
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: STRIMZI_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: STRIMZI_FULL_RECONCILIATION_INTERVAL_MS
+          value: "120000"
+        - name: STRIMZI_OPERATION_TIMEOUT_MS
+          value: "300000"
+        - name: STRIMZI_DEFAULT_ZOOKEEPER_IMAGE
+          value: strimzi/zookeeper:0.11.1-kafka-2.0.0
+        - name: STRIMZI_KAFKA_IMAGES
+          value: |
+            2.0.0=strimzi/kafka:0.11.1-kafka-2.0.0
+            2.0.1=strimzi/kafka:0.11.1-kafka-2.0.1
+            2.1.0=strimzi/kafka:0.11.1-kafka-2.1.0
+        - name: STRIMZI_KAFKA_CONNECT_IMAGES
+          value: |
+            2.0.0=strimzi/kafka-connect:0.11.1-kafka-2.0.0
+            2.0.1=strimzi/kafka-connect:0.11.1-kafka-2.0.1
+            2.1.0=strimzi/kafka-connect:0.11.1-kafka-2.1.0
+        - name: STRIMZI_KAFKA_CONNECT_S2I_IMAGES
+          value: |
+            2.0.0=strimzi/kafka-connect-s2i:0.11.1-kafka-2.0.0
+            2.0.1=strimzi/kafka-connect-s2i:0.11.1-kafka-2.0.1
+            2.1.0=strimzi/kafka-connect-s2i:0.11.1-kafka-2.1.0
+        - name: STRIMZI_KAFKA_MIRROR_MAKER_IMAGES
+          value: |
+            2.0.0=strimzi/kafka-mirror-maker:0.11.1-kafka-2.0.0
+            2.0.1=strimzi/kafka-mirror-maker:0.11.1-kafka-2.0.1
+            2.1.0=strimzi/kafka-mirror-maker:0.11.1-kafka-2.1.0
+        - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
+          value: strimzi/topic-operator:0.11.1
+        - name: STRIMZI_DEFAULT_USER_OPERATOR_IMAGE
+          value: strimzi/user-operator:0.11.1
+        - name: STRIMZI_DEFAULT_KAFKA_INIT_IMAGE
+          value: strimzi/kafka-init:0.11.1
+        - name: STRIMZI_DEFAULT_TLS_SIDECAR_ZOOKEEPER_IMAGE
+          value: strimzi/zookeeper-stunnel:0.11.1
+        - name: STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE
+          value: strimzi/kafka-stunnel:0.11.1
+        - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
+          value: strimzi/entity-operator-stunnel:0.11.1
+        - name: STRIMZI_LOG_LEVEL
+          value: INFO
+        livenessProbe:
+          httpGet:
+            path: /healthy
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 30
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 256Mi
+          requests:
+            cpu: 200m
+            memory: 256Mi
+  strategy:
+    type: Recreate

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/templates/kafka/strimzi.clusterrolebinding.yaml.j2
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/templates/kafka/strimzi.clusterrolebinding.yaml.j2
@@ -1,0 +1,32 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: strimzi-cluster-operator-{{ project_name }}
+  labels:
+    app: strimzi
+    project: {{ project_name }}
+subjects:
+- kind: ServiceAccount
+  name: strimzi-cluster-operator
+  namespace: "{{ project_name }}"
+roleRef:
+  kind: ClusterRole
+  name: strimzi-cluster-operator-global
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: strimzi-cluster-operator-kafka-broker-delegation-{{ project_name }}
+  labels:
+    app: strimzi
+    project: {{ project_name }}
+subjects:
+- kind: ServiceAccount
+  name: strimzi-cluster-operator
+  namespace: "{{ project_name }}"
+roleRef:
+  kind: ClusterRole
+  name: strimzi-kafka-broker
+  apiGroup: rbac.authorization.k8s.io

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/templates/kafka/strimzi.rolebinding.yaml.j2
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/templates/kafka/strimzi.rolebinding.yaml.j2
@@ -1,0 +1,56 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: strimzi-cluster-operator
+  labels:
+    app: strimzi
+subjects:
+- kind: ServiceAccount
+  name: strimzi-cluster-operator
+roleRef:
+  kind: ClusterRole
+  name: strimzi-cluster-operator-namespaced
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: strimzi-cluster-operator-entity-operator-delegation
+  labels:
+    app: strimzi
+subjects:
+- kind: ServiceAccount
+  name: strimzi-cluster-operator
+roleRef:
+  kind: ClusterRole
+  name: strimzi-entity-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: strimzi-cluster-operator-topic-operator-delegation
+  labels:
+    app: strimzi
+subjects:
+- kind: ServiceAccount
+  name: strimzi-cluster-operator
+roleRef:
+  kind: ClusterRole
+  name: strimzi-topic-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: StrimziAdminBinding
+subjects:
+  - kind: User
+    name: "{{ user_name }}"
+  - kind: ServiceAccount
+    name: opendatahub-operator
+roleRef:
+  kind: ClusterRole
+  name: StrimziAdmin
+  apiGroup: rbac.authorization.k8s.io

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/templates/kafka/strimzi.serviceaccount.yaml.j2
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/templates/kafka/strimzi.serviceaccount.yaml.j2
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: strimzi-cluster-operator
+  labels:
+    app: strimzi

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/templates/opendatahub-operator.operatorgroup.yaml.j2
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/templates/opendatahub-operator.operatorgroup.yaml.j2
@@ -1,0 +1,9 @@
+# For more info on OperatorGroups
+# See https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/design/operatorgroups.md
+apiVersion: operators.coreos.com/v1alpha2
+kind: OperatorGroup
+metadata:
+  name: opendatahub-operator
+spec:
+ targetNamespaces:
+   - {{ project_name }}

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/templates/opendatahub-operator.v0.4.0.clusterserviceversion.yaml.j2
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/templates/opendatahub-operator.v0.4.0.clusterserviceversion.yaml.j2
@@ -1,0 +1,973 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    capabilities: Basic Install
+    categories: "AI/Machine Learning, Big Data"
+    description: Open Data Hub is a community effort
+    containerImage: quay.io/opendatahub/opendatahub-operator:v0.4.0
+    createdAt: 2019-08-06T13:32:33Z
+    repository: https://gitlab.com/opendatahub/opendatahub-operator
+    support: Open Data Hub
+    certified: "false"
+    alm-examples: |
+      [
+        {
+          "apiVersion": "opendatahub.io/v1alpha1",
+          "kind": "OpenDataHub",
+          "metadata": {
+            "name": "example-opendatahub"
+          },
+          "spec": {
+            "aicoe-jupyterhub": {
+              "odh_deploy": true,
+              "notebook_memory": "{{ jupyter_notebook_memory }}",
+              "deploy_all_notebooks": false,
+              "registry": "{{ jupyterhub_image_registry }}",
+              "repository": "{{ jupyterhub_image_repository }}",
+              "storage_class": "",
+              "db_memory": "1Gi",
+              "jupyterhub_memory": "1Gi",
+              "notebook_image": "s2i-minimal-notebook:3.6",
+              "s3_endpoint_url": "{{ rgw_endpoint_url }}",
+              "spark_configmap_template": "jupyterhub-spark-operator-configmap",
+              "spark_pyspark_submit_args": "{{ spark_submit_args }}",
+              "spark_pyspark_driver_python": "jupyter",
+              "spark_pyspark_driver_python_opts": "notebook",
+              "spark_home": "/opt/app-root/lib/python3.6/site-packages/pyspark/",
+              "spark_pythonpath": "{{ spark_pythonpath }}",
+              "spark_worker_nodes": {{ spark_worker_count }},
+              "spark_master_nodes": {{ spark_master_count }},
+              "spark_memory": "{{ spark_node_memory }}",
+              "spark_cpu": "{{ spark_node_cpu }}",
+              "spark_image": "{{ spark_node_image }}"
+            },
+            "spark-operator": {
+              "odh_deploy": true
+            },
+            "monitoring": {
+              "odh_deploy": true
+            },
+            "kafka": {
+              "odh_deploy": true
+            },
+            "seldon": {
+              "odh_deploy": false
+            },
+            "ai-library": {
+              "odh_deploy": false
+            },
+            "beakerx": {
+              "odh_deploy": false
+            }
+          }
+        }
+      ]
+  name: opendatahub-operator.v0.4.0
+  namespace: {{ project_name }}
+spec:
+  maturity: alpha
+  version: 0.4.0
+  replaces: opendatahub-operator.v0.3.0
+  apiservicedefinitions: {}
+  minKubeVersion: 1.11.0
+  labels:
+    operated-by: opendatahub-operator
+  selector:
+    matchLabels:
+      operated-by: opendatahub-operator
+  customresourcedefinitions:
+    owned:
+    - kind: OpenDataHub
+      name: opendatahubs.opendatahub.io
+      version: v1alpha1
+      displayName: Open Data Hub
+      description: Deployment of components from the Open Data Hub community
+  description: |
+    The Open Data Hub is a machine-learning-as-a-service platform built on Red Hat's Kubernetes-based OpenShift® Container Platform, Ceph Object Storage, and Kafka/Strimzi integrating a collection of open source projects.
+
+    Open Data Hub is a meta-project that integrates open source projects into a practical solution. It aims to foster collaboration between communities, vendors, user-enterprises, and academics following open source best practices. The open source community can experiment and develop intelligent applications without incurring high costs and having to master the complexity of modern machine learning and artificial intelligence software stacks.
+
+    ### Core Components
+    * JupyterHub - open source multi-user notebook platform
+    * Apache Spark - unified analytics engine for large-scale data processing
+    * Ceph - open source object storage
+    * Prometheus - monitoring and alerting tool
+    * Grafana - data visualization and monitoring
+    * AI-Library - an open source collection of machine learning algorithms
+    * Apache Kafka - open source stream processing platform
+
+  keywords:
+  - "open data hub"
+  - "aicoe"
+  - "open source"
+  maintainers:
+  - name: Open Data Hub
+    email: contributors@lists.opendatahub.io
+  provider:
+    name: Open Data Hub
+  links:
+  - name: Open Data Hub
+    url: https://opendatahub.io
+  - name: Open Data Hub Community
+    url: https://gitlab.com/opendatahub
+  - name: Open Data Hub Getting Started
+    url: https://gitlab.com/opendatahub/getting-started
+  displayName: Open Data Hub Operator
+  icon:
+  - base64data: "iVBORw0KGgoAAAANSUhEUgAAAUIAAAEiCAYAAACMWdvGAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAACAASURBVHic7N15eFTV+Qfw73vuTBKyQdhVkIC4orjUBREtO6KE1ewBqVqsW0Xb+lOxNq11a+tWbVW0ikAWiIAQQSEo1gWtuyAKsiS4IMoSkplsM3PP+/sjC5NJcu8kmSQQ3s/z5HmYc8895wyTvHPvPRsghBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQnQR1dAPEsWnWluJzoTECzB4itf6ls7rtDMyz5p8cftDtmgXCZcTKy8Rrd1RF52Vmku6INovOSwKhaFeJWzisCxe/CEaaX7LJzA8uGtrjj7UJSzNLunvD1BsAzvE/n8Gvd4+OmXrFb6mqvdosOj/V0Q0Qx5YufOjBgCAIAAYR3TNzU/Hs2gRPOD2BgCAIAAS6vNjlvquNmymOMRIIRbuZXVgYAebfNHWciG8DgBczOYKYEpssiGhWGzRPHMMkEHZi5eU7+u/lvVEd3Y5avvLu/QBEWmQ5DQAiHBW9AIQ3nY1PDGnDxDFPAmEnwsyq1Lvr0hLPrn+Vegr3+hzGt5HeipJSb+HKgxU7Ozx4kPY6bbKEAYAG2f1eyu+tCClHRzdAtF6xp+hcAzq91FuURKD+AT1gBhiTHYY6u5S//0Us9TvQMa0U4sglgfAoxczKVVU4CYp+B/BlANkNARjAHs9tAO5plwYKcRSRQHiUYf6ui9vrm+XyFt0ORac051wi9cu2apcQRzMJhEcJZlYub9Esl893P4DjW1iKL6SNEqKTkEB4FHB5i0aVeoseIeBccCsKIqwLWaOE6EQkEB7BDlbsPNHhUE8w89TWTwGiLysdZU+GoFlCdDoyDOEIVeLZNcthqE1gTG1dSeRm4BntpMt60xB3aFonROciV4RHGBdv78U+xzNgTG9FMZVgWs+k86qc5cslAAphTQLhEeSQd9d49tJCAH1acj4DnxPwhNfpW96DTi4NcfOE6LQkEB4hXJ7COcz8L7ToM+H3oPFwbPjAV4moNd0pQhyTJBB2MObt4S6v42kGftXsVdEYaxT0ndHhJ21uaf17OD+yqkzFal0VC8OIVT42lIN9Xu2scpoo9+nyAyd1TyppaflCHA0kEHYgF+/o7fKq5QAuaeapmzXx77qFDSoI9oQ9nB9Z5eYLwPpiKJwKplMADK5y696AhiID0AAUQWuCARPaAJQRjkLXylIA3zGhiIBNpPkjr8P86OTIGd83s91CHJEkEHYQNxf21V68AeCMZpxWSsAd0c7454nItMu8u2zFLzSrGQBGV7n1eQCcIEILxiLGAhhCjCEArmQiOEwHCl0rfyDQa8x4NTyGCo6nhPJmlyzEEUACYQdw864+2ov1aF4Q3MjavDo2YvAOq0xFruWnazauJYXpWmNg61pq6wQGXwfCdVVurihyrVwNmPfGx0z/uo3rFSKkJBC2sxZcCVaCkBnjiP9HU1eBG3iDY6C7dLIG38ig0USgVs1AaZkuDFxFMC4vKsv/ZXxUwqft3gIhWkgCYTty8Y7e2kvvADw4qBOIvtdMU7s5B3zS2GHmTLW77NxUuEszGRhsu/5MO2AgGlo/ieY/9xSiw8jMknbCXBjBXmNF0EEQ+MBw4MJuYY0HwV2lryQUuc/9nBmLGQi2zPZy8e5Dr8Z1dCOECJZcEbYDZqZSb9ECAoYHdwYtinHyHKL4ysAj35Xnn+Az9b8ATAlxM0OJtIMsltoX4sgigbAdlHoK7yOi5CCzPxvjHHBD4MBoZqbd7vwbfKZ+ENW9uG2hFIAJAAzEUMt/P3YOjL5yb+iaJUTbkkDYxlxVuxKZaF4weQl4PNoZf3tgECwsXtGtyL1qAUJxFUgoIo13taIvSGO7Ir0dpuPHAd0mFQdm3cJLw2JKnP1NA/2J1SBNOI+ILgDz2Wh6cyVm8J2tbqcQ7UgCYRsqL9/R30f0bHC5+ZGYsEG/D0wtdK84B6xeBnBSC5tRxYT1pHmZYdDaE6Om7An2xCGU5AGws+bnLQAvAEAhb4igctco1jyZgEkM9AMAAr5n4A+DYqa+3MK2CtEhJBC2kZoVpRcACKbTYEFsY0GwdNUUMOcA6NLc+gn8JYP+rb1V2aGeIjeQRlUCeK3m54bt5cv6KQpTgyI++Z4oU4eyLiHagwTCNuLyFf0fgNFBZH0nxulrsOl5UemqazXxMy14TvcmoO+Lj5n2VjPPazGZaieOdhII24Dbs+tszfhzEFm3sdMxlWhglX9iYemq/2PiB6k5qzAQfahAdw+ITnijue0V4lgngTDEmJlc3qInAdhsZk5uaHNyV+p/0D+1yLXqRgY/1IwqS0G4Nz6q8imiJNv5x7UymdW3m0viTdKnAziRwX1AFEGMrly9/MKh6h/+ltjYobly66Kz+5Y1o11HvKVL2ajaWTpQEQ1hpuMI3JW06sqAArEXxG4CDjBUkUnGN7Pu7PJtR7dZtA0JhCFW6tmdRoRLg8h6a2zESd/4JxS5V6Yzc3P2FVnrMNS1/SMTfggm86wtxeey5isU6Je7viy+GITow0erF2NoODOPwKRBFOaZtelAToSHbp1/fvejclmuZ59lZ3Sx+2JoTABorHeHe6iCigDXXnoT2L/DnmtnKjIM9iHrAZcbwHsg3qBM442UeZGfyPqPnYMEwhDax1tjyMcP287zJayIdca/4J+0y50/nlm/iOBm+2gAf4mP/uw+u86Ja7buO97nVXMASofmwQSAWzYROQxEV1eG45TEpXxpXpL96jdHisUPuc8izXNwwJ0BoFt1aov+D6IBTADTBK00sh9078h+wLWIyLcw9a64opA1WLQ7CYQhFO4JvweEEywzEX6Aw/lr/6RdFasHkM+XDdvbaYAANxQlxUdNfs0q38zN+08nUvf4vEgMptxmuLjL6QevArAkhGW2iez73eOY+E/Q3Fbzngcz8Gdmx72LH3AthaIHM+6MbvEiuaLjSCAMERfv6A0vbra9GNQ8N4b6Hah9vZ3XhJPLmwdCD/ta6CCYJsVHJbzfVI6Mr/Ydp0zjYQDp4LaZS05Ml+IIDoQ5D5RcpKEeZPCodqrSICAVmlOyHnAt9Wnjd1ffExnU4wpxZJBAGCLsMW4DIdIm25sx4YPqDTY23N5HQLggiCp+ZOZRA2Mnb2u8AUyzNhffBBP3o+2m4NVW5m3b8lvm2UyOjAlz36+B36JjFhQhAMkOZV6R/YA70zE46omko+gRwrFMVp8JgYO8sysIDcYC1sc+xXquf0qha9UvCbgxiCpKQPqKQbFTGg2Cs7f83HfWl8WvgfAk2jwIAiBY3pZ3hKy/llwYHe7+nIG56Pjf6xgGP+Ld4S5Y+jd33w5uiwhCR//CdApOn3Ez6h7CN45A//LfZKmQN0QA/CzsxwpWaFaTBkZP+7yxg7O/3H+BNh2fAJjQ3Ha30NKXzuqxrp3qCkr2/e4MKPVfME7u6LYEGOX18edZD7ku6+iGCGtya9xKzFvCXF6+1SZbJTlRb2wguUvnMXBqEBXcdFJswruNHcrYVDxVM2eDmj8Fz48H4E3MtF8pcmlwsWIyGNwHQD8CHcfgngCKALzw7f64v7WirpBiZsp5oOx+Jr6rNeUQ8AMD3wD4EQw3FJdBUxQIcSD0B+MUAN1bWHwfaKzLftCVnnZXzLLWtFO0HQmEreT2dJkMQi+rPAz+TzQNqluWalfF6gHs8/3BrmwCPR8fO+XFxo7N/PJgCjEvQvM/Q2bgv8RYBkN/WIEen+cNIU8zyzgiZD/kegREtzX7RMZ+EPIArPeB/3v13bEH7E7JebA4ntkYpUGXEzAZQEQzagxnxpLFD5TekHF37HPNbq9ocxIIW4mhrrYZk+bVJv3DP4FM371oehmrWls4OuaWxg5kbCqeSsyLARjNaOpegJ5RPry04Nyjf8xb9gPuh5m5uUHwPQL/w9UzZvX111OzOnxqxgm+CODFpQ8d7OrVzjQAvwcwKMgiDAI9k32/qyRtXszS5jVbtLWO3+TiKFa9ERN/B5DFFwotjg2Ln1n7amfp8lOIjC02iyloYr40PnbqxsADs784MEwrehPBr0hTzsyPVhrmw3lDeruDPKdNzNy8/3SC+soqz8KzulPWXysGQPmKQlj1JjDmps+L2RDCMrEhkx17nK4MED0EoE+Qp3mY6YqMedEyJ/wIIleEraB9nGEdBAEi/Vz918a9Qawo82xjQTB18099NGg5gg+Ca2DqOYvO6Wk7pm0DZzrCD5T0gabeBqEswlQ/nN33H0f73GIPQPOO90Q9PiqTfKEuvKbMBS9mFr8S5nT8HYTrgjgtjIiXLnyo4lyZu3zkkCvCVij1FH0E8PkWWXbFOOMH185HLXSv7gv27QYQZnFOMXx60MC4aYf8EzOZ1a4tB9eBaUwQTTPB9OdBZ3W7P5Oo0Sl4H/78h74+8k0m1lMYOA+g3mg4isAFYDsDrzHRK5f0fOwTasVGoe17RUiFSlNS6j1RH7eunOBl3e9KAeE5wH8Od5Ped/eI/mVzb9FF25ArwhYq5W094eXzrPIQ4SX/SfnMvl+TdRAEGH8PDIIAsOvLQzcBQQXBMiaeseis7msbO/jBz7eO0KD7fPBeBoZi6+/CGADnEXAeMc97f9/c79/fR48WH/L9+4qTn6yyOrGDfUaMian3RP3UnpWmz4vJzXqwbDtYrwHQ2yb7xdH73X8EcG87NE3YkHGELcSesHGw/v9jnw8L617wUoOYr7Updl9VFZ4KTLxm677jAb4viGZ5wEhcdGaPBkHwgwO3nPHeT3NXatA7AEbatL0p/Zj50W5dja3v75ubzjZRtGPwR07lHZU2L7pdg2Ct9LuiPjHAlwKwr59wR+4Dpae0fauEHQmELURkO4B5c1yXgUW1LwrLuowB0QDrU/ip03pNcQWmer3G3wB0tanPhOL0hUO7N5j18f7Pt12tTeNTIky2KSNY8cxY/P6+uS9/sff3USEqs/UI25ygK5Pu7NhlwlLujv1Gs7oC1bsCWgk3QQ2++ET7k0DYAsxMIIyzzkT1rsqIebpldsBnKHo+MH3W5oNDCUgNolF3LBzS4+X6SaD3fpqbyeAFsB+u0xLTy5Rv4/s/zo1vg7KbicoMhWlJd8fs6+iWAMDMeVGfkuYM2K/3NS7rfld7LQ4hmiCBsAVcVbtOBuN4qzxKmXXT0JgzFcAJlvmBFY3uMMf0R9h8Tgy8Neis7o8Hpr+/b+4CIvzJ6twQGMoGNr578NYT27gea4wbU/4v5usObUOAtHti8xkNH3U0QLinHZojLEggbAEiOsfyOFAe5dDv1L4uKj3vQsA6cDJTVmDarC0HTwTxVJvmlJoGzQ7sHd748213Aphlc26oHKd8tLIDb5PXpc+LXmifrf1pZ9ldAL6zyTY654GSi9qjPaJxEghbgIGzbY5/RHRyXa8qke1uduXhMVTQIFXjetj17DMeyD4jbrd/0vv7bp0M8P02dTbFheoVsJvrnHJlvtQBHSheA9zoDJwjwaw/9C1j4Ha7fJrVNe3RHtE4CYQtYntF+IX/aya2+7Z//XhKKK+XwkywfzZ40BFm/ts/YcPPN0Yz03wE/9luZvCd0DQ0zFceNbz347Hf9/ohDIr6gSgdwMsAglpTj8EzPth3W2KQ9YYGUVbK3bHf2GfsOOl3RS8D8JllJkLy0ke5NYtniFaQcYQtoXC21SNwBn0RkHShVXEEfjMwbeZXBy4E1ECr85jpiRdO61WvlzmCwn7HHNR0r5+Y+ffDe8dlB+57kkR5JoAfAGQDyP7gwC1nmKbxOMGmgwgAg+//mOesOJ/mt8dAYTYUHzGr4TSFiDj7QfffmTnbIltXX6VrAoBX2qtd4jC5Imymfbw1Bmy9L4mGuan23zsr8k8EYLk4p6nof4FpZBrjbZriDTNUvQfxH/x0ax9m/N7mPAD8mcNQF1zS54nFdps/AcCwHk9+NbxXt8sR3Dajgz37IucEka/VCHj3SOsgaYqjKmoZAMtVbhg0tp2aIwJIIGymsCqn7YrD5c4uddPIyNR2aw5WVkZWbWqQSmw9i4T47f8M6VpvT2Qmug4207sY+MYM84y5sMejdg/w61dHmXp47yfuItDDQWSfa5+l9ZiwuD3qCYWkTPJw9WMGK8HMHBJtQAJhM5FBdoHw0PF0fN3zPmKyvL0FsHUIJdVbDzBxKRuA9T4mxGpVYBoDU2zqqiJlTLm029PFNvmaNKxX17vBaHArH2Dwe3t/e2ZL6wiWMo0jbssAK0rzapsspy38u8tuap5oAxIIm4m07fO3vfVeEewC4a7AhPBT9w8GrDeCMphe9X+9cf9tJwCwWgACxPzU8J6PbLVpjyWiTA2mubDrWVZkN+yntXak3hPZrKvajuZw+N6GTceTYeK0dmqO8COBsJk0WT/vQ8AcU2bub5WZGUWBaUo5zrCpw/XC0G71AigxT4T1akImAX+3KTcow/s+thmgNVZ5CHRFKOqy0G6ryoRKzdS/xnchrMUSCDuCBMJmUkTW+w8T/VzvZfUKLlYF/thIaj/LKoDtgWnMtislbxzW54kQLkSg7Xo3z2zTMYVsE1COXJZDfRg0uL0aIg6TQNhMWpP18vjM9cYDMthytgUxN7L4KVtedTKwo0E5NucA/J718eYxtGn3nDDmnb239Axlnf6YqLCtym5TxJbtJs1x7dUUcZgEwjZGIMtAyNQwEDLYpueX9zZMI8spfARqOI+5FXb3+elb2Cwo4DAcdivmtBxpu5VdjkyarNtNNncQok1IIGxjxNaD1hXQcAl5Issd0gjU4JaTAcuAq0Eh3a+kZtC15fL32qy/4o1WDdvdUgTVYLmyowGRXSDk2HZqivAjgbCNMaHc6rjWDXuHia17Fokbfm4KZPn8z/7WuXk+OHBLLACnZaZwXS9YGabtmopI3MLWK3jXUCY1WMX7aMA2ny3Y5tGLaBMSCEOMwPWvABmWGyARNTpMxvLqTauGAUiDLW99CXyy1fFmM9VQmxxalan6awPadTQBiPD9ZB1ca4ty6qN9YylxBJFA2EykYH0lwlRvs3ci60AIUGMPxy3rIEZ8gzSgsd7nw80CXVm9LmJoaFJ2q11/O7z/YxX12sBk23nSLbJPyHebE8KOBMJmYm29FwVT/QHXDFivmNzI8v0MshsofHqDFK0/tDmn9wf7DtltLxCUNdtvCQc4ySoPMxrrpbZbvNV8cjA8NnmECDkJhM1kKNN6LF7Ayi/MsB7mwQ1nnrDmIptm9Ltm6756vYthfSrfBshy6hwDD4XiqjCum+NGMKz3X6HGVlHhi61PwRfw2/WvLbiqdp/h9u4ce6iiyG7GjziGSCBsLpsrQhB6MfPh/1ebcWNo5NmdQ9NmWA9NIY9XDfNPOJ/me5nZcrYHgKHv7y9u1bLwHxy45QxmzrTJVsUUVm/PlsSlbBDBMhACaLO5w4cqdw8q9RS+x6S3aFYFyuBdpd7CVaW8rc3GOoqjhwTCZuIwtpudYZRU7q67WjKUXSDECd+Wraw3BnDBuXGH0MgcZH8KNK2RxBybugCmzPf3zU23zdeIjftvO0GbxkoAlkM8CPTqiF5/q9dj3GXIoaGw2YmPNL9qdbyl9vLeKKV0AYDh9Q4wEuB1vlLvi0sck+QXoJmicdJ+2IzJU4rrelR1ZLctgPVzL9NUDRZuJeJ3Gstbdxw0PTPgD/iSXo+vBvC+1XkAiBmL3vtpbuZSTgx6qMbGn347HJo/AmA3Bcw0zYYbRpGGXfA9VLat+0fBtqc5orwVM4GmpiDSJSW+QlkH8BgngbCZiEgDvNkyjzq8p8lAGlUJkE1+PTwwTYMabNLuj8F9dn5VMjIwXYHvsDqvtkoi/Knf/hO+2PjT3KkbOLPJQd//23f7KRv3zV0IUu8AOC6Isl8acdxjW/wTbtnO4Qy+2vo0fjMviYLaEqC52GbrVQX6RVvUK44eslR/y2wCmn7exeCh9V/r/5HFHxszTQJQL4CFkbHOy6YHQJMDjMk05wH11wYc1vuJdzf+PPdlAFdZvoPqhg0BYUX4vpLi93++da0GthCpnwGOZMYgYhpjsrZbCcdfiTLMBleDpRXFV4Fg/SyOaZ3l8dbQuNhq+QdmPipnqYjQkSvCFgjcnKkBpnP9XyqijdYl8uk7S/LrdZr8Z0jXgyCbzgOi0VdvKr4sMFlT2DUAvrSus179cQxKIdB9YH4WjMcIuAXEzQmCGsQZw3o8+b1/4sgN7GDC/9mcW+E0jLxm1BW0QxVFA0F2V7LUJrfk4ughgbAFmFTDpfXrG3SocnfdMymHNl9nm3m5iswZgWla0wK7tmjiP9fseFdnRK+/uQztm8zAfrvzQ4WJ7hje64kGnR39ex26GcBZ1mdTTuC2A6FCSl9ik6Uy1lluvcOc6PQkELZAlaNiE8CWgc1Qum7zpX6x0w8QGh1gfBjRdYFj/Kq2dstHI0tu1TsNGDlrc/FNgekX9X2qUDGmwmbDoJAg+vslvR57JDB55heu3sTc4FY5EIOebpuGASBq8Pw1IMPHRENkEPcxTgJhC/Si01yA+sAqDxPq7UJHhHybYk/6tuwXo/wT8pLIZMLjtg0i/H3mFwcb7BFycZ/H3zOZLgRhS2OnhUAVAb8a3uuxBh00iUvZIMO7AEA3mzLeW3RWtzZZbZqrr5Qn2WQK6TqN4ugkgbCFiPC6ZQbGGOaP6xYQ8CleCpv9KjT41sC0buFxzwM2s1OACFLIDpxtAgCX9nlsl1LmcALnwmb9wGbaDtajL+79+ILGDnY5vfghMCbalMFKcxDbj7ZMqbfoIgIst0qA/XAjcQyQQNhCmk27Xs7YUrNn3VXh4Mip37Ft8OSEnWWr6u1e9+TJVEWEeUE06Syf11gz84u9DdYlHNbjydKLez+RyoovAvBWEGU13URgP4PvPFRinjW8zz8b7QS6elPxrwD7/ZUZyF5wdg/LK+vWIKYGz10DVJSHdVnfVvWLo4cEwhaKdQ76BDYLKhDrX9VL0PysXbkG872BaS8NicslUEEQzRpBKix/zsd7Gt0B75KeT3w0vPfjoxTzeAaeB2ymC9ZieACsI8aNHngGXtL7iYevOPnJqsayzvzy4E1M/HwQpZY7wHcFVX9LEU+3Po61famvLOclZBxhSxGRLvUUvQ7wzCYzMSWU8raesXTqfgAYGONZU+QK293YijN1pzAm7XbnjxkQnfCGX2VMnxXPYQc2wW4zKGBUZXjE+l9tPpD84lk9Gl3FZlifJwoAFDBnqg9+PnQxAxcz4VQi9AIQBYYXzMVEahdDbwpzRqw7v/vDJZa1MtPMzQf/Qozg5jIT3/rimY23LxRc3sKRdhtaMfPytqpfHF0kELaCJr1IMTUdCIEw9jpTATwJAERJZqFr5UMALHtJNeunC3nD0OpZKdUWnBtXdPWXB69nRnYQTbvYBH02a/PB2QvP6t7k/F2iTI3q3uxWdRjM+nz/Cfiy+BkQWXdM1GAga9GZPYK5amwxBn5rk8XLTqNN5jaLo4/cGrdCV8fANwj41ioPgX7jP6m/PLrqBTDvtin6ZLhdDW4bXzqzew4ITwXZvB4AVs3adHD+NVv3WW7s1GLMNHPzgWthqC9h1zt72NZK5fuNVQbTEUSnjslNdjwdrNh5IpgTLM9nrO9GAyyXLRPHDgmErUBEWjMttMl2httTWPesaggleRh0v13ZDL57V+krlwamf7sv7jaC7VCcuiaC8Guf19g+68uDD167paR7kOdZmvMxO2dtOpg2a3PxJwR6HvZDZKox9mhlJOQN6W25aEVFZcR+AF6LLF7lqWxyawKHUjcCZHe3M9/muDiGSCBsJWa1ADbDUjTRPPab/bE7JvZFAJ9bnUOAQxFlbyvNrzdH961R5AuvqkwhguXqNAEiwbjTq80fZm0qzsvYVDz1lu0cbn+aH2aavaX4nFmbD95dGV68A4QsEM61P7EagX5S0GMWD+lqOUAcAK7PpHIASy1KW5yU2XgwLeHvuoNwvU0Vu2PC4oP9MhHHAHlG2ErdIk7cWeIpeoPATS7lRMA5rqrCSai5khtFo3xFpfk3Mul3YfFlxEC/cNI5W3jplUMoqW72w/zzjy+f+cXeiUqFr2Cw5coqASJAfJUCriqpLC6dtfngJ8z0uVL4XGvsViC3Jl+5kx1VptLHaaA/MfoDGEpfHhqnwX1sa2jcPq157KKze24N9gQf+FYH6HQA5/mnE/CO9lTNbeo88ph3gWyuUAn/JmqblW7E0Slk+8wey1zeotHM/IZVHgY+j3XGn+//B1joWvUMwHZXLwCQGx/9WXpN50adW7ZzeEll8fMAMlrW8naxycFq2gtDu1kuNNuYpZkc5nG6MhThMobyMXHBjqrovMxM0o3lLy/f0d/nML4BYLUvdAWczv6x1K/tpx42Iut+960gtpottC797piQ7C0jgidXhCEQ44x/s9RTuBGBKyD7IeCcUm/hDcDhzg5lqru0YU6E/aZGKYWuc/cA+J1/4pMnUxWAmbM2HfgMRA/jyPs8l7D2XPvC2S0bq5eUSR4AL9T82PI5jExYB0EAWNRRQVAcueQZYYiwsu8AIdD9ZVxUtyTUgG6TilnrRNisYA0ARLi90LXy6cY2X1o4tMejivRwAEHferaxUoB+u/DMuNRFLQyCzVXiKRwGwGbxV1T6TG37ObUp4jbdnEq0jATCEOnqiF8DkN3iAbGml+v9IQ7qOu1DJgpmCh0A/Ga369yXPuZnG2yCvuDMnh9VuMrOI+K/AKho5Nz2wchxOM3TF54V92RjO9J9x0u7FJXmX1xYsmrYdl7TvA6bxWnmTgAAIABJREFUpqrk7eEE/AeA9dYDTE9273KS5XCnNsf42fI48d52aonwI4EwhDTpu4PINrvEV3SFf8LAqIRHAAQ1y4EJGT3dfd8sKlvWYLHRvOH9K146s8eflI/OAPhFWA9BCSkivMNKjVk4tHvaC6f1ajC0hZmp0LXyBp87/AcmvRGK33e6vd/vcq9s9fNNl8eRCcBuEdlDHGY81Nq6WstHXACgyRWxCcp+Ay4RctJZEmKl3qI8MNstk7/PcNLZURT/Y23Cd7y0i+kOX8fAiCCr+pGZkwfFTm1yGE3aV8UDHCbfjOpbxl5BltscHgBLidXjLw3t9klTmbaV5vcMU/xCE4OcmRlTB8VOWdWSBpR4dl5AoI224wYJd8c6Bz7YkjpCbfH97jQiXojAK1jG/PR5McF0nokQk0AYYjU9l18DaLAKjD8GrY91DphQvRlUte9Klnb3qfB3YH91U8sE0z/DY+ie4ymhvKlMiVs4rIt5aCIpPbVmf5TW7OVbRaC3mfgVRb7lC4b0tryVK3SvvByM5wGcYJHt84ExU4Iek1irlLf1hDfsY8Bms3nQjhinMZSof8c9Mgiw+K8lw0ip2wGcBuAnBi1OvytqIbXxBveicRII20Cpt/BOMOyvPojmxTrjH/BP2lH+Sn/DpDcANNj43cIuUnRzfNRk+w3SmSn9q4OnK42LAQwl0KmoDiQ9an5qH5e4Ub26zh6AtjHxNjbxviO25KMFAwdWNl74YTsr8k9UPv0YAOsVYGpadSB6b/j5dH3Qt/LMbJR6d79uNX6zhibiUTHOQW8HW7Y49kggbAPMW8Jc3shPAQyxyaqJOSUmfFC9jYsK3av7gn1rAQxt4rym/JdY3RUfm9Bhi43ucC3vbZDxOwA3ga2viv2Ux0dPjm7O1VBpVeHDINhuXUqgp2LC4m8JtlxxbJJA2EbcVTvP0qQ+hP24tkoQjYl1xtdb5HT3oVfjtGGuATCsuXUz+A1i46n4mIp8oqR2mUGxs3T5KYqMGwH8GkCj6yE2jbIHxky22wC+Tqmn6BqAn4f9729hpbN8aG8aYjm3WQgJhG3I5Sm6kcH/ss9J+1n7Lu4aMbjePNw9nB9Z6dbzCQg6SNQvFkXMlKUUL4uPmhLyndq+L13ew6uMSWBci+pOnpb8Pn3rMNTw/pEJPwST2VW1K4mJsmE3VAYwiTA2xjnwrRa0SRxjJBC2sVJv4QpU7yZnjfEjQY2NCR/wVeChXa6VNxPwCCw2ew/CLoAKmPhd8up3B8ZNK2puAd+XLu/hUc5fEJvDAJoI4ALYByQra5lw9aDoKUGtlH3Iu2ucYsoHYD/+kPiOWOegv7eibeIYIoGwjZXwd93J6/sUtj2bsAyGRaWvDGeihQBOClXTANoB8HZm/EDEpSAqAVMFCJHQCCfiaGacCEI/EAaBER+iuj1MNG9gVMIjwT4XLPEWXk6M5QC62GYmejnGMSBJemBFsCQQtgNX1e4hTPo9AF2DyL5PgcdFhw36IvDAHs6PrHTp+4hwK1p3JdaB6BOlzOsHRE1rctxhoFJP4dUAngPQYEZNI76qclYNq95yVYjgSCBsJ27v7jGa9WsI7o+5FEqnxzpOanQp+cKSVy6Con8jYImqI1wxgHnx0VXzm9OBU+otuhvMf0VQv6u0H9q8JDbipG9a3kxxLJJA2I5KPYWzUb2SSjD/7xqEe2Ic8Q81dovHzFTozk8k8H0ATglxU0OpAqDnfHD89eSYKyx3/fPH/F0Xl9f3FIBrgjylVEOP6RZ2UptsFi86NwmE7czlLZrH1Vc4QWFgSZWz/LqmhoBs4A2OgS7X1SA9l0Fnhq6lrUOAG4SnNfBIsJ0htVxVRaczYSnAQb0fAsqZ+PJY56DmrNotRB0JhB0g6JknhxUS4Rq7oSBFrlWjGXwzgMnouGeInxL4BfZx1sC4aYeae3LNVfNTsJmi6MfDhCldnQNfb25dQtSSQNhBSjyFt9UMiQn2M9AEPOlyht99PB3f5LxioHqRAyfMqQSaAcJotG7YjS0Cfwmi10DIael4xeKKwnhD8VMgujL4elHOSic39SxViGBJIOxALk/hDQz8C836HGgHGHfEhsevCCb3zoNLu8IRcalSuISYRzBwPuxnu1gxCfw1M30Coo3aQa+f1CWhxWv8MX/sdPl63EaMP3GzZqTQfgYndA0b+EFL6xailgTCDuaq2nUVEy1A8LeCtd7W0L9rbucA81Lj25LIAdrhO5kYg5nQH0xxALoB3I1Aihk+IrgYMAHsJcJ3zPwDtNrdpSJ8c9++E1q96jQzk8uzeyqI74P9nOxAhdA8MTZi0LbWtkMIQALhEcFdtWuoJnoFwMBmnsoMLNGgv8WFxYd8Cl1bYGZyVRUmsKJMQvDbgfr5yHDSFP+1HIVoLQmER4iatfWWAhjVwiLeZEWPxhoD1hyJMyr28t6oSG9lCoNvamEAZAL+Ge0sv4NoiO0eL0I0hwTCIwjzBofLM+DP1ctL2ay43LRviJDFps49EgYWuz2F55jgXxMoA0BsC4spBuNXseEDV4aybULUkkB4BCrxFF5EwAJUr17cYgR8ysS5SvPrUWGDvmyPK0Xmj51uX89LmXkSQAkAD25difSuaeqMuC6DdoemhUI0JIHwCFUzs+J+ALciJJts0X4Qv83MbzH4fa/Tuy0U83FL+fse7PNeoIALWdMFIB4BoFvr24uDAN8Z4xz4/JF4qy86FwmER7iaq8NHYbF5fEsx8B1A2wC9TRF+0oxDYBTDUMUGm1UAYEIZSnP1LS2pXszcD0T9AR6A6o3p7VfVaTZaTE7f72JosPXWl0KEiATCowAzk9tTOIOJHkLoluE6En1ARHfHOOM3dHRDxLFFAuFRhHlLWKk38iZi3AFC345uTwh9yIoyuzri7TefEqINSCA8CjFvD3d5HWkA3R7swgRHJn6PlXqwqyN+dUe3RBzbJBAexZiZSn1F40ljLgjjcHQs1nqIQIvBvmdjwgd/2dGNEQKQQNhpuHlXH9OLJAKlALgYR9Zn62HQ2wTOdjvDl9gtGiFEezuS/lhEiBRX7BpgONRV0DwahEsBxHRAMw4A9BqxzveG8drudFJJB7RBiKBIIOzkmDc4Sr3xvyDCSGhcBsIQVA97CeFnzz6AvgL4IwJ9ZII+6uoc8AURtcueykK0lgTCY9Ae3hPZxes51cF8KhROZcZxDMQpII5BcQDHgREJQgUAMFCiAM1AFQPfE/h7Bu0mxrea9PeVzqiv+1LfVq9II4QQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEO3jmFiqf8OGDRE+n+98Zu6vlIph5v1KqaJ33nnn88zMTG117tq1a/sbhnGqVR4iOlheXr41ISGh0d3ZXn311bjw8PDhzW23w+H436hRo/YDwJo1a3qFhYWdXXvM6/XumDhxYlFT52ZmZqoRI0aMrn2ttT40fvz4j+3qnJCY2D1C03lWeUxN+xzcZfcrryw4FNQbCZAwI3WIgnlcXdtg/Ji/LGdLYL4piYlnsGkMbEkdBod9sGLFwgOB6ZOmpl1oGL7YuroV78zPyytsSR2JiYlGlWlcXvvaJO1bvWzpWqtzJk9PudL/9arluXV7Ok+ZktIfDl33u6ZhfJ+/LGdrU2VNnJ7eL4y8p9W+9mn6YfWKJV/Xvp40LfViQ5lRVu1hRkWVwV+vzcs7aJWvs3N0dAPa0htvvHGe1vpun883EUAkEYGZAQBaa1xyySX7CwoKchwOx99GjRr1fWNlKKWmMPOTVvUwMyIiInwFBQVvaq0fnjBhwpv+xyMiIs5k5leb236v1zsBwDoAcDgcFzPzytpjDofj2/Xr1583duzYBn/sADB+/PjwsrKygtrXRPQugEvt6nSyca5mFFjlIQJMqjQTpqd8CtCiCMP3fF5eXkUw72nOnDnOvftLX9dQ/Q6n8g9z5swZOH/+fK9/Xq2N6wH8NphyA3kNz1gAb/inTZs2s7ePvG9rVuF1iT68BWBUS+oA0IWBus9VsSoH0GTgyczMVJ9s2hr4e1B3McIOnsKs6n7XiPhfAG5uqjyDzUka6um6+omfBfAbv/Of06yG2L2JMBNImJ7yKRE9tmpZThYAtjuns1Ed3YC28PHHHzvXr1//uNb6YwAzAEQ2kbUngFt8Pt8369evv7aV1ToAjFdKrS8oKPhTK8sKxonM/BIzd9RVvQHgAoD/WWka26ZclRLUFe+P+0sTGegXkHzCnv2lU0LfxPp88N0EILxeImHk5BmpQ9u67qPAecy8KGF68vyObkhH6HSBcMOGDY7i4uJXmPlWBH/r34WZn1+3bt29IWgCAchcv3791BCUZefK9evX/64d6rHTX2u8NWlG2hVB5G30Co9At4S4TfVMnDgxHMRzGjumwU1edR176LogP8dOpdMFQq/X+zCAwA/yBwB/IKKzmfkEZr6Ame8DUG/TcSLKLCgomGFTxZPjxo2jcePG0dixYxUzn0BECQA+98/EzPOaKoCZN3q93gi7n3HjxlneotZ4sKCgYEQQ+VrqPV2lutf+sGH2Y4VRRHgGgMcvn5OYc6+ckTaoqYISpicPA3CRX5LfLRhfNmla8tn++SOUeS8bZj//H4Iejfq2B+Zhw+xnlpW865/JiIhNBtC3sbqJkT4hMbG7zf/DUU8Z5pD85blU++OrKIkgpokgFPvnI9aTOqqNHaVTPSMsKCg4HQ2vONYDuGrcuHH+QW8PgI/feOON/2itXwdQ+8CZADy6cePGNcOHD7d95kVEXFPWnrVr136olPoKQI+aw7949dVX4yZNmlTc2HlXXHFFVfPeXZMczJyzYcOGc2s7VkKK4V29Otv/PRSj+ovlrSlXpSzSGmsAdK3JHEOM+wGkNl6UupUOxx8G0wOgw18YRHQLgOtqX+fl5ZUg4MsqYUZqN3C9R1i+V/PyfrB7GzVl1yoB4SVw3e9KpFOrawH83a6czuS1116rAvB6woyU+QD+7/ARdnZUmzpKp7oiJKKbUD+47+rSpcv0gCBYZ8yYMbtN00wAUOmXfGJZWdm05tY9YcKEnwG8598cp9N5QnPLaQki6uf1ehdmZma26+e58uXcjSC6oV5bwIkJCak9A/NOnpxyPIEPX20zCiIcvvsB+PdWpk2bNqtH4LmtNXl60mUAzj+cwguhzEcAmHXtZropMTHRCHXdRwMGAq6Gle3ogs6mU10RMnOC/2siemDEiBEuq3Muv/zyHQUFBQvg19sGYDKA7ObWT0TEflcrhmF4msgaXlBQcKJVWZWVlfubGo5TYzWAMQAiauqeOHz48DsBPNC8VrdO/rKc3ITpKX8BMLgmyYCTxyPg/087cDMBdVcaTHgmLy+vImF68kKA5tYkd/HBcx2Ah0PZRiZ1q/9NuGbMX52X923CjJR1YEysSR5QqR0JAF4JZd1HEs2q35Uz0uq+9BWb3QC6HIxf1WVi2ubqGv5ShzSwA3WaQLhx48YuZWVl9YKLYRirm8rvj5lfIyK/YQd0mlX+xqxfv74HM/v3nHpN02zqlu18ALutyouIiEgGsLSp40T0BYBVzPysX9p969at+9/48ePfaOq8NsAA3sThQAgQD/bPkJiY2KXSxK/9kn48vmds9TASUs/Cv2OLcOPIkSMfeeutt3yhaNwV09MGgPXkwyn09uoVuV8CADQ/C6KJdYeYb0HrAmGXhOkpjQ7DAoBPNjU5JLB9aFqr4D9stl5fohfAcgccv31rwYJKHGM6za2xy+UKvB3TI0eO/CnI0/f4v2DmXsHWu3bt2qiCgoKRzLwah58PAsC7EyZMKAu2nJYYO3bsfAAL/ZIUEWW9/vrrxzV1Tptg2lv/Nep9FpWmIx04nEbA/NoxgzUDht/2y35idPe+9a7sW8MgfTP8v/CrO3kAABEO/SqAb/2yj54yJf2sVlRHAE6w+TlSVRGoyqd8nb7TqDGdJhBGRUUFznJQa9eujQvmXKVUvT9cZm7QweFnzvr16w+uX7/+YEFBwSGllBvABgT0hjLz/UE1vJW01jcC+MovqY9hGFlVVVXt9ryL6zpLahNUwP8f+3dU+Lwwnq93mOjZei9DNJQmISEhEoxr/JL2+8oPLa99kZeXZxLwYr2WOswbQ1H3EYlRCkJx3U/1VWCtaAbPAvMHNb37x5ROc2s8YsQIV0FBwT4AdVdzSqkxAPKCOH2k/wsi2mmRN5yZwy2OM4C7rW5PiegLrfV1TR0HAI/HY9WGOhMmTCh78803k0zT/BCHB46PMk3znmDODwUirveHw9BFtf9OmJY6GmD/AcufKM19rpya1qc2QZHerRnlqGs/j5oyJf2slSuzNreqXWGRVzP7dQQw3lThcWdeOTXtcBKbn4HI7zVmTp06+64WTh/0MjU9bEqxIgY3+fxTa5T5NQXM1NREgNoCI+E/np7I6pkylMO8eGVeXt2XZmZmpvroi69PNYjuZ6C2g7ArQP8G8AscQzNMOk0gBAAiWs3Ms/1e37lhw4YVo0aNavJ50/r163sACBxo2+zpcDXeI6I/jx071nL8HzO7g5n3G6zRo0dvWbdu3U1EVHd1w8x3hKp8K1NmpFykuf7VsDLp8Hxb0nMDnkVdpJSu9951I7O9tWHeDOD6VjSNmAOuLAlJinRSQLbA86K0qroWwCMtqNP76rIlTQ7BqZli12QgJMbe+s1hyznfpOlc//wM/jH4pgI18+y/TkxMTKk0jQMAomsOnXvljLSBq5dl72pOeUezTnNrDABE9Bzqf4udZ5rm00uXLm30NnHt2rVRzLyEmf1voQ9WVVW9bFHNf4noer+fDGaeoLXuM27cuBF2QbCtjB8/fgERLfBLavOpd5Mnp/bRmgJ6GPm1Vaty9wBAQmLiQIBaOkthZmuG0kyeljoBwOktOZfBt3TEUBrtNT4A4P+lffbk6SmTG8s7dWrySSBc5Z9mEL3XWN4gmPAbSgQADviaHBjfGXWqK8IxY8ZsXLdu3RIiSqlNY+br4uLiTlu7du2fSkpK/puUlGSuWbMmPCwsbGLNc7wzAor5U2ODoP1sqemkOOIYhnGDaZrnMvPZ9rlbLjExsWuFT01n4vtQvwOgSvPhgbnsc9xKxC0NKF188PwKwD9acjIT39rCegFgQIV2XAEgvxVlNNvq1dnFCdOTXwWobnomA9mTZyT/oTIybOG6RYvKEhMTjUqvGm8q+jdqhk7V2B5G5v+aW2diYmLXKm08hIDnvD4d0AHWyXWqQAgAkZGRcyorK08PCAYjlFJvxMXFVaxbt+4AEfVq4jnforFjx/6rHZp5fkFBge1tBzM/P378+KDHBY4aNapy/fr1SQA+BhDTmgbWIYxImJFyeNAzQ1Wa6EoNrzeZiK5bvbx6aMrkyZNjmA4/pgBQ5TPM/q/l5e1rqqqEGalJYF7iV/fNiYmJj+Xl5ZlNndOYSTPSTgbr8X5J30UY5kCrciZPT/kjA3+pq7p6KE27BkIAUIaep01jHA6vYhPFTP8OL/M+kTA95cdKEz2hGiwiwiC6w+7/SZvG0skzUuqGxjCja6WJ/ghciILpq9Urchssi9aZdapbY6C60wTVA40bWxeuCxH1Q+AHX21+XFzctTXT5tpaOICBQfw0+9Zw7Nix3xBRo4sLtJADjLi6n8AeYgBglBJz8qplOYvrkozIX/nnJdDLVkEQAI7rEbMCgP9zrgGVPtXsea/E5lz4/W4T8JxdkPAZ5nOo34s67sppyWc2t+7WWpmX9xUTpQIInOLpBHAiGq6kxADuyV+WE8z4xyHM+EXtD6rHfgb+LZSA9GwcQx0lQCcMhAAwduzYA8XFxVcS0WwAO2yyvwNg1Lhx464///zzvTZ5jwpjx47NBfBcO1T1MwgPO+A8edWKJf698wRQvWEopuJnYWP+/PleBhbUT23eUJqpU2d3A2iWX5JPG+YLduetycvbC6p/BagINzSVvy29uiwnXzNfCK5ei9LCl0xqUv7y3FDMJvIB/IrJfGH+8iUfhaC8o0qnuzWulZSUZAJ4iZkXrl27dqjD4fil1noAEUUT0X6tdaFhGAVjxoyxnOGhlNpomuadfkmfNbctRLSLmf/Q3PMA1P1Caq2/Ukrd6ff6fasTHQ7Hb30+3zfM1c/olFJNznjwp7XaYbC+s6njpLiMoX4mYOuqZTmb0ciVw7RpM3v54H2x7ghR1eqXc94Jpn4Y5r/gM+rmhhMRT5w4MbxmgQA4tHOvD57D/5eEegtNmEZVX2j8tfY1g38MZlEGAFA+I1Mr88PD55LbKn9cXFzVj/tK69pCii2/SDMzM3XCtJSgfg9Wr1jyJYAJkxMTB2ufMYoUTgEjFuBygvqeod/OX77kY1hfuT0WOLjdHxExiA+Z0LvDdMTHja3oLYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEKKTa/OlmjpCWlrayVojOTc3+6/+6YmJs040DHNEbm5Wg42ZUlLSrwKoeqczhUqG3q693pV5eXluAEhJzdhhKD4vKyurtLntSUnLyARzEoDyvT/+MCxU+3F0ZikpKf1BanluTvYFDY6lpi8B09O5uYvfak0diYmJ0Q5H2FRmPgXAftOh1uQtXmw3JTPkRo4c6ejb94SpRDgLwH6fwht5WVlf2Z4oQqZTzjXWTHeC6DdJaWmj/NMNQw9gvyW66iFMZGIHK/0JtN6pGOcZjrBPMzIymrX/R2pqxtLk5JlnHn6d2gfMU3NzsoZIEDxypKRkDDccYV9pYAQUdkOprobJa5NT0+9t77b0Oa7fciZOAWiPBuIMjWXJyckntXc7jmWdbq7xzJkze3t8+gJoXKOIbkf1fiJBUaD3c7KzltW8XJScmvGDz6dvAFDvj2POnDnOErf7CsV0qibaq71VuXl5eZ7k5JmnM+t4MvTwpLS0vuz1vsdEU8CoSkpLG6O03gGgKDk5/QIoupRIlxDzypycnP1A9R+nUrrKJHIC6Gkwv6c1TXQ61XqvVycC3AXQL+fm5hYlp6cPI+ZfQmNPbGx0bu1mSP5SUtKnGQY+8jKfZjBdwIzte/f+8Ip/ME5KSxurNM5hhR/LXdEr8vPnl6empl/t83ny8/LyDgJAWlraOczqlJycxXW76qWkpV1bHhGx9LwTTyz7+ptvEqr/L3jb6aeckp+Zmalnz54dUVXly3A61QqPx0wpKTn4/GuvvVaVmpo6gpmGEdFen8/zSu0Vd2Zmptq6dfsUJpwB4q9Nr+Njw2H9nZGaOnM0oC/SxDt+2rNnxSmnnEIuV9lvcnKynqzNk5aWNoBZnZuTs/iVw+el9mTwMjDNWJK7eGNt+uRrrnk8sqJqQ3Ja2s4l2dlZ1e+bowHs1zASiPkQkV5R+3kBQHp6+lk+ptGkuZxIr8rJyfmpuo6MGcy+95VS5zDT2QB9k5OzeDkC5gYnJMyJJJRdHhsTHeX3Gd7nny8lZeb5gHkpFEpNr3dVXs0qPqmpGVOV4o+zsrK+B+quLK/Lzc16BgCS0zJu1t6q/yhHeAqxb21ubu4e//YC5uu5ubnf1fyf9GFWk1lRpIP4zays1m2TcLTpdFeEPp/+LTGeXbIkax0T+iUnz2zRKsUAQIwdUNRgR7sSV9mDYDqdiL9UrM8zHGG5AMCG2QuELtDop4BBYWFhTmI6AUCkAgYBiEtJSbuHFD9ErPcRUzeGeic1NXVIdcl6tGb8jTR+pzRVAejJhDu9Pv0SERQT9QIZ/0tOy7hZab6BWB0CYWapu2xBE28hw9R4xmAaw4ytAI3ue9wJBSNHjnQAQEpK+osGqzlE6gfFdEpUdNn/EhMTezFwqnI6k2sL0Ux3MPix2bNnRwBARkbGccx0a7jLVb512/bVBDqfmbYopmFbt23PAYCysrJIBt/j9Zq5UBzdv39/nZKS8RBDXQ+orwH0NIywgoSEOZEAaOu27atAmK5AW8F0unL4HrX6bJjwBw09gRlbCfTLvsed8OY333zDDFyRnJ5et4cKM90EcMDSYSoDTCty/YIgAKx64QWXJr6dNN0KAFrTMIbxV4a6l5gLiRDHUBsTZ84cCADJqRm/Mhn/UIzdUOxl0Ku1xxg8C2TM11BjmVHK0HempqY3WKY/P39+OQNbSkvdj6anp/erbXbt8eTU9DtB+u+s1AFm1dVwhL2dnl69056GztBax9fm7dWrlxN0eGFcYr7H4Qh/SYHjnU6nLyUl/RpT43nS7AIQBnJkT77mmpjk5IyzGfQqETyk+VtT8+OpqRl1i8MeCzrVFWFCwpxI5rJk0/ScCwDEeJKVvhX1N28PysyZM6O8Pj2HmBYGHluSk/V7v5drUlLTf0hMTDSWZme/nZKW/h1rtWxJ9uIvACAtLW2FZnX+kuys+YmJs05wOMwMn88zNC8vzwMAycnpX7EyHkT1pvIAyJObk5VYc+7JBAwk6NF1V41p6f3AemROTvZVNe95UVR02feZmZmqZg+K+pi/yMnNrt1QaEVKWnpWn+OPvyo1NfV7AANychaPrs2anJaxz3CG38WmekYp8zkATyckzIlklJ0OYHGFx3MFgOVejSQFLCYj7CoGti/JzvpjTRGrU1LTs5OTM87Wuuo7AP219o1ZsmTJzuTk5JNIOS7NzckagZo/9JSUNIqKKktPTk7fzYBjSU7WzMNtSbshYAe6wDf25ZKcrNo/+hWpqWkvHXfcCSmA/jdpmgPgg5EjRzoYmFTmjsqsdyZhMJgbXUWoMiLisy4VVSf75e6Sm5OVXtvm1NT0nwyfvmfkyJHXE/gu0+s5Oy8vr6Lms9xjmHwLgNtRfcKHS7IX/6X6vaasYDI2Amiwl0yYQ03wmnynqfnDlLT0r9jE35YsyVqXmDi7L7H32ogI51kLavYaTkpL2wSmhwEEtQUCkV6QnZ29Zs6cOU6vWfaniDDn2QsW1G1M9S8ASElLf5BNdX3uksUo1QP9AAAILklEQVSfAkBiYuKbhiNsDTrxZveBOlUgjIxxXw3QdlLOYUlpaWDCz6SRlJiY+Mc8m0VBAYDBf0tJTb+LAcPr07FgfjEnN6vBJuvJaRk3E+tpBNLV5yHO7XY7ELDvQyCHQ5/BwEe1QRAAtPa8Zaiwpw+3gQL3PNnifytGjEImVfde8vPnl6ekppd88smeCAANdjEjUgHLX/F/FdOZmhBHoLfrHTLpLRh66pIlC79JSU13pqSkxANlF4FouUm8zND0ZwDLSXOiMpBiMq4nxujU1PS6NjPQVynzRK3xHUCFS5Ys2VndDucQgPunpqav88sbC+Y1MFSkYv5v/bYYb0GZTQdChXrvi5n+C9CZp5126t3btm1/KC0tLU5rdSmIC/Lz5wf8v9AeDtiEvlZkeflgkHF42a7qfUDqrtB8DvW24dM39OnTZwCAHg5H2KrU1PSa90NOMNftka2g36z9d25u7p6U1HT/pfXrLFq06GcAt48cOfKO4447biKUWpCUlpYCeAyAPlngt+F6t+jo/5a6yl5srJyqmBhHZEVVvTSv17seANxudzxYFfoFQX9DlOKHa98HADCjd2N1dFadJhBmZmaqbdu238zAe4pVYt0BwibDGf4bVD93sUTAn4h4tTsiwrfqhRdcjeVJTJx1Imkz5bTTTrms5gqMUlLT620Qbxi60d54rdVuIvNU/7T/b+9uY+yoyjiA/59z5rI3FpVUsTVUg1HZ1sIHYmIIfFjEBlGJLZJL5850634w25akvCSkgKJt2n4QStiSmKoYy9runbnr0PBSaEp4TUQgYiIJ1IpbXivvJBS3l+7OnXMeP9x93+0WAwGy+f++3XvPzDw5dzI55zmT8xjTtgTAS2MxqJ+SGJOhiZ9UoOJ18t0+C9+qybJ/7HiVMwVywEIPe2jHpMbWLYE3rVgUu1SCiqieY+Cvq9eSgbAafyWO47Ocx2CtVvtPGMavwODOdHxEOKZSqcwHxvfnM8a/4iEH06T2/altV0bRTwAsnxbLLDvtGY9vYWK1QSNnwuvzmzZt8mEU7VIvkYpfBmenxeaspLbQJ6Io2pEkycT9KAWwmyfVOladlFox3i8FcNh7/5o18m5RDF90vN2vvTEnXBhbvXr1F44EQX7Pzp2DI7nbvWEULxOVc63on52ivRVXqzcajcZiKF5uBSvHVM1YudLy0NDZU18EybKsCQCDgye/Ou/kxund3d2laflkj8NFIOs+iRXzT4s58yB87rlDPwbkQD3tm7RNfWdn55eazj/V1dW1bWho9vtSFY00TWYr3IRSqRj0KvMHBgaWViqr3wuC4koFTlmwYEHrDvR4U0V+EIarTiuXg4fyfGzwh5GR1qEwWnWLOvM7tcVCUWwXjOd1PmoCvaxajd8qrDwVOP2eQn5ojN6Q582GDU76RRhG16i6O0VKi0V1C8StAIByuVQfGi4eFsGRJEkGRjroDufNn6B6MwA4l6dWTnoiDOODQSCP5N4vtSoXpmlt2vQvSZKnw2rcDKNVv3RNs7NUKhZ6b7rL5eDKRqNxrwRtG6vVeH1R2LuNcYsFWDPbnqMKXBqG0esuMH+zhX4XqsvL5dK3AUBU/6gijwjwVr1/97NTj812735xZRRd5VX+Eobxjcbokw5YJGquhugbRTPfPt5/+FoYRptFNFG1X4fTHkB+mmXZsZXVeE8QlP4QRdFW52ybiLvcWrlxdPHig2g2/fmfaQ7fXK3GtwL+H6ryVSgugZcVSX/thTCKnwmjeLszsiNw7lTnsV1EWjWrRR8FsLla7TwKFPP8LKmEvXtvez+MVmWDg+/fXq1WbxKRsldZD3XXqsWvrdNdURStbzaDt60tLhXRQ2mafuw1Wz4pc2axRNV/Q1Vumvp9a9qhO44da56lKu8A+viMx4v+3Rg9/k7GovvzPG8mSfIuVNY4jw225K5XlX0Q3NZoNDwAGKNbVLAERi8EUPbeHzHQx0ZP44q8E14PGuN/ZSCXQaU7TfseAAA1+KeqDIy2NcYcheDRSXFCD0wtQK/AvqI4POOoRGB+7iFftk63KrBI4M6r1Wr/zbLMuSJf1rpOaauIv8D74kdpmv4LAHp7e49AcIcX/c342XwC0X83GvPuAoAsy466Iu8QQXvhtcdAOqyVnpHGuU4YiQLA5z477xJ4/54N3DYPExvjf9vb2zuUZVlebgs6AHzRWtcjoh0Guk4gD874X6g+aUTXAFhgnW4F5HRXlM4bnfalafoOFM8LZMYpJAD0J0ndWbkAgtOc4nooLoZiWz2phRNHeCpSV4OnAbsRRi9WRTS6yNKf1q7zgodUsVFE13uDu0cfggL81apO2vFZodMeLGnat0e9rPDAIlVzBYDvQN3y/pF83eIzvtklKs9Ypzd4mKp6rEvTvv2t3864XUV/D+haQM4X9VcosO9416snfRtU/f2A3eBVLhdIrV6vv9Zfq90LlWs85GdBUGwRMYPt7e33Ha/v5qI5+UI1tYRhvEfE96Rp+tiJW88NXV1dp+R5Pt+r3FduK509Mb/2/wrDeC2MLKwnfZs+ugjp02jOTI1pBgYNLyfOU80VlUrl80PDzcehUlbF2g/zEAQAFRmG6oc6BxERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERfbz+BxL4U4Izn2y+AAAAAElFTkSuQmCC"
+    mediatype: image/png
+  install:
+    strategy: deployment
+    spec:
+      deployments:
+      - name: opendatahub-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: opendatahub-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: opendatahub-operator
+            spec:
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: opendatahub-operator
+                image: quay.io/opendatahub/opendatahub-operator:v0.4.0
+                imagePullPolicy: Always
+                name: opendatahub-operator
+                resources: {}
+              serviceAccountName: opendatahub-operator
+      permissions:
+      - rules:
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - clusterserviceversions
+          - catalogsources
+          - installplans
+          - subscriptions
+          - packagemanifests
+          verbs:
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - clusterserviceversions
+          - catalogsources
+          - installplans
+          - subscriptions
+          - packagemanifests
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - automationbroker.io
+          resources:
+          - ansible-service-broker-openshift-automation-broker-user-auth
+          verbs:
+          - create
+        - apiGroups:
+          - logging.openshift.io
+          resources:
+          - elasticsearches
+          verbs:
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          - serviceaccounts
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          - image.openshift.io
+          resources:
+          - imagestreamimages
+          - imagestreammappings
+          - imagestreams
+          - imagestreams/secrets
+          - imagestreamtags
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          - image.openshift.io
+          resources:
+          - imagestreamimports
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          - image.openshift.io
+          resources:
+          - imagestreams/layers
+          verbs:
+          - get
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          - project.openshift.io
+          resources:
+          - projects
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - pods/attach
+          - pods/exec
+          - pods/portforward
+          - pods/proxy
+          - secrets
+          - services/proxy
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - pods/attach
+          - pods/exec
+          - pods/portforward
+          - pods/proxy
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - patch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - endpoints
+          - persistentvolumeclaims
+          - replicationcontrollers
+          - replicationcontrollers/scale
+          - secrets
+          - serviceaccounts
+          - services
+          - services/proxy
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - patch
+          - update
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          - deployments
+          - deployments/rollback
+          - deployments/scale
+          - replicasets
+          - replicasets/scale
+          - statefulsets
+          - statefulsets/scale
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - patch
+          - update
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - autoscaling
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - patch
+          - update
+        - apiGroups:
+          - batch
+          resources:
+          - cronjobs
+          - jobs
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - patch
+          - update
+        - apiGroups:
+          - extensions
+          resources:
+          - daemonsets
+          - deployments
+          - deployments/rollback
+          - deployments/scale
+          - ingresses
+          - networkpolicies
+          - replicasets
+          - replicasets/scale
+          - replicationcontrollers/scale
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - patch
+          - update
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - patch
+          - update
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - patch
+          - update
+        - apiGroups:
+          - ""
+          - image.openshift.io
+          resources:
+          - imagestreams
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          - build.openshift.io
+          resources:
+          - builds/details
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          - build.openshift.io
+          resources:
+          - builds
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          - build.openshift.io
+          resources:
+          - buildconfigs
+          - buildconfigs/webhooks
+          - builds
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          - build.openshift.io
+          resources:
+          - builds/log
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - build.openshift.io
+          resources:
+          - buildconfigs/instantiate
+          - buildconfigs/instantiatebinary
+          - builds/clone
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          - deploymentconfigs/scale
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          - apps.openshift.io
+          resources:
+          - deploymentconfigrollbacks
+          - deploymentconfigs/instantiate
+          - deploymentconfigs/rollback
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs/log
+          - deploymentconfigs/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - image.openshift.io
+          resources:
+          - imagestreams/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - quota.openshift.io
+          resources:
+          - appliedclusterresourcequotas
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          - route.openshift.io
+          resources:
+          - routes/custom-host
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          - route.openshift.io
+          resources:
+          - routes/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - template.openshift.io
+          resources:
+          - processedtemplates
+          - templateconfigs
+          - templateinstances
+          - templates
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - extensions
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          - build.openshift.io
+          resources:
+          - buildlogs
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - resourcequotausages
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - servicecatalog.k8s.io
+          resources:
+          - servicebrokers
+          - serviceclasses
+          - serviceplans
+          - serviceinstances
+          - servicebindings
+          verbs:
+          - create
+          - update
+          - delete
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups:
+          - settings.k8s.io
+          resources:
+          - podpresets
+          verbs:
+          - create
+          - update
+          - delete
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resourceNames:
+          - elasticsearches.logging.openshift.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+        - apiGroups:
+          - logging.openshift.io
+          resources:
+          - elasticsearches
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - image.openshift.io
+          resources:
+          - imagestreamimages
+          - imagestreammappings
+          - imagestreams
+          - imagestreamtags
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - image.openshift.io
+          resources:
+          - imagestreams/layers
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - endpoints
+          - events
+          - nodes
+          - persistentvolumeclaims
+          - pods
+          - replicationcontrollers
+          - replicationcontrollers/scale
+          - serviceaccounts
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - bindings
+          - events
+          - limitranges
+          - namespaces/status
+          - pods/log
+          - pods/status
+          - replicationcontrollers/status
+          - resourcequotas
+          - resourcequotas/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - controllerrevisions
+          - daemonsets
+          - deployments
+          - deployments/scale
+          - replicasets
+          - replicasets/scale
+          - statefulsets
+          - statefulsets/scale
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - autoscaling
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - batch
+          resources:
+          - cronjobs
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - extensions
+          resources:
+          - daemonsets
+          - deployments
+          - deployments/scale
+          - ingresses
+          - networkpolicies
+          - replicasets
+          - replicasets/scale
+          - replicationcontrollers/scale
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - build.openshift.io
+          resources:
+          - buildconfigs
+          - buildconfigs/webhooks
+          - builds
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          - deploymentconfigs/scale
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - template.openshift.io
+          resources:
+          - processedtemplates
+          - templateconfigs
+          - templateinstances
+          - templates
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - build.openshift.io
+          resources:
+          - buildlogs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - servicecatalog.k8s.io
+          resources:
+          - servicebrokers
+          - serviceclasses
+          - serviceplans
+          - serviceinstances
+          - servicebindings
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - logging.openshift.io
+          resources:
+          - elasticsearches
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          - authorization.openshift.io
+          resources:
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          - authorization.openshift.io
+          resources:
+          - localresourceaccessreviews
+          - localsubjectaccessreviews
+          - subjectrulesreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - localsubjectaccessreviews
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          - project.openshift.io
+          resources:
+          - projects
+          verbs:
+          - delete
+          - get
+        - apiGroups:
+          - ""
+          - authorization.openshift.io
+          resources:
+          - resourceaccessreviews
+          - subjectaccessreviews
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          - security.openshift.io
+          resources:
+          - podsecuritypolicyreviews
+          - podsecuritypolicyselfsubjectreviews
+          - podsecuritypolicysubjectreviews
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          - authorization.openshift.io
+          resources:
+          - rolebindingrestrictions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - project.openshift.io
+          resources:
+          - projects
+          verbs:
+          - delete
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - ""
+          - route.openshift.io
+          resources:
+          - routes/status
+          verbs:
+          - update
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apiextensions.k8s.io
+          resourceNames:
+          - opendatahubs.opendatahub.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resourceNames:
+          - opendatahub-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - opendatahub.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - machinelearning.seldon.io
+          resources:
+          - seldondeployments
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - machinelearning.seldon.io
+          resources:
+          - seldondeployments/status
+          verbs:
+          - get
+          - update
+          - patch
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          - validatingwebhookconfigurations
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        serviceAccountName: opendatahub-operator
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/templates/opendatahub_v1alpha1_opendatahub_cr.yaml.j2
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/templates/opendatahub_v1alpha1_opendatahub_cr.yaml.j2
@@ -1,0 +1,28 @@
+apiVersion: opendatahub.io/v1alpha1
+kind: OpenDataHub
+metadata:
+  name: example-opendatahub
+spec:
+  aicoe-jupyterhub:
+    odh_deploy: true
+    notebook_memory: "{{ jupyter_notebook_memory }}"
+    registry: "{{ jupyterhub_image_registry }}"
+    repository: "{{ jupyterhub_image_repository }}"
+    storage_class: ''
+    db_memory: 1Gi
+    jupyterhub_memory: "{{ jupyterhub_memory }}"
+    s3_endpoint_url: "{{ rgw_endpoint_url }}"
+
+    spark_worker_nodes: "{{ spark_worker_count }}"
+    spark_master_nodes: "{{ spark_master_count }}"
+    spark_memory: "{{ spark_node_memory }}"
+    spark_cpu: "{{ spark_node_cpu }}"
+    spark_image: "{{ spark_node_image }}"
+    spark_pyspark_submit_args: "{{ spark_submit_args }}"
+    spark_pythonpath: "/opt/app-root/lib/python3.6/site-packages/pyspark/python/:/opt/app-root/lib/python3.6/site-packages/pyspark/python/lib/py4j-0.10.7-src.zip"
+  spark-operator:
+    odh_deploy: true
+  monitoring:
+    odh_deploy: true
+  kafka:
+    odh_deploy: true

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/templates/workshop-notebook.imagestream.yaml.j2
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/templates/workshop-notebook.imagestream.yaml.j2
@@ -1,0 +1,16 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  # This a hack until we can include additional notebooks in the singleuser profile
+  name: "{{ workshop_jupyter_notebook_imagestream_name }}"
+  namespace: "{{ project_name }}"
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+    - from:
+        kind: DockerImage
+        name: "{{ workshop_jupyter_notebook_imagestream_image }}"
+      name: "{{ workshop_jupyter_notebook_imagestream_tag }}"
+      referencePolicy:
+        type: Source


### PR DESCRIPTION
##### SUMMARY
Add roles for deploying Open Data Hub for the Red Hat Tech Exchange Analytics and Data Engineering on OpenShift workshop
* ocp4-workload-rhte-analytics_data_ocp_infra - Deploys Ceph using Rook
  and create CRDs & ClusterRoles for Kafka and Seldon
* ocp4-workload-rhte-analytics_data_ocp_workshop - Sets up the user
  project space for Open Data Hub and adds ODH to the catalog

##### ISSUE TYPE
- New role Pull Request

##### COMPONENT NAME
ocp4-workload-rhte-analytics_data_ocp_infra
ocp4-workload-rhte-analytics_data_ocp_workshop

##### ADDITIONAL INFORMATION
Tasks order should be
- `ocp4-workload-rhte-analytics_data_ocp_infra` Run once per cluster
- `ocp4-workload-rhte-analytics_data_ocp_workshop` Run once per user in the class and supply the name of the OCP user with the variable `user_name`

If you have a workload file named: `rhte_analytics_data_ocp_workload.yml`
```yaml
---
- name: Deploy a workload role on a master host
  hosts: all
  become: false
  gather_facts: False
  tags:
    - step007
  roles:
    - role: "ocp4-workload-rhte-analytics_data_ocp_infra"
    - role: "ocp4-workload-rhte-analytics_data_ocp_workshop"
```
```bash
ansible-playbook -i ${BASTION_HOST}, rhte_analytics_data_ocp_workload.yml -e"ansible_ssh_private_key_file=~/.ssh/id_rsa" -e"ansible_user=${BASTION_SSH_USER}" -e"ocp_username=${OCP_USERNAME}" -e"silent=False" -e"guid=${CLUSTER_GUID}" -e"ACTION=create" -e"user_count=${WORKSHOP_USER_COUNT}"
```