### PR TITLE
Fixes to updated AMI ids for Server 2012

### DIFF
--- a/ansible/configs/ans-tower-lab/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/ans-tower-lab/files/cloud_providers/ec2_cloud_template.j2
@@ -3,7 +3,7 @@ Mappings:
   RegionMapping:
     us-east-1:
       RHELAMI: ami-c998b6b2
-      WIN2012R2AMI: ami-067ff23da8261d1c7 # Windows_Server-2012-R2_RTM-English-64Bit-Base-
+      WIN2012R2AMI: ami-01a2180a66e81fae2  # Windows_Server-2012-R2_RTM-English-64Bit-Base-
     us-east-2:
       RHELAMI: ami-cfdafaaa
       WIN2012R2AMI: ami-0f472fb9bdac629b0 # Windows_Server-2012-R2_RTM-English-64Bit-Base-
@@ -13,7 +13,7 @@ Mappings:
       RHELAMI: ami-9fa343e7
     eu-central-1:
       RHELAMI: ami-d74be5b8
-      WIN2012R2AMI: ami-086486be06fe637e7 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019
+      WIN2012R2AMI: ami-0297bc3628de600e3 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019
     eu-west-1:
       RHELAMI: ami-bb9a6bc2
     eu-west-2:
@@ -24,13 +24,13 @@ Mappings:
       WIN2012R2AMI: ami-067e4426b17364c26 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
     ap-northeast-1:
       RHELAMI: ami-30ef0556
-      WIN2012R2AMI: ami-0b2a38bdf41532387 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
+      WIN2012R2AMI: ami-0eeeab3e23597eaae  # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
     ap-northeast-2:
       RHELAMI: ami-44db152a
       WIN2012R2AMI: ami-033a1501143ab3c9a # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
     ap-southeast-1:
       RHELAMI: ami-10bb2373
-      WIN2012R2AMI: ami-0b0123f1a50d17a38 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019
+      WIN2012R2AMI: ami-0c506e54506222e59  # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019
     ap-southeast-2:
       RHELAMI: ami-ccecf5af
       WIN2012R2AMI: ami-01048eb9bccc4829d # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09

--- a/ansible/configs/ansible-windows/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/ansible-windows/files/cloud_providers/ec2_cloud_template.j2
@@ -3,16 +3,16 @@ Mappings:
   RegionMapping:
     us-east-1:
       RHELAMI: ami-c998b6b2
-      WIN2012R2AMI: ami-067ff23da8261d1c7  # Windows_Server-2012-R2_RTM-English-64Bit-Base-
+      WIN2012R2AMI: ami-01a2180a66e81fae2  # Windows_Server-2012-R2_RTM-English-64Bit-Base-
     eu-central-1:
       RHELAMI: ami-d74be5b8
-      WIN2012R2AMI: ami-086486be06fe637e7 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019
+      WIN2012R2AMI: ami-0297bc3628de600e3 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019
     ap-northeast-1:
       RHELAMI: ami-30ef0556
-      WIN2012R2AMI: mi-0b2a38bdf41532387  # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
+      WIN2012R2AMI: ami-0eeeab3e23597eaae  # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
     ap-southeast-1:
       RHELAMI: ami-10bb2373
-      WIN2012R2AMI: ami-0b0123f1a50d17a38 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019
+      WIN2012R2AMI: ami-0c506e54506222e59  # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019
   DNSMapping:
     "us-east-1":
       domain: "us-east-1.compute.internal"


### PR DESCRIPTION
##### SUMMARY
Microsoft updated the AMIs for Server 2012 used by the following configs:

ans-tower-lab
ansible-windows

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
Updated both configs CF J2 template for 4 regions:

us-east-1
eu-central-1
ap-southeast-1
ap-northeast-1


