### PR TITLE
Updates to num users logic and 1.7.5 of etherpad

### DIFF
--- a/ansible/roles/ocp-workload-etherpad/defaults/main.yml
+++ b/ansible/roles/ocp-workload-etherpad/defaults/main.yml
@@ -9,10 +9,10 @@ etherpad_project: "etherpad"
 etherpad_project_display: "Etherpad"
 etherpad_app_name: "etherpad"
 
-user_count: 200
+num_users: 200
 
 # Mysql
-etherpad_image: quay.io/wkulhanek/etherpad:1.7.0
+etherpad_image: quay.io/wkulhanek/etherpad:1.7.5
 mysql_database: sampledb
 mysql_password: user123XYZ
 mysql_root_password: root123XYZ

--- a/ansible/roles/ocp-workload-etherpad/templates/etherpad.txt.j2
+++ b/ansible/roles/ocp-workload-etherpad/templates/etherpad.txt.j2
@@ -10,7 +10,7 @@ To start using this collaboration tool, we are going to identify some logistics.
 Find an open user login and assign yourself one. Remember it, you will use it
 to login:
 
-{% for user_num in range(1, user_count|int + 1) %}
+{% for user_num in range(1, num_users|int + 1) %}
 user{{ user_num }}=
 {% endfor %}
 


### PR DESCRIPTION
##### SUMMARY
Logic was using user_count which always was 200. Now using num_users with defaults to the amount of users selected when provisioning the environment.

Also, upgraded etherpad to 1.7.5
