### PR TITLE
Integreatly: don't fail silently

### DIFF
--- a/ansible/roles/ocp-workload-integreatly/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-integreatly/tasks/workload.yml
@@ -8,6 +8,7 @@
 
 - name: Run Integreatly installer
   shell: |
+          set -o pipefail
           ansible-playbook -i "{{ inventory_hosts_file }}" \
           playbooks/install.yml \
           -e eval_self_signed_certs="{{ self_signed_certs_enabled }} \


### PR DESCRIPTION
Use set -o pipefail to be aware when the ansible-playbook command fails

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
