### PR TITLE
Fix kind on project request template

### DIFF
--- a/ansible/roles/ocp4-workload-project-request-template/templates/project_request_template.j2
+++ b/ansible/roles/ocp4-workload-project-request-template/templates/project_request_template.j2
@@ -1,5 +1,5 @@
 apiVersion: template.openshift.io/v1
-kind: templates
+kind: Template
 metadata:
   name: project-request
   namespace: openshift-config


### PR DESCRIPTION
##### SUMMARY
Project request template can't be created with `kind: templates`, This change sets the kind to `Template`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


