### PR TITLE
Fix broken task blocking CI checks

### DIFF
--- a/ansible/roles/ocp-workload-edge-deployments/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-edge-deployments/tasks/workload.yml
@@ -10,7 +10,7 @@
   shell: "ssh-keygen -N '' -f /opt/apb/id_rsa"
 
 - name: add new ssh-key as authorized on BASTION host
-  cat /opt/apb/id_rsa | ssh -i /root/.ssh/milan-fa8ckey.pem ec2-user@bastion 'cat >> .ssh/authorized_keys'
+  shell: cat /opt/apb/id_rsa | ssh -i /root/.ssh/milan-fa8ckey.pem ec2-user@bastion 'cat >> .ssh/authorized_keys'
 
 - name: Create project for IoT Development
   shell: "oc new-project iot-development"


### PR DESCRIPTION
ansible/roles/ocp-workload-edge-deployments/tasks/workload.yml has bad task and looks like it is blocking CI tests from passing.

This fixes the broken task.