### PR TITLE
RHTE Analytics Data - Change rook scc apiVersion to v1

### DIFF
--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/scc.yaml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/scc.yaml
@@ -1,7 +1,8 @@
 ---
 kind: SecurityContextConstraints
+#apiVersion: security.openshift.io/v1
 # older versions of openshift have "apiVersion: v1"
-apiVersion: security.openshift.io/v1
+apiVersion: v1
 metadata:
   name: rook-ceph
 allowPrivilegedContainer: true


### PR DESCRIPTION
##### SUMMARY
Fix issue where deployer now fails when creating an SCC with apiVersion securitycontext.openshift.io. Setting SCC apiVersion to v1

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
Workload: ocp4-workload-rhte-analytics_data_ocp_infra

##### ADDITIONAL INFORMATION
N/A