### PR TITLE
Fix workload.yaml and README.adoc in ocp4-workload-rhte-jupyter-spark…

### DIFF
--- a/ansible/roles/ocp4-workload-rhte-jupyter-spark/README.adoc
+++ b/ansible/roles/ocp4-workload-rhte-jupyter-spark/README.adoc
@@ -22,6 +22,7 @@ Optionally, you may choose to override following default variables.
 [source, yaml]
 ----
 jupyter_spark_namespace: my-analytics
+----
 
 == Delete the workload
 ----

--- a/ansible/roles/ocp4-workload-rhte-jupyter-spark/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-rhte-jupyter-spark/tasks/workload.yml
@@ -12,7 +12,7 @@
 - include_tasks: wait_for_deploy.yml
   vars:
     app_to_check: "openshift.io/build.name=openshift-spark-py36-inc-1"
-  static: no
+##  static: no
 
 - name: Create the Openshift openshift-spark-py36 build
   shell: |
@@ -27,7 +27,7 @@
 - include_tasks: wait_for_deploy.yml
   vars:
     app_to_check: "openshift.io/build.name=openshift-spark-py36-1"
-  static: no
+##  static: no
 
 - name: Create the jupyter-notebook builds
   shell: |
@@ -41,7 +41,7 @@
 - include_tasks: wait_for_deploy.yml
   vars:
     app_to_check: "openshift.io/build.name=jupyter-notebook-1"
-  static: no
+##  static: no
 
 - name: Workload Tasks Complete
   debug:


### PR DESCRIPTION
… role

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix workload.yaml and README.adoc in ocp4-workload-rhte-jupyter-spark role

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request: fix workload.yaml and README.adoc in ocp4-workload-rhte-jupyter-spark role


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4-workload-rhte-jupyter-spark role

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
