### PR TITLE
lifecycle.yml: check guid and env_type instead of project tag

### DIFF
--- a/ansible/lifecycle.yml
+++ b/ansible/lifecycle.yml
@@ -12,8 +12,14 @@
   become: no
   tasks:
     - fail:
-        msg: "project_tag is not defined"
-      when: project_tag is not defined or project_tag == ''
+        msg: "guid and env_type must be defined"
+      when: >-
+        guid is not defined or guid == ''
+        or env_type is not defined or env_type == ''
+
+    - when: project_tag is not defined
+      set_fact:
+        project_tag: "{{ env_type }}-{{ guid }}"
 
     - fail:
         msg: "ACTION is not defined"


### PR DESCRIPTION
The lifecycle playbook fails with test-empty-config

- project_tag is not always defined, for example test-empty-config
- project_tag can be built using env_type+guid


