### PR TITLE
ocp-workshop : Support for enabling cloud provider

### DIFF
--- a/ansible/cloud_providers/ec2_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/ec2_infrastructure_deployment.yml
@@ -95,6 +95,7 @@
     - name: Run infra-ec2-linux-set-hostname Role
       import_role:
         name: infra-ec2-linux-set-hostname
+      when: not install_cloud_provider  # ec2 cloud provider uses default hostnames
 
 - name: Step 001.4 Configure Windows Hosts and Wait for Connection
   gather_facts: false

--- a/ansible/configs/ocp-workshop/destroy_env.yml
+++ b/ansible/configs/ocp-workshop/destroy_env.yml
@@ -33,6 +33,29 @@
         - s3_result is not succeeded
         - cloud_provider == 'ec2'
 
+    - name: Delete ec2 cloud provider created resources
+      environment:
+        AWS_ACCESS_KEY_ID: "{{ aws_access_key_id }}"
+        AWS_SECRET_ACCESS_KEY: "{{ aws_secret_access_key }}"
+        AWS_DEFAULT_REGION: "{{ aws_region_final|d(aws_region) }}"
+      block:
+      - name: Finding ELBs
+        action:
+          module: ec2_elb_facts
+        register: elbs
+
+      - set_fact:
+          elb_names: "{{ elbs | json_query(query) }}"
+        vars:
+          query: "elbs[?tags.\"kubernetes.io/cluster/{{ guid }}\" == 'owned'].name"
+
+      - name: Deleting ELBs provisioned by cloud provider
+        ec2_elb_lb:
+          name: "{{ item }}"
+          state: absent
+        loop: "{{ elb_names }}"
+      when: cloud_provider == 'ec2' and install_cloud_provider|bool
+
     - name: Run infra-ec2-template-destroy
       include_role:
         name: "infra-{{cloud_provider}}-template-destroy"

--- a/ansible/configs/ocp-workshop/env_vars.yml
+++ b/ansible/configs/ocp-workshop/env_vars.yml
@@ -52,6 +52,9 @@ deploy_openshift: true
 deploy_openshift_post: true
 deploy_env_post: true
 
+# cloud provider config
+install_cloud_provider: false
+
 install_bastion: true
 install_student_user: false
 install_common: true

--- a/ansible/configs/ocp-workshop/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/ocp-workshop/files/cloud_providers/ec2_cloud_template.j2
@@ -155,6 +155,10 @@ Resources:
         - Key: Hostlication
           Value:
             Ref: "AWS::StackId"
+{% if install_cloud_provider %}
+        - Key: "kubernetes.io/cluster/{{ guid }}"
+          Value: "owned"
+{% endif %}
       MapPublicIpOnLaunch: true
       VpcId:
         Ref: Vpc
@@ -176,6 +180,10 @@ Resources:
       Tags:
         - Key: Name
           Value: host_sg
+{% if install_cloud_provider %}
+        - Key: "kubernetes.io/cluster/{{ guid }}"
+          Value: "owned"
+{% endif %}
 
   HostUDPPorts:
     Type: "AWS::EC2::SecurityGroupIngress"
@@ -313,6 +321,10 @@ Resources:
           Value: "{{project_tag}}"
         - Key: "{{project_tag}}"
           Value: "{{ instance['name'] }}"
+{% if install_cloud_provider %}
+        - Key: "kubernetes.io/cluster/{{ guid }}"
+          Value: "owned"
+{% endif %}
 {% for tag in instance['tags'] %}
         - Key: {{tag['key']}}
           Value: {{tag['value']}}

--- a/ansible/configs/ocp-workshop/files/hosts_template.3.11.104.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.3.11.104.j2
@@ -271,6 +271,12 @@ ansible_service_broker_local_registry_whitelist=['.*-apb$']
 ###########################################################################
 
 {% if cloud_provider == 'ec2' %}
+{% if install_cloud_provider %}
+openshift_cloudprovider_kind=aws
+openshift_clusterid={{ guid }}
+openshift_cloudprovider_aws_access_key={{ aws_access_key_id }}
+openshift_cloudprovider_aws_secret_key={{ aws_secret_access_key }}
+{% endif %}
 {% elif cloud_provider == 'azure' %}
 openshift_web_console_extension_stylesheet_urls=['https://raw.githubusercontent.com/vincepower/ocp-console-logo/master/azure.css']
 #openshift_storageclass_parameters={'kind': 'managed', 'storageaccounttype': 'Premium_LRS'}

--- a/ansible/roles/infra-common-ssh-config-generate/tasks/main.yml
+++ b/ansible/roles/infra-common-ssh-config-generate/tasks/main.yml
@@ -38,7 +38,7 @@
     dest: "{{ ansible_ssh_config }}"
     marker: "##### {mark} ADDED BASTION PROXY HOST {{ bastion_hostname }} {{ env_type }}-{{ guid }} ######"
     content: |
-        Host {{ bastion_hostname }} {{ hostvars[bastion_hostname].shortname |d('')}}
+        Host {{ hostvars[bastion_hostname].internaldns }} {{ bastion_hostname }} {{ hostvars[bastion_hostname].shortname |d('')}}
           Hostname {{ hostvars[bastion_hostname].public_dns_name }}
           IdentityFile {{ ssh_key | default(infra_ssh_key) | default(ansible_ssh_private_key_file) | default(default_key_name)}}
           IdentitiesOnly yes

--- a/ansible/roles/infra-ec2-create-inventory/tasks/main.yml
+++ b/ansible/roles/infra-ec2-create-inventory/tasks/main.yml
@@ -46,7 +46,7 @@
   ignore_errors: yes
 
 - add_host:
-    name: "{{item.tags.internaldns | default(item.private_dns_name)}}"
+    name: "{{item.tags.internaldns if not install_cloud_provider|bool else item.private_dns_name | default(item.private_dns_name)}}"
     shortname: "{{item.tags.Name | default(item.private_dns_name)}}"
     groups:
       - "tag_Project_{{stack_tag}}"
@@ -82,7 +82,7 @@
 
 # AnsibleGroup tag can have several comma-separated values. Ex: activedirectories,windows
 - add_host:
-    name: "{{item.tags.internaldns | default(item.private_dns_name)}}"
+    name: "{{item.tags.internaldns if not install_cloud_provider|bool else item.private_dns_name| default(item.private_dns_name)}}"
     groups: "{{item.tags.AnsibleGroup}}"
   with_items: "{{ec2_facts['instances']}}"
   when: item.state.name != 'terminated'


### PR DESCRIPTION
##### SUMMARY
Adds support for enabling AWS cloud provider on OCP3 clusters. 

The default `ocp-workshop` uses custom DNS as OpenShift node names. When AWS cloud provider is installed, the custom DNS names do not work. We need a way to tell AgnosticD to use the default EC2 DNS names for access within the VPC. The external DNS names are not a problem. 

**Changes :** 
1. Do not set hostnames on Linux hosts when AWS cloud provider is to be installed. Use the default EC2 hostnames. 
2. Add `kubernetes.io/cluster/{{ guid }} = owned` tags to all EC2 instances, at least one security group directly applied to all nodes, subnet of those security groups.
3. Add Cloud Provider configuration in OpenShift Ansible hosts file.
4. In the inventory, use EC2 dns addresses for all nodes instead of the route 53 addresses. 

**About deletion:** 
Cloud Provider creates resources in the existing cloud formation stack which need to be deleted before attempting to delete CloudFormation template.

The changes are backward compatible

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request (config)

##### COMPONENT NAME
ocp-workshop

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
cc: @jwmatthews 