### PR TITLE
Add ocp_workload_shared_cluster_access

### DIFF
--- a/ansible/roles/ocp_workload_shared_cluster_access/README.adoc
+++ b/ansible/roles/ocp_workload_shared_cluster_access/README.adoc
@@ -1,0 +1,53 @@
+# ocp_workload_shared_cluster_access
+
+Manage user access to shared clusters by creating a cluster role binding for self-provisioner access and a cluster resource quota to control resource consumption.
+
+## Configuration
+
+.Configuration Variables
+[options="header",cols="30%,10%,60%"]
+|===
+| Variable
+| Default
+| Description
+
+| ocp_shared_cluster_access_quota_requests_cpu
+| 10
+| Total allowed CPU resource requests
+
+| ocp_shared_cluster_access_quota_limits_cpu
+| 20
+| Total allowed CPU resource limits
+
+| ocp_shared_cluster_access_quota_requests_memory
+| 20Gi
+| Total allowed memory resource requests
+
+| ocp_shared_cluster_access_quota_limits_memory
+| 40Gi
+| Total allowed memory resource limits
+
+| ocp_shared_cluster_access_quota_configmaps
+| 15
+| Total number allowed config maps
+
+| ocp_shared_cluster_access_quota_pods
+| 30
+| Total number allowed pods
+
+| ocp_shared_cluster_access_quota_persistentvolumeclaims
+| 15
+| Total number allowed persistent volume claims
+
+| ocp_shared_cluster_access_quota_services
+| 150
+| Total number allowed services
+
+| ocp_shared_cluster_access_quota_secrets
+| 150
+| Total number allowed secrets
+
+| ocp_shared_cluster_access_quota_requests_storage
+| 50Gi
+| Total allowed storage requests
+|===

--- a/ansible/roles/ocp_workload_shared_cluster_access/defaults/main.yml
+++ b/ansible/roles/ocp_workload_shared_cluster_access/defaults/main.yml
@@ -1,0 +1,20 @@
+---
+# User for which to provision cluster access
+# ocp_username is a required variable
+#ocp_username: ...
+
+# OpenShift 
+ocp_shared_cluster_access_quota_requests_cpu: 10
+ocp_shared_cluster_access_quota_limits_cpu: 20
+ocp_shared_cluster_access_quota_requests_memory: 20Gi
+ocp_shared_cluster_access_quota_limits_memory: 40Gi
+ocp_shared_cluster_access_quota_configmaps: 15
+ocp_shared_cluster_access_quota_pods: 30
+ocp_shared_cluster_access_quota_persistentvolumeclaims: 15
+ocp_shared_cluster_access_quota_services: 150
+ocp_shared_cluster_access_quota_secrets: 150
+ocp_shared_cluster_access_quota_requests_storage: 50Gi
+
+# Override become on all tasks
+become_override: false
+silent: false

--- a/ansible/roles/ocp_workload_shared_cluster_access/tasks/main.yml
+++ b/ansible/roles/ocp_workload_shared_cluster_access/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+
+# Do not modify this file
+
+- name: Running Pre Workload Tasks
+  include_tasks:
+    file: pre_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload Tasks
+  include_tasks:
+    file: workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  include_tasks:
+    file: post_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload removal Tasks
+  include_tasks:
+    file: remove_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles/ocp_workload_shared_cluster_access/tasks/post_workload.yml
+++ b/ansible/roles/ocp_workload_shared_cluster_access/tasks/post_workload.yml
@@ -1,0 +1,5 @@
+---
+- name: post_workload Tasks Complete
+  debug:
+    msg: post_workload complete
+  when: not silent|bool

--- a/ansible/roles/ocp_workload_shared_cluster_access/tasks/pre_workload.yml
+++ b/ansible/roles/ocp_workload_shared_cluster_access/tasks/pre_workload.yml
@@ -1,0 +1,4 @@
+---
+- name: pre_workload Tasks Complete
+  debug:
+    msg: pre_workload complete

--- a/ansible/roles/ocp_workload_shared_cluster_access/tasks/remove_workload.yml
+++ b/ansible/roles/ocp_workload_shared_cluster_access/tasks/remove_workload.yml
@@ -7,6 +7,9 @@
   k8s_facts:
     api_version: v1
     kind: Namespace
+    label_selectors:
+    - '!AAD'
+    - '!usernamespace.gpte.redhat.com/user-uid'
   register: r_get_namespaces
 
 - name: Remove user namespaces

