### PR TITLE
ocp4-workshop lifecycle: enable env_type when filtering instances

### DIFF
--- a/ansible/configs/ocp4-workshop/lifecycle.yml
+++ b/ansible/configs/ocp4-workshop/lifecycle.yml
@@ -67,8 +67,7 @@
         wait: no
         filters:
           "tag:guid": "{{ guid }}"
-          # TODO: uncomment this in a few weeks
-          #"tag:env_type": "{{ env_type }}"
+          "tag:env_type": "{{ env_type }}"
 
     - name: Start instances by (guid, env_type) tags
       when: ACTION == 'start'
@@ -77,8 +76,7 @@
         wait: true
         filters:
           "tag:guid": "{{ guid }}"
-          # TODO: uncomment this in a few weeks
-          #"tag:env_type": "{{ env_type }}"
+          "tag:env_type": "{{ env_type }}"
 
     - when: ACTION == 'status'
       block:
@@ -86,8 +84,7 @@
           ec2_instance_facts:
             filters:
               "tag:guid": "{{ guid }}"
-              # TODO: uncomment this in a few weeks
-              #"tag:env_type": "{{ env_type }}"
+              "tag:env_type": "{{ env_type }}"
           register: r_instances
 
         - name: Print status information to a file


### PR DESCRIPTION
When stopping/starting instances of an environment, we are (temporarily)
filtering only by the tag `guid`. It used to be filtered by (`guid`,
`env_type`). It was changed to (`guid`) because of a change in CF:
`env_type` was not passed in the `cloud_tags` dictionary, and the instances only had `guid` in their tags.

To be able to stop the environments we commented out tags with key `env_type`.

Now this is fixed in Cloudforms, and also `env_type` and `guid` tags are
enforced in agnosticd.

All environments now have both `guid` and `env_type` tags.

This commit if applied will restore filters to (`guid`, `env_type`).

(guid, env_type) is a better filter in case of guid collision.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-workshop  lifecycle.yml


