### PR TITLE
Workload to deploy gogs

### DIFF
--- a/ansible/roles/ocp-workload-gogs/defaults/main.yml
+++ b/ansible/roles/ocp-workload-gogs/defaults/main.yml
@@ -1,0 +1,29 @@
+---
+become_override: False
+ocp_username: user-redhat.com
+silent: False
+tmp_kubeconfig: /tmp/{{ guid }}/.kube-config
+
+gogs_project: "gogs"
+gogs_project_display: "Gogs"
+gogs_app_name: "gogs"
+
+# Gogs
+gogs_version: 0.11.34
+gogs_pvc_capacity: 1Gi
+install_lock: true
+skip_tls_verify: false
+gogs_deploy_retry_delay: 30
+gogs_deploy_retry_count: 10
+gogs_admin_user: gogs  # Don't use admin, as gogs doesn't support it
+gogs_admin_password: gogs
+gogs_hostname:  # LEAVE EMPTY AS IT'S CALCULATED IN THE ROLE
+
+# Postgresql
+database_user: gogs
+database_password: gogs
+database_name: gogs
+database_admin_password: admin123!
+database_max_connections: 100
+database_shared_buffers: 12MB
+database_pvc_capacity: 1Gi

--- a/ansible/roles/ocp-workload-gogs/defaults/main.yml
+++ b/ansible/roles/ocp-workload-gogs/defaults/main.yml
@@ -2,7 +2,8 @@
 become_override: False
 ocp_username: user-redhat.com
 silent: False
-tmp_kubeconfig: /tmp/{{ guid }}/.kube-config
+tmp_dir: /tmp/{{ guid }}
+tmp_kubeconfig: "{{ tmp_dir }}/.kube/config"
 
 gogs_project: "gogs"
 gogs_project_display: "Gogs"

--- a/ansible/roles/ocp-workload-gogs/readme.adoc
+++ b/ansible/roles/ocp-workload-gogs/readme.adoc
@@ -1,0 +1,67 @@
+= ocp-workload-gogs - Gogs Workload Role
+
+== Role overview
+
+Deploys an instance of gogs on your cluster, into a new project or an existing project.
+
+== Review the defaults variable file
+
+* This file link:./defaults/main.yml[./defaults/main.yml] contains all the variables you need to define to control the deployment of your workload.
+* The variable *ocp_username* is mandatory to assign the workload to the correct OpenShift user.
+* A variable *silent=True* can be passed to suppress debug messages.
+* You can modify any of these default values by adding `-e "variable_name=variable_value"` to the command line
+
+=== Deploy a Workload with the `ocp-workload` playbook [Mostly for testing]
+
+----
+TARGET_HOST="bastion.na39.openshift.opentlc.com"
+OCP_USERNAME="shacharb-redhat.com"
+WORKLOAD="ocp-workload-gogs"
+GUID=1001
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=ec2-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"silent=False" \
+    -e"guid=${GUID}" \
+    -e"ACTION=create"
+----
+
+=== To Delete an environment
+
+----
+TARGET_HOST="bastion.na39.openshift.opentlc.com"
+OCP_USERNAME="ankay-redhat.com"
+WORKLOAD="ocp-workload-gogs"
+GUID=1002
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=ec2-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"guid=${GUID}" \
+    -e"ACTION=remove"
+----
+
+
+== Other related information:
+
+=== Deploy Workload on OpenShift Cluster from an existing playbook:
+
+[source,yaml]
+----
+- name: Deploy a workload role on a master host
+  hosts: all
+  become: true
+  gather_facts: False
+  tags:
+    - step007
+  roles:
+    - { role: "{{ocp_workload}}", when: 'ocp_workload is defined' }
+----
+NOTE: You might want to change `hosts: all` to fit your requirements

