### PR TITLE
Fix App Deploy Homework for Users with "_" in their user name

### DIFF
--- a/ansible/roles/ocp4-workload-app-deploy-homework/tasks/remove_workload.yml
+++ b/ansible/roles/ocp4-workload-app-deploy-homework/tasks/remove_workload.yml
@@ -7,21 +7,12 @@
   - ocp_username is defined
   - ocp_user_groups | default([]) | length > 0
 
-- name: "Remove user {{ ocp_username }}'s Quotas"
-  k8s:
-    state: absent
-    api_version: quota.openshift.io/v1
-    kind: ClusterResourceQuota
-    name: "{{ item }}"
-  loop:
-  - "clusterquota-{{ ocp_username }}-{{ guid }}"
-  - "clusterquota-{{ ocp_username }}"
-
-- name: "Remove user {{ ocp_username }} from Grading Jenkins"
+- name: Remove ClusterResourceQuota and remove access to Grading Jenkins
   k8s:
     state: absent
     definition: "{{ lookup('template', item ) | from_yaml }}"
   loop:
+  - ./templates/cluster_resource_quota.j2
   - ./templates/jenkins_role_binding.j2
 
 - name: "Find all projects for user {{ ocp_username }}"

--- a/ansible/roles/ocp4-workload-app-deploy-homework/templates/cluster_resource_quota.j2
+++ b/ansible/roles/ocp4-workload-app-deploy-homework/templates/cluster_resource_quota.j2
@@ -1,7 +1,7 @@
 apiVersion: quota.openshift.io/v1
 kind: ClusterResourceQuota
 metadata:
-  name: "clusterquota-{{ ocp_username }}-{{ guid }}"
+  name: "clusterquota-app-deploy-homework-{{ guid }}"
 spec:
   selector:
     annotations:


### PR DESCRIPTION
Some IBMers have a "_" in their user name. For example benoit_godin@be.ibm.com.

"_" is an invalid character for a Kubernetes resource - so creating a cluster resource quota including the user name fails. Fixed by removing the user name from the name of the quota.