### PR TITLE
Added missing vpc setting to AWS::EC2:EIP

### DIFF
--- a/ansible/configs/ocp-workshop/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/ocp-workshop/files/cloud_providers/ec2_cloud_template.j2
@@ -356,6 +356,7 @@ Resources:
     DependsOn:
     - VpcGA
     Properties:
+      Domain: vpc
       InstanceId:
         Ref: {{instance['name']}}{{loop.index}}
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #574   
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Added "Domain: vpc" as a property to "AWS::EC2::EIP"  in the AWS CloudFormation Template.  This corrects the error for accounts where "standard" is the default domain value rather than "vpc".
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-eip.html
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