--- a/ansible/roles/ocp-workload-gogs/tasks/main.yml
+++ b/ansible/roles/ocp-workload-gogs/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+# Do not modify this file
+
+- name: Running Pre Workload Tasks
+  include_tasks:
+    file: ./pre_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload Tasks
+  include_tasks:
+    file: ./workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  include_tasks:
+    file: ./post_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload removal Tasks
+  include_tasks:
+    file: ./remove_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles/ocp-workload-gogs/tasks/post_workload.yml
+++ b/ansible/roles/ocp-workload-gogs/tasks/post_workload.yml
@@ -1,0 +1,28 @@
+---
+# Implement your Post Workload deployment tasks here
+- name: Remove temp kube config
+  file: 
+    path: "{{ tmp_kubeconfig }}"
+    state: absent
+
+# Leave these as the last tasks in the playbook
+
+# For deployment onto a dedicated cluster (as part of the
+# cluster deployment) set workload_shared_deployment to False
+# This is the default so it does not have to be set explicitely
+- name: pre_workload tasks complete
+  debug:
+    msg: "Post-Workload tasks completed successfully."
+  when:
+  - not silent|bool
+  - not workload_shared_deployment|d(False)
+
+# For RHPDS deployment (onto a shared cluster) set
+# workload_shared_deployment to True
+# (in the deploy script or AgnosticV configuration)
+- name: pre_workload tasks complete
+  debug:
+    msg: "Post-Software checks completed successfully"
+  when:
+  - not silent|bool
+  - workload_shared_deployment|d(False)

--- a/ansible/roles/ocp-workload-gogs/tasks/pre_workload.yml
+++ b/ansible/roles/ocp-workload-gogs/tasks/pre_workload.yml
@@ -2,13 +2,13 @@
 # Implement your Pre Workload deployment tasks here
 - name: Ensure directory exists
   file:
-    path: "/tmp/{{ guid }}"
+    path: "{{ tmp_dir }}"
     state: directory
 
 - name: Copy .kube/config and set env var
   copy:
-    src: ~/.kube/config
-    dest: "{{ tmp_kubeconfig }}"
+    src: ~/.kube
+    dest: "{{ tmp_dir }}"
     remote_src: yes
 
 # Leave these as the last tasks in the playbook

--- a/ansible/roles/ocp-workload-gogs/tasks/pre_workload.yml
+++ b/ansible/roles/ocp-workload-gogs/tasks/pre_workload.yml
@@ -1,0 +1,34 @@
+---
+# Implement your Pre Workload deployment tasks here
+- name: Ensure directory exists
+  file:
+    path: "/tmp/{{ guid }}"
+    state: directory
+
+- name: Copy .kube/config and set env var
+  copy:
+    src: ~/.kube/config
+    dest: "{{ tmp_kubeconfig }}"
+    remote_src: yes
+
+# Leave these as the last tasks in the playbook
+
+# For deployment onto a dedicated cluster (as part of the
+# cluster deployment) set workload_shared_deployment to False
+# This is the default so it does not have to be set explicitely
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Workload tasks completed successfully."
+  when:
+  - not silent|bool
+  - not workload_shared_deployment|d(False)
+
+# For RHPDS deployment (onto a shared cluster) set
+# workload_shared_deployment to True
+# (in the deploy script or AgnosticV configuration)
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Software checks completed successfully"
+  when:
+  - not silent|bool
+  - workload_shared_deployment|d(False)

--- a/ansible/roles/ocp-workload-gogs/tasks/remove_workload.yml
+++ b/ansible/roles/ocp-workload-gogs/tasks/remove_workload.yml
@@ -1,0 +1,28 @@
+---
+# Implement your Workload removal tasks here
+
+- name: Create OpenShift objects for workload
+  k8s:
+    state: absent
+    definition: "{{ lookup('template', item ) | from_yaml }}"
+  loop:
+  - ./templates/route.j2
+  - ./templates/service_app.j2
+  - ./templates/deployment_app.j2
+  - ./templates/service_postgresql.j2
+  - ./templates/deployment_postgresql.j2
+  - ./templates/configmap_app.j2
+  - ./templates/pvc_data.j2
+  - ./templates/pvc_postgresql_data.j2
+  - ./templates/service_account.j2
+
+- name: Remove temp kube config
+  file: 
+    path: "{{ tmp_kubeconfig }}"
+    state: absent
+
+# Leave this as the last task in the playbook.
+- name: remove_workload tasks complete
+  debug:
+    msg: "Remove Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp-workload-gogs/tasks/remove_workload.yml
+++ b/ansible/roles/ocp-workload-gogs/tasks/remove_workload.yml
@@ -1,24 +1,37 @@
 ---
 # Implement your Workload removal tasks here
+- name: Ensure directory exists
+  file:
+    path: "{{ tmp_dir }}"
+    state: directory
 
