### PR TITLE
Change ddns variable names

### DIFF
--- a/ansible/configs/ocp-clientvm/sample_vars_osp.yml
+++ b/ansible/configs/ocp-clientvm/sample_vars_osp.yml
@@ -24,11 +24,11 @@ own_repo_path: http://admin.example.com/repos/version
 cloud_provider: osp                     # Which AgnosticD Cloud Provider to use
 
 # The domain that you want to add DNS entries to
-ocp_cluster_dns_zone: blue.osp.opentlc.com
+osp_cluster_dns_zone: blue.osp.opentlc.com
 
 # The dynamic DNS server you will add entries to.
 # NOTE: This is only applicable when {{ use_dynamic_dns}} is true
-ocp_cluster_dns_server: ddns01.opentlc.com
+osp_cluster_dns_server: ddns01.opentlc.com
 
 # Instance type
 

--- a/ansible/configs/ocp4-cluster/destroy_env.yml
+++ b/ansible/configs/ocp4-cluster/destroy_env.yml
@@ -13,8 +13,8 @@
 
     - name: Remove DNS entry for OpenShift API and ingress
       nsupdate:
-        server: "{{ ocp_cluster_dns_server }}"
-        zone: "{{ ocp_cluster_dns_zone }}"
+        server: "{{ osp_cluster_dns_server }}"
+        zone: "{{ osp_cluster_dns_zone }}"
         record: "{{ item }}.{{ guid }}"
         type: A
         key_name: "{{ ddns_key_name }}"
@@ -23,6 +23,6 @@
       loop:
         - "api"
         - "*.apps"
-      when: 
+      when:
         - openshift_fip_provision
         - use_dynamic_dns

--- a/ansible/configs/ocp4-cluster/env_vars.yml
+++ b/ansible/configs/ocp4-cluster/env_vars.yml
@@ -130,11 +130,11 @@ use_dynamic_dns: true
 # use_route53: false
 
 # The domain that you want to add DNS entries to
-ocp_cluster_dns_zone: blue.osp.opentlc.com
+osp_cluster_dns_zone: blue.osp.opentlc.com
 
 # The dynamic DNS server you will add entries to.
 # NOTE: This is only applicable when {{ use_dynamic_dns}} is true
-ocp_cluster_dns_server: ddns01.opentlc.com
+osp_cluster_dns_server: ddns01.opentlc.com
 
 # Whether to wait for an ack from the DNS servers before continuing
 wait_for_dns: true

--- a/ansible/configs/ocp4-cluster/post_infra.yml
+++ b/ansible/configs/ocp4-cluster/post_infra.yml
@@ -15,7 +15,9 @@
   tasks:
     - name: Create DNS entries for OpenShift FIPs
       debug:
-        msg: Currently using {{ ocp_cluster_dns_zone }} on server {{ ocp_cluster_dns_server }}
+        msg: >-
+          Currently using {{ osp_cluster_dns_zone }}
+          on server {{ osp_cluster_dns_server }}
       when: openshift_fip_provision
 
     - set_fact:
@@ -29,11 +31,11 @@
       vars:
         query: "outputs[?@.output_key=='ocp_ingress_fip'].output_value|[0]"
       when: openshift_fip_provision
-    
+
     - name: Add DNS entry for OpenShift API and ingress
       nsupdate:
-        server: "{{ ocp_cluster_dns_server }}"
-        zone: "{{ ocp_cluster_dns_zone }}"
+        server: "{{ osp_cluster_dns_server }}"
+        zone: "{{ osp_cluster_dns_zone }}"
         record: "{{ item.dns }}.{{ guid }}"
         type: A
         ttl: 5

--- a/ansible/configs/ocp4-cluster/post_software.yml
+++ b/ansible/configs/ocp4-cluster/post_software.yml
@@ -12,19 +12,19 @@
         msg: "{{ item }}"
       loop:
         - "user.info: You can access your bastion via SSH:"
-        - "user.info: ssh {{ student_name }}@bastion.{{ guid }}.{{ ocp_cluster_dns_zone }}"
+        - "user.info: ssh {{ student_name }}@bastion.{{ guid }}.{{ osp_cluster_dns_zone }}"
         - "user.info: "
         - "user.info: Make sure you use the username '{{ student_name }}' and the password '{{ hostvars['bastion']['student_password'] }}' when prompted."
         - "user.info: "
