### PR TITLE
The nexus pod was taking too long to start

### DIFF
--- a/ansible/roles/ocp4-workload-nexus-operator/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-nexus-operator/tasks/workload.yml
@@ -32,7 +32,7 @@
         definition: "{{ lookup('template', './templates/opentlc-nexus.j2' ) | from_yaml }}"
     - name: Wait for Nexus Pod to start creating
       pause:
-        seconds: 10
+        seconds: 20
     - name: Get pod name for nexus pod
       k8s_facts:
         kind: Pod
@@ -40,33 +40,17 @@
         label_selectors:
           - app={{ _nexus_name }}
       register: nexus_pods
-    - name: Nexus pod name
-      set_fact:
-        nexus_pod_name: "{{ nexus_pods.resources[0].metadata.name }}"
-    - name: Wait for Nexus Pod to start
+    - name: Get Admin password
       k8s:
-        api_version: v1
-        kind: Pod
-        name: "{{ nexus_pod_name }}"
+        api_version: gpte.opentlc.com/v1alpha1
+        kind: Nexus
+        name: "{{ _nexus_name }}"
         namespace: "{{ _nexus_operator_project }}"
-      register: nexus_pod
+      register: nexus_cr
       until:
-      - nexus_pod.result is defined
-      - nexus_pod.result.status.phase == "Running"
+      - nexus_cr.result.status.conditions[0].type == "Running"
       retries: 50
-      delay: 10
-      changed_when: false
-    - name: Wait for the Nexus Pod to be ready
-      k8s:
-        api_version: v1
-        kind: Pod
-        name: "{{ nexus_pod_name }}"
-        namespace: "{{ _nexus_operator_project }}"
-      register: nexus_pod
-      until:
-      - nexus_pod.result.status.containerStatuses[0].ready|d(False)|bool
-      retries: 50
-      delay: 10
+      delay: 5
       changed_when: false
     - name: Get Admin password
       k8s:


### PR DESCRIPTION
##### SUMMARY
The nexus pod was taking too long to start and the label selector query was returning empty and hence the following task was erroring with an undefined variable. Now we check the status in the CR status for Running.