-- name: Create OpenShift objects for workload
-  k8s:
-    state: absent
-    definition: "{{ lookup('template', item ) | from_yaml }}"
-  loop:
-  - ./templates/route.j2
-  - ./templates/service_app.j2
-  - ./templates/deployment_app.j2
-  - ./templates/service_postgresql.j2
-  - ./templates/deployment_postgresql.j2
-  - ./templates/configmap_app.j2
-  - ./templates/pvc_data.j2
-  - ./templates/pvc_postgresql_data.j2
-  - ./templates/service_account.j2
+- name: Copy .kube/config and set env var
+  copy:
+    src: ~/.kube
+    dest: "{{ tmp_dir }}"
+    remote_src: yes
+
+- environment:
+    KUBECONFIG: "{{ tmp_kubeconfig }}"
+  block:
+    - name: Create OpenShift objects for workload
+      k8s:
+        state: absent
+        definition: "{{ lookup('template', item ) | from_yaml }}"
+      loop:
+      - ./templates/route.j2
+      - ./templates/service_app.j2
+      - ./templates/deployment_app.j2
+      - ./templates/service_postgresql.j2
+      - ./templates/deployment_postgresql.j2
+      - ./templates/configmap_app.j2
+      - ./templates/pvc_data.j2
+      - ./templates/pvc_postgresql_data.j2
+      - ./templates/service_account.j2
 
 - name: Remove temp kube config
   file: 
-    path: "{{ tmp_kubeconfig }}"
+    path: "{{ tmp_dir }}"
     state: absent
 
 # Leave this as the last task in the playbook.

--- a/ansible/roles/ocp-workload-gogs/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-gogs/tasks/workload.yml
@@ -1,0 +1,89 @@
+---
+# Implement your Workload deployment tasks here
+
+- name: Setting up workload for user
+  debug:
+    msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
+
+- name: Create Project {{ gogs_project }}
+  k8s:
+    state: present
+    definition: "{{ lookup('template', item ) | from_yaml }}"
+  loop:
+  - ./templates/project.j2
+  register: r_createproject
+  until: r_createproject is succeeded
+  retries: 5
+
+- name: Get apps route suffix
+  block:
+    - k8s:
+        state: present
+        definition:
+          apiVersion: "route.openshift.io/v1"
+          kind: Route
+          metadata:
+            name: dummy
+            namespace: "{{ gogs_project }}"
+          spec:
+            to:
+              kind: Service
+              name: dummy
+            ports:
+            - targetPort: 8080
+    - k8s_facts:
+        api_version: "route.openshift.io/v1"
+        kind: Route
+        name: dummy
+        namespace: "{{ gogs_project }}"
+      register: dummy_route
+    - set_fact:
+        apps_hostname_suffix: "{{ dummy_route.resources[0].spec.host|regex_replace('^dummy-' + gogs_project + '\\.(.*)$', '\\1') }}"
+    - k8s:
+        state: absent
+        api_version: "route.openshift.io/v1"
+        kind: Route
+        name: dummy
+        namespace: "{{ gogs_project }}"
+    - set_fact:
+        gogs_hostname: "{{ gogs_app_name }}-{{ gogs_project }}.{{ apps_hostname_suffix }}"
+
+- name: Create OpenShift objects for workload
+  k8s:
+    state: present
+    definition: "{{ lookup('template', item ) | from_yaml }}"
+  loop:
+  - ./templates/service_account.j2
+  - ./templates/pvc_data.j2
+  - ./templates/pvc_postgresql_data.j2
+  - ./templates/configmap_app.j2
+  - ./templates/deployment_postgresql.j2
+  - ./templates/service_postgresql.j2
+  - ./templates/deployment_app.j2
+  - ./templates/service_app.j2
+  - ./templates/route.j2
+
+- name: wait for gogs to be running
+  uri:
+    url: http://{{ gogs_hostname }}
+    status_code: 200
+  register: result
+  until: result.status == 200
+  retries: "{{ gogs_deploy_retry_count }}"
+  delay: "{{ gogs_deploy_retry_delay }}"
+
+# Create gogs admin user
+- name: create gogs admin user '{{ gogs_admin_user }}'
+  uri:
+    url: http://{{ gogs_hostname }}/user/sign_up
+    method: POST
+    body: "user_name={{ gogs_admin_user }}&password={{ gogs_admin_password }}&&retype={{ gogs_admin_password }}&&email={{ gogs_admin_user }}@gogs.com"
+    headers:
+      Content-Type: "application/x-www-form-urlencoded"
+    status_code: 302,200
+
+# Leave this as the last task in the playbook.
+- name: workload tasks complete
+  debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp-workload-gogs/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-gogs/tasks/workload.yml
@@ -18,38 +18,24 @@
       until: r_createproject is succeeded
       retries: 5
 