-        - "user.info: Your base domain is '{{ ocp_cluster_dns_zone }}'"
+        - "user.info: Your base domain is '{{ osp_cluster_dns_zone }}'"
         - "user.info: "
         - "user.info: For reference, the floating IPs you will use for OpenShift are:"
         - "user.info: "
         - "user.info: API IP: {{ ocp_api_fip }}"
-        - "user.info: API FQDN: api.{{ guid }}.{{ ocp_cluster_dns_zone }}"
+        - "user.info: API FQDN: api.{{ guid }}.{{ osp_cluster_dns_zone }}"
         - "user.info: "
         - "user.info: Ingress IP: {{ ocp_ingress_fip }}"
-        - "user.info: Ingress FQDN: *.apps.{{ guid }}.{{ ocp_cluster_dns_zone }}"
+        - "user.info: Ingress FQDN: *.apps.{{ guid }}.{{ osp_cluster_dns_zone }}"
 
     - debug:
         msg: "Post-Software checks completed successfully"

--- a/ansible/configs/ocp4-disconnected-osp-lab/destroy_env.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/destroy_env.yml
@@ -13,8 +13,8 @@
 
     - name: Remove DNS entry for OpenShift API and ingress
       nsupdate:
-        server: "{{ ocp_cluster_dns_server }}"
-        zone: "{{ ocp_cluster_dns_zone }}"
+        server: "{{ osp_cluster_dns_server }}"
+        zone: "{{ osp_cluster_dns_zone }}"
         record: "{{ item }}.{{ guid }}"
         type: A
         key_name: "{{ ddns_key_name }}"
@@ -23,6 +23,6 @@
       loop:
         - "api"
         - "*.apps"
-      when: 
+      when:
         - openshift_fip_provision
         - use_dynamic_dns

--- a/ansible/configs/ocp4-disconnected-osp-lab/env_vars.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/env_vars.yml
@@ -130,11 +130,11 @@ use_dynamic_dns: true
 # use_route53: false
 
 # The domain that you want to add DNS entries to
-ocp_cluster_dns_zone: blue.osp.opentlc.com
+osp_cluster_dns_zone: blue.osp.opentlc.com
 
 # The dynamic DNS server you will add entries to.
 # NOTE: This is only applicable when {{ use_dynamic_dns}} is true
-ocp_cluster_dns_server: ddns01.opentlc.com
+osp_cluster_dns_server: ddns01.opentlc.com
 
 # Whether to wait for an ack from the DNS servers before continuing
 wait_for_dns: true

--- a/ansible/configs/ocp4-disconnected-osp-lab/post_infra.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/post_infra.yml
@@ -15,7 +15,7 @@
   tasks:
     - name: Create DNS entries for OpenShift FIPs
       debug:
-        msg: Currently using {{ ocp_cluster_dns_zone }} on server {{ ocp_cluster_dns_server }}
+        msg: Currently using {{ osp_cluster_dns_zone }} on server {{ osp_cluster_dns_server }}
       when: openshift_fip_provision
 
     - set_fact:
@@ -29,11 +29,11 @@
       vars:
         query: "outputs[?@.output_key=='ocp_ingress_fip'].output_value|[0]"
       when: openshift_fip_provision
-    
+
     - name: Add DNS entry for OpenShift API and ingress
       nsupdate:
-        server: "{{ ocp_cluster_dns_server }}"
-        zone: "{{ ocp_cluster_dns_zone }}"
+        server: "{{ osp_cluster_dns_server }}"
+        zone: "{{ osp_cluster_dns_zone }}"
         record: "{{ item.dns }}.{{ guid }}"
         type: A
         ttl: 5

--- a/ansible/configs/ocp4-disconnected-osp-lab/post_software.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/post_software.yml
@@ -12,19 +12,19 @@
         msg: "{{ item }}"
       loop:
         - "user.info: You can access your bastion via SSH:"
-        - "user.info: ssh {{ student_name }}@bastion.{{ guid }}.{{ ocp_cluster_dns_zone }}"
+        - "user.info: ssh {{ student_name }}@bastion.{{ guid }}.{{ osp_cluster_dns_zone }}"
         - "user.info: "
         - "user.info: Make sure you use the username '{{ student_name }}' and the password '{{ hostvars['bastion']['student_password'] }}' when prompted."
         - "user.info: "
