### PR TITLE
add become: true to  workload.yml for some tasks

### DIFF
--- a/ansible/roles/ocp-workload-edge-deployments/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-edge-deployments/tasks/workload.yml
@@ -13,9 +13,11 @@
 
 - name: Generate a brand new SSH key on MASTER that will be used also by APB container (provision.yml)
   shell: "ssh-keygen -N '' -f /opt/apb/id_rsa"
+  become: true
 
 - name: add new ssh-key as authorized on BASTION host
   shell: "cat /opt/apb/id_rsa | ssh -i /root/.ssh/milan-fa8ckey.pem ec2-user@bastion 'cat >> .ssh/authorized_keys'"
+  become: true
 
 - name: Create project for IoT Development
   shell: "oc new-project iot-development"


### PR DESCRIPTION
##### SUMMARY
add become: true to :
- Generate a brand new SSH key on MASTER that will be used also by APB container (provision.yml)
- add new ssh-key as authorized on BASTION host

##### ISSUE TYPE
- Bugfix Pull Request

