### PR TITLE
Fix aws-nuke edge cases

### DIFF
--- a/ansible/roles/infra-aws-sandbox/defaults/main.yml
+++ b/ansible/roles/infra-aws-sandbox/defaults/main.yml
@@ -30,7 +30,7 @@ opentlc_admin_backdoor: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCvZvn+GL0wTOsAdh1i
 # variable for RESET operation
 ####################################
 nuke_sandbox: true
-aws_nuke_binary_url: https://github.com/rebuy-de/aws-nuke/releases/download/v2.8.0/aws-nuke-v2.8.0-linux-amd64
+aws_nuke_binary_url: https://github.com/rebuy-de/aws-nuke/releases/download/v2.11.0/aws-nuke-v2.11.0-linux-amd64
 
 aws_nuke_account_blacklist:
   - 017310218799 # Master account

--- a/ansible/roles/infra-aws-sandbox/tasks/keypair.yml
+++ b/ansible/roles/infra-aws-sandbox/tasks/keypair.yml
@@ -2,19 +2,11 @@
 - environment:
     AWS_PROFILE: "{{ account_name }}"
   block:
-    - name: Fetch all AWS regions
-      command: >-
-        aws ec2 describe-regions
-        --query "Regions[].RegionName"
-        --output json --region us-east-1
-      register: _regions
-      changed_when: false
-
     - name: Import OPENTLC backdoor key
       ec2_key:
         name: opentlc_admin_backdoor
         region: "{{ _region }}"
         key_material: "{{ opentlc_admin_backdoor }}"
-      loop: "{{ _regions.stdout | from_json | list }}"
+      loop: "{{ all_regions }}"
       loop_control:
         loop_var: _region

--- a/ansible/roles/infra-aws-sandbox/tasks/main.yml
+++ b/ansible/roles/infra-aws-sandbox/tasks/main.yml
@@ -12,6 +12,7 @@
     - account_destination_ou is defined
     - operation == 'CREATE'
   tags: ou
+- include_tasks: regions.yml
 - include_tasks: reset.yml
   when: operation == 'RESET'
 - import_tasks: user.yml

--- a/ansible/roles/infra-aws-sandbox/tasks/manual_cleanup.yml
+++ b/ansible/roles/infra-aws-sandbox/tasks/manual_cleanup.yml
@@ -1,0 +1,21 @@
+---
+- environment:
+    AWS_PROFILE: "{{ account_name }}"
+    AWS_REGION: "{{ _region }}"
+  ignore_errors: yes
+  block:
+    - name: Get all security groups
+      register: r_all_sg
+      ec2_group_facts:
+
+    - when: r_all_sg.security_groups | length > 0
+      name: Clean up all ingress and egress rules
+      loop: "{{ r_all_sg.security_groups }}"
+      loop_control:
+        loop_var: _sg
+      ec2_group:
+        rules: []
+        rules_egress: []
+        name: "{{ _sg.group_name }}"
+        description: "{{ _sg.description }}"
+        vpc_id: "{{ _sg.vpc_id }}"

--- a/ansible/roles/infra-aws-sandbox/tasks/manual_cleanup.yml
+++ b/ansible/roles/infra-aws-sandbox/tasks/manual_cleanup.yml
@@ -1,9 +1,14 @@
 ---
 - environment:
-    AWS_PROFILE: "{{ account_name }}"
+    AWS_PROFILE: "{{ account_profile }}"
     AWS_REGION: "{{ _region }}"
   ignore_errors: yes
   block:
+    - debug:
+        var: _region
+
+    # Security groups
+
     - name: Get all security groups
       register: r_all_sg
       ec2_group_facts:
@@ -23,3 +28,60 @@
 
         - set_fact:
             run_aws_nuke_again: true
+
+    # Instance
+
+    - name: Get all instances
+      ec2_instance_facts:
+      register: r_all_instances
+
+    - when: r_all_instances.instances | length > 0
+      block:
+        - name: Disable termination protection on all instances
+          command: >-
+            aws ec2 --profile "{{ account_profile }}"
+            --region "{{ _region }}"
+            modify-instance-attribute
+            --instance-id {{ _instance.instance_id }}
+            --no-disable-api-termination
+          when:
+            - '"state" in _instance'
+            - _instance.state.name != "terminated"
+          loop: "{{ r_all_instances.instances }}"
+          loop_control:
+            loop_var: _instance
+
+        - set_fact:
+            run_aws_nuke_again: true
+    # EIP
+
+    - ec2_eip_facts:
+      register: r_all_eips
+
+    - when: r_all_eips.addresses | length > 0
+      block:
+        # The following does not seem to work with aws profile
+        # Thus use the aws CLI instead.
+        # - name: Disassociate and release EIP
+        #   ec2_eip:
+        #     state: absent
+        #     release_on_disassociation: true
+        #     public_ip: "{{ _eip.public_ip }}"
+        #     profile: "{{ account_profile }}"
+        #   loop: "{{ r_all_eips.addresses }}"
+        #   loop_control:
+        #     loop_var: _eip
+
+        - name: Disassociate EIP
+          command: >-
+            aws ec2 --profile "{{ account_profile }}"
+            --region "{{ _region }}"
+            disassociate-address
+            --public-ip "{{ _eip.public_ip }}"
+          loop: "{{ r_all_eips.addresses }}"
+          loop_control:
+            loop_var: _eip
+
+        - set_fact:
+            run_aws_nuke_again: true
+

