### PR TITLE
Change default memory quota in OSP project

### DIFF
--- a/ansible/configs/ocp4-disconnected-osp-lab/env_vars.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/env_vars.yml
@@ -154,7 +154,7 @@ openshift_fip_dns: True
 # Quotas to set for new project that is created
 quota_num_instances: 15
 quota_num_cores: 72
-quota_memory: 131072 # in MB
+quota_memory: 163840 # in MB
 quota_num_volumes: 25
 quota_volumes_gigs: 500
 #quota_loadbalancers: #when Octavia is available


### PR DESCRIPTION
Memory quota was too small to complete the labs as they are being written. This increases the default value to 160GB per project.