### PR TITLE
Update workload to track CodeReady Workspaces operator updates

### DIFF
--- a/ansible/roles/ocp4-workload-ccnrd/files/preparelab_ccn.sh
+++ b/ansible/roles/ocp4-workload-ccnrd/files/preparelab_ccn.sh
@@ -71,8 +71,8 @@ done
 oc new-project labs-infra
 
 # adjust limits for admin
-oc get userquota/default 
-RESULT=$? 
+oc get userquota/default
+RESULT=$?
 if [ $RESULT -eq 0 ]; then
   oc delete userquota/default
 else
@@ -171,8 +171,8 @@ for MODULE in $(echo $MODULE_TYPE | sed "s/,/ /g") ; do
 done
 
 # Setup Istio Service Mesh
-oc get project istio-operator 
-RESULT=$? 
+oc get project istio-operator
+RESULT=$?
 if [ $RESULT -eq 0 ]; then
   echo -e "istio-operator already exists..."
 elif [ -z "${MODULE_TYPE##*m3*}" ] || [ -z "${MODULE_TYPE##*m4*}" ] ; then
@@ -181,8 +181,8 @@ elif [ -z "${MODULE_TYPE##*m3*}" ] || [ -z "${MODULE_TYPE##*m4*}" ] ; then
   oc apply -n istio-operator -f https://raw.githubusercontent.com/RedHat-Middleware-Workshops/cloud-native-workshop-v2-infra/ocp-4.1/files/servicemesh-operator.yaml
 fi
 
-oc get project istio-system 
-RESULT=$? 
+oc get project istio-system
+RESULT=$?
 if [ $RESULT -eq 0 ]; then
   echo -e "istio-system already exists..."
 elif [ -z "${MODULE_TYPE##*m3*}" ] || [ -z "${MODULE_TYPE##*m4*}" ] ; then
@@ -198,27 +198,27 @@ echo -e "Creating coolstore & bookinfo projects for each user... \n"
 for i in $(eval echo "{0..$USERCOUNT}") ; do
   if [ -z "${MODULE_TYPE##*m1*}" ] || [ -z "${MODULE_TYPE##*m2*}" ] || [ -z "${MODULE_TYPE##*m3*}" ] ; then
     oc new-project user$i-inventory
-    oc adm policy add-scc-to-user anyuid -z default -n user$i-inventory 
-    oc adm policy add-scc-to-user privileged -z default -n user$i-inventory 
+    oc adm policy add-scc-to-user anyuid -z default -n user$i-inventory
+    oc adm policy add-scc-to-user privileged -z default -n user$i-inventory
     oc adm policy add-role-to-user admin user$i -n user$i-inventory
     oc new-project user$i-catalog
-    oc adm policy add-scc-to-user anyuid -z default -n user$i-catalog 
-    oc adm policy add-scc-to-user privileged -z default -n user$i-catalog 
-    oc adm policy add-role-to-user admin user$i -n user$i-catalog 
+    oc adm policy add-scc-to-user anyuid -z default -n user$i-catalog
+    oc adm policy add-scc-to-user privileged -z default -n user$i-catalog
+    oc adm policy add-role-to-user admin user$i -n user$i-catalog
   fi
   if [ -z "${MODULE_TYPE##*m3*}" ] ; then
-    oc new-project user$i-bookinfo 
-    oc adm policy add-scc-to-user anyuid -z default -n user$i-bookinfo 
-    oc adm policy add-scc-to-user privileged -z default -n user$i-bookinfo 
-    oc adm policy add-role-to-user admin user$i -n user$i-bookinfo 
-    oc adm policy add-role-to-user view user$i -n istio-system 
+    oc new-project user$i-bookinfo
+    oc adm policy add-scc-to-user anyuid -z default -n user$i-bookinfo
+    oc adm policy add-scc-to-user privileged -z default -n user$i-bookinfo
+    oc adm policy add-role-to-user admin user$i -n user$i-bookinfo
+    oc adm policy add-role-to-user view user$i -n istio-system
   fi
   if [ -z "${MODULE_TYPE##*m4*}" ] ; then
-    oc new-project user$i-cloudnativeapps 
-    oc adm policy add-scc-to-user anyuid -z default -n user$i-cloudnativeapps 
-    oc adm policy add-scc-to-user privileged -z default -n user$i-cloudnativeapps 
-    oc adm policy add-role-to-user admin user$i -n user$i-cloudnativeapps 
-    oc adm policy add-role-to-user view user$i -n istio-system  
+    oc new-project user$i-cloudnativeapps
+    oc adm policy add-scc-to-user anyuid -z default -n user$i-cloudnativeapps
+    oc adm policy add-scc-to-user privileged -z default -n user$i-cloudnativeapps
+    oc adm policy add-role-to-user admin user$i -n user$i-cloudnativeapps
+    oc adm policy add-role-to-user view user$i -n istio-system
   fi
 done
 
