### PR TITLE
Reduce wait time for startup to 3 minutes

### DIFF
--- a/ansible/configs/ocp4-workshop/lifecycle.yml
+++ b/ansible/configs/ocp4-workshop/lifecycle.yml
@@ -105,9 +105,9 @@
     delegate_to: "{{ groups['bastions'] | first }}"
     when: ACTION == 'start'
     block:
-    - name: Wait (default 5m) for Nodes to settle and pods to start
+    - name: Wait (default 3m) for Nodes to settle and pods to start
       pause:
-        seconds: "{{ lifecycle_start_pause | default(300) }}"
+        seconds: "{{ lifecycle_start_pause | default(180) }}"
 
     - name: Get CSRs that need to be patched
       command: oc get csr -oname


### PR DESCRIPTION
5 Minutes to wait for nodes to show NotReady was too long. 2 Minutes should be fine. Setting to 3 Minutes to be safe. This may also eliminate the need or the second go around on CSRs.