### PR TITLE
add *.example.com to default ssh conf

### DIFF
--- a/ansible/roles/set_env_authorized_key/files/host_ssh_config.j2
+++ b/ansible/roles/set_env_authorized_key/files/host_ssh_config.j2
@@ -1,4 +1,4 @@
-Host ec2* *.internal
+Host ec2* *.internal *.example.com
    User {{remote_user}}
    IdentityFile ~/.ssh/{{env_authorized_key}}.pem
    ForwardAgent yes


### PR DESCRIPTION
The *.example.com Host will be added to the ssh config file that is placed. This is in addition to the existing *.internal and ec2* so that we can support new deployments easily on OpenStack.