### PR TITLE
Fixes to remove conditions in inherited tasks and empty remove_workload

### DIFF
--- a/ansible/roles/ocp4-workload-rhte-jupyter-spark/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-rhte-jupyter-spark/tasks/pre_workload.yml
@@ -3,4 +3,4 @@
 - name: pre_workload tasks complete
   debug:
     msg: "Pre-Workload tasks completed successfully."
-  when: not silent|bool
+##  when: not silent|bool

--- a/ansible/roles/ocp4-workload-rhte-jupyter-spark/tasks/remove_workload.yml
+++ b/ansible/roles/ocp4-workload-rhte-jupyter-spark/tasks/remove_workload.yml
@@ -1,9 +1,2 @@
 ---
-- name: "Removing workload"
-  include_tasks: "{{ item }}"
-  with_items:
-    - "./pre_workload.yml"
-    - "./workload.yml"
-    - "./post_workload.yml"
-  vars:
-    ceph_workload_destroy: yes
+

--- a/ansible/roles/ocp4-workload-rhte-jupyter-spark/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-rhte-jupyter-spark/tasks/workload.yml
@@ -50,4 +50,4 @@
 - name: workload tasks complete
   debug:
     msg: "Workload Tasks completed successfully."
-  when: not silent|bool
+##  when: not silent|bool


### PR DESCRIPTION
##### SUMMARY
Fixes to remove conditions in inherited tasks and empty remove_workload

##### ISSUE TYPE
- Bugfix Pull Request: removed silent var in the conditional, as was giving problems in the pre_workload.yml. Empty remove_workload.yml from any task.


##### COMPONENT NAME
ocp4-workload-rhte-jupyter-spark role

##### ADDITIONAL INFORMATION
