### PR TITLE
user passwords are incorrect in the email

### DIFF
--- a/ansible/roles/ocp-workload-integreatly/defaults/main.yml
+++ b/ansible/roles/ocp-workload-integreatly/defaults/main.yml
@@ -10,10 +10,10 @@ self_signed_certs_enabled: True
 amq_streams: True
 openshift_master_config_path: /etc/origin/master/master-config.yaml
 cluster_admin_username: admin@example.com
-cluster_admin_password: "{{ lookup('password', '/dev/null length=15 chars=ascii_letters,digits') }}"
-evals_password: "{{ lookup('password', '/dev/null length=15 chars=ascii_letters,digits') }}"
+cluster_admin_password: "{{ lookup('password', '/tmp/cluster_admin_password length=15 chars=ascii_letters,digits') }}"
+evals_password: "{{ lookup('password', '/tmp/evals_password length=15 chars=ascii_letters,digits') }}"
 customer_admin_username: customer-admin
-customer_admin_password: "{{ lookup('password', '/dev/null length=15 chars=ascii_letters,digits') }}"
+customer_admin_password: "{{ lookup('password', '/tmp/customer_admin_password length=15 chars=ascii_letters,digits') }}"
 letsencrypt_staging_root_cert_url: https://letsencrypt.org/certs/fakelerootx1.pem
 letsencrypt_staging_root_cert_path: /etc/origin/master/fakelerootx1.pem
 rhsso_identity_provider_ca_cert_path: "{{ letsencrypt_staging_root_cert_path }}"

--- a/ansible/roles/ocp-workload-integreatly/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-integreatly/tasks/workload.yml
@@ -12,7 +12,8 @@
           playbooks/install.yml \
           -e eval_self_signed_certs="{{ self_signed_certs_enabled }} \
           -e rhsso_identity_provider_ca_cert_path={{ rhsso_identity_provider_ca_cert_path }} \
-          -e amq_streams={{ amq_streams }} -e rhsso_seed_users_password={{ evals_password }} \
+          -e amq_streams={{ amq_streams }} \
+          -e rhsso_seed_users_password={{ evals_password }} \
           -e rhsso_evals_admin_password={{ customer_admin_password }} \
           -e rhsso_cluster_admin_password={{ cluster_admin_password }}"
   args:


### PR DESCRIPTION
##### SUMMARY
These password variables had different values every time they were read :man_facepalming: 

Using a filename makes them sticky values.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
integreatly

@mikenairn @pmccarthy 
