### PR TITLE
fixes issues with ansible 2.7.9 compat

### DIFF
--- a/ansible/roles/ocp4-workload-istio-controlplane-infra/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-istio-controlplane-infra/tasks/workload.yml
@@ -5,7 +5,7 @@
 # TODO: change to variable-based versions
 - name: set relevant facts for re-use
   set_fact:
-    elastic_version: "elasticsearch-operator.4.2.1-201910221723"
+    elastic_version: "elasticsearch-operator.4.2.4-201911050122"
     jaeger_version: "jaeger-operator.v1.13.1"
     kiali_version: "kiali-operator.v1.0.7"
     servicemesh_version: "servicemeshoperator.v1.0.2"
@@ -35,8 +35,11 @@
     namespace: openshift-operators
   register: operator_subscription_out
   until: 
+    - operator_subscription_out is defined
+    - operator_subscription_out.resources is defined
+    - operator_subscription_out.resources[0] is defined
     - operator_subscription_out.resources[0].status is defined
-    - operator_subscription_out.resources[0].status.installplan.name is defined
+    - operator_subscription_out.resources[0].status.installplan is defined
   retries: 30
   delay: 20
 
@@ -76,8 +79,11 @@
     namespace: openshift-operators
   register: operator_subscription_out
   until: 
+    - operator_subscription_out is defined
+    - operator_subscription_out.resources is defined
+    - operator_subscription_out.resources[0] is defined
     - operator_subscription_out.resources[0].status is defined
-    - operator_subscription_out.resources[0].status.installplan.name is defined
+    - operator_subscription_out.resources[0].status.installplan is defined
   retries: 30
   delay: 20
 
@@ -117,8 +123,11 @@
     namespace: openshift-operators
   register: operator_subscription_out
   until: 
+    - operator_subscription_out is defined
+    - operator_subscription_out.resources is defined
+    - operator_subscription_out.resources[0] is defined
     - operator_subscription_out.resources[0].status is defined
-    - operator_subscription_out.resources[0].status.installplan.name is defined
+    - operator_subscription_out.resources[0].status.installplan is defined
   retries: 30
   delay: 20
 
@@ -158,8 +167,11 @@
     namespace: openshift-operators
   register: operator_subscription_out
   until: 
+    - operator_subscription_out is defined
+    - operator_subscription_out.resources is defined
+    - operator_subscription_out.resources[0] is defined
     - operator_subscription_out.resources[0].status is defined
-    - operator_subscription_out.resources[0].status.installplan.name is defined
+    - operator_subscription_out.resources[0].status.installplan is defined
   retries: 30
   delay: 20
 


### PR DESCRIPTION
2.8.0 introduced better support for `is defined` on dicts where stuff doesn't exist. the provisioning server still runs 2.7.9 which needs more loving care.