### PR TITLE
Update OCP migration workload to not get migration route

### DIFF
--- a/ansible/roles/ocp-workload-migration/tasks/post_workload.yml
+++ b/ansible/roles/ocp-workload-migration/tasks/post_workload.yml
@@ -7,7 +7,7 @@
 - name: "Gathering information about launched resources"
   block:
   - name: "Waiting for route to be created"
-    shell: "oc get route -n mig migration -o go-template='{{ '{{' }} .spec.host {{ '}}' }}{{ '{{' }} println {{ '}}' }}'"    
+    shell: "oc get route -n openshift-migration-operator migration -o go-template='{{ '{{' }} .spec.host {{ '}}' }}{{ '{{' }} println {{ '}}' }}'"    
     register: mig_ui_route
     until: mig_ui_route.rc == 0
     retries: 20

--- a/ansible/roles/ocp-workload-migration/tasks/post_workload.yml
+++ b/ansible/roles/ocp-workload-migration/tasks/post_workload.yml
@@ -4,20 +4,6 @@
     path: "{{ repodir.path }}"
     state: absent
 
-- name: "Gathering information about launched resources"
-  block:
-  - name: "Waiting for route to be created"
-    shell: "oc get route -n openshift-migration-operator migration -o go-template='{{ '{{' }} .spec.host {{ '}}' }}{{ '{{' }} println {{ '}}' }}'"    
-    register: mig_ui_route
-    until: mig_ui_route.rc == 0
-    retries: 20
-    delay: 3
-
-  - name: "Please note the following information..."
-    debug: 
-      msg: "Mig UI is launched at - {{ mig_ui_route.stdout }}"
-  when: mig_operator_deploy_ui|bool and not migration_workload_destroy|bool
-
 # Leave this as the last task in the playbook.
 - name: post_workload tasks complete
   debug:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Changes post_workload task to not print the route for debugging.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp-workload-migration

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
