### PR TITLE
Fix multiple OSP Deployments

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -13,6 +13,3 @@ bin_ansible_callbacks   = True
 
 [privilege_escalation]
 become                  = False
-
-[ssh_connection]
-ssh_args=

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -13,6 +13,3 @@ bin_ansible_callbacks   = True
 
 [privilege_escalation]
 become                  = False
-
-[ssh_connection]
-ssh_args=

--- a/ansible/cloud_providers/osp_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/osp_infrastructure_deployment.yml
@@ -159,9 +159,10 @@
         # set python interpreter: Useful when the distrib running ansible has a different path
         # ex: when running using the alpine image
         #ansible_python_interpreter: env python
-        ansible_ssh_extra_args: >-
+        ansible_ssh_common_args: >-
           {{ ansible_ssh_extra_args|d() }}
           -F {{ output_dir }}/{{ env_type }}_{{ guid }}_ssh_conf
+          -o ControlPath=/tmp/{{ guid }}-%r-%h-%p
 
     - name: Run infra-osp-wait_for_linux_hosts Role
       import_role:

--- a/ansible/configs/ocp4-disconnected-osp-lab/env_vars.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/env_vars.yml
@@ -94,7 +94,7 @@ repo_method: file
 # If using file, these are needed in addition to the repos_template.j2 file:
 osrelease: 4.2.0
 repo_version: '4.2'
-own_repo_path: http://d3s3zqyaz8cp2d.cloudfront.net/repos/ocp/{{osrelease}}
+own_repo_path: # Should be defined in secrets
 
 # Packages to install on all of the hosts deployed as part of the agnosticd config
 # This invokes the "common" role

--- a/ansible/configs/ocp4-disconnected-osp-lab/env_vars.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/env_vars.yml
@@ -85,19 +85,16 @@ install_ftl: false
 # TODO: Decide on whether to use sat or give access to repos directly with key
 # This will tell Agnosticd to use either:
 # sattelite, rhn, or file for repos
-repo_method: satellite
+repo_method: file
 # If using satellite, these are needed:
-satellite_url: satellite.opentlc.com
-satellite_activationkey: # This should be stored in secrets
-satellite_org: # This should be stored in secrets
-use_content_view: true
-# When using satellite, these are ignored and what is published in Content
-# View is used. If you are using another repo_method, you may need to enable these.
-# rhel_repos:
-#   - rhel-7-server-rpms
-#   - rhel-7-server-extras-rpms
-#   - rhel-7-server-ansible-2.8-rpms
-#   - rhel-7-server-optional-rpms
+# satellite_url: satellite.opentlc.com
+# satellite_activationkey: # This should be stored in secrets
+# satellite_org: # This should be stored in secrets
+# use_content_view: true
+# If using file, these are needed in addition to the repos_template.j2 file:
+osrelease: 4.2.0
+repo_version: '4.2'
+own_repo_path: http://d3s3zqyaz8cp2d.cloudfront.net/repos/ocp/{{osrelease}}
 
 # Packages to install on all of the hosts deployed as part of the agnosticd config
 # This invokes the "common" role


### PR DESCRIPTION
Setting the `ssh_args=` degraded performance for scp & sftp. It was causing the following warnings:

`[WARNING]: sftp transfer mechanism failed`
`[WARNING]: scp transfer mechanism failed`

This PR reverts that change.

To fix the issue it was originally meant to, the `cloud_provider` for OSP has been changed to add `ansible_ssh_common_args` and append the ssh_conf as well as the ControlPath pointing to a unique socket for each deployment, even if they have the same hostnames (guid will be unique).

This was only applied to the OSP cloud provider, since AWS and others were not experiencing a problem. This change minimizes the potential impact on other cloud providers.

Also, changed the default env_vars to use file repo_method.