-    - name: Get apps route suffix
-      block:
-        - k8s:
-            state: present
-            definition:
-              apiVersion: "route.openshift.io/v1"
-              kind: Route
-              metadata:
-                name: dummy
-                namespace: "{{ gogs_project }}"
-              spec:
-                to:
-                  kind: Service
-                  name: dummy
-                ports:
-                - targetPort: 8080
-        - k8s_facts:
-            api_version: "route.openshift.io/v1"
-            kind: Route
-            name: dummy
-            namespace: "{{ gogs_project }}"
-          register: dummy_route
-        - set_fact:
-            apps_hostname_suffix: "{{ dummy_route.resources[0].spec.host|regex_replace('^dummy-' + gogs_project + '\\.(.*)$', '\\1') }}"
-        - k8s:
-            state: absent
-            api_version: "route.openshift.io/v1"
-            kind: Route
-            name: dummy
-            namespace: "{{ gogs_project }}"
-        - set_fact:
-            gogs_hostname: "{{ gogs_app_name }}-{{ gogs_project }}.{{ apps_hostname_suffix }}"
+    - name: Create OpenShift objects for workload
+      k8s:
+        state: present
+        definition: "{{ lookup('template', item ) | from_yaml }}"
+      loop:
+      - ./templates/route.j2
+
+    - name: Retrieve created route
+      k8s_facts:
+        api_version: "route.openshift.io/v1"
+        kind: Route
+        name: "{{ gogs_app_name }}"
+        namespace: "{{ gogs_project }}"
+      register: r_route
+
+    - name: Get gogs route hostname
+      set_fact:
+        gogs_hostname: "{{ r_route.resources[0].spec.host }}"
 
     - name: Create OpenShift objects for workload
       k8s:
@@ -64,7 +50,6 @@
       - ./templates/service_postgresql.j2
       - ./templates/deployment_app.j2
       - ./templates/service_app.j2
-      - ./templates/route.j2
 
     - name: wait for gogs to be running
       uri:

--- a/ansible/roles/ocp-workload-gogs/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-gogs/tasks/workload.yml
@@ -5,82 +5,85 @@
   debug:
     msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
 
-- name: Create Project {{ gogs_project }}
-  k8s:
-    state: present
-    definition: "{{ lookup('template', item ) | from_yaml }}"
-  loop:
-  - ./templates/project.j2
-  register: r_createproject
-  until: r_createproject is succeeded
-  retries: 5
-
-- name: Get apps route suffix
+- environment:
+    KUBECONFIG: "{{ tmp_kubeconfig }}"
   block:
-    - k8s:
+    - name: Create Project {{ gogs_project }}
+      k8s:
         state: present
-        definition:
-          apiVersion: "route.openshift.io/v1"
-          kind: Route
-          metadata:
+        definition: "{{ lookup('template', item ) | from_yaml }}"
+      loop:
+      - ./templates/project.j2
+      register: r_createproject
+      until: r_createproject is succeeded
+      retries: 5
+
+    - name: Get apps route suffix
+      block:
+        - k8s:
+            state: present
+            definition:
+              apiVersion: "route.openshift.io/v1"
+              kind: Route
+              metadata:
+                name: dummy
+                namespace: "{{ gogs_project }}"
+              spec:
+                to:
+                  kind: Service
+                  name: dummy
+                ports:
+                - targetPort: 8080
+        - k8s_facts:
+            api_version: "route.openshift.io/v1"
+            kind: Route
             name: dummy
             namespace: "{{ gogs_project }}"
