### PR TITLE
Update os_server_info > os_server_facts

### DIFF
--- a/ansible/lifecycle.yml
+++ b/ansible/lifecycle.yml
@@ -95,11 +95,11 @@
                   vm_state: active
               register: r_osp_facts
 
-            - when: r_osp_facts.openstack_servers | length > 0
+            - when: r_osp_facts.ansible_facts.openstack_servers | length > 0
               block:
                 - set_fact:
                     all_instances: >-
-                      {{ r_osp_facts.openstack_servers
+                      {{ r_osp_facts.ansible_facts.openstack_servers
                       | json_query('[*].id') }}
 
                 - name: Stop all servers
@@ -116,11 +116,11 @@
                   vm_state: stopped
               register: r_osp_facts
 
-            - when: r_osp_facts.openstack_servers | length > 0
+            - when: r_osp_facts.ansible_facts.openstack_servers | length > 0
               block:
                 - set_fact:
                     all_instances: >-
-                      {{ r_osp_facts.openstack_servers
+                      {{ r_osp_facts.ansible_facts.openstack_servers
                       | json_query('[*].id') }}
 
                 - name: Start all servers


### PR DESCRIPTION
##### SUMMARY
The `lifecycle.yml` was using the `os_server_info` module, but that is only available in Ansible 2.9+. We are currently using Ansible 2.8.6 for these OSP configs and the module was called `os_server_facts`. This PR will update the playbook to use the proper module and reference the proper results, including `ansible_facts`.

##### ISSUE TYPE
- Bugfix Pull Request


