### PR TITLE
Scale the rhamt-web-console-executor

### DIFF
--- a/ansible/roles/ocp4-workload-ccnrd/files/preparelab_ccn.sh
+++ b/ansible/roles/ocp4-workload-ccnrd/files/preparelab_ccn.sh
@@ -106,6 +106,8 @@ if [ -z "${MODULE_TYPE##*m1*}" ] ; then
       -p WEB_CONSOLE_REQUESTED_MEMORY=$REQUESTED_MEMORY \
       -p EXECUTOR_REQUESTED_CPU=$REQUESTED_CPU \
       -p EXECUTOR_REQUESTED_MEMORY=2Gi | oc create -n labs-infra  -f -
+
+  oc scale dc/rhamt-web-console-executor --replicas=$(($USERCOUNT / 2)) -n labs-infra
 fi
 
 # deploy gogs


### PR DESCRIPTION
Scale the `rhamt-web-console-executor` pod based on the number of users

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The `rhamt-web-console-executor` pod only has a single instance, which means all users running RHAMT are processed sequentially. This fix scales the pod based on the number of users in the cluster.

