### PR TITLE
revert to 1.0.0 for envoy bugfix

### DIFF
--- a/ansible/roles/ocp4-workload-istio-controlplane-infra/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-istio-controlplane-infra/tasks/workload.yml
@@ -100,7 +100,7 @@
         source: service-mesh-catalog-source-config
         name: servicemeshoperator
         sourceNamespace: service-mesh-operators
-        startingCSV: servicemeshoperator.v1.0.1
+        startingCSV: servicemeshoperator.v1.0.0
         installPlanApproval: Manual
 
 - name: wait for the status of the subscriptions to not be empty


### PR DESCRIPTION
there was a bug in service mesh 1.0.1 that's a show stopper. 1.0.1 just fixed a CVE which we don't care about for workshops