### PR TITLE
ocp-workload-logging: add retry to the k8s first task

### DIFF
--- a/ansible/roles/ocp4-workload-logging/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-logging/tasks/workload.yml
@@ -4,6 +4,10 @@
 
 - name: Create OpenShift Objects for Logging
   ignore_errors: yes
+  retries: 5
+  delay: 10
+  until: r_objects is succeeded
+  register: r_objects
   k8s:
     state: present
     merge_type:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

logging is very unstable 1/2 of deployments have failed logging.

Try to fix this error:
```
TASK [ocp4-workload-logging : Create OpenShift Objects for Logging] ************
Friday 20 September 2019  21:54:18 +0000 (0:00:00.094)       1:02:44.572 ****** 
changed: [clientvm.68ed.internal] => (item=./files/namespace.yaml)
changed: [clientvm.68ed.internal] => (item=./files/operatorgroup.yaml)
changed: [clientvm.68ed.internal] => (item=./files/elasticsearch_catalog_source.yaml)
failed: [clientvm.68ed.internal] (item=./files/elasticsearch_subscription.yaml) => {...}
changed: [clientvm.68ed.internal] => (item=./files/logging_catalog_source.yaml)
changed: [clientvm.68ed.internal] => (item=./files/logging_subscription.yaml)
...ignoring
```

##### COMPONENT NAME
ocp-workload-logging

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
