### PR TITLE
Add ignore_errors to the task trying to get the webapp route

### DIFF
--- a/ansible/roles/ocp-workload-integreatly/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-integreatly/tasks/workload.yml
@@ -37,6 +37,7 @@
   retries: 5
   delay: 10
   until: webapp_route is succeeded
+  ignore_errors: yes
 
 - set_fact:
     openshift_master_url: "{{ (openshift_master_config['content'] | b64decode | from_yaml)['masterPublicURL'] }}"


### PR DESCRIPTION
This route is only used in print debug user.info tasks later, no need to fail
because of this.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