-        - "user.info: Your base domain is '{{ ocp_cluster_dns_zone }}'"
+        - "user.info: Your base domain is '{{ osp_cluster_dns_zone }}'"
         - "user.info: "
         - "user.info: For reference, the floating IPs you will use for OpenShift are:"
         - "user.info: "
         - "user.info: API IP: {{ ocp_api_fip }}"
-        - "user.info: API FQDN: api.{{ guid }}.{{ ocp_cluster_dns_zone }}"
+        - "user.info: API FQDN: api.{{ guid }}.{{ osp_cluster_dns_zone }}"
         - "user.info: "
         - "user.info: Ingress IP: {{ ocp_ingress_fip }}"
-        - "user.info: Ingress FQDN: *.apps.{{ guid }}.{{ ocp_cluster_dns_zone }}"
+        - "user.info: Ingress FQDN: *.apps.{{ guid }}.{{ osp_cluster_dns_zone }}"
 
     - debug:
         msg: "Post-Software checks completed successfully"

--- a/ansible/configs/ocp4-disconnected-osp-lab/software.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/software.yml
@@ -12,7 +12,7 @@
               - gcc
               - python3
               - python3-devel
-        
+
         - name: Copy requirements.txt
           copy:
             src: "./files/openstack_requirements.txt"
@@ -25,7 +25,7 @@
           file:
             path: "/root/requirements.txt"
             state: absent
-          
+
         - name: Add /usr/local/bin to PATH
           copy:
             dest: /etc/profile.d/custom-path.sh
@@ -45,7 +45,7 @@
             dest: "/home/{{ student_name }}/.config/openstack/clouds.yaml"
             owner: "{{ student_name }}"
             mode: 0700
-          
+
         - name: Add environment variables for API and Ingress FIPs
           lineinfile:
             path: "/home/{{ student_name }}/.bashrc"
@@ -59,12 +59,12 @@
           loop_control:
             label: item.ip
           when: openshift_fip_provision
-        
+
         - name: Add environment variable for DNS domain
           lineinfile:
             path: "/home/{{ student_name }}/.bashrc"
             regexp: "^export OPENSHIFT_DNS_ZONE"
-            line: "export OPENSHIFT_DNS_ZONE={{ ocp_cluster_dns_zone }}"
+            line: "export OPENSHIFT_DNS_ZONE={{ osp_cluster_dns_zone }}"
           when: openshift_fip_provision
 
         - name: Add environment variable for OpenStack credentials
@@ -86,7 +86,7 @@
             dest: "/home/{{ student_name }}/resources/update_ignition.py"
             src: "./files/update_ignition.py"
             owner: "{{ student_name }}"
-        
+
         - name: Add jinja for machinesets to resources directory
           copy:
             dest: "/home/{{ student_name }}/resources/general-ms.yaml.j2"
@@ -98,7 +98,7 @@
         #   command: |
         #     /usr/local/bin/openstack --os-cloud {{ osp_project_name }} container create ignition
         #   become_user: "{{ student_name }}"
-        
+
         # - name: Set ACL for ignition container
         #   command: |
         #     /usr/local/bin/swift post --read-acl ".r:*,.rlistings" ignition

--- a/ansible/configs/three-tier-app/sample_vars_osp.yml
+++ b/ansible/configs/three-tier-app/sample_vars_osp.yml
@@ -24,11 +24,11 @@ own_repo_path: http://admin.example.com/repos/version
 cloud_provider: osp                     # Which AgnosticD Cloud Provider to use
 
 # The domain that you want to add DNS entries to
-ocp_cluster_dns_zone: blue.osp.opentlc.com
+osp_cluster_dns_zone: blue.osp.opentlc.com
 
 # The dynamic DNS server you will add entries to.
 # NOTE: This is only applicable when {{ use_dynamic_dns}} is true
-ocp_cluster_dns_server: ddns01.opentlc.com
+osp_cluster_dns_server: ddns01.opentlc.com
 
 # Instance type
 

--- a/ansible/roles/host-ocp4-provisioner/tasks/osp_prereqs.yml
+++ b/ansible/roles/host-ocp4-provisioner/tasks/osp_prereqs.yml
@@ -56,7 +56,7 @@
   lineinfile:
     path: "/home/{{ ansible_user }}/.bashrc"
     regexp: "^export OPENSHIFT_DNS_ZONE"
