### PR TITLE
Added a second loop to approve CSRs that have appeared while approvin…

### DIFF
--- a/ansible/configs/ocp4-workshop/lifecycle.yml
+++ b/ansible/configs/ocp4-workshop/lifecycle.yml
@@ -119,6 +119,8 @@
       command: "oc adm certificate approve {{ item }}"
       loop: "{{ r_csrs.stdout_lines }}"
 
+    # TODO: Implement proper loop to watch for incoming CSRS while we are
+    # approving them. For now, this is a workaround, just wait and re-approve.
     - name: Wait 10s for additional CSRs to appear
       pause:
         seconds: 10

--- a/ansible/configs/ocp4-workshop/lifecycle.yml
+++ b/ansible/configs/ocp4-workshop/lifecycle.yml
@@ -118,3 +118,17 @@
       name: Approve all Pending CSRs
       command: "oc adm certificate approve {{ item }}"
       loop: "{{ r_csrs.stdout_lines }}"
+
+    - name: Wait 10s for additional CSRs to appear
+      pause:
+        seconds: 10
+
+    - name: Get additional CSRs that need to be patched
+      command: oc get csr -oname
+      register: r_new_csrs
+      changed_when: false
+
+    - when: r_new_csrs.stdout_lines | length > 0
+      name: Approve all Pending CSRs
+      command: "oc adm certificate approve {{ item }}"
+      loop: "{{ r_new_csrs.stdout_lines }}"


### PR DESCRIPTION
On one of my tests new CSRs appeared after we had gotten the CSRs to be approved. Which then didn't get approved and rendered a few nodes NotReady.

Add a second iteration to catch those.