### PR TITLE
Fix broken API LE cert config

### DIFF
--- a/ansible/roles/ocp4-workload-enable-lets-encrypt-certificates/files/deploy_certs.yml
+++ b/ansible/roles/ocp4-workload-enable-lets-encrypt-certificates/files/deploy_certs.yml
@@ -14,11 +14,11 @@
   tasks:
   - name: Determine API server hostname
     shell: "oc whoami --show-server | cut -f 2 -d ':' | cut -f 3 -d '/' | sed 's/-api././'"
-    register: api_hostname
+    register: r_api_hostname
 
   - name: Compute domain name
     set_fact:
-      _certbot_domain: "{{ api_hostname.stdout }}"
+      _certbot_domain: "{{ r_api_hostname.stdout }}"
 
   - name: "Install certificates into {{ _certbot_install_dir }}/{{ item }}"
     copy:

--- a/ansible/roles/ocp4-workload-enable-lets-encrypt-certificates/templates/api-server.j2
+++ b/ansible/roles/ocp4-workload-enable-lets-encrypt-certificates/templates/api-server.j2
@@ -6,6 +6,6 @@ spec:
   servingCerts:
     namedCertificates:
     - names:
-      - {{ api_hostname.stdout }}
+      - {{ r_api_hostname.stdout }}
       servingCertificate:
         name: api-certs


### PR DESCRIPTION
##### SUMMARY
Trying to provision LE certs for the API endpoint through the `ocp4-workload-enable-lets-encrypt-certificates` and the `_lets_encrypt_certificates_install_api: true` variable fails with the following error:
```
TASK [ocp4-workload-enable-lets-encrypt-certificates : Add Certs to API Server] ***
Thursday 21 November 2019  20:06:30 +0000 (0:00:01.580)       0:42:47.789 ***** 
fatal: [clientvm.7hrdp.internal]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'api_hostname' is undefined\n\nThe error appears to be in '/var/lib/awx/projects/_8__agnosticd_ocp4_workshop_prod_128/ansible/roles/ocp4-workload-enable-lets-encrypt-certificates/tasks/workload.yml': line 105, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n    - name: Add Certs to API Server\n      ^ here\n"}
```
It seems #825 changed the `api_hostname` variable to `r_api_hostname` in the `ocp4-workload-enable-lets-encrypt-certificates` role. This change also needed in two additional files.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
>ocp4-workload-enable-lets-encrypt-certificates

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
