### PR TITLE
ensure backwards compatibility ready for v1.6.x

### DIFF
--- a/ansible/roles/ocp-workload-integreatly/defaults/main.yml
+++ b/ansible/roles/ocp-workload-integreatly/defaults/main.yml
@@ -3,7 +3,8 @@
 become_override: True
 silent: False
 install_dir: /tmp/integreatly
-inventory_hosts_file: inventories/hosts.template
+inventory_hosts_file_legacy: inventories/hosts.template
+inventory_hosts_file: inventories/pds.template
 release_tag: "release-{{ ig_version }}"
 webapp_namespace: webapp
 self_signed_certs_enabled: True

--- a/ansible/roles/ocp-workload-integreatly/tasks/main.yml
+++ b/ansible/roles/ocp-workload-integreatly/tasks/main.yml
@@ -1,8 +1,9 @@
 ---
 
+# This block can be removed once 1.5.2 is no longer a supported version.
 - set_fact:
     inventory_hosts_file: "{{ inventory_hosts_file_legacy }}"
-  when: ig_version in ['1.4.1', '1.5.1', '1.5.2']
+  when: release_tag in ['release-1.4.1', 'release-1.5.1', 'release-1.5.2']
 
 - name: Running Pre Workload Tasks
   import_tasks: ./pre_workload.yml

--- a/ansible/roles/ocp-workload-integreatly/tasks/main.yml
+++ b/ansible/roles/ocp-workload-integreatly/tasks/main.yml
@@ -1,5 +1,9 @@
 ---
 
+- set_fact:
+    inventory_hosts_file: "{{ inventory_hosts_file_legacy }}"
+  when: ig_version in ['1.4.1', '1.5.1', '1.5.2']
+
 - name: Running Pre Workload Tasks
   import_tasks: ./pre_workload.yml
   become: "{{ become_override | bool }}"


### PR DESCRIPTION
##### SUMMARY
in v1.6.x of integreatly we want to use a new inventory file, however the
older releases of integreatly should still maintain using the older hosts
inventory file.

this change adds a version check to ig_version, if it is within the current
known legacy versions that are installable from pds, the older hosts
inventory will be used. Else, the new pds inventory will be used.

the aim of this is to ensure the removal of this logic will be simple once
it is no longer needed.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New config Pull Request

##### COMPONENT NAME
Integreatly (RHMI)

@trepel @pmccarthy would you mind taking a look, i'm not familiar with how this repo can be tested from an intly perspective? 