### PR TITLE
Adding openshift-applier workload

### DIFF
--- a/ansible/roles/ocp-workload-openshift-applier/readme.adoc
+++ b/ansible/roles/ocp-workload-openshift-applier/readme.adoc
@@ -1,0 +1,71 @@
+= ocp-workload-openshift-applier - execute an openshift-applier run 
+
+== Role overview
+
+* This role uses the [openshift-applier](https://github.com/redhat-cop/openshift-applier)
+ to manage content within an OpenShift Container Platform. It consists of the following playbooks:
+** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Not used.
+*** Debug task will print out: `pre_workload Tasks completed successfully.`
+
+** Playbook: link:./tasks/workload.yml[workload.yml] - Used to
+ execute the openshift-applier role.
+*** Debug task will print out: `workload Tasks completed successfully.`
+
+** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Not used.
+*** Debug task will print out: `post_workload Tasks completed successfully.`
+
+** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Not Used.
+*** Debug task will print out: `remove_workload Tasks completed successfully.`
+
+** Note: the workload accepts 'openshift_cluster_content' as a dictionary, or
+ you can use 'openshift_cluster_content_list' for multiple 'openshift_cluster_content' content to be processed.
+
+=== Deploy a Workload with the `ocp-workload` playbook [Mostly for testing]
+
+----
+TARGET_HOST="bastion.my.domain.com"
+OCP_USERNAME="my-admin-user"
+WORKLOAD="ocp-workload-openshift-applier"
+GUID=1001
+DEFAULT_WORKLOADS="{[ ocp-workload-openshift-applier ]}" 
+
+# a TARGET_HOST is specified on the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=ec2-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"default_workloads=${DEFAULT_WORKLOADS}" \
+    -e"silent=False" \
+    -e"guid=${GUID}" \
+    -e"ACTION=create"
+----
+
+== Other related information:
+
+=== Set up your Ansible inventory
+
+* You can create an Ansible inventory file to define your connection method to your host (Master/Bastion with `oc` command)
+* The below inventory needs tailoring to fit your environment to work correctly
+
+inventory/hosts
+----
+[bastions]
+192.168.10.1 ansible_user=ec2-user ansible_ssh_private_key_file=<path-to-private-key>
+----
+
+inventory/group_vars/all.yml
+----
+become_override: no 
+silent: False
+
+default_workloads:
+- ocp-workload-openshift-applier
+
+openshift_cluster_content:
+- object: projectrequest
+  content:
+  - name: Create HTTPd project
+    file: "https://raw.githubusercontent.com/redhat-cop/openshift-applier/master/tests/files/cluster-template/project1.yml"
+    action: create
+
+----

--- a/ansible/roles/ocp-workload-openshift-applier/tasks/main.yml
+++ b/ansible/roles/ocp-workload-openshift-applier/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+
+# Do not modify this file
+
+- name: Running Pre Workload Tasks
+  include_tasks:
+    file: ./pre_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload Tasks
+  include_tasks:
+    file: ./workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  include_tasks:
+    file: ./post_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload removal Tasks
+  include_tasks:
+    file: ./remove_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles/ocp-workload-openshift-applier/tasks/post_workload.yml
+++ b/ansible/roles/ocp-workload-openshift-applier/tasks/post_workload.yml
@@ -1,0 +1,9 @@
+---
+# Implement your Post Workload deployment tasks here
+
+
+# Leave this as the last task in the playbook.
+- name: post_workload tasks complete
+  debug:
+    msg: "Post-Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp-workload-openshift-applier/tasks/pre_workload.yml
+++ b/ansible/roles/ocp-workload-openshift-applier/tasks/pre_workload.yml
@@ -1,0 +1,9 @@
+---
+# Implement your Pre Workload deployment tasks here
+
+
+# Leave this as the last task in the playbook.
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp-workload-openshift-applier/tasks/remove_workload.yml
+++ b/ansible/roles/ocp-workload-openshift-applier/tasks/remove_workload.yml
@@ -1,0 +1,9 @@
+---
+# Implement your Workload removal tasks here
+
+
+# Leave this as the last task in the playbook.
+- name: remove_workload tasks complete
+  debug:
+    msg: "Remove Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp-workload-openshift-applier/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-openshift-applier/tasks/workload.yml
@@ -1,0 +1,27 @@
+---
+# Implement your Workload deployment tasks here
+
+# Add 'openshift_cluster_content' to the list of items to process
+# - allowing a list to be passed to this role
+- set_fact:
+    openshift_cluster_content_list: "{{ openshift_cluster_content_list|d([]) + [ openshift_cluster_content ] }}"
+  when:
+  - openshift_cluster_content is defined
+  - openshift_cluster_content|length > 0
+
+# Run 'openshift-applier'
+- include_role:
+    name: openshift-applier/roles/openshift-applier
+  vars:
+    openshift_cluster_content: "{{ cluster_content }}"
+  loop: "{{ openshift_cluster_content_list }}"
+  loop_control:
+    loop_var: cluster_content
+  tags:
+  - openshift-applier
+ 
+# Leave this as the last task in the playbook.
+- name: workload tasks complete
+  debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent|bool


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds support for utilizing [openshift-applier](https://github.com/redhat-cop/openshift-applier) as a workload as part of the various configs - e.g.: part of the `default_workloads`. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp-workload-openshift-applier

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
