### PR TITLE
Fix include_vars playbook when everything is skipped

### DIFF
--- a/ansible/include_vars.yml
+++ b/ansible/include_vars.yml
@@ -24,7 +24,14 @@
     - name: Include vars files
       include_vars:
         file: "{{ item.stat.path }}"
-      when: item.stat.exists
+      when:
+        - item is not skipped
+        - item.stat.exists
       loop: "{{ rstat_varfiles.results }}"
       loop_control:
-        label: "{{ item.stat.path | default(item._ansible_item_label) | default(item) }}"
+        label: >-
+          {{ (
+            item.stat.path
+            | default(item._ansible_item_label)
+            | default(item)
+          ) if 'stat' in item else item }}


### PR DESCRIPTION
This loop_control.label fails on ansible **2.7.9** when everything is skipped in the
playbook:

```
TASK [Include vars files] *********************************************************************************************************************************************************************
Monday 09 December 2019  03:40:35 -0500 (0:00:00.044)       0:00:04.049 *******
fatal: [localhost]: FAILED! => {"msg": "'dict object' has no attribute 'stat'"}
        to retry, use: --limit @/tmp/agnosticd/ansible/destroy.retry
```

This commit if applied fix that error.

- Bugfix Pull Request