### PR TITLE
Use idempotent logic to retrieve CertificateSigningRequest

### DIFF
--- a/ansible/configs/ocp4-workshop/lifecycle.yml
+++ b/ansible/configs/ocp4-workshop/lifecycle.yml
@@ -109,15 +109,17 @@
       pause:
         seconds: "{{ lifecycle_start_pause | default(180) }}"
 
-    - name: Get CSRs that need to be patched
-      command: oc get csr -oname
+    - name: Get CSRs that need to be approved
+      k8s_facts:
+        api_version: certificates.k8s.io/v1beta1
+        kind: CertificateSigningRequest
       register: r_csrs
-      changed_when: false
 
-    - when: r_csrs.stdout_lines | length > 0
+    - when: r_csrs.resources | length > 0
       name: Approve all Pending CSRs
-      command: "oc adm certificate approve {{ item }}"
-      loop: "{{ r_csrs.stdout_lines }}"
+      command: "oc adm certificate approve {{ item.metadata.name }}"
+      # when: item.status.conditions[0].type == "Pending"
+      loop: "{{ r_csrs.resources }}"
 
     # TODO: Implement proper loop to watch for incoming CSRS while we are
     # approving them. For now, this is a workaround, just wait and re-approve.
@@ -125,12 +127,15 @@
       pause:
         seconds: 10
 
-    - name: Get additional CSRs that need to be patched
-      command: oc get csr -oname
+    - name: Get additional CSRs that need to be approved
+      k8s_facts:
+        api_version: certificates.k8s.io/v1beta1
+        kind: CertificateSigningRequest
       register: r_new_csrs
-      changed_when: false
 
-    - when: r_new_csrs.stdout_lines | length > 0
+    - when: r_csrs.resources | length > 0
       name: Approve all Pending CSRs
-      command: "oc adm certificate approve {{ item }}"
-      loop: "{{ r_new_csrs.stdout_lines }}"
+      command: "oc adm certificate approve {{ item.metadata.name }}"
+      # when: item.status.conditions[0].type == "Pending"
+      loop: "{{ r_new_csrs.resources }}"
+


### PR DESCRIPTION
Use idempotent logic to retrieve CertificateSigningRequest (do not fail if there are no CSRs - e.g. after a subsequent resume)

This still approves all CSRs (even already approved ones). It may be too risky to merge the commented out when: clause.