### PR TITLE
Ocp workloads with openshift applier

### DIFF
--- a/ansible/configs/ocp-workloads/env_vars.yml
+++ b/ansible/configs/ocp-workloads/env_vars.yml
@@ -1,1 +1,2 @@
 ---
+become_override: false

--- a/ansible/configs/ocp-workloads/examples/cakephp-openshift-applier.yml
+++ b/ansible/configs/ocp-workloads/examples/cakephp-openshift-applier.yml
@@ -1,0 +1,36 @@
+---
+cloud_provider: none
+env_type: ocp-workloads
+
+ocp_workloads:
+  - ocp-workload-openshift-applier
+
+ocp_username: gucore-redhat.com
+guid: testgucore
+
+openshift_cluster_content:
+
+  - object: projectrequest
+    content:
+    - name: Create namespace
+      template: https://raw.githubusercontent.com/redhat-cop/openshift-applier/v2.1.1/tests/files/templates/projectrequest.yml
+      params_from_vars:
+        NAMESPACE: "{{ guid }}"
+        NAMESPACE_DESCRIPTION: Sample namespace for student {{ ocp_username }}
+        NAMESPACE_DISPLAY_NAME: Sample namespace for student {{ ocp_username }}
+
+  - object: cakephprequest
+    content:
+    - name: Create cake-php mysql
+      template: https://raw.githubusercontent.com/openshift/origin/v4.1.0/examples/quickstarts/cakephp-mysql.json
+      params_from_vars:
+        NAME: "cakephp-mysql-{{ guid }}"
+      namespace: "{{ guid }}"
+
+target_host:
+  ansible_host: bastion.dev.openshift.opentlc.com
+  ansible_port: 22
+  ansible_user: ec2-user
+  #ansible_ssh_private_key_content: "{{ target_host_ssh_private_key_content }}"
+  ansible_ssh_private_key_file: ~/.ssh/opentlc_admin_backdoor.pem
+  #ansible_ssh_extra_args: 

--- a/ansible/configs/ocp-workloads/examples/cakephp-openshift-applier.yml
+++ b/ansible/configs/ocp-workloads/examples/cakephp-openshift-applier.yml
@@ -12,22 +12,22 @@ openshift_cluster_content:
 
   - object: projectrequest
     content:
-    - name: Create namespace
-      template: https://raw.githubusercontent.com/redhat-cop/openshift-applier/v2.1.1/tests/files/templates/projectrequest.yml
-      params_from_vars:
-        NAMESPACE: "{{ guid }}"
-        NAMESPACE_DESCRIPTION: Sample namespace for student {{ ocp_username }}
-        NAMESPACE_DISPLAY_NAME: Sample namespace for student {{ ocp_username }}
-      action: "{{ applier_action }}"
+      - name: Create namespace
+        template: https://raw.githubusercontent.com/redhat-cop/openshift-applier/v2.1.1/tests/files/templates/projectrequest.yml
+        params_from_vars:
+          NAMESPACE: "{{ guid }}"
+          NAMESPACE_DESCRIPTION: Sample namespace for student {{ ocp_username }}
+          NAMESPACE_DISPLAY_NAME: Sample namespace for student {{ ocp_username }}
+        action: "{{ applier_action }}"
 
   - object: cakephprequest
     content:
-    - name: Create cake-php mysql
-      template: https://raw.githubusercontent.com/openshift/origin/v4.1.0/examples/quickstarts/cakephp-mysql.json
-      params_from_vars:
-        NAME: "cakephp-mysql-{{ guid }}"
-      namespace: "{{ guid }}"
-      action: "{{ applier_action }}"
+      - name: Create cake-php mysql
+        template: https://raw.githubusercontent.com/openshift/origin/v4.1.0/examples/quickstarts/cakephp-mysql.json
+        params_from_vars:
+          NAME: "cakephp-mysql-{{ guid }}"
+        namespace: "{{ guid }}"
+        action: "{{ applier_action }}"
 
 target_host:
   ansible_host: bastion.dev.openshift.opentlc.com

--- a/ansible/configs/ocp-workloads/examples/cakephp-openshift-applier.yml
+++ b/ansible/configs/ocp-workloads/examples/cakephp-openshift-applier.yml
@@ -18,6 +18,7 @@ openshift_cluster_content:
         NAMESPACE: "{{ guid }}"
         NAMESPACE_DESCRIPTION: Sample namespace for student {{ ocp_username }}
         NAMESPACE_DISPLAY_NAME: Sample namespace for student {{ ocp_username }}
+      action: "{{ applier_action }}"
 
   - object: cakephprequest
     content:
@@ -26,6 +27,7 @@ openshift_cluster_content:
       params_from_vars:
         NAME: "cakephp-mysql-{{ guid }}"
       namespace: "{{ guid }}"
+      action: "{{ applier_action }}"
 
 target_host:
   ansible_host: bastion.dev.openshift.opentlc.com

--- a/ansible/configs/ocp-workloads/post_infra.yml
+++ b/ansible/configs/ocp-workloads/post_infra.yml
@@ -52,3 +52,5 @@
           add_host:
             name: "{{ target_host }}"
             group: ocp_bastions
+
+- import_playbook: ../../include_vars.yml

--- a/ansible/configs/ocp-workloads/requirements.yml
+++ b/ansible/configs/ocp-workloads/requirements.yml
@@ -1,0 +1,5 @@
+---
+# External role to allow use of ocp-workload-openshift-applier
+- src: https://github.com/redhat-cop/openshift-applier
+  name: openshift-applier
+  version: v2.1.1

--- a/ansible/roles/ocp-workload-openshift-applier/tasks/main.yml
+++ b/ansible/roles/ocp-workload-openshift-applier/tasks/main.yml
@@ -14,6 +14,8 @@
     file: ./workload.yml
     apply:
       become: "{{ become_override | bool }}"
+  vars:
+    applier_action: apply
   when: ACTION == "create" or ACTION == "provision"
 
 - name: Running Post Workload Tasks
@@ -22,6 +24,15 @@
     apply:
       become: "{{ become_override | bool }}"
   when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload removal Tasks
+  include_tasks:
+    file: ./workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  vars:
+    applier_action: delete
+  when: ACTION == "destroy" or ACTION == "remove"
 
 - name: Running Workload removal Tasks
   include_tasks:


### PR DESCRIPTION
##### SUMMARY

Patch ocp-workloads config to work with openshift-applier.

- add openshift-applier in `requirements.yml`
- add `become_override` to `env_vars.yml`  (default false)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request