@@ -226,13 +226,13 @@ done
 if [ -z "${MODULE_TYPE##*m4*}" ] ; then
   echo -e "Installing Knative Subscriptions..."
   oc apply -f https://raw.githubusercontent.com/RedHat-Middleware-Workshops/cloud-native-workshop-v2-infra/ocp-4.1/files/catalog-sources.yaml
-  
+
   echo -e "Installing Knative Serving..."
   oc apply -f https://raw.githubusercontent.com/RedHat-Middleware-Workshops/cloud-native-workshop-v2-infra/ocp-4.1/files/knative-serving-subscription.yaml
- 
+
   echo -e "Installing Knative Eventing..."
   oc apply -f https://raw.githubusercontent.com/RedHat-Middleware-Workshops/cloud-native-workshop-v2-infra/ocp-4.1/files/knative-eventing-subscription.yaml
-  
+
 echo -e "Creating Role, Group, and assign Users"
 for i in $(eval echo "{0..$USERCOUNT}") ; do
 cat <<EOF | oc apply -n user$i-cloudnativeapps -f -
@@ -434,7 +434,7 @@ done
 if [ -z "${MODULE_TYPE##*m2*}" ] ; then
   oc replace -f https://raw.githubusercontent.com/RedHat-Middleware-Workshops/cloud-native-workshop-v2-infra/ocp-4.1/files/jenkins-ephemeral.yml -n openshift
   oc get project jenkins
-  RESULT=$? 
+  RESULT=$?
   if [ $RESULT -eq 0 ]; then
     echo -e "jenkins project already exists..."
   elif [ -z "${MODULE_TYPE##*m2*}" ] ; then
@@ -510,7 +510,7 @@ if [ -z "${MODULE_TYPE##*m1*}" ] ; then
   for i in $(jq '. | keys | .[]' <<< "$USER_ID_LIST"); do
     USER_ID=$(jq -r ".[$i].id" <<< "$USER_ID_LIST")
     USER_NAME=$(jq -r ".[$i].username" <<< "$USER_ID_LIST")
-    if [ "$USER_NAME" != "rhamt" ] ; then 
+    if [ "$USER_NAME" != "rhamt" ] ; then
       RES=$(curl -s -w '%{http_code}' -o /dev/null -k -X PUT https://secure-rhamt-web-console-labs-infra.$HOSTNAME_SUFFIX/auth/admin/realms/rhamt/users/$USER_ID/reset-password \
         -H "Content-Type: application/json" \
         -H "Accept: application/json" \
@@ -535,7 +535,7 @@ kind: CatalogSourceConfig
 metadata:
   finalizers:
   - finalizer.catalogsourceconfigs.operators.coreos.com
-  name: installed-redhat-che
+  name: installed-redhat-codeready
   namespace: openshift-marketplace
 spec:
   targetNamespace: labs-infra
@@ -548,9 +548,9 @@ cat <<EOF | oc apply -n labs-infra -f -
 apiVersion: operators.coreos.com/v1alpha2
 kind: OperatorGroup
 metadata:
-  name: che-operator-group
+  name: codeready-operator-group
   namespace: labs-infra
-  generateName: che-
+  generateName: codeready-
   annotations:
     olm.providedAPIs: CheCluster.v1.org.eclipse.che
 spec:
@@ -565,15 +565,15 @@ metadata:
   name: codeready-workspaces
   namespace: labs-infra
   labels:
-    csc-owner-name: installed-redhat-che
+    csc-owner-name: installed-redhat-codeready
     csc-owner-namespace: openshift-marketplace
 spec:
-  channel: final
+  channel: previous
   installPlanApproval: Automatic
   name: codeready-workspaces
-  source: installed-redhat-che
+  source: installed-redhat-codeready
   sourceNamespace: labs-infra
-  startingCSV: crwoperator.v1.2.0
+  startingCSV: crwoperator.v1.2.2
 EOF
 
 # Wait for checluster to be a thing
@@ -669,7 +669,7 @@ SSO_TOKEN=$(curl -s -d "username=${KEYCLOAK_USER}&password=${KEYCLOAK_PASSWORD}&
 
 echo -e "SSO_TOKEN: $SSO_TOKEN"
 
-# Import realm 
+# Import realm
 wget https://raw.githubusercontent.com/RedHat-Middleware-Workshops/cloud-native-workshop-v2-infra/ocp-4.1/files/ccnrd-realm.json
 curl -v -H "Authorization: Bearer ${SSO_TOKEN}" -H "Content-Type:application/json" -d @ccnrd-realm.json \
   -X POST "http://keycloak-labs-infra.$HOSTNAME_SUFFIX/auth/admin/realms"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
CRW has updated the operator to install CRW 2 by default. This is a major revision to CRW (and underlying Che) so for now we must use the `previous` operator update channel so that existing CCN roadshows continue to use CRW 1.2 while we plan the transition to CRW 2.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
`ocp4-workload-ccnrd`

