### PR TITLE
ocp4-workload-ceph: Clean up volumes on cluster termination

### DIFF
--- a/ansible/roles/ocp4-workload-ceph/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-ceph/tasks/pre_workload.yml
@@ -50,6 +50,7 @@
     instance: "{{ item.name }}"
     volume_type: "gp2"
     volume_size: "100"
+    delete_on_termination: yes
     name: "ceph-vol-{{ item.name }}-{{ item.aZone }}"
     tags:
       ceph-cluster-id: "{{ ceph_cluster_id }}"

--- a/ansible/roles/ocp4-workload-ceph/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-ceph/tasks/workload.yml
@@ -31,14 +31,14 @@
   shell: "oc get pods -o json --selector=app=rook-ceph-mon -n rook-ceph"
   register: mon_pods
   until: mon_pods.stdout|from_json|json_query('items[*].status.phase')|unique == ["Running"]
-  retries: 12
-  delay: 24
+  retries: 30
+  delay: 20
   when: not ceph_workload_destroy | bool
 
 - name: "Waiting for OSD pods to come up..."
   shell: "oc get pods -o json --selector=app=rook-ceph-osd -n rook-ceph"
   register: osd_pods
   until: osd_pods.stdout|from_json|json_query('items[*].status.phase')|unique == ["Running"]
-  retries: 12
-  delay: 24
+  retries: 30
+  delay: 20
   when: not ceph_workload_destroy | bool


### PR DESCRIPTION
##### SUMMARY
This PR ensures that ceph volumes are removed upon cluster destroy/termination on EC2. Currently volumes can potentially be left intact on EC2 if issues with workload removal arise.

#### Changes
- Set  delete_on_termination during the provisioning of volumes on worker nodes
- Double retries OSD/MON pods to come online, in some environments the current ~5mins gets very close to exhaustion

##### ISSUE TYPE
- Bugfix Pull Request

@pranavgaikwad @jwmatthews 
