### PR TITLE
Wait for imagestream to be defined before attempting import

### DIFF
--- a/ansible/roles/ocp4-workload-quarkus-workshop/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/tasks/workload.yml
@@ -337,6 +337,21 @@
   loop:
   - ./templates/stack.imagestream.j2
 
+- name: Wait for ImageStream definition
+  k8s_facts:
+    kind: ImageStream
+    name: quarkus-stack
+    namespace: openshift
+  register: r_imagestream_d
+  retries: 200
+  delay: 10
+  ignore_errors: yes
+  until: r_imagestream_d.resources | list | length == 1
+
+- name: print imagestream
+  debug:
+    msg: "imagestream: {{ r_imagestream_d }}"
+
 - name: import imagestream
   shell: |
     oc import-image --all quarkus-stack -n openshift


### PR DESCRIPTION
##### SUMMARY
Add a check to ensure the `ImageStream` is properly defined in OpenShift before attempting to import its images.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
`ocp4-workload-quarkus-workshop`

