### PR TITLE
Added the ability to fail test-empty-config at any stage

### DIFF
--- a/ansible/cloud_providers/test_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/test_infrastructure_deployment.yml
@@ -21,6 +21,11 @@
 #  Optional future debugging code can go here - e.g. an output of what instances could have been
 #  created etc
 
+    - when: fail_test_cloud_provider | default(false)
+      name: Fail the test-empty-config test cloud_provider if requested
+      fail:
+        msg: test cloud_provider failed as requested
+
     - name: Exiting the test-empty-config cloud_provider test_infrastructure_deployment.yml
       debug:
         msg:

--- a/ansible/configs/test-empty-config/README.adoc
+++ b/ansible/configs/test-empty-config/README.adoc
@@ -34,6 +34,25 @@ directory.
 
 `ansible-playbook main.yml -e @configs/test-empty-config/sample_vars.yml`
 
+== Force failing the `test-empty-config`
+
+You can force this config to fail at any stage including the cloud provider stage
+by setting or passing the appropriate boolean value:
+
+[source,yaml]
+----
+fail_pre_infra
+fail_test_cloud_provider
+fail_post_infra
+fail_pre_software
+fail_software
+fail_post_software
+----
+
+
+`ansible-playbook main.yml -e @configs/test-empty-config/sample_vars.yml -e '{ "fail_software" : true }'`
+
+
 === To Delete an environment
 
 This step is unnecessary as nothing is actiually created. However the following

--- a/ansible/configs/test-empty-config/post_infra.yml
+++ b/ansible/configs/test-empty-config/post_infra.yml
@@ -13,6 +13,11 @@
         msg:
           - Entering the test-empty-config post_infra.yml
 
+    - when: fail_post_infra | default(false)
+      name: Fail the test-empty-config post_infra.yml if requested
+      fail:
+        msg: post_infra.yml failed as requested
+
     - name: Exiting the test-empty-config post_infra.yml
       debug:
         msg:

--- a/ansible/configs/test-empty-config/post_software.yml
+++ b/ansible/configs/test-empty-config/post_software.yml
@@ -13,6 +13,11 @@
         msg:
           - Entering the test-empty-config post_software.yml
 
+    - when: fail_post_software | default(false)
+      name: Fail the test-empty-config post_software.yml if requested
+      fail:
+        msg: post_software.yml failed as requested
+
     - when: pause_post_software | default(false)
       pause:
         seconds: 30

--- a/ansible/configs/test-empty-config/pre_infra.yml
+++ b/ansible/configs/test-empty-config/pre_infra.yml
@@ -16,6 +16,11 @@
         msg: 
           - Entering the test-empty-config pre_infra.yml
 
+    - when: fail_pre_infra | default(false)
+      name: Fail the test-empty-config pre_infra.yml if requested
+      fail:
+        msg: pre_infra.yml failed as requested
+
     - name: Exiting the test-empty-config pre_infra.yml
       debug:
         msg: 

--- a/ansible/configs/test-empty-config/pre_software.yml
+++ b/ansible/configs/test-empty-config/pre_software.yml
@@ -13,6 +13,11 @@
         msg:
           - Entering the test-empty-config pre_software.yml
 
+    - when: fail_pre_software | default(false)
+      name: Fail the test-empty-config pre_software.yml if requested
+      fail:
+        msg: pre_software.yml failed as requested
+
     - name: Exiting the test-empty-config pre_software.yml
       debug:
         msg:

--- a/ansible/configs/test-empty-config/software.yml
+++ b/ansible/configs/test-empty-config/software.yml
@@ -13,6 +13,11 @@
         msg:
           - Entering the test-empty-config software.yml
 
+    - when: fail_software | default(false)
+      name: Fail the test-empty-config software.yml if requested
+      fail:
+        msg: software.yml failed as requested
+
     - name: Exiting the test-empty-config software.yml
       debug:
         msg:


### PR DESCRIPTION
##### SUMMARY
Added the ability to fail the test-empty-config at any stage

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME
test-empty-config

##### ADDITIONAL INFORMATION
(README up to date). Added a task to each stage including clour provider to fail via an optional boolean:

```
fail_pre_infra
fail_test_cloud_provider
fail_post_infra
fail_pre_software
fail_software
fail_post_software
```
For example:
`ansible-playbook main.yml -e @configs/test-empty-config/sample_vars.yml -e '{ "fail_software" : true }'
`