### PR TITLE
Modidy RHSM playbook and fix issues for RHEL 8 based bastion

### DIFF
--- a/ansible/roles/bastion/tasks/main.yml
+++ b/ansible/roles/bastion/tasks/main.yml
@@ -75,6 +75,7 @@
     state: present
     chain: INPUT
     jump: ACCEPT
+  ignore_errors: yes
 
 - name: Stat /etc/sysconfig/iptables
   stat:

--- a/ansible/roles/set-repositories/tasks/rhn-repos.yml
+++ b/ansible/roles/set-repositories/tasks/rhn-repos.yml
@@ -1,41 +1,31 @@
 # vim: set ft=ansible:
 ---
-- name: Force unregister before register
-  redhat_subscription:
-    state: absent
-  register: task_result
-  until: task_result | succeeded
-  retries: 10
-  delay: 5
 
-- name: register node with subscription-manager
+- name: Force unregister before register
+  command: "{{ item }}"
+  args:
+    warn: False
+  with_items:
+  - 'subscription-manager clean'
+  - 'subscription-manager remove --all'
+  - 'yum remove -y "katello-ca-consumer-*"'
+
+- name: 'Register system using Red Hat Subscription Manager'
   redhat_subscription:
     state: present
     username: "{{ rhel_subscription_user }}"
     password: "{{ rhel_subscription_pass }}"
-    autosubscribe: false
-  register: task_result
-  until: task_result | succeeded
-  retries: 10
-  delay: 5
+    pool_ids: "{{ rhsm_pool_ids }}"
+    auto_attach: false
 
-# TODO: should take pool ids from a var
-- name: get product pool id
-  shell: /usr/bin/subscription-manager list --all --available --matches="*{{rhn_pool_id_string}}*" | awk '/Pool ID/ {print $3}' | head -1
-  # command: subscription-manager list --all --available --matches="OpenShift Container Platform" | awk '/Pool ID/ {print $3}' | head -1
-  register: pool_id
-  until: pool_id | succeeded
-  retries: 10
-  delay: 5
-
-- name: attach host to subscription pool
-  shell: /usr/bin/subscription-manager attach --pool={{ pool_id.stdout }}
-  register: task_result
-  until: task_result.rc == 0
-  retries: 10
-  delay: 5
-
-- name: enable repos for rhel
-  command: subscription-manager repos --enable "{{ item }}"
+- name: "Build command line for repos to enable"
+  set_fact:
+    repos_params: "{{ repos_params|default('') }} --enable={{ item }}"
   with_items:
-    - '{{ rhel_repos }}'
+  - "{{ rhel_repos }}"
+
+- name: "Run 'subscription-manager to disable/enable repos"
+  command: "subscription-manager repos {{ repos_params }}"
+  when:
+  - repos_params is defined
+  - repos_params | length > 0

--- a/ansible/roles/set-repositories/tasks/rhn-repos.yml
+++ b/ansible/roles/set-repositories/tasks/rhn-repos.yml
@@ -18,14 +18,9 @@
     pool_ids: "{{ rhsm_pool_ids }}"
     auto_attach: false
 
-- name: "Build command line for repos to enable"
-  set_fact:
-    repos_params: "{{ repos_params|default('') }} --enable={{ item }}"
-  with_items:
-  - "{{ rhel_repos }}"
-
 - name: "Run 'subscription-manager to disable/enable repos"
-  command: "subscription-manager repos {{ repos_params }}"
-  when:
-  - repos_params is defined
-  - repos_params | length > 0
+  command: >-
+    subscription-manager repos {% for repo in rhel_repos %}
+    --enable={{ repo }}
+    {% endfor %}
+  when: rhel_repos | default([]) | length > 0


### PR DESCRIPTION
##### SUMMARY
The RSHM playbook for the `set-repositories` role had lot of issues and was not reliable. This is an effort to make it idempotent while using `repo_method: rhn` variable.

This has been tested several times in the Novello OSP environment with no errors.

At the same time I'm adding `ignore_errors: yes` to the Mosh Iptables task, to be aligned to the previous tasks for Mosh and others where errors where ignored if the packages are not installed. This was particularly failing in a vanilla RHEL 8.1 deployment.

##### ISSUE TYPE
Role not working properly

##### COMPONENT NAME
The `set-repositories` role
