### PR TITLE
Separate Che/OpenShift password parameters; improve error detection; …

### DIFF
--- a/ansible/roles/ocp4-workload-quarkus-workshop/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/defaults/main.yml
@@ -7,8 +7,10 @@ crw_workspace: che
 guides_workspace: guides
 che_stack_definition: docker.io/schtool/che-quarkus-odo:latest
 user_count: 5
-workshop_user_name: userNN
-workshop_user_password: 'r3dh4t1!'
+workshop_openshift_user_name: userNN
+workshop_openshift_user_password: 'r3dh4t1!'
+workshop_che_user_name: userNN
+workshop_che_user_password: passNN
 
 # OCP Limit Range
 pod_min_mem: 10Mi

--- a/ansible/roles/ocp4-workload-quarkus-workshop/tasks/remove_workload.yml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/tasks/remove_workload.yml
@@ -32,6 +32,11 @@
   - ./files/codeready_catalog_source.yaml
   - ./files/codeready_subscription.yaml
 
+- name: delete CodeReady CRD
+  shell: |
+         oc delete customresourcedefinition/checlusters.org.eclipse.che
+  ignore_errors: true
+
 - name: Delete OpenShift Objects for Strimzi
   ignore_errors: yes
   k8s:

--- a/ansible/roles/ocp4-workload-quarkus-workshop/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/tasks/workload.yml
@@ -34,7 +34,20 @@
           openshift.io/display-name: "Quarkus Workshop Guides"
 
 - name: deploy guides
-  shell: "oc new-app -n guides quay.io/osevg/workshopper --name=web -e USER_NAME='{{ workshop_user_name}}' -e USER_PASSWORD='{{ workshop_user_password }}' -e MASTER_URL={{ master_url }} -e CONSOLE_URL={{ console_url }} -e CHE_URL=http://codeready-che.{{ route_subdomain }} -e KEYCLOAK_URL=http://keycloak-che.{{ route_subdomain }} -e ROUTE_SUBDOMAIN={{ route_subdomain }} -e CONTENT_URL_PREFIX=https://raw.githubusercontent.com/RedHatWorkshops/quarkus-workshop/master/docs/ -e WORKSHOPS_URLS=https://raw.githubusercontent.com/RedHatWorkshops/quarkus-workshop/master/docs/_workshop.yml -e LOG_TO_STDOUT=true"
+  shell: >
+    oc new-app -n guides quay.io/osevg/workshopper --name=web
+    -e CHE_USER_NAME='{{ workshop_che_user_name}}'
+    -e CHE_USER_PASSWORD='{{ workshop_che_user_password }}'
+    -e OPENSHIFT_USER_NAME='{{ workshop_openshift_user_name }}'
+    -e OPENSHIFT_USER_PASSWORD='{{ workshop_openshift_user_password }}'
+    -e MASTER_URL={{ master_url }}
+    -e CONSOLE_URL={{ console_url }}
+    -e CHE_URL=http://codeready-che.{{ route_subdomain }}
+    -e KEYCLOAK_URL=http://keycloak-che.{{ route_subdomain }}
+    -e ROUTE_SUBDOMAIN={{ route_subdomain }}
+    -e CONTENT_URL_PREFIX='https://raw.githubusercontent.com/RedHatWorkshops/quarkus-workshop/master/docs/'
+    -e WORKSHOPS_URLS='https://raw.githubusercontent.com/RedHatWorkshops/quarkus-workshop/master/docs/_workshop.yml'
+    -e LOG_TO_STDOUT=true
   ignore_errors: true
 
 - name: create the Route for guides
@@ -59,7 +72,6 @@
 
 # Install Che via operator
 - name: Create OpenShift Objects for Che
-  ignore_errors: yes
   k8s:
     state: present
     merge_type:
@@ -94,7 +106,6 @@
     namespace: che
     name: codeready
   register: r_codeready_cr
-  ignore_errors: yes
 
 - name: show cr
   debug:
@@ -108,7 +119,6 @@
     - strategic-merge
     - merge
     definition: "{{ lookup('file', item ) | from_yaml }}"
-  ignore_errors: yes
   loop:
   - ./files/codeready.yaml
 
@@ -339,7 +349,6 @@
     oc create -f /tmp/che-limitrange.yaml -n che
 
 - name: Import stack imagestream
-  ignore_errors: yes
   k8s:
     state: present
     merge_type:
@@ -352,7 +361,6 @@
 - name: import imagestream
   shell: |
     oc import-image --all quarkus-stack -n openshift
-  ignore_errors: true
 
 - name: Pre-create user workspaces
   include_tasks: create_che_workspace.yaml
@@ -364,7 +372,6 @@
   # Install Strimzi operator for all workspaces
   # Install Che via operator
 - name: Create OpenShift Objects for Strimzi
-  ignore_errors: yes
   k8s:
     state: present
     merge_type:


### PR DESCRIPTION
##### SUMMARY
- Remove unnecessary `ignore_errors` where ignorance may result in failed deployment
- Use Ansible 'folded' syntax to improve readability of long `shell:` task
- Align with recent changes to workshop content that separate the Che username/password from OpenShift username/password
- Remove CRDs created by CRW Operator in the removal tasks

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

- `ocp4-workload-quarkus-workshop`

