### PR TITLE
Remove broken task to fetch all branches. Only master is necessary

### DIFF
--- a/ansible/roles/ocp4-workload-security-compliance-lab/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-security-compliance-lab/tasks/workload.yml
@@ -56,16 +56,6 @@
     chdir: "{{ git_dir.path }}"
   tags: gogs
 
-- name: checkout all the remote
-  shell: |
-    for tag in `git branch -a | grep "origin" | grep "\." | cut -d "/" -f 3`
-    do
-      git checkout -b $tag remotes/origin/$tag
-    done
-  args:
-    chdir: "{{ git_dir.path }}/{{ reponame }}"
-  tags: gogs
-
 - include_tasks: per_user.yml
   with_sequence: start={{user_count_start}} end={{ user_count_end }} format={{ user_format }}
 


### PR DESCRIPTION
##### SUMMARY
The "checkout all the remote" task was attempting to (unnecessarily) fetch all remote branches when only master is required.  The command now seems invalid for some unknown reason (causing a failure), so it is being removed. Task was likely put in as part of a "copy-and-paste" without being analyzed for necessity.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-workload-security-compliance-lab role

##### ADDITIONAL INFORMATION


