### PR TITLE
openshift-applier workload: allow annotation for ocp_username

### DIFF
--- a/ansible/configs/ocp-workloads/examples/cakephp-openshift-applier.yml
+++ b/ansible/configs/ocp-workloads/examples/cakephp-openshift-applier.yml
@@ -8,6 +8,19 @@ ocp_workloads:
 ocp_username: gucore-redhat.com
 guid: testgucore
 
+# Specify here the target namespaces.
+# When using the applier and system:admin, the namespaces specified here
+# will be annotated with openshift.io/requester = {{ ocp_username }}
+target_namespaces:
+  - "{{ guid }}"
+
+# 'ocp_projects' is an alias for 'target_namespaces'
+# ocp_projects:
+#   - "{{ guid }}"
+
+# This works too:
+# ocp_project: "{{ guid }}"
+
 openshift_cluster_content:
 
   - object: projectrequest
@@ -15,7 +28,7 @@ openshift_cluster_content:
       - name: Create namespace
         template: https://raw.githubusercontent.com/redhat-cop/openshift-applier/v2.1.1/tests/files/templates/projectrequest.yml
         params_from_vars:
-          NAMESPACE: "{{ guid }}"
+          NAMESPACE: "{{ target_namespaces[0] }}"
           NAMESPACE_DESCRIPTION: Sample namespace for student {{ ocp_username }}
           NAMESPACE_DISPLAY_NAME: Sample namespace for student {{ ocp_username }}
         action: "{{ applier_action }}"
@@ -26,7 +39,7 @@ openshift_cluster_content:
         template: https://raw.githubusercontent.com/openshift/origin/v4.1.0/examples/quickstarts/cakephp-mysql.json
         params_from_vars:
           NAME: "cakephp-mysql-{{ guid }}"
-        namespace: "{{ guid }}"
+        namespace: "{{ target_namespaces[0] }}"
         action: "{{ applier_action }}"
 
 target_host:

--- a/ansible/roles/ocp-workload-openshift-applier/tasks/post_workload.yml
+++ b/ansible/roles/ocp-workload-openshift-applier/tasks/post_workload.yml
@@ -1,9 +1,44 @@
 ---
 # Implement your Post Workload deployment tasks here
+- name: Get current user
+  command: oc whoami
+  register: current_user
 
+- when:
+    - ocp_username is defined
+    - ocp_username != current_user.stdout
+  block:
+    - name: Annotate the completed project as requested by user (ocp_projects)
+      command: >-
+        oc annotate namespace {{_ocp_project}}
+        openshift.io/requester={{ocp_username}} --overwrite
+      loop: "{{ ocp_projects | default([]) }}"
+      loop_control:
+        loop_var: _ocp_project
 
-# Leave this as the last task in the playbook.
-- name: post_workload tasks complete
-  debug:
-    msg: "Post-Workload Tasks completed successfully."
-  when: not silent|bool
+    - name: Annotate the completed project as requested by user (target_namespaces)
+      command: >-
+        oc annotate namespace {{_ocp_project}}
+        openshift.io/requester={{ocp_username}} --overwrite
+      loop: "{{ target_namespaces | default([]) }}"
+      loop_control:
+        loop_var: _ocp_project
+
+    - name: Annotate the completed project as requested by user
+      when:
+        - ocp_project is defined
+        - ocp_project != ''
+      command: >-
+        oc annotate namespace {{ocp_project}}
+        openshift.io/requester={{ocp_username}} --overwrite
+    # Leave this as the last task in the playbook.
+    - name: post_workload tasks complete
+      debug:
+        msg: "Post-Workload Tasks completed successfully."
+      when: not silent|bool
+  rescue:
+    - debug:
+        msg: >-
+          ocp_username is different from the user you're connected to.
+          The workload tries to change the annotation openshift.io/request,
+          but failed.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
This commit, if applied, makes ocp-workload-openshift-applier add the annotation 'openshift.io/requester' for the namespaces specified in `target_namespaces` list.

When the applier workload is run as 'system:admin' and 'ocp_username' var is
provided, the 'target_namespaces' are annotated properly.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp-workload-openshift-applier

