### PR TITLE
Pin EPEL sourced RPMs from GPTE Public S3 Bucket

### DIFF
--- a/ansible/configs/ocp-clientvm/pre_software.yml
+++ b/ansible/configs/ocp-clientvm/pre_software.yml
@@ -61,22 +61,32 @@
   - name: Install FTL
     when: install_ftl | d(False) | bool
     block:
-    - name: Add epel-release repo
-      yum:
-        state: present
-        name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-
-    - name: Install Python Dependencies
+    - name: Install Python2 OpenShift Library (and dependencies)
       yum:
         state: present
         name:
-        - python-openshift
+        - https://gpte-public.s3.amazonaws.com/python-cachetools-1.0.3-1.el7.noarch.rpm
+        - https://gpte-public.s3.amazonaws.com/python2-six-1.9.0-0.el7.noarch.rpm
+        - https://gpte-public.s3.amazonaws.com/python2-rsa-3.4.1-1.el7.noarch.rpm
+        - https://gpte-public.s3.amazonaws.com/python2-google-auth-1.1.1-5.el7.noarch.rpm
+        - https://gpte-public.s3.amazonaws.com/python2-certifi-2018.10.15-5.el7.noarch.rpm
+        - https://gpte-public.s3.amazonaws.com/python2-kubernetes-8.0.1-1.el7.noarch.rpm
+        - https://gpte-public.s3.amazonaws.com/python2-string_utils-0.6.0-4.el7.noarch.rpm
+        - https://gpte-public.s3.amazonaws.com/python2-dictdiffer-0.7.1-2.el7.noarch.rpm
+        - https://gpte-public.s3.amazonaws.com/python2-typing-3.5.2.2-4.el7.noarch.rpm
+        - https://gpte-public.s3.amazonaws.com/python2-ruamel-ordereddict-0.4.9-2.el7.x86_64.rpm
+        - https://gpte-public.s3.amazonaws.com/python2-ruamel-yaml-0.13.14-2.el7.x86_64.rpm
+        - https://gpte-public.s3.amazonaws.com/python2-openshift-0.8.8-1.el7.noarch.rpm
+        - https://gpte-public.s3.amazonaws.com/python2-pip-8.1.2-9.el7.noarch.rpm
+        - git
 
+    # Dependencies (pip and git) are installed by the previous task
     - name: Install FTL
       include_role:
         name: ftl-injector
       vars:
         student_login: "{{ student_name }}"
+        install_dependencies: false
 
 - name: PreSoftware flight-check
   hosts: localhost

--- a/ansible/configs/ocp4-workshop/software.yml
+++ b/ansible/configs/ocp4-workshop/software.yml
@@ -51,14 +51,21 @@
               aws_access_key_id = {{ hostvars.localhost.student_access_key_id }}
               aws_secret_access_key = {{ hostvars.localhost.student_secret_access_key }}
 
+        - name: Install Python Packages
+          become: yes
+          yum:
+            name:
+            - https://gpte-public.s3.amazonaws.com/python2-botocore-1.6.0-1.el7.noarch.rpm
+            - https://gpte-public.s3.amazonaws.com/python2-s3transfer-0.1.10-1.el7.noarch.rpm
+            - https://gpte-public.s3.amazonaws.com/python2-boto-2.45.0-3.el7.noarch.rpm
+            - https://gpte-public.s3.amazonaws.com/python2-boto3-1.4.6-1.el7.noarch.rpm
+
         - name: Install Packages
           become: yes
           package:
             name:
-              - golang
-              - python2-boto
-              - python2-boto3
-              - unzip
+            - golang
+            - unzip
 
         # For GA Releases 
         - name: Set URLs for OpenShift GA releases

--- a/ansible/roles/bastion/tasks/k8s.yml
+++ b/ansible/roles/bastion/tasks/k8s.yml
@@ -2,18 +2,20 @@
 - tags:
     - bastion_k8s
   block:
-    - name: Add epel-release repo
-      yum:
-        name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-      register: _r_yum_epel
-      retries: 30
-      delay: 10
-      until: _r_yum_epel is succeeded
-
-    - name: Install openshift python module
-      yum:
-        name: python-openshift
-      register: _r_yum_epel2
-      retries: 30
-      delay: 10
-      until: _r_yum_epel2 is succeeded
+  - name: Install Python2 OpenShift Library (and dependencies)
+    yum:
+      state: present
+      name:
+      - https://gpte-public.s3.amazonaws.com/python-cachetools-1.0.3-1.el7.noarch.rpm
+      - https://gpte-public.s3.amazonaws.com/python2-six-1.9.0-0.el7.noarch.rpm
+      - https://gpte-public.s3.amazonaws.com/python2-rsa-3.4.1-1.el7.noarch.rpm
+      - https://gpte-public.s3.amazonaws.com/python2-google-auth-1.1.1-5.el7.noarch.rpm
+      - https://gpte-public.s3.amazonaws.com/python2-certifi-2018.10.15-5.el7.noarch.rpm
+      - https://gpte-public.s3.amazonaws.com/python2-kubernetes-8.0.1-1.el7.noarch.rpm
+      - https://gpte-public.s3.amazonaws.com/python2-string_utils-0.6.0-4.el7.noarch.rpm
+      - https://gpte-public.s3.amazonaws.com/python2-dictdiffer-0.7.1-2.el7.noarch.rpm
+      - https://gpte-public.s3.amazonaws.com/python2-typing-3.5.2.2-4.el7.noarch.rpm
+      - https://gpte-public.s3.amazonaws.com/python2-ruamel-ordereddict-0.4.9-2.el7.x86_64.rpm
+      - https://gpte-public.s3.amazonaws.com/python2-ruamel-yaml-0.13.14-2.el7.x86_64.rpm
+      - https://gpte-public.s3.amazonaws.com/python2-openshift-0.8.8-1.el7.noarch.rpm
+      - https://gpte-public.s3.amazonaws.com/python2-pip-8.1.2-9.el7.noarch.rpm

--- a/ansible/roles/bastion/tasks/main.yml
+++ b/ansible/roles/bastion/tasks/main.yml
@@ -99,30 +99,24 @@
         line: "-A INPUT -p udp -m multiport --dports 60001:61000 -j ACCEPT"
       when: ensuresshpresent.rc == 0
 
-- name: Install Python pip/openshift/virtualenv for k8s module use on bastion
+- name: Install Python libraries for k8s module/FTL use on bastion
   include_tasks: k8s.yml
-  when: install_k8s_modules | default(false)
+  when: install_k8s_modules | d(false) or install_ftl | d (false)
 
-# Add FTL to bastions
+# Add FTL to bastions. Python Dependencies are set up by the previous task
 - name: Install FTL
   when: install_ftl | d(False) | bool
   block:
-  - name: Add epel-release repo
+  - name: Ensure git is installed
     yum:
+      name: git
       state: present
-      name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-
-  - name: Install Python Dependencies
-    yum:
-      state: present
-      name:
-      - python-openshift
-
   - name: Install FTL
     include_role:
       name: ftl-injector
     vars:
       student_login: "{{ student_name }}"
+      install_dependencies: false
 
 - name: Install jq on the bastion
   get_url:


### PR DESCRIPTION
Instead of installing EPEL I downloaded all relevant RPMs from our mirrored EPEL Repo and added them to our public GPTE S3 Bucket.

Tested this on Client VM and OCP4 Workshop.

This should pin the "correct (old)" rpms until we have a proper solution.