--- a/ansible/roles/infra-aws-sandbox/tasks/manual_cleanup.yml
+++ b/ansible/roles/infra-aws-sandbox/tasks/manual_cleanup.yml
@@ -9,13 +9,17 @@
       ec2_group_facts:
 
     - when: r_all_sg.security_groups | length > 0
-      name: Clean up all ingress and egress rules
-      loop: "{{ r_all_sg.security_groups }}"
-      loop_control:
-        loop_var: _sg
-      ec2_group:
-        rules: []
-        rules_egress: []
-        name: "{{ _sg.group_name }}"
-        description: "{{ _sg.description }}"
-        vpc_id: "{{ _sg.vpc_id }}"
+      block:
+        - name: Clean up all ingress and egress rules
+          loop: "{{ r_all_sg.security_groups }}"
+          loop_control:
+            loop_var: _sg
+          ec2_group:
+            rules: []
+            rules_egress: []
+            name: "{{ _sg.group_name }}"
+            description: "{{ _sg.description }}"
+            vpc_id: "{{ _sg.vpc_id }}"
+
+        - set_fact:
+            run_aws_nuke_again: true

--- a/ansible/roles/infra-aws-sandbox/tasks/profile.yml
+++ b/ansible/roles/infra-aws-sandbox/tasks/profile.yml
@@ -11,6 +11,7 @@
     grep -q '\[profile {{ account_profile }}\]' ~/.aws/config
   register: _grepprofile
   failed_when: false
+  changed_when: false
 
 - name: Creating a new AWS profile for the new account if not present
   when: _grepprofile.rc != 0

--- a/ansible/roles/infra-aws-sandbox/tasks/regions.yml
+++ b/ansible/roles/infra-aws-sandbox/tasks/regions.yml
@@ -1,0 +1,14 @@
+---
+- environment:
+    AWS_PROFILE: "{{ account_name }}"
+  block:
+    - name: Fetch all AWS regions
+      command: >-
+        aws ec2 describe-regions
+        --query "Regions[].RegionName"
+        --output json --region us-east-1
+      register: _regions
+      changed_when: false
+
+    - set_fact:
+        all_regions: "{{ _regions.stdout | from_json | list }}"

--- a/ansible/roles/infra-aws-sandbox/tasks/reset.yml
+++ b/ansible/roles/infra-aws-sandbox/tasks/reset.yml
@@ -83,6 +83,10 @@
           delay: 30
           until: _awsnuke2 is succeeded
 
+        - debug:
+            var: _awsnuke2
+
+
     - name: Report aws-nuke error
       fail:
         msg: aws-nuke failed

--- a/ansible/roles/infra-aws-sandbox/tasks/reset.yml
+++ b/ansible/roles/infra-aws-sandbox/tasks/reset.yml
@@ -59,6 +59,29 @@
     - debug:
         var: _awsnuke
 
+    - when: _awsnuke is failed
+      block:
+        - include_tasks: manual_cleanup.yml
+          loop: "{{ all_regions }}"
+          loop_control:
+            loop_var: _region
+
+        - name: Run aws-nuke again
+          command: >-
+            aws-nuke --profile {{ account_name }}
+            -c "{{ output_dir }}/{{ account_name }}_nuke-config.yml"
+            --no-dry-run
+            --force
+          args:
+            stdin: "{{ account_name }}{{ alias_suffix }}"
+          register: _awsnuke
+          async: 1800
+          poll: 30
+          ignore_errors: true
+          retries: "{{ aws_nuke_retries }}"
+          delay: 30
+          until: _awsnuke is succeeded
+
     - name: Report aws-nuke error
       fail:
         msg: aws-nuke failed

--- a/ansible/roles/infra-aws-sandbox/tasks/reset.yml
+++ b/ansible/roles/infra-aws-sandbox/tasks/reset.yml
@@ -7,7 +7,7 @@
     mode: 755
     owner: root
     group: root
-  ignore_errors: yes
+  failed_when: false
 
 - name: Grab or create the public zone
   environment:

--- a/ansible/roles/infra-aws-sandbox/tasks/reset.yml
+++ b/ansible/roles/infra-aws-sandbox/tasks/reset.yml
@@ -67,6 +67,7 @@
             loop_var: _region
 
         - name: Run aws-nuke again
+          when: run_aws_nuke_again | default(false)
           command: >-
             aws-nuke --profile {{ account_name }}
             -c "{{ output_dir }}/{{ account_name }}_nuke-config.yml"
@@ -74,15 +75,17 @@
             --force
           args:
             stdin: "{{ account_name }}{{ alias_suffix }}"
-          register: _awsnuke
+          register: _awsnuke2
           async: 1800
           poll: 30
           ignore_errors: true
           retries: "{{ aws_nuke_retries }}"
           delay: 30
-          until: _awsnuke is succeeded
+          until: _awsnuke2 is succeeded
 
     - name: Report aws-nuke error
       fail:
         msg: aws-nuke failed
-      when: _awsnuke is failed
+      when:
+        - _awsnuke is failed
+        - _awsnuke2 is failed or _awsnuke2 is skipped


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Sometimes the aws-nuke command fails to nuke a sandbox.
Indeed, it happens that resources have complex dependencies and aws-nuke is not ready to deal with those dependencies.

This change brings workarounds to fix certain situations:

* Deactivate termination protection on all the instances
* VPC deletion when default security group has egress or ingress rules referring other security groups, see  https://github.com/rebuy-de/aws-nuke/issues/410
* VPC deletion when EIP are still associated


##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
aws-infra-sandbox role
