### PR TITLE
Add example.com to additional templates

### DIFF
--- a/ansible/roles/bastion-lite/files/bastion_ssh_config.j2
+++ b/ansible/roles/bastion-lite/files/bastion_ssh_config.j2
@@ -1,4 +1,4 @@
-Host ec2* *.internal
+Host ec2* *.internal *.example.com
   User {{remote_user}}
 {% if use_own_key|bool %}
   IdentityFile ~/.ssh/{{env_authorized_key}}.pem

--- a/ansible/roles/bastion/files/bastion_ssh_config.j2
+++ b/ansible/roles/bastion/files/bastion_ssh_config.j2
@@ -1,4 +1,4 @@
-Host ec2* *.internal
+Host ec2* *.internal *.example.com
   User {{remote_user}}
 {% if use_own_key|bool %}
   IdentityFile ~/.ssh/{{env_authorized_key}}.pem


### PR DESCRIPTION
Add `*.example.com` to additional ssh config templates for support of OpenStack environments.