### PR TITLE
Use the copied kube/config

### DIFF
--- a/ansible/roles/ocp-workload-ocp-ops-view/defaults/main.yml
+++ b/ansible/roles/ocp-workload-ocp-ops-view/defaults/main.yml
@@ -2,7 +2,8 @@
 become_override: False
 ocp_username: user-redhat.com
 silent: False
-tmp_kubeconfig: /tmp/{{ guid }}/.kube-config
+tmp_dir: /tmp/{{ guid }}
+tmp_kubeconfig: "{{ tmp_dir }}/.kube/config"
 
 opsview_project: "ocp-ops-view"
 opsview_project_display: "OCP Ops Viewer"

--- a/ansible/roles/ocp-workload-ocp-ops-view/tasks/post_workload.yml
+++ b/ansible/roles/ocp-workload-ocp-ops-view/tasks/post_workload.yml
@@ -2,7 +2,7 @@
 # Implement your Post Workload deployment tasks here
 - name: Remove temp kube config
   file: 
-    path: "{{ tmp_kubeconfig }}"
+    path: "{{ tmp_dir }}"
     state: absent
 
 # Leave these as the last tasks in the playbook

--- a/ansible/roles/ocp-workload-ocp-ops-view/tasks/pre_workload.yml
+++ b/ansible/roles/ocp-workload-ocp-ops-view/tasks/pre_workload.yml
@@ -2,13 +2,13 @@
 # Implement your Pre Workload deployment tasks here
 - name: Ensure directory exists
   file:
-    path: "/tmp/{{ guid }}"
+    path: "{{ tmp_dir }}"
     state: directory
 
 - name: Copy .kube/config and set env var
   copy:
-    src: ~/.kube/config
-    dest: "{{ tmp_kubeconfig }}"
+    src: ~/.kube
+    dest: "{{ tmp_dir }}"
     remote_src: yes
 
 # Leave these as the last tasks in the playbook

--- a/ansible/roles/ocp-workload-ocp-ops-view/tasks/remove_workload.yml
+++ b/ansible/roles/ocp-workload-ocp-ops-view/tasks/remove_workload.yml
@@ -1,12 +1,33 @@
 ---
 # Implement your Workload removal tasks here
+- name: Ensure directory exists
+  file:
+    path: "{{ tmp_dir }}"
+    state: directory
 
-- name: remove Workshop OCP ops view project
-  k8s:
-    name: "{{ opsview_project }}"
-    api_version: v1
-    kind: Namespace
-    state: absent
+- name: Copy .kube/config and set env var
+  copy:
+    src: ~/.kube
+    dest: "{{ tmp_dir }}"
+    remote_src: yes
+
+- environment:
+    KUBECONFIG: "{{ tmp_kubeconfig }}"
+  block:
+    - name: Create OpenShift objects for OCP ops view workload
+      k8s:
+        state: absent
+        definition: "{{ lookup('template', item ) | from_yaml }}"
+      loop:
+      - ./templates/route.j2
+      - ./templates/service_app.j2
+      - ./templates/deployment_app.j2
+      - ./templates/service_redis.j2
+      - ./templates/deployment_redis.j2
+      - ./templates/cluster_role_binding.j2
+      - ./templates/role_binding.j2
+      - ./templates/cluster_role.j2
+      - ./templates/service_account.j2
 
 - name: Remove temp kube config
   file: 

--- a/ansible/roles/ocp-workload-ocp-ops-view/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-ocp-ops-view/tasks/workload.yml
@@ -5,30 +5,33 @@
   debug:
     msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
 
-- name: Create Project {{ opsview_project }}
-  k8s:
-    state: present
-    definition: "{{ lookup('template', item ) | from_yaml }}"
-  loop:
-  - ./templates/project.j2
-  register: r_createproject
-  until: r_createproject is succeeded
-  retries: 5
+- environment:
+    KUBECONFIG: "{{ tmp_kubeconfig }}"
+  block:
+    - name: Create Project {{ opsview_project }}
+      k8s:
+        state: present
+        definition: "{{ lookup('template', item ) | from_yaml }}"
+      loop:
+      - ./templates/project.j2
+      register: r_createproject
+      until: r_createproject is succeeded
+      retries: 5
 
-- name: Create OpenShift objects for OCP ops view workload
-  k8s:
-    state: present
-    definition: "{{ lookup('template', item ) | from_yaml }}"
-  loop:
-  - ./templates/service_account.j2
-  - ./templates/cluster_role.j2
-  - ./templates/role_binding.j2
-  - ./templates/cluster_role_binding.j2
-  - ./templates/deployment_redis.j2
-  - ./templates/service_redis.j2
-  - ./templates/deployment_app.j2
-  - ./templates/service_app.j2
-  - ./templates/route.j2
+    - name: Create OpenShift objects for OCP ops view workload
+      k8s:
+        state: present
+        definition: "{{ lookup('template', item ) | from_yaml }}"
+      loop:
+      - ./templates/service_account.j2
+      - ./templates/cluster_role.j2
+      - ./templates/role_binding.j2
+      - ./templates/cluster_role_binding.j2
+      - ./templates/deployment_redis.j2
+      - ./templates/service_redis.j2
+      - ./templates/deployment_app.j2
+      - ./templates/service_app.j2
+      - ./templates/route.j2
 
 # Leave this as the last task in the playbook.
 - name: workload tasks complete


### PR DESCRIPTION
##### SUMMARY
Now the role uses the copied .kube/config so that it doesn't have any dependency with any other role