### PR TITLE
ocp-workload-migration : Supporting new versions of migration operator

### DIFF
--- a/ansible/roles/ocp-workload-migration/README.adoc
+++ b/ansible/roles/ocp-workload-migration/README.adoc
@@ -2,9 +2,13 @@
 
 == Overview
 
-This is a workload for Cluster Application Migration Tool.
+The workload includes migration operator which deploys migration controller, migration ui and Velero.
 
-It includes the migration operator which deploys migration controller, migration ui and Velero.
+== Supported Versions
+
+This workload supports following versions of Cluster Application Migration Tool
+
+- release-1.0
 
 === Deploy the workload
 [source,'bash']
@@ -28,30 +32,21 @@ This workload does not require any variables. Following variables can be overrid
 |===
 | Variable | Default Value | Description
 
-| mig_operator_deploy_velero
-| true
-| Deploy Velero?
-| No
+| mig_operator_repo
+| https://github.com/fusor/mig-operator
+| Repository for migration operator
 
-| mig_operator_deploy_controller
-| default
-| Deploy migration controller?
-| No
+| mig_operator_repo_branch
+| master
+| Branch in operator repo
 
-| mig_operator_deploy_ui
-| true
-| Deploy migration UI?
-| No
+| mig_operator_version
+| latest
+| Migration operator version 
 
-| mig_controller_limits_memory
-| '600Mi'
-| Memory limits for controller
-| No
-
-| mig_controller_requests_memory
-| '512Mi'
-| Memory requests for controller
-| No
+| mig_ocp_version
+| 4
+| Version of OpenShift cluster
 |===
 
 

--- a/ansible/roles/ocp-workload-migration/README.adoc
+++ b/ansible/roles/ocp-workload-migration/README.adoc
@@ -10,6 +10,8 @@ This workload supports following versions of Cluster Application Migration Tool
 
 - release-1.0
 
+Older version are no longer supported
+
 === Deploy the workload
 [source,'bash']
 ----

--- a/ansible/roles/ocp-workload-migration/defaults/main.yml
+++ b/ansible/roles/ocp-workload-migration/defaults/main.yml
@@ -1,12 +1,7 @@
 mig_operator_repo: https://github.com/fusor/mig-operator
 mig_operator_repo_branch: master
-
-mig_operator_deploy_velero: true
-mig_operator_deploy_controller: true
-mig_operator_deploy_ui: true
-
-mig_controller_limits_memory: '600Mi'
-mig_controller_requests_memory: '512Mi'
+mig_operator_version: latest
+mig_ocp_version: 4
 
 # workload vars
 migration_workload_destroy: "{{ False if (ACTION=='create' or ACTION=='provision') else True }}"

--- a/ansible/roles/ocp-workload-migration/tasks/pre_workload.yml
+++ b/ansible/roles/ocp-workload-migration/tasks/pre_workload.yml
@@ -93,37 +93,6 @@
     repo: "{{ mig_operator_repo }}"
     dest: "{{ repodir.path }}"
     version: "{{ mig_operator_repo_branch }}"
-    
-- name: "Applying variables"
-  replace:
-    path: "{{ repodir.path }}/controller-4.yml"
-    regexp: "{{ item.pattern }}"
-    replace: "{{ item.replace }}"
-  loop:
-    - { pattern: "migration_velero:.*", replace: "migration_velero: {{ mig_operator_deploy_velero }}" }
-    - { pattern: "migration_controller:.*", replace: "migration_controller: {{ mig_operator_deploy_controller }}" }
-    - { pattern: "migration_ui:.*", replace: "migration_ui: {{ mig_operator_deploy_ui }}" }
-  when: not migration_workload_destroy|bool
-
-- name: "Applying mig cluster api endpoint"
-  replace:
-    path: "{{ repodir.path }}/controller-4.yml"
-    regexp: "{{ item.pattern }}"
-    replace: "{{ item.replace }}"
-  loop:
-    - { pattern: "#mig_ui_cluster_api_endpoint:.*", replace: "mig_ui_cluster_api_endpoint: {{ mig_operator_ui_cluster_api_endpoint }}" }
-  when: not migration_workload_destroy|bool and mig_operator_ui_cluster_api_endpoint is defined
-
-- name: "Add memory limits to controller"
-  lineinfile:
-    path: "{{ repodir.path }}/controller-4.yml"
-    insertafter: "migration_ui"
-    line: "  {{ item.key }}: {{ item.val }}"
-    state: present
-  loop:
-    - { key: mig_controller_limits_memory, val: "{{ mig_controller_limits_memory }}" }
-    - { key: mig_controller_requests_memory, val: "{{ mig_controller_requests_memory }}" }
-  when: not migration_workload_destroy|bool
 
 # Leave this as the last task in the playbook.
 - name: pre_workload tasks complete

--- a/ansible/roles/ocp-workload-migration/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-migration/tasks/workload.yml
@@ -3,11 +3,11 @@
   shell: "oc apply -f {{ repodir.path }}/deploy/non-olm/{{ mig_operator_version }}/{{ item }}"
   loop:
     - "operator.yml"
-    - "{{ 'controller-4.yml' if mig_ocp_version == 4 else 'controller-3.yml' }}"
+    - "controller-{{ mig_ocp_version }}.yml"
   when: not migration_workload_destroy|bool
 
 - name: "Removing controller and operator"
-  shell: "oc delete --ignore-not-found -f {{ repodir.path }}/{{ item }}"
+  shell: "oc delete --ignore-not-found -f {{ repodir.path }}/deploy/non-olm/{{ mig_operator_version }}/{{ item }}"
   loop:
     - "operator.yml"
   when: migration_workload_destroy|bool

--- a/ansible/roles/ocp-workload-migration/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-migration/tasks/workload.yml
@@ -1,9 +1,9 @@
 ---
 - name: "Creating controller and operator"
-  shell: "oc apply -f {{ repodir.path }}/{{ item }}"
+  shell: "oc apply -f {{ repodir.path }}/deploy/non-olm/{{ mig_operator_version }}/{{ item }}"
   loop:
     - "operator.yml"
-    - "controller-4.yml"
+    - "{{ 'controller-4.yml' if mig_ocp_version == 4 else 'controller-3.yml' }}"
   when: not migration_workload_destroy|bool
 
 - name: "Removing controller and operator"


### PR DESCRIPTION
##### SUMMARY
Adds support for newer versions of migration operator

Removes support for pre-RHTE versions.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp-workshop-migration 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
