### PR TITLE
Updated logic to certificate renewal for LE Certs

### DIFF
--- a/ansible/roles/ocp4-workload-enable-lets-encrypt-certificates/files/deploy_certs.yml
+++ b/ansible/roles/ocp4-workload-enable-lets-encrypt-certificates/files/deploy_certs.yml
@@ -20,7 +20,7 @@
     set_fact:
       _certbot_domain: "{{ api_hostname.stdout }}"
 
-  - name: Install certificates
+  - name: "Install certificates into {{ _certbot_install_dir }}/{{ item }}"
     copy:
       src: "{{ _certbot_dir }}/config/live/{{ _certbot_domain }}/{{ item }}"
       dest: "{{ _certbot_install_dir }}/{{ item }}"
@@ -41,15 +41,49 @@
       src: "$HOME/certificates/privkey.pem"
     register: server_key
 
-  - name: Create Router Certificate
+  - name: Delete old Ingress Controller Certificate if present
+    k8s:
+      state: absent
+      api_version: v1
+      kind: Secret
+      name: router-certs
+      namespace: openshift-ingress
+
+  - name: Create new Ingress Controller Certificate
     k8s:
       state: present
       definition: "{{ lookup('template', './router-certs.j2' ) | from_yaml }}"
 
-  - name: Create API Certificate
+  - name: Find Ingress Controller Pods
+    k8s_facts:
+      api_version: v1
+      kind: Pod
+      namespace: openshift-ingress
+      label_selectors:
+      - ingresscontroller.operator.openshift.io/deployment-ingresscontroller=default
+    register: r_ingress_controller_pods
+
+  - name: Delete all Ingress Controller Pods (to trigger rollout with new certificates)
+    k8s:
+      state: absent
+      api_version: v1
+      kind: Pod
+      namespace: openshift-ingress
+      name: "{{ item.metadata.name }}"
+    loop: "{{ r_ingress_controller_pods.resources }}"
+
+  - name: Delete old API Certificate if present
+    k8s:
+      state: absent
+      api_version: v1
+      kind: Secret
+      name: api-certs
+      namespace: openshift-config
+
+  - name: Create new API Certificate
     k8s:
       state: present
-      definition: "{{ lookup('template', './templates/api-certs.j2' ) | from_yaml }}"
+      definition: "{{ lookup('template', './api-certs.j2' ) | from_yaml }}"
 
   - name: Find all Kube Configs
     become: yes

--- a/ansible/roles/ocp4-workload-enable-lets-encrypt-certificates/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-enable-lets-encrypt-certificates/tasks/workload.yml
@@ -56,6 +56,7 @@
       dest: "/home/{{ ansible_user }}/certbot/renewal-hooks/deploy/deploy_certs.sh"
       mode: 0775
       owner: "{{ ansible_user }}"
+
   - name: Install redeploy hook playbook
     copy:
       src: "./files/{{ item }}"
@@ -64,6 +65,7 @@
       owner: "{{ ansible_user }}"
     loop:
     - deploy_certs.yml
+
   - name: Install redeploy secret templates
     copy:
       src: "./templates/{{ item }}"


### PR DESCRIPTION
Fixed script that is deployed for certbot deploy hook to deploy certificates.
- Delete secrets first before recreate.
- Delete ingress-controller pods (to force picking up of certificates)