### PR TITLE
Fix issues with NFS and RHEL 8

### DIFF
--- a/ansible/roles/host-ocp-nfs/handlers/main.yml
+++ b/ansible/roles/host-ocp-nfs/handlers/main.yml
@@ -13,7 +13,7 @@
     - /var/named
     - /etc/named.conf
 
-- name: restart nfs services
+- name: restart nfs services 7
   service:
     name: '{{  item }}'
     enabled: true
@@ -25,7 +25,7 @@
     - nfs-idmap
   when: ansible_facts['distribution_major_version']|int <= 7
 
-- name: restart nfs services
+- name: restart nfs services 8
   service:
     name: '{{  item }}'
     enabled: true

--- a/ansible/roles/host-ocp-nfs/handlers/main.yml
+++ b/ansible/roles/host-ocp-nfs/handlers/main.yml
@@ -23,3 +23,16 @@
     - nfs-server
     - nfs-lock
     - nfs-idmap
+  when: ansible_facts['distribution_major_version']|int <= 7
+
+- name: restart nfs services
+  service:
+    name: '{{  item }}'
+    enabled: true
+    state: restarted
+  with_items:
+    - rpcbind
+    - nfs-server
+    - rpc-statd
+    - nfs-idmapd
+  when: ansible_facts['distribution_major_version']|int >= 8

--- a/ansible/roles/host-ocp-nfs/tasks/nfs_exports.yml
+++ b/ansible/roles/host-ocp-nfs/tasks/nfs_exports.yml
@@ -12,6 +12,21 @@
     - '{{ nfs_shares }}'
   notify: restart nfs services
   run_once: True
+  when: ansible_facts['distribution_major_version']|int <= 7
+
+- name: create lab directory
+  file:
+    name: '/srv/nfs/{{ item }}'
+    state: directory
+    mode: 0777
+    owner: nobody
+    group: nobody
+    recurse: True
+  with_items:
+    - '{{ nfs_shares }}'
+  notify: restart nfs services
+  run_once: True
+  when: ansible_facts['distribution_major_version']|int >= 8
 
 - file:
     path: /etc/exports.d/{{ env_type }}-{{ guid }}.exports

--- a/ansible/roles/host-ocp-nfs/tasks/nfs_exports.yml
+++ b/ansible/roles/host-ocp-nfs/tasks/nfs_exports.yml
@@ -10,7 +10,7 @@
     recurse: True
   with_items:
     - '{{ nfs_shares }}'
-  notify: restart nfs services
+  notify: restart nfs services 7
   run_once: True
   when: ansible_facts['distribution_major_version']|int <= 7
 
@@ -24,7 +24,7 @@
     recurse: True
   with_items:
     - '{{ nfs_shares }}'
-  notify: restart nfs services
+  notify: restart nfs services 8
   run_once: True
   when: ansible_facts['distribution_major_version']|int >= 8
 
@@ -40,5 +40,17 @@
     state: present
   with_items:
     - '{{ nfs_shares }}'
-  notify: restart nfs services
+  notify: restart nfs services 7
   run_once: True
+  when: ansible_facts['distribution_major_version']|int <= 7
+
+- name: create exports file
+  lineinfile:
+    dest: /etc/exports.d/{{ env_type }}-{{ guid }}.exports
+    line: '/srv/nfs/{{ item }} {{ nfs_exports_config }}'
+    state: present
+  with_items:
+    - '{{ nfs_shares }}'
+  notify: restart nfs services 8
+  run_once: True
+  when: ansible_facts['distribution_major_version']|int <= 8


### PR DESCRIPTION
##### SUMMARY
There are several changes happening in RHEL 8 regarding NFS Server service. As an example the following ones that prevent using this role as-is:

https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/considerations_in_adopting_rhel_8/index#the-nobody-user-replaces-nfsnobody_shells-and-command-line-tools

https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/considerations_in_adopting_rhel_8/index#the-etc-sysconfig-nfs-file-and-legacy-nfs-service-names-are-no-longer-available_file-systems-and-storage

In order to evaluate the RHEL major version for some tasks, some conditionals have been added to configure the system accordingly to the corresponding RHEL release

##### ISSUE TYPE
Role not working in RHEL 8

##### COMPONENT NAME
Role host-ocp-nfs
