### PR TITLE
Added guid tag for linklight

### DIFF
--- a/ansible/configs/linklight-foundations/post_infra.yml
+++ b/ansible/configs/linklight-foundations/post_infra.yml
@@ -81,14 +81,15 @@
     when: item.tags.short_name == 'ansible'
     with_items: "{{ ec2_facts['instances'] }}"
 
-  - name: Ensure Project and AnsibleGroup tags are present on all resources
+  - name: Ensure Project AnsibleGroup and guid tags are present on all resources
     ec2_tag:
       region: "{{ aws_region_final|d(aws_region) | default(region) | default('us-east-1') }}"
       resource: "{{ item.id }}"
       state: present
       tags:
-        Project: "{{ env_type }}-{{ guid }}"
-        AnsibleGroup: "all"
+        Project:        "{{ env_type }}-{{ guid }}"
+        AnsibleGroup:   "all"
+        guid:           "{{ guid }}"
     with_items: "{{ ec2_facts['instances'] }}"
 
   - name: tag bastion hosts with the bastion group tag


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
 
The Ansible Foundations Labs as they are deployed by Ansible Workshop deployer don't carry a guid tag. This adds that to an existing tagging task.

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME
config: ansible-foundations

##### ADDITIONAL INFORMATION

Very simple change. Requested for cost manangement
