### PR TITLE
Updated Logic to force rotation of prometheus-adapters after shutdown…

### DIFF
--- a/ansible/configs/ocp4-workshop/post_software.yml
+++ b/ansible/configs/ocp4-workshop/post_software.yml
@@ -371,13 +371,24 @@
       loop:
       - "csr-signer-signer"
       - "csr-signer"
-    # The next two tasks are to fix the bug fixed in https://github.com/openshift/cluster-kube-controller-manager-operator/pull/305
+    # The next tasks are to fix the bug fixed in https://github.com/openshift/cluster-kube-controller-manager-operator/pull/305
+    # Also the operator dealing with prometheus adapters doesn't watch the certificates.
+    # Need to force it to reconcile
     - name: Wait 15 seconds before next command
       pause:
         seconds: 15
-    - name: Annotate ConfigMap to force reconciliation
-      command: "oc annotate cm controller-manager-kubeconfig please=reconcile_me -n openshift-kube-controller-manager"
-
+    - name: Get Config Map Definition
+      shell: oc get configmap extension-apiserver-authentication -n kube-system -o yaml >/tmp/extension-apiserver-authentication.yaml
+    - name: Add an empty line to config map file
+      lineinfile:
+        path: /tmp/extension-apiserver-authentication.yaml
+        firstmatch: true
+        insertafter: '-----END CERTIFICATE-----'
+        line: ''
+    - name: Update Config Map with new file
+      k8s:
+        state: present
+        src: /tmp/extension-apiserver-authentication.yaml
 - name: Tell CloudForms we are done
   hosts: bastions
   run_once: yes


### PR DESCRIPTION
Updated the logic to force rotation of prometheus-adapter pods on openshift-monitoring. This _should_ prevent errors in both the prometheus-adapter and the catalogserver pods down the line.