-          spec:
-            to:
-              kind: Service
-              name: dummy
-            ports:
-            - targetPort: 8080
-    - k8s_facts:
-        api_version: "route.openshift.io/v1"
-        kind: Route
-        name: dummy
-        namespace: "{{ gogs_project }}"
-      register: dummy_route
-    - set_fact:
-        apps_hostname_suffix: "{{ dummy_route.resources[0].spec.host|regex_replace('^dummy-' + gogs_project + '\\.(.*)$', '\\1') }}"
-    - k8s:
-        state: absent
-        api_version: "route.openshift.io/v1"
-        kind: Route
-        name: dummy
-        namespace: "{{ gogs_project }}"
-    - set_fact:
-        gogs_hostname: "{{ gogs_app_name }}-{{ gogs_project }}.{{ apps_hostname_suffix }}"
+          register: dummy_route
+        - set_fact:
+            apps_hostname_suffix: "{{ dummy_route.resources[0].spec.host|regex_replace('^dummy-' + gogs_project + '\\.(.*)$', '\\1') }}"
+        - k8s:
+            state: absent
+            api_version: "route.openshift.io/v1"
+            kind: Route
+            name: dummy
+            namespace: "{{ gogs_project }}"
+        - set_fact:
+            gogs_hostname: "{{ gogs_app_name }}-{{ gogs_project }}.{{ apps_hostname_suffix }}"
 
-- name: Create OpenShift objects for workload
-  k8s:
-    state: present
-    definition: "{{ lookup('template', item ) | from_yaml }}"
-  loop:
-  - ./templates/service_account.j2
-  - ./templates/pvc_data.j2
-  - ./templates/pvc_postgresql_data.j2
-  - ./templates/configmap_app.j2
-  - ./templates/deployment_postgresql.j2
-  - ./templates/service_postgresql.j2
-  - ./templates/deployment_app.j2
-  - ./templates/service_app.j2
-  - ./templates/route.j2
+    - name: Create OpenShift objects for workload
+      k8s:
+        state: present
+        definition: "{{ lookup('template', item ) | from_yaml }}"
+      loop:
+      - ./templates/service_account.j2
+      - ./templates/pvc_data.j2
+      - ./templates/pvc_postgresql_data.j2
+      - ./templates/configmap_app.j2
+      - ./templates/deployment_postgresql.j2
+      - ./templates/service_postgresql.j2
+      - ./templates/deployment_app.j2
+      - ./templates/service_app.j2
+      - ./templates/route.j2
 
-- name: wait for gogs to be running
-  uri:
-    url: http://{{ gogs_hostname }}
-    status_code: 200
-  register: result
-  until: result.status == 200
-  retries: "{{ gogs_deploy_retry_count }}"
-  delay: "{{ gogs_deploy_retry_delay }}"
+    - name: wait for gogs to be running
+      uri:
+        url: http://{{ gogs_hostname }}
+        status_code: 200
+      register: result
+      until: result.status == 200
+      retries: "{{ gogs_deploy_retry_count }}"
+      delay: "{{ gogs_deploy_retry_delay }}"
 
-# Create gogs admin user
-- name: create gogs admin user '{{ gogs_admin_user }}'
-  uri:
-    url: http://{{ gogs_hostname }}/user/sign_up
-    method: POST
-    body: "user_name={{ gogs_admin_user }}&password={{ gogs_admin_password }}&&retype={{ gogs_admin_password }}&&email={{ gogs_admin_user }}@gogs.com"
-    headers:
-      Content-Type: "application/x-www-form-urlencoded"
-    status_code: 302,200
+    # Create gogs admin user
+    - name: create gogs admin user '{{ gogs_admin_user }}'
+      uri:
+        url: http://{{ gogs_hostname }}/user/sign_up
+        method: POST
+        body: "user_name={{ gogs_admin_user }}&password={{ gogs_admin_password }}&&retype={{ gogs_admin_password }}&&email={{ gogs_admin_user }}@gogs.com"
+        headers:
+          Content-Type: "application/x-www-form-urlencoded"
+        status_code: 302,200
 
 # Leave this as the last task in the playbook.
 - name: workload tasks complete

