### PR TITLE
Don't set ControlP* via ansible since we generate our own ssh_conf

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -13,3 +13,6 @@ bin_ansible_callbacks   = True
 
 [privilege_escalation]
 become                  = False
+
+[ssh_connection]
+ssh_args=

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -13,3 +13,6 @@ bin_ansible_callbacks   = True
 
 [privilege_escalation]
 become                  = False
+
+[ssh_connection]
+ssh_args=


### PR DESCRIPTION
##### SUMMARY
Working on the OSP cloud provider in agnosticd revealed that when using the same hostname for hosts accross different concurrent deployments (for example `bastion`, the deployments fail.

This is because they share the same controlpath socket.

When running `ansible-playbook` with `-vvv`, it shows:

```
ssh -C -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o 'User="cloud-user"' -o ConnectTimeout=60 -o StrictHostKeyChecking=no -F /home/opentlc-mgr/nstephan/63e1/output_dir/ocp4-disconnected-osp-lab_63e1_ssh_conf -o ControlPath=/home/opentlc-mgr/.ansible/cp/7e8c96cf49 bastion
```

Notice the `-o ControlPath=/home/opentlc-mgr/.ansible/cp/7e8c96cf49` at the end of the ssh command line.

This never was a problem with ec2, and the issue never happened because we've always had the guid in the shortname, ex: `bastion.GUID.internal`.

This PR tries to fix that by deactivating ControlPersist and ControlPath in ansible, and let everything happen via the generated ssh conf file.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
