### PR TITLE
bump quotas to enable IPI for short term

### DIFF
--- a/ansible/configs/ocp4-disconnected-osp-lab/env_vars.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/env_vars.yml
@@ -163,8 +163,8 @@ quota_networks: 3
 quota_subnets: 3
 quota_routers: 3
 quota_fip: 5
-quota_sg: 10
-quota_sg_rules: 100
+quota_sg: 20
+quota_sg_rules: 200
 
 # The external network in OpenStack where the floating IPs (FIPs) come from
 provider_network: external


### PR DESCRIPTION
Increasing security group quotas in this config to allow for IPI installs. Without this, IPI will try to create a number of security groups and will exceed the quota set for this assuming it would be used for UPI installs.
