### PR TITLE
Move Workloads before cluster shutdown enabled

### DIFF
--- a/ansible/configs/ocp4-workshop/post_software.yml
+++ b/ansible/configs/ocp4-workshop/post_software.yml
@@ -337,6 +337,9 @@
             msg: "FAIL Smoke tests"
           ignore_errors: no
 
+- name: Deploy Default, Infra and Student Workloads
+  import_playbook: ocp_workloads.yml
+
 - name: Enable Cluster Shutdown and Resume
   hosts: bastions
   run_once: yes
@@ -368,9 +371,6 @@
       loop:
       - "csr-signer-signer"
       - "csr-signer"
-
-- name: Deploy Default, Infra and Student Workloads
-  import_playbook: ocp_workloads.yml
 
 - name: Tell CloudForms we are done
   hosts: bastions


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Move calling of workloads to before the cluster shutdown enablement logic.

That way the workloads should not be affected by rotating cluster operators (like API Server operators)

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4_workshop
