### PR TITLE
Checking correctly for nexus pod

### DIFF
--- a/ansible/roles/ocp4-workload-nexus-operator/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-nexus-operator/tasks/workload.yml
@@ -33,11 +33,21 @@
     - name: Wait for Nexus Pod to start creating
       pause:
         seconds: 10
+    - name: Get pod name for nexus pod
+      k8s_facts:
+        kind: Pod
+        namespace: "{{ _nexus_operator_project }}"
+        label_selectors:
+          - app={{ _nexus_name }}
+      register: nexus_pods
+    - name: Nexus pod name
+      set_fact:
+        nexus_pod_name: "{{ nexus_pods.resources[0].metadata.name }}"
     - name: Wait for Nexus Pod to start
       k8s:
         api_version: v1
         kind: Pod
-        name: "{{ _nexus_name }}"
+        name: "{{ nexus_pod_name }}"
         namespace: "{{ _nexus_operator_project }}"
       register: nexus_pod
       until:
@@ -50,7 +60,7 @@
       k8s:
         api_version: v1
         kind: Pod
-        name: "{{ _nexus_name }}"
+        name: "{{ nexus_pod_name }}"
         namespace: "{{ _nexus_operator_project }}"
       register: nexus_pod
       until:


### PR DESCRIPTION
##### SUMMARY
Nexus workload was not correctly checking for the nexus pod as the pod was named something like `nexus-6b6bf487db-94s2f` and it was checking for `nexus`.
We add a k8s_fact to get the pod name to check for it's status.
