### PR TITLE
changes to how operator catalog is deployed

### DIFF
--- a/ansible/roles/ocp4-workload-istio-controlplane-infra/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-istio-controlplane-infra/tasks/workload.yml
@@ -10,6 +10,39 @@
     kiali_version: "kiali-operator.v1.0.7"
     servicemesh_version: "servicemeshoperator.v1.0.2"
 
+- name: create a namespace for the service mesh operators
+  k8s:
+    state: present
+    definition:
+      apiVersion: project.openshift.io/v1
+      kind: Project
+      metadata:
+        name: service-mesh-operators
+
+- name: create an OperatorGroup so that the CSVs will get installed
+  k8s:
+    state: present
+    definition:
+      apiVersion: operators.coreos.com/v1
+      kind: OperatorGroup
+      metadata:
+        name: service-mesh-operators
+        namespace: service-mesh-operators
+
+- name: create the CatalogSource for the snapshot
+  k8s:
+    state: present
+    definition:
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: CatalogSource
+      metadata:
+        name: redhat-operators-snapshot
+        namespace: service-mesh-operators
+      spec:
+        sourceType: grpc
+        image: quay.io/openshiftroadshow/operator-snapshot@sha256:e4c2f914d49d47f283e4a683eb75e17853aaf26eedf1ce3b04e97da6ea81ea5c
+        displayName: Red Hat Operators Snapshot
+
 - name: create elastic subscription
   k8s:
     state: present
@@ -18,11 +51,11 @@
       kind: Subscription
       metadata:
         name: service-mesh-elastic
-        namespace: openshift-operators
+        namespace: service-mesh-operators
       spec:
         channel: "4.2"
-        source: redhat-operators
-        sourceNamespace: openshift-marketplace
+        source: redhat-operators-snapshot
+        sourceNamespace: service-mesh-operators
         name: elasticsearch-operator
         startingCSV: "{{ elastic_version }}"
         installPlanApproval: Manual
@@ -32,7 +65,7 @@
     api_version: operators.coreos.com/v1alpha1
     kind: Subscription
     name: service-mesh-elastic
-    namespace: openshift-operators
+    namespace: service-mesh-operators
   register: operator_subscription_out
   until: 
     - operator_subscription_out is defined
@@ -49,7 +82,7 @@
       apiVersion: operators.coreos.com/v1alpha1
       kind: InstallPlan
       metadata:
-        namespace: openshift-operators
+        namespace: service-mesh-operators
         name: "{{ operator_subscription_out.resources[0].status.installplan.name }}"
       spec:
         approved: true
@@ -62,11 +95,11 @@
       kind: Subscription
       metadata:
         name: service-mesh-jaeger
-        namespace: openshift-operators
+        namespace: service-mesh-operators
       spec:
         channel: stable
-        source: redhat-operators
-        sourceNamespace: openshift-marketplace
+        source: redhat-operators-snapshot
+        sourceNamespace: service-mesh-operators
         name: jaeger-product
         startingCSV: "{{ jaeger_version }}"
         installPlanApproval: Manual
@@ -76,7 +109,7 @@
     api_version: operators.coreos.com/v1alpha1
     kind: Subscription
     name: service-mesh-jaeger
-    namespace: openshift-operators
+    namespace: service-mesh-operators
   register: operator_subscription_out
   until: 
     - operator_subscription_out is defined
@@ -93,7 +126,7 @@
       apiVersion: operators.coreos.com/v1alpha1
       kind: InstallPlan
       metadata:
-        namespace: openshift-operators
+        namespace: service-mesh-operators
         name: "{{ operator_subscription_out.resources[0].status.installplan.name }}"
       spec:
         approved: true
@@ -106,11 +139,11 @@
       kind: Subscription
       metadata:
         name: service-mesh-kiali
-        namespace: openshift-operators
+        namespace: service-mesh-operators
       spec:
         channel: stable
-        source: redhat-operators
-        sourceNamespace: openshift-marketplace
+        source: redhat-operators-snapshot
+        sourceNamespace: service-mesh-operators
         name: kiali-ossm
         startingCSV: "{{ kiali_version }}"
         installPlanApproval: Manual
@@ -120,7 +153,7 @@
     api_version: operators.coreos.com/v1alpha1
     kind: Subscription
     name: service-mesh-kiali
-    namespace: openshift-operators
+    namespace: service-mesh-operators
   register: operator_subscription_out
   until: 
     - operator_subscription_out is defined
@@ -137,7 +170,7 @@
       apiVersion: operators.coreos.com/v1alpha1
       kind: InstallPlan
       metadata:
-        namespace: openshift-operators
+        namespace: service-mesh-operators
         name: "{{ operator_subscription_out.resources[0].status.installplan.name }}"
       spec:
         approved: true
@@ -150,11 +183,11 @@
       kind: Subscription
       metadata:
         name: service-mesh-operator
-        namespace: openshift-operators
+        namespace: service-mesh-operators
       spec:
         channel: "1.0"
-        source: redhat-operators
-        sourceNamespace: openshift-marketplace
+        source: redhat-operators-snapshot
+        sourceNamespace: service-mesh-operators
         name: servicemeshoperator
         startingCSV: "{{ servicemesh_version }}"
         installPlanApproval: Manual
@@ -164,7 +197,7 @@
     api_version: operators.coreos.com/v1alpha1
     kind: Subscription
     name: service-mesh-operator
-    namespace: openshift-operators
+    namespace: service-mesh-operators
   register: operator_subscription_out
   until: 
     - operator_subscription_out is defined
@@ -181,7 +214,7 @@
       apiVersion: operators.coreos.com/v1alpha1
       kind: InstallPlan
       metadata:
-        namespace: openshift-operators
+        namespace: service-mesh-operators
         name: "{{ operator_subscription_out.resources[0].status.installplan.name }}"
       spec:
         approved: true
@@ -191,7 +224,7 @@
     api_version: operators.coreos.com/v1alpha1
     kind: ClusterServiceVersion
     name: "{{ item }}"
-    namespace: openshift-operators
+    namespace: service-mesh-operators
   register: csv_exists_out
   retries: 5
   delay: 70
@@ -207,7 +240,7 @@
     api_version: operators.coreos.com/v1alpha1
     kind: ClusterServiceVersion
     name: "{{ item }}"
-    namespace: openshift-operators
+    namespace: service-mesh-operators
   register: csv_exists_out
   retries: 5
   delay: 70


### PR DESCRIPTION
we had to use a snapshot image of the operator catalog and this changes to use a working one