### PR TITLE
feat: Add sudoer cluster role to lab A2026

### DIFF
--- a/ansible/roles/ocp-workload-dekorate-component-operator/defaults/main.yml
+++ b/ansible/roles/ocp-workload-dekorate-component-operator/defaults/main.yml
@@ -19,7 +19,7 @@ kubedb_enablewebhook: true
 halkyon_crd_operator_install: true
 halkyon_crd_operator_remove: false
 
-halkyon_operator_docker_image_version: v0.1.2
+halkyon_operator_docker_image_version: v0.1.4
 halkyon_operator_watch_namespace: ""
 halkyon_operator_namespace: "operators"
 halkyon_operator_name: "halkyon-operator"

--- a/ansible/roles/ocp-workload-dekorate-component-operator/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-dekorate-component-operator/tasks/workload.yml
@@ -21,6 +21,13 @@
   include_tasks:
     file: ./operator.yml
 
+- name: Grant cluster sudoer role to users
+  shell: |
+    oc --kubeconfig={{ kube_config }} adm policy add-cluster-role-to-user sudoer {{ item }}
+  with_items:
+    - user1
+    - opentlc-mgr
+
 # Leave this as the last task in the playbook.
 - name: workload tasks complete
   debug:


### PR DESCRIPTION
##### SUMMARY
feat: Add sudoer cluster role to lab A2026 for user1, opentlc-mgr
chore: Bump workshop to latest version of the operator

##### ISSUE TYPE
- New role Pull Request

##### COMPONENT NAME
ocp-workload-dekorate-component-operator
