### PR TITLE
updates workflows workshop to work with changes to other roles

### DIFF
--- a/ansible/roles/ocp4-workload-ml-workflows-workshop/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-ml-workflows-workshop/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 become_override: False
-ocp_username: wibenton-redhat.com
+ocp_username: opentlc-mgr
 silent: False

--- a/ansible/roles/ocp4-workload-ml-workflows-workshop/tasks/per_user_remove_workload.yml
+++ b/ansible/roles/ocp4-workload-ml-workflows-workshop/tasks/per_user_remove_workload.yml
@@ -1,0 +1,40 @@
+---
+# Implement your Workload deployment tasks here
+
+- debug:
+    msg: "Removing ML Workflows workshop materials from preexisting project {{ project_name }}"
+
+- name: Create the custom notebook image
+  k8s:
+    state: absent
+    namespace: "{{ project_name }}"
+    definition: "{{ item }}"
+  with_items:
+    - "{{ lookup('template', 'custom-notebook-imagestream.yaml.j2') }}"
+
+- name: Create the pipeline builder image
+  k8s:
+    state: absent
+    namespace: "{{ project_name }}"
+    definition: "{{ item }}"
+  with_items:
+    - "{{ lookup('template', 'pipeline-s2i-imagestream.yaml.j2') }}"
+
+- name: Create the pipeline build and app
+  k8s:
+    state: absent
+    namespace: "{{ project_name }}"
+    definition: "{{ item }}"
+  with_items:
+    - "{{ lookup('template', 'pipeline-imagestream.yaml.j2') }}"
+    - "{{ lookup('template', 'pipeline-buildconfig.yaml.j2') }}"
+    - "{{ lookup('template', 'pipeline-deploymentconfig.yaml.j2') }}"
+    - "{{ lookup('template', 'pipeline-service.yaml.j2') }}"
+  when: instructor_mode
+
+# Leave this as the last task in the playbook.
+- name: workload tasks complete
+  debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent|bool
+

--- a/ansible/roles/ocp4-workload-ml-workflows-workshop/tasks/per_user_workload.yml
+++ b/ansible/roles/ocp4-workload-ml-workflows-workshop/tasks/per_user_workload.yml
@@ -1,0 +1,66 @@
+---
+# Implement your Workload deployment tasks here
+
+- set_fact:
+    user_name: "user{{ user_num }}"
+
+- set_fact:
+    project_name: "opendatahub-{{ user_name }}"
+
+- debug:
+    msg: "Deploying ML Workflows workshop materials to preexisting project {{ project_name }}"
+
+- name: Verify user can create projects
+  command: "oc auth can-i create project"
+  register: canicreateprojects
+  failed_when: canicreateprojects.stdout != 'yes'
+
+- name: "Make sure project {{ project_name }} is there"
+  k8s:
+    state: present
+    name: "{{ project_name }}"
+    kind: Project
+    api_version: project.openshift.io/v1
+
+- name: Create the custom notebook image
+  k8s:
+    state: present
+    namespace: "{{ project_name }}"
+    definition: "{{ item }}"
+  with_items:
+    - "{{ lookup('template', 'custom-notebook-imagestream.yaml.j2') }}"
+
+- name: Create the pipeline builder image
+  k8s:
+    state: present
+    namespace: "{{ project_name }}"
+    definition: "{{ item }}"
+  with_items:
+    - "{{ lookup('template', 'pipeline-s2i-imagestream.yaml.j2') }}"
+
+- name: Create the pipeline build and app
+  k8s:
+    state: present
+    namespace: "{{ project_name }}"
+    definition: "{{ item }}"
+  with_items:
+    - "{{ lookup('template', 'pipeline-imagestream.yaml.j2') }}"
+    - "{{ lookup('template', 'pipeline-buildconfig.yaml.j2') }}"
+    - "{{ lookup('template', 'pipeline-deploymentconfig.yaml.j2') }}"
+    - "{{ lookup('template', 'pipeline-service.yaml.j2') }}"
+  when: instructor_mode
+
+- name: Kick Jupyterhub
+  shell: |
+      oc scale dc/jupyterhub --replicas=0 -n {{ project_name }}
+
+- name: Nudge Jupyterhub
+  shell: |
+      oc scale dc/jupyterhub --replicas=1 -n {{ project_name }}
+
+# Leave this as the last task in the playbook.
+- name: workload tasks complete
+  debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent|bool
+

--- a/ansible/roles/ocp4-workload-ml-workflows-workshop/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-ml-workflows-workshop/tasks/workload.yml
@@ -1,56 +1,20 @@
 ---
 # Implement your Workload deployment tasks here
-
 - fail:
-    msg: No user specified. Make sure you specify a value for 'user_name'
-  when: not user_name
+    msg: User count end({{ user_count_end }}) < user count start ({{ user_count_start }})
+  when: user_count_end|int < user_count_start|int
 
-- debug:
-    msg: "Deploying ML Workflows workshop materials to preexisting project {{ project_name }}"
+- name: Setting up workload for user
+  debug:
+    msg: "Setting up workload for {{ user_count }} users"
 
-- name: Verify user can create projects
-  command: "oc auth can-i create project"
-  register: canicreateprojects
-  failed_when: canicreateprojects.stdout != 'yes'
-
-- name: "Make sure project {{ project_name }} is there"
-  k8s:
-    state: present
-    name: "{{ project_name }}"
-    kind: Project
-    api_version: project.openshift.io/v1
-
-- name: Create the custom notebook image
-  k8s:
-    state: present
-    namespace: "{{ project_name }}"
-    definition: "{{ item }}"
-  with_items:
-    - "{{ lookup('template', 'custom-notebook-imagestream.yaml.j2') }}"
-
-- name: Create the pipeline builder image
-  k8s:
-    state: present
-    namespace: "{{ project_name }}"
-    definition: "{{ item }}"
-  with_items:
-    - "{{ lookup('template', 'pipeline-s2i-imagestream.yaml.j2') }}"
-
-- name: Create the pipeline build and app
-  k8s:
-    state: present
-    namespace: "{{ project_name }}"
-    definition: "{{ item }}"
-  with_items:
-    - "{{ lookup('template', 'pipeline-imagestream.yaml.j2') }}"
-    - "{{ lookup('template', 'pipeline-buildconfig.yaml.j2') }}"
-    - "{{ lookup('template', 'pipeline-deploymentconfig.yaml.j2') }}"
-    - "{{ lookup('template', 'pipeline-service.yaml.j2') }}"
-  when: instructor_mode
+- include_tasks: per_user_workload.yml
+  loop: "{{ range(user_count_start|int, user_count_end|int)|list }}"
+  loop_control:
+    loop_var: user_num
 
 # Leave this as the last task in the playbook.
 - name: workload tasks complete
   debug:
     msg: "Workload Tasks completed successfully."
   when: not silent|bool
-


### PR DESCRIPTION
##### SUMMARY

Fixes the ML Workflows Workshop to work with recent changes to the analytics/ODH workshop roles it depends on.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

ocp4-workload-ml-workflows-workshop

##### ADDITIONAL INFORMATION

This includes fixes to the ML Workflows Workshop to work with recent changes to the analytics/ODH workshop roles it depends on.

NB:  all roles must be run with the following variable settings:  ```-e"jupyter_notebook_memory=6Gi" -e"deploy_odh_cr=true" -e"rgw_service_ip=rook-ceph-rgw-my-store" -e"rgw_service_port=8000"```  Since we don't control the ODH roles, we can't set them there.