--- a/ansible/roles/ocp-workload-gogs/templates/configmap_app.j2
+++ b/ansible/roles/ocp-workload-gogs/templates/configmap_app.j2
@@ -1,0 +1,34 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    app: {{ gogs_app_name }}
+  name: {{ gogs_app_name }}-config
+  namespace: {{ gogs_project }}
+data:
+  app.ini: |
+    RUN_MODE = prod
+    RUN_USER = gogs
+
+    [database]
+    DB_TYPE  = postgres
+    HOST     = {{ gogs_app_name }}-postgresql:5432
+    NAME     = {{ database_name }}
+    USER     = {{ database_user }}
+    PASSWD   = {{ database_password }}
+
+    [repository]
+    ROOT = /opt/gogs/data/repositories
+
+    [server]
+    ROOT_URL=http://{{ gogs_hostname }}
+    SSH_DOMAIN={{ gogs_hostname }}
+
+    [security]
+    INSTALL_LOCK = {{ install_lock }}
+
+    [service]
+    ENABLE_CAPTCHA = false
+
+    [webhook]
+    SKIP_TLS_VERIFY = {{ skip_tls_verify }}

--- a/ansible/roles/ocp-workload-gogs/templates/deployment_app.j2
+++ b/ansible/roles/ocp-workload-gogs/templates/deployment_app.j2
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ gogs_app_name }}
+  name: {{ gogs_app_name }}
+  namespace: {{ gogs_project }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ gogs_app_name }}
+  template:
+    metadata:
+      labels:
+        app: {{ gogs_app_name }}
+    spec:
+      serviceAccount: {{ gogs_app_name }}
+      containers:
+      - image: docker.io/openshiftdemos/gogs:{{ gogs_version }}
+        imagePullPolicy: Always
+        name: {{ gogs_app_name }}
+        ports:
+        - containerPort: 3000
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        volumeMounts:
+        - name: gogs-data
+          mountPath: /opt/gogs/data
+        - name: gogs-config
+          mountPath: /etc/gogs/conf
+        readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+              scheme: HTTP
+            initialDelaySeconds: 40
+            timeoutSeconds: 1
+            periodSeconds: 20
+            successThreshold: 1
+            failureThreshold: 10
+        livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+              scheme: HTTP
+            initialDelaySeconds: 40
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 10
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: gogs-data
+        persistentVolumeClaim:
+          claimName: {{ gogs_app_name }}-data
+      - name: gogs-config
+        configMap:
+          name: {{ gogs_app_name }}-config
+          items:
+            - key: app.ini
+              path: app.ini
+      resources:
+        limits:
+          cpu: 1
+          memory: 2Gi
+        requests:
+          cpu: 200m
+          memory: 512Mi

--- a/ansible/roles/ocp-workload-gogs/templates/deployment_postgresql.j2
+++ b/ansible/roles/ocp-workload-gogs/templates/deployment_postgresql.j2
@@ -1,0 +1,86 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: {{ gogs_app_name }}-postgresql
+  namespace: {{ gogs_project }}
+  labels:
+    app: {{ gogs_app_name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ gogs_app_name }}-postgresql
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: {{ gogs_app_name }}-postgresql
+    spec:
+      restartPolicy: Always
+      serviceAccountName: {{ gogs_app_name }}
+      schedulerName: default-scheduler
+      terminationGracePeriodSeconds: 30
+      securityContext: {}
+      containers:
+        - resources:
+            limits:
+              memory: 512Mi
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - '-i'
+                - '-c'
+                - >-
+                  psql -h 127.0.0.1 -U ${POSTGRESQL_USER} -q -d
+                  ${POSTGRESQL_DATABASE} -c 'SELECT 1'
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 10
+          terminationMessagePath: /dev/termination-log
+          name: postgresql
+          livenessProbe:
+            tcpSocket:
+              port: 5432
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
+            periodSeconds: 20
+            successThreshold: 1
+            failureThreshold: 10
+          env:
+            - name: POSTGRESQL_USER
+              value: {{ database_user }}
+            - name: POSTGRESQL_PASSWORD
+              value: {{ database_password }}
+            - name: POSTGRESQL_DATABASE
+              value: {{ database_name }}
+            - name: POSTGRESQL_MAX_CONNECTIONS
+              value: '{{ database_max_connections }}'
+            - name: POSTGRESQL_SHARED_BUFFERS
+              value: {{ database_shared_buffers }}
+            - name: POSTGRESQL_ADMIN_PASSWORD
+              value: {{ database_admin_password }}
+          ports:
+            - containerPort: 5432
+              protocol: TCP
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: gogs-postgres-data
+              mountPath: /var/lib/pgsql/data
+          terminationMessagePolicy: File
+          image: 'registry.access.redhat.com/rhscl/postgresql-96-rhel7:latest'
+      serviceAccount: gogs
+      volumes:
+        - name: gogs-postgres-data
+          persistentVolumeClaim:
+            claimName: {{ gogs_app_name }}-postgresql-data
+      dnsPolicy: ClusterFirst
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 600

