### PR TITLE
Updating bash-git-prompt so it uses remote_user instead of hardcoded …

### DIFF
--- a/ansible/roles/bastion/tasks/main.yml
+++ b/ansible/roles/bastion/tasks/main.yml
@@ -141,7 +141,7 @@
     clone: yes
   loop:
   - "/root"
-  - "/home/ec2-user"
+  - "/home/{{remote_user}}"
   - "/etc/skel"
   tags:
   - install_bash_customization
@@ -154,7 +154,7 @@
     recurse: yes
   loop:
   - { directory: "/root",          user: "root",     group: "root" }
-  - { directory: "/home/ec2-user", user: "ec2-user", group: "ec2-user" }
+  - { directory: "/home/{{remote_user}}", user: "{{remote_user}}", group: "{{remote_user}}" }
   - { directory: "/etc/skel",      user: "root",     group: "root" }
   tags:
   - install_bash_customization
@@ -168,7 +168,7 @@
     group: "{{ item.group }}"
   loop:
   - { directory: "/root",          user: "root",     group: "root" }
-  - { directory: "/home/ec2-user", user: "ec2-user", group: "ec2-user" }
+  - { directory: "/home/{{remote_user}}", user: "{{remote_user}}", group: "{{remote_user}}" }
   - { directory: "/etc/skel",      user: "root",     group: "root" }
   tags:
   - install_bash_customization
@@ -182,7 +182,7 @@
     group: "{{ item.group }}"
   loop:
   - { directory: "/root",          user: "root",     group: "root" }
-  - { directory: "/home/ec2-user", user: "ec2-user", group: "ec2-user" }
+  - { directory: "/home/{{remote_user}}", user: "{{remote_user}}", group: "{{remote_user}}" }
   - { directory: "/etc/skel",      user: "root",     group: "root" }
   tags:
   - install_bash_customization

--- a/ansible/roles/ocp-client-vm/tasks/packages.yml
+++ b/ansible/roles/ocp-client-vm/tasks/packages.yml
@@ -118,7 +118,7 @@
     clone: yes
   with_items:
   - "/root"
-  - "/home/ec2-user"
+  - "/home/{{remote_user}}"
   - "/etc/skel"
   tags:
   - install_bash_customization
@@ -131,7 +131,7 @@
     recurse: yes
   with_items:
   - { directory: "/root",          user: "root",     group: "root" }
-  - { directory: "/home/ec2-user", user: "ec2-user", group: "ec2-user" }
+  - { directory: "/home/{{remote_user}}", user: "{{remote_user}}", group: "{{remote_user}}" }
   - { directory: "/etc/skel",      user: "root",     group: "root" }
   tags:
   - install_bash_customization
@@ -145,7 +145,7 @@
     group: "{{ item.group }}"
   with_items:
   - { directory: "/root",          user: "root",     group: "root" }
-  - { directory: "/home/ec2-user", user: "ec2-user", group: "ec2-user" }
+  - { directory: "/home/{{remote_user}}", user: "{{remote_user}}", group: "{{remote_user}}" }
   - { directory: "/etc/skel",      user: "root",     group: "root" }
   tags:
   - install_bash_customization
@@ -159,7 +159,7 @@
     group: "{{ item.group }}"
   with_items:
   - { directory: "/root",          user: "root",     group: "root" }
-  - { directory: "/home/ec2-user", user: "ec2-user", group: "ec2-user" }
+  - { directory: "/home/{{remote_user}}", user: "{{remote_user}}", group: "{{remote_user}}" }
   - { directory: "/etc/skel",      user: "root",     group: "root" }
   tags:
   - install_bash_customization

--- a/ansible/roles/ocp4-client-vm/tasks/main.yml
+++ b/ansible/roles/ocp4-client-vm/tasks/main.yml
@@ -159,7 +159,7 @@
     clone: yes
   loop:
   - "/root"
-  - "/home/ec2-user"
+  - "/home/{{remote_user}}"
   - "/etc/skel"
   tags:
   - install_bash_customization
@@ -172,7 +172,7 @@
     recurse: yes
   loop:
   - { directory: "/root",          user: "root",     group: "root" }
-  - { directory: "/home/ec2-user", user: "ec2-user", group: "ec2-user" }
+  - { directory: "/home/{{remote_user}}", user: "{{remote_user}}", group: "{{remote_user}}" }
   - { directory: "/etc/skel",      user: "root",     group: "root" }
   tags:
   - install_bash_customization
@@ -186,7 +186,7 @@
     group: "{{ item.group }}"
   loop:
   - { directory: "/root",          user: "root",     group: "root" }
-  - { directory: "/home/ec2-user", user: "ec2-user", group: "ec2-user" }
+  - { directory: "/home/{{remote_user}}", user: "{{remote_user}}", group: "{{remote_user}}" }
   - { directory: "/etc/skel",      user: "root",     group: "root" }
   tags:
   - install_bash_customization
@@ -200,7 +200,7 @@
     group: "{{ item.group }}"
   loop:
   - { directory: "/root",          user: "root",     group: "root" }
-  - { directory: "/home/ec2-user", user: "ec2-user", group: "ec2-user" }
+  - { directory: "/home/{{remote_user}}", user: "{{remote_user}}", group: "{{remote_user}}" }
   - { directory: "/etc/skel",      user: "root",     group: "root" }
   tags:
   - install_bash_customization


### PR DESCRIPTION
…ec2-user which broke it on Azure

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
This change broke the install on Azure (and any other future cloud)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
bastion, ocp-client-vm, and ocp4-client-vm roles

##### ADDITIONAL INFORMATION
Tracked down why the OpenShift on Azure deployment started failing, there is no ec2-user on any cloud but AWS.