### PR TITLE
Update jenkins docker build to select a java version

### DIFF
--- a/ansible/roles/ocp4-workload-security-compliance-lab/tasks/infrastructure.yml
+++ b/ansible/roles/ocp4-workload-security-compliance-lab/tasks/infrastructure.yml
@@ -66,7 +66,8 @@
   delegate_to: "{{ bastion_internal }}"
 
 - name: Create custom jenkins image
-  command: "{{ openshift_cli }} new-build -D 'FROM jenkins:latest\nUSER 0\nRUN curl -L https://updates.jenkins-ci.org/download/plugins/ssh-steps/1.2.1/ssh-steps.hpi -o /usr/lib/jenkins/ssh-steps.hpi && chmod 664 /usr/lib/jenkins/ssh-steps.hpi\nUSER 1000' --to=custom-jenkins -n openshift"
+  shell: |
+    {{ openshift_cli }} new-build -D $'FROM jenkins:latest\nUSER 0\nRUN curl -L https://updates.jenkins-ci.org/download/plugins/ssh-steps/1.2.1/ssh-steps.hpi -o /usr/lib/jenkins/ssh-steps.hpi && chmod 665 /usr/lib/jenkins/ssh-steps.hpi && sed -i '\''s/{ print $1; }/ {a=$1} END{print a}/'\'' /usr/libexec/s2i/run' --to=custom-jenkins -n openshift
   ignore_errors: true
 
 - name: Wait for custom jenkins build to finish


### PR DESCRIPTION


##### SUMMARY
The latest jenkins image contains 2 versions of java (1.8 and 1.11).  The /usr/libexec/s2i/run script currently does not properly select a java version since it was not written to handle the case of more than one version. This pull request will update the run script to select the 1.8 java version


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-workload-security-compliance-lab 

##### ADDITIONAL INFORMATION