--- a/ansible/roles/ocp-workload-gogs/templates/project.j2
+++ b/ansible/roles/ocp-workload-gogs/templates/project.j2
@@ -1,0 +1,11 @@
+apiVersion: project.openshift.io/v1
+kind: Project
+metadata:
+  annotations:
+    openshift.io/description: ""
+    openshift.io/display-name: {{ gogs_project_display }}
+    openshift.io/requester: {{ ocp_username }}
+  name: {{ gogs_project }}
+spec:
+  finalizers:
+  - kubernetes

--- a/ansible/roles/ocp-workload-gogs/templates/pvc_data.j2
+++ b/ansible/roles/ocp-workload-gogs/templates/pvc_data.j2
@@ -1,0 +1,13 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  labels:
+    app: {{ gogs_app_name }}
+  name: {{ gogs_app_name }}-data
+  namespace: {{ gogs_project }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ gogs_pvc_capacity }}

--- a/ansible/roles/ocp-workload-gogs/templates/pvc_postgresql_data.j2
+++ b/ansible/roles/ocp-workload-gogs/templates/pvc_postgresql_data.j2
@@ -1,0 +1,13 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  labels:
+    app: {{ gogs_app_name }}
+  name: {{ gogs_app_name }}-postgresql-data
+  namespace: {{ gogs_project }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ database_pvc_capacity }}

--- a/ansible/roles/ocp-workload-gogs/templates/route.j2
+++ b/ansible/roles/ocp-workload-gogs/templates/route.j2
@@ -1,0 +1,14 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    app: {{ gogs_app_name }}
+  name: {{ gogs_app_name }}
+  namespace: {{ gogs_project }}
+spec:
+  host: {{ gogs_hostname }}
+  to:
+    kind: Service
+    name: {{ gogs_app_name }}
+    weight: 100
+  wildcardPolicy: None

--- a/ansible/roles/ocp-workload-gogs/templates/service_account.j2
+++ b/ansible/roles/ocp-workload-gogs/templates/service_account.j2
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata: 
+  name: {{ gogs_app_name }}
+  namespace: {{ gogs_project }}
+  labels: 
+    app: {{ gogs_app_name }}

--- a/ansible/roles/ocp-workload-gogs/templates/service_app.j2
+++ b/ansible/roles/ocp-workload-gogs/templates/service_app.j2
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ gogs_app_name }}
+  name: {{ gogs_app_name }}
+  namespace: {{ gogs_project }}
+spec:
+  selector:
+    app: {{ gogs_app_name }}
+  type: ClusterIP
+  ports:
+  - port: 3000
+    protocol: TCP
+    targetPort: 3000

--- a/ansible/roles/ocp-workload-gogs/templates/service_postgresql.j2
+++ b/ansible/roles/ocp-workload-gogs/templates/service_postgresql.j2
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ gogs_app_name }}-postgresql
+  name: {{ gogs_app_name }}-postgresql
+  namespace: {{ gogs_project }}
+spec:
+  selector:
+    app: {{ gogs_app_name }}-postgresql
+  type: ClusterIP
+  ports:
+  - port: 5432
+    protocol: TCP
+    targetPort: 5432

--- a/ansible/roles/ocp-workload-gogs/tests/test-local.yml
+++ b/ansible/roles/ocp-workload-gogs/tests/test-local.yml
@@ -1,0 +1,9 @@
+---
+- hosts: localhost
+  connection: local
+  remote_user: root
+  vars:
+#    become_override: false
+    guid: abcde12345
+    tmp_kubeconfig: /tmp/{{ guid }}/kube-config
+#    ocp_username: opentlc-mgr


### PR DESCRIPTION
##### SUMMARY
Workload to deploy gogs. This workload is used in OpenShift BU workshops (for now) and it's meant to replace the role `https://github.com/siamaksade/ansible-openshift-gogs` used in the current APB