-    line: "export OPENSHIFT_DNS_ZONE={{ ocp_cluster_dns_zone }}"
+    line: "export OPENSHIFT_DNS_ZONE={{ osp_cluster_dns_zone }}"
   when: openshift_fip_provision
 
 - name: Add environment variable for OpenStack credentials

--- a/ansible/roles/infra-osp-create-inventory/tasks/main.yml
+++ b/ansible/roles/infra-osp-create-inventory/tasks/main.yml
@@ -66,7 +66,7 @@
     - name: Make sure bastion has public DNS name defined
       add_host:
         name: "{{ host.name }}"
-        public_dns_name: "{{ host.name }}.{{ guid }}.{{ocp_cluster_dns_zone }}"
+        public_dns_name: "{{ host.name }}.{{ guid }}.{{osp_cluster_dns_zone}}"
       loop: "{{ r_osp_facts.ansible_facts.openstack_servers }}"
       loop_control:
         label: "{{ host.name }}"
@@ -79,7 +79,7 @@
     var: hostvars[local_bastion].public_ip_address
 
 - debug:
-    msg: "bastion IP is {{ lookup('dig',local_bastion ~ '.' ~ guid ~ '.' ~ ocp_cluster_dns_zone) }}"
+    msg: "bastion IP is {{ lookup('dig',local_bastion ~ '.' ~ guid ~ '.' ~ osp_cluster_dns_zone) }}"
   ignore_errors: true
 
 - name: Verify that DNS matches bastion host_var
@@ -88,7 +88,7 @@
     # Requires dnspython library
     - lookup('dig', bastion_lookup) == hostvars[local_bastion].public_ip_address
   vars:
-    bastion_lookup: "{{ local_bastion ~ '.' ~ guid ~ '.' ~ ocp_cluster_dns_zone }}"
+    bastion_lookup: "{{ local_bastion ~ '.' ~ guid ~ '.' ~ osp_cluster_dns_zone }}"
 
 - name: debug hostvars
   debug:

--- a/ansible/roles/infra-osp-dns/tasks/nested_loop.yml
+++ b/ansible/roles/infra-osp-dns/tasks/nested_loop.yml
@@ -11,8 +11,8 @@
 
     - name: DNS entry ({{ _dns_state | default('present') }})
       nsupdate:
-        server: "{{ ocp_cluster_dns_server }}"
-        zone: "{{ ocp_cluster_dns_zone }}"
+        server: "{{ osp_cluster_dns_server }}"
+        zone: "{{ osp_cluster_dns_zone }}"
         record: "{{ _instance_name }}.{{ guid }}"
         type: A
         ttl: "{{ _infra_osp_dns_default_ttl }}"
@@ -25,8 +25,8 @@
   block:
     - name: DNS entry ({{ _dns_state | default('present') }})
       nsupdate:
-        server: "{{ ocp_cluster_dns_server }}"
-        zone: "{{ ocp_cluster_dns_zone }}"
+        server: "{{ osp_cluster_dns_server }}"
+        zone: "{{ osp_cluster_dns_zone }}"
         record: "{{ _instance_name }}.{{ guid }}"
         type: A
         ttl: "{{ _infra_osp_dns_default_ttl }}"

--- a/ansible/roles/infra-osp-dns/tasks/pre_checks.yml
+++ b/ansible/roles/infra-osp-dns/tasks/pre_checks.yml
@@ -1,13 +1,13 @@
 ---
 - when: >-
-    ocp_cluster_dns_server is not defined
-    or ocp_cluster_dns_zone is not defined
+    osp_cluster_dns_server is not defined
+    or osp_cluster_dns_zone is not defined
     or ddns_key_name is not defined
     or ddns_key_secret is not defined
   fail:
     msg: |
       All the following variables must be defined:
-      - ocp_cluster_dns_server
-      - ocp_cluster_dns_zone
+      - osp_cluster_dns_server
+      - osp_cluster_dns_zone
       - ddns_key_name
       - ddns_key_secret


### PR DESCRIPTION
Those variables:

ocp_cluster_dns_server
ocp_cluster_dns_zone

are not ocp related. This commit if applied will rename them.

Those are not used neither in OPEN_Admin neither agnosticv gpte repo.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
