### PR TITLE
Add tasks for trunk & volume cleanup

### DIFF
--- a/ansible/roles/infra-osp-resources-destroy/tasks/delete_osp_resources.yml
+++ b/ansible/roles/infra-osp-resources-destroy/tasks/delete_osp_resources.yml
@@ -29,6 +29,14 @@
           command: |
             openstack project purge --keep-project --project {{ osp_project_name }}
           when: project_purge_out is succeeded
+
+        - name: Delete any remaining volumes in project
+          command: |
+            openstack volume list --project {{ osp_project_name }} -f value -c ID | xargs openstack volume delete
+        
+        - name: Delete any trunk ports in project
+          command: |
+            openstack port list --project {{ osp_project_name }} -f json -c trunk_details | jq '.[].trunk_details.trunk_id | select (.!=null)' | xargs openstack network trunk delete
         
         - name: Purge network resources
           command: |

--- a/ansible/roles/infra-osp-resources-destroy/tasks/delete_osp_resources.yml
+++ b/ansible/roles/infra-osp-resources-destroy/tasks/delete_osp_resources.yml
@@ -31,12 +31,16 @@
           when: project_purge_out is succeeded
 
         - name: Delete any remaining volumes in project
-          command: |
-            openstack volume list --project {{ osp_project_name }} -f value -c ID | xargs openstack volume delete
+          shell: >-
+            openstack volume list --project {{ osp_project_name }} -f value -c ID
+            | xargs openstack volume delete
         
         - name: Delete any trunk ports in project
-          command: |
-            openstack port list --project {{ osp_project_name }} -f json -c trunk_details | jq '.[].trunk_details.trunk_id | select (.!=null)' | xargs openstack network trunk delete
+          command: >-
+            openstack port list --project {{ osp_project_name }} -f json -c trunk_details
+            | jq '.[].trunk_details.trunk_id
+            | select (.!=null)'
+            | xargs openstack network trunk delete
         
         - name: Purge network resources
           command: |

--- a/ansible/roles/infra-osp-resources-destroy/tasks/delete_osp_resources.yml
+++ b/ansible/roles/infra-osp-resources-destroy/tasks/delete_osp_resources.yml
@@ -36,7 +36,7 @@
             | xargs openstack volume delete
         
         - name: Delete any trunk ports in project
-          command: >-
+          shell: >-
             openstack port list --project {{ osp_project_name }} -f json -c trunk_details
             | jq '.[].trunk_details.trunk_id
             | select (.!=null)'

--- a/ansible/roles/infra-osp-resources-destroy/tasks/delete_osp_resources.yml
+++ b/ansible/roles/infra-osp-resources-destroy/tasks/delete_osp_resources.yml
@@ -40,8 +40,7 @@
           shell: >-
             set -o pipefail;
             openstack port list --project {{ osp_project_name }} -f json -c trunk_details
-            | jq '.[].trunk_details.trunk_id
-            | select (.!=null)'
+            | jq '.[].trunk_details.trunk_id | select (.!=null)'
             | xargs openstack network trunk delete
         
         - name: Purge network resources

--- a/ansible/roles/infra-osp-resources-destroy/tasks/delete_osp_resources.yml
+++ b/ansible/roles/infra-osp-resources-destroy/tasks/delete_osp_resources.yml
@@ -32,11 +32,13 @@
 
         - name: Delete any remaining volumes in project
           shell: >-
+            set -o pipefail;
             openstack volume list --project {{ osp_project_name }} -f value -c ID
             | xargs openstack volume delete
         
         - name: Delete any trunk ports in project
           shell: >-
+            set -o pipefail;
             openstack port list --project {{ osp_project_name }} -f json -c trunk_details
             | jq '.[].trunk_details.trunk_id
             | select (.!=null)'


### PR DESCRIPTION
The teardown was failing when there were instances, volumes, and trunks created by the OpenShift machine-api. 

The trunks were not being deleted by the `neutron purge`, so they will now be deleted prior to that. `neutron purge` will pick up everything else.

The volumes were not being deleted by `openstack project purge`. I think this is because these volumes were created in such a way that they were not set to be deleted with the instance. If we ran this command again, it might pick up these volumes as unused and remove them, but this is more foolproof.