### PR TITLE
Disable janitor in deletion

### DIFF
--- a/ansible/configs/ocp4-ha-lab/destroy_env.yml
+++ b/ansible/configs/ocp4-ha-lab/destroy_env.yml
@@ -250,7 +250,7 @@
 
         - when:
             - commandjanitor.rc == 0
-            - run_janitor | default(true) | bool
+            - run_janitor | default(false) | bool
           block:
             - name: Run janitor to get existing resources
               environment:

--- a/ansible/configs/ocp4-shared/destroy_env.yml
+++ b/ansible/configs/ocp4-shared/destroy_env.yml
@@ -255,7 +255,7 @@
 
         - when:
             - commandjanitor.rc == 0
-            - run_janitor | default(true) | bool
+            - run_janitor | default(false) | bool
           block:
             - name: Run janitor to get existing resources
               environment:

--- a/ansible/configs/ocp4-workshop/destroy_env.yml
+++ b/ansible/configs/ocp4-workshop/destroy_env.yml
@@ -286,7 +286,7 @@
 
         - when:
             - commandjanitor.rc == 0
-            - run_janitor | default(true) | bool
+            - run_janitor | default(false) | bool
           block:
             - name: Run janitor to get existing resources
               environment:


### PR DESCRIPTION
##### SUMMARY
Disable janitor by default
Janitor is a readonly tool that list all the resources that remain for a user.
Sometimes it fails, and also it's an expensive task. Deactivate by default.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
