### PR TITLE
Revert a SCC apiVersion update in ocp4-workload-rhte-analytics_data_ocp_infra

### DIFF
--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/scc.yaml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/files/scc.yaml
@@ -1,8 +1,7 @@
 ---
 kind: SecurityContextConstraints
-#apiVersion: security.openshift.io/v1
+apiVersion: security.openshift.io/v1
 # older versions of openshift have "apiVersion: v1"
-apiVersion: v1
 metadata:
   name: rook-ceph
 allowPrivilegedContainer: true


### PR DESCRIPTION
##### SUMMARY
This reverts a one-line change that was added in 7da383be72f0e978612ae7ce873ba70b4a097547 to potentially resolve the error
"""
Failed to find exact match for security.openshift.io/v1.SecurityContextConstraints by [kind, name, singularName, shortNames]
"""    
This same error occurs when the apiversion is "security.openshift.io/v1" or "v1" so I want to restore the file to what has been verified to work.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
Workload ocp4-workload-rhte-analytics_data_ocp_infra

##### ADDITIONAL INFORMATION
This error never occurs when run outside of the lab deployer system