### PR TITLE
s2020:  fix instructor_mode-related failures

### DIFF
--- a/ansible/roles/ocp4-workload-ml-workflows-workshop/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-ml-workflows-workshop/defaults/main.yml
@@ -6,3 +6,4 @@ silent: False
 user_count_start: 1
 # The last user number to start with when creating projects
 user_count_end: "{{user_count_start|int + num_users|int}}"
+instructor_mode: false

--- a/ansible/roles/ocp4-workload-ml-workflows-workshop/tasks/per_user_workload.yml
+++ b/ansible/roles/ocp4-workload-ml-workflows-workshop/tasks/per_user_workload.yml
@@ -48,7 +48,6 @@
     - "{{ lookup('template', 'pipeline-buildconfig.yaml.j2') }}"
     - "{{ lookup('template', 'pipeline-deploymentconfig.yaml.j2') }}"
     - "{{ lookup('template', 'pipeline-service.yaml.j2') }}"
-  when: instructor_mode
 
 - name: Kick Jupyterhub
   shell: |


### PR DESCRIPTION
This commit removes a check for `instructor_mode` in the S2020 automation, which we had added to the role for DevConf.

##### SUMMARY

This commit prevents a role failure in S2020 when `instructor_mode` wasn't defined (and adds a default for `instructor_mode` if we need to add a check for it in the future).

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

- `ocp4-workload-ml-workflows-workshop`
