### PR TITLE
fix broken copy, remove unnecessary ssh keys

### DIFF
--- a/ansible/roles/ocp-workload-migration/tasks/pre_workload.yml
+++ b/ansible/roles/ocp-workload-migration/tasks/pre_workload.yml
@@ -10,50 +10,10 @@
   ignore_errors: true
 
 - block:
-  - name: "Ensuring SSH directory"
-    file:
-      path: "/home/{{ student_name }}/.ssh"
-      state: directory
-      owner: "{{ student_name }}"
-
-  - name: "Checking if SSH keys exist on bastion"
-    stat: 
-      path: /home/{{ student_name }}/.ssh/openshift_key
-    register: ssh_key
-
-  - name: "Creating SSH keys on bastion"
-    shell: "ssh-keygen -q -t rsa -f /home/{{ student_name }}/.ssh/openshift_key -C '' -N ''"
-    when: not ssh_key.stat.exists|d('false')
-
-  - name: "Fixing permissions of SSH key"
-    file:
-      path: "/home/{{ student_name }}/.ssh/{{ item }}"
-      owner: "{{ student_name }}"
-      mode: "0600"
-    loop:
-      - "openshift_key"
-      - "openshift_key.pub"
-    when: ssh_key.stat.exists|d('false')
-
-  - name: "Finding SSH key"
-    stat: 
-      path: /home/{{ student_name }}/.ssh/openshift_key.pub
-    register: public_key
-
-  - name: "Reading public key"
-    shell: "cat /home/{{ student_name }}/.ssh/openshift_key.pub"
-    register: pub_key_contents
-    when: public_key.stat.exists|d('false')
-
   - name: copy lab scripts to bastion
     copy:
       src: "{{ role_path }}/files/"
       dest: "/home/{{ student_name }}/"
-
-  - name: copy lab scripts to bastion
-    copy:
-      src: /
-      dest: "/home/{{ student_name }}/scripts/"
 
   - name: "Downloading CPMA binary to bastion"
     get_url:
@@ -66,13 +26,6 @@
   when: student_name is defined and not status.failed
   delegate_to: "{{ bastion_host | d( groups.bastions | first ) }}"
   become: yes
-
-- name: "Adding public key to authorized_keys"
-  authorized_key:
-    user: "{{ migration_master_user_name | d('ec2-user') }}"
-    state: present
-    key: "{{ pub_key_contents.stdout }}"
-  when: pub_key_contents.stdout is defined and student_name is defined
 
 - name: "Creating temp directory for operator repo"
   tempfile: 


### PR DESCRIPTION
##### SUMMARY
- upstream author created unused ssh-keys
- I did the same copy twice, the second one was busted

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp-workload-migration
