### PR TITLE
ocp-workload-dekorate-component-operator:  sudoer not needed for open…

### DIFF
--- a/ansible/roles/ocp-workload-dekorate-component-operator/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-dekorate-component-operator/tasks/workload.yml
@@ -26,7 +26,6 @@
     oc --kubeconfig={{ kube_config }} adm policy add-cluster-role-to-user sudoer {{ item }}
   with_items:
     - user1
-    - opentlc-mgr
 
 # Leave this as the last task in the playbook.
 - name: workload tasks complete


### PR DESCRIPTION
…tlc-mgr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
