### PR TITLE
Update ocp-workload-mssql for bugfix

### DIFF
--- a/ansible/roles/ocp-workload-mssql/templates/manifest.yaml.j2
+++ b/ansible/roles/ocp-workload-mssql/templates/manifest.yaml.j2
@@ -47,7 +47,7 @@ spec:
           value: Yukon900
         - name: ACCEPT_EULA
           value: '''Y'''
-        image: tigervin/tech-exchange-db-ctp31
+        image: quay.io/quaa/tech-exchange-db-ctp31
         imagePullPolicy: IfNotPresent
         name: db-ctp31
         ports:


### PR DESCRIPTION
##### SUMMARY
using a longer delay to run the db-init.sh script within the entrypoint to fix an issue with the database script running before the DB comes up

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp-workload-mssql
