### PR TITLE
Modify Satellite role to get it working with the latest release

### DIFF
--- a/ansible/roles/satellite-installation/tasks/main.yml
+++ b/ansible/roles/satellite-installation/tasks/main.yml
@@ -1,3 +1,4 @@
 ---
-- import_tasks: satellite_installation.yml
 - import_tasks: firewalld.yml
+- import_tasks: satellite_installation.yml
+

--- a/ansible/roles/satellite-installation/tasks/satellite_installation.yml
+++ b/ansible/roles/satellite-installation/tasks/satellite_installation.yml
@@ -1,4 +1,9 @@
 ---
+
+- name: Ensure server hostname is set as FQDN hostname
+  hostname: 
+    name: "{{ ansible_hostname }}.{{guid}}.internal"
+
 - name: Add internal dns name in hosts file
   lineinfile: 
     dest: /etc/hosts 
@@ -25,13 +30,13 @@
     - install_satellite
     - install_satellite_package
 
-- name: configure satellite 
+- name: configure satellite
   command: >-
-    satellite-installer --scenario satellite 
-    --foreman-admin-username {{ satellite_admin }}
-    --foreman-admin-password {{ satellite_admin_password }}
+    satellite-installer --scenario satellite
+    --foreman-initial-admin-username {{ satellite_admin }}
+    --foreman-initial-admin-password {{ satellite_admin_password }}
   async: 3600
-  poll: 36   
+  poll: 36
   tags:
     - install_satellite
     - install_satellite_setup


### PR DESCRIPTION
##### SUMMARY
Latest Satellite release is expecting different parameters from the one configured at the moment. Also the order on how the playbooks are executed needs to change as Satellite will prevent to install `firewalld` package if Satellite is installed before the package

##### ISSUE TYPE
The actual role is failing with 2 issues:

- `foreman-admin-username` and `foreman-admin-password` have been deprecated in favour of `foreman-initial-admin-username` and `foreman-initial-admin-password
- `firewalld` won't be installed due to packages been excluded by `foreman-protector`

##### COMPONENT NAME
Role `satellite-installation`
