### PR TITLE
Redo of os_server_facts module change

### DIFF
--- a/ansible/lifecycle.yml
+++ b/ansible/lifecycle.yml
@@ -87,7 +87,7 @@
         - when: ACTION == 'stop'
           block:
             - name: Gather instance facts
-              os_server_info:
+              os_server_facts:
                 filters:
                   metadata:
                     guid: "{{ guid }}"
@@ -108,7 +108,7 @@
         - when: ACTION == 'start'
           block:
             - name: Gather instance facts
-              os_server_info:
+              os_server_facts:
                 filters:
                   metadata:
                     guid: "{{ guid }}"
@@ -129,7 +129,7 @@
         - when: ACTION == 'status'
           block:
             - name: Get OSP facts using (guid, env_type) metadata
-              os_server_info:
+              os_server_facts:
                 filters:
                   metadata:
                     guid: "{{ guid }}"


### PR DESCRIPTION
The last PR missed changing the actual module names. This one fixes that.