### PR TITLE
ocp4-workload-operator-mssql : fixing wrong namespace in operator mssql

### DIFF
--- a/ansible/roles/ocp4-workload-operator-mssql/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-operator-mssql/defaults/main.yml
@@ -1,4 +1,4 @@
-operator_mssql_namespace: operator-mssql
+operator_mssql_namespace: operator-db-app
 
 # workload vars
 operator_mssql_workload_destroy: "{{ False if (ACTION == 'create' or ACTION == 'provision') else True }}"

--- a/ansible/roles/ocp4-workload-operator-mssql/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-operator-mssql/tasks/workload.yml
@@ -67,7 +67,7 @@
     when: not operator_mssql_workload_destroy|bool
 
   - name: "Init the database"
-    shell: "oc exec -n operator-db-app {{ item }} -- sh /db-init.sh"
+    shell: "oc exec -n {{ operator_mssql_namespace }} {{ item }} -- sh /db-init.sh"
     loop:
       - "sql-0"
       - "sql-1"


### PR DESCRIPTION
##### SUMMARY
bug fix in operator mssql workload

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-workload-operator-mssql

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
