### PR TITLE
Fix for SSO token expiring during workload run

### DIFF
--- a/ansible/roles/ocp4-workload-quarkus-workshop/tasks/add_che_user.yaml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/tasks/add_che_user.yaml
@@ -1,0 +1,34 @@
+---
+- name: Get SSO admin token
+  uri:
+    url: http://keycloak-che.{{ route_subdomain }}/auth/realms/master/protocol/openid-connect/token
+    method: POST
+    body:
+      username: "{{ sso_admin_username.stdout }}"
+      password: "{{ sso_admin_password.stdout }}"
+      grant_type: "password"
+      client_id: "admin-cli"
+    body_format: form-urlencoded
+    status_code: 200,201,204
+  register: sso_admin_token
+
+- name: Add user {{ user }} to Che
+  uri:
+    url: http://keycloak-che.{{ route_subdomain }}/auth/admin/realms/codeready/users
+    method: POST
+    headers:
+      Content-Type: application/json
+      Authorization: "Bearer {{ sso_admin_token.json.access_token }}"
+    body:
+      username: "{{ user }}"
+      enabled: true
+      emailVerified: true
+      firstName: "{{ user }}"
+      lastName: Developer
+      email: "{{ user }}@no-reply.com"
+      credentials:
+        - type: password
+          value: "{{ user | replace('user', 'pass') }}"
+          temporary: false
+    body_format: json
+    status_code: 201,409

--- a/ansible/roles/ocp4-workload-quarkus-workshop/tasks/create_project.yaml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/tasks/create_project.yaml
@@ -1,5 +1,5 @@
 ---
-- name: create project
+- name: create project for {{ user }}
   k8s:
     state: present
     kind: Project
@@ -10,5 +10,20 @@
         annotations:
           openshift.io/description: ""
           openshift.io/display-name: "Quarkus Workshop"
-- name: assign perms for user
-  shell: "oc adm policy add-role-to-user admin {{ user }} -n {{ user }}-project"
+- name: assign permissions for user {{ user }}
+  k8s:
+    state: present
+    kind: RoleBinding
+    api_version: rbac.authorization.k8s.io/v1
+    definition:
+      metadata:
+        name: admin
+        namespace: "{{ user }}-project"
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: admin
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: User
+        name: "{{ user }}"

--- a/ansible/roles/ocp4-workload-quarkus-workshop/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/tasks/workload.yml
@@ -226,18 +226,22 @@
     oc get deployment keycloak -n che -o=jsonpath={'.spec.template.spec.containers[0].env[?(@.name=="SSO_ADMIN_PASSWORD")].value'}
   register: sso_admin_password
 
+- name: Print SSO connection info
+  debug:
+    msg: "url: http://keycloak-che.{{ route_subdomain }} username: {{ sso_admin_username.stdout }} password: {{ sso_admin_password.stdout }}"
+
 - name: Get SSO admin token
   uri:
     url: http://keycloak-che.{{ route_subdomain }}/auth/realms/master/protocol/openid-connect/token
     method: POST
+    body:
+      username: "{{ sso_admin_username.stdout }}"
+      password: "{{ sso_admin_password.stdout }}"
+      grant_type: "password"
+      client_id: "admin-cli"
     body_format: form-urlencoded
-    body: "username={{ sso_admin_username.stdout }}&password={{ sso_admin_password.stdout }}&grant_type=password&client_id=admin-cli"
     status_code: 200,201,204
   register: sso_admin_token
-
-- name: Print SSO connection info
-  debug:
-    msg: "url: http://keycloak-che.{{ route_subdomain }} username: {{ sso_admin_username.stdout }} password: {{ sso_admin_password.stdout }}"
 
 - name: Import realm
   uri:
@@ -251,36 +255,11 @@
     ## accept 409 Conflict in case realm exists
     status_code: 200,201,204,409
 
-- name: get existing users
-  uri:
-    url: http://keycloak-che.{{ route_subdomain }}/auth/admin/realms/codeready/users
-    method: GET
-    headers:
-      Authorization: "Bearer {{ sso_admin_token.json.access_token }}"
-    status_code: 200
-  register: sso_users
-
 # Add users to Che
-- name: Add users to Che
-  uri:
-    url: http://keycloak-che.{{ route_subdomain }}/auth/admin/realms/codeready/users
-    method: POST
-    headers:
-      Content-Type: application/json
-      Authorization: "Bearer {{ sso_admin_token.json.access_token }}"
-    body:
-      username: "{{ item }}"
-      enabled: true
-      emailVerified: true
-      firstName: "{{ item }}"
-      lastName: Developer
-      email: "{{ item }}@no-reply.com"
-      credentials:
-        - type: password
-          value: "{{ item | replace('user', 'pass') }}"
-          temporary: false
-    body_format: json
-    status_code: 201,409
+- name: Add users to che
+  include_tasks: add_che_user.yaml
+  vars:
+    user: "{{ item }}"
   with_list: "{{ users }}"
 
 # Import stack definition


### PR DESCRIPTION
##### SUMMARY
Changed to not rely on a single SSO token generated when provisioning Che workspaces. With > 47 users, the token expires before the workload completes the provisioning.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

roles/ocp4-workload-quarkus-workshop