--- a/ansible/roles/ocp_workload_shared_cluster_access/tasks/remove_workload.yml
+++ b/ansible/roles/ocp_workload_shared_cluster_access/tasks/remove_workload.yml
@@ -1,0 +1,46 @@
+---
+- name: pre_workload Tasks Complete
+  debug:
+    msg: pre_workload tasks complete
+
+- name: Get Namespaces
+  k8s_facts:
+    api_version: v1
+    kind: Namespace
+  register: r_get_namespaces
+
+- name: Remove user namespaces
+  k8s:
+    api_version: v1
+    kind: namespace
+    name: "{{ user_namespace }}"
+    state: absent
+  vars:
+    user_namespace_query: >-
+      [?@.metadata.annotations."openshift.io/requester"==`{{ ocp_username | to_json }}`].metadata.name
+  loop: >
+    {{ r_get_namespaces.resources | default([]) | json_query(user_namespace_query) }}
+  loop_control:
+    loop_var: user_namespace
+
+- name: Remove user self-provisioner access
+  k8s:
+    api_version: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    name: self-provisioner:{{ ocp_username }}
+    state: absent
+
+- name: Delete user clusterresourcequota
+  k8s:
+    api_version: quota.openshift.io/v1
+    kind: ClusterResourceQuota
+    name: "user-{{ ocp_username }}"
+    state: absent
+
+- name: workload Tasks Complete
+  debug:
+    msg: workload complete
+
+- name: post_workload Tasks Complete
+  debug:
+    msg: post_workload complete

--- a/ansible/roles/ocp_workload_shared_cluster_access/tasks/workload.yml
+++ b/ansible/roles/ocp_workload_shared_cluster_access/tasks/workload.yml
@@ -1,0 +1,44 @@
+---
+- name: Create user clusterresourcequota
+  k8s:
+    definition:
+      apiVersion: quota.openshift.io/v1
+      kind: ClusterResourceQuota
+      metadata:
+        name: "user-{{ ocp_username }}"
+      spec:
+        selector:
+          annotations:
+            openshift.io/requester: "{{ ocp_username }}"
+        quota:
+          hard:
+            requests.cpu: "{{ quota_requests_cpu }}"
+            limits.cpu: "{{ quota_limits_cpu }}"
+            requests.memory: "{{ quota_requests_memory }}"
+            limits.memory: "{{ quota_limits_memory }}"
+            configmaps: "{{ quota_configmaps }}"
+            pods: "{{ quota_pods }}"
+            persistentvolumeclaims: "{{ quota_persistentvolumeclaims }}"
+            services: "{{ quota_services }}"
+            secrets: "{{ quota_secrets }}"
+            requests.storage: "{{ quota_requests_storage }}"
+
+- name: Grant user self-provisioner access
+  k8s:
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: self-provisioner:{{ ocp_username }}
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: self-provisioner
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: User
+        name: "{{ ocp_username }}"
+
+- name: workload Tasks Complete
+  debug:
+    msg: workload complete

--- a/ansible/roles/ocp_workload_shared_cluster_access/vars/main.yml
+++ b/ansible/roles/ocp_workload_shared_cluster_access/vars/main.yml
@@ -1,0 +1,12 @@
+---
+# Map prefixed variable names to short names
+quota_requests_cpu: "{{ ocp_shared_cluster_access_quota_requests_cpu }}"
+quota_limits_cpu: "{{ ocp_shared_cluster_access_quota_limits_cpu }}"
+quota_requests_memory: "{{ ocp_shared_cluster_access_quota_requests_memory }}"
+quota_limits_memory: "{{ ocp_shared_cluster_access_quota_limits_memory }}"
+quota_configmaps: "{{ ocp_shared_cluster_access_quota_configmaps }}"
+quota_pods: "{{ ocp_shared_cluster_access_quota_pods }}"
+quota_persistentvolumeclaims: "{{ ocp_shared_cluster_access_quota_persistentvolumeclaims }}"
+quota_services: "{{ ocp_shared_cluster_access_quota_services }}"
+quota_secrets: "{{ ocp_shared_cluster_access_quota_secrets }}"
+quota_requests_storage: "{{ ocp_shared_cluster_access_quota_requests_storage }}"


### PR DESCRIPTION
##### SUMMARY

Add ocp_workload_shared_cluster_access

A workload to enable self-provisioner access and create a cluster resource quota for the user.

##### ISSUE TYPE
- New role Pull Request

##### COMPONENT NAME
ocp_workload_shared_cluster_access