### PR TITLE
Added use_ssh_args option to rsync task to copy workload files.

### DIFF
--- a/ansible/roles/ocp-workload-pam7-cc-dispute-dmn-pmml/tasks/pre_workload.yml
+++ b/ansible/roles/ocp-workload-pam7-cc-dispute-dmn-pmml/tasks/pre_workload.yml
@@ -38,6 +38,7 @@
     rsync_opts:
       - "--no-motd"
       - "--exclude=.git,*.qcow2"
+    use_ssh_args: true
 
 - name: pre_workload Tasks Complete
   debug:


### PR DESCRIPTION
##### SUMMARY
use_ssh_args needed in rsync tasks to copy files to node.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp-workload-pam7-cc-dispute-dmn-pmml

##### ADDITIONAL INFORMATION
Should fix this problem:

TASK [ocp-workload-pam7-cc-dispute-dmn-pmml : Copy the files used in this role] ***
Wednesday 18 December 2019 22:40:47 -0500 (0:00:01.493) 0:42:43.798 ****
fatal: [clientvm.test-7e17.internal]: FAILED! => {"changed": false, "cmd": "/usr/bin/rsync --delay-updates -F --compress --archive --rsh=/usr/bin/ssh -S none -i /home/opentlc-mgr/.ssh/opentlc_admin_backdoor.pem -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null --no-motd --exclude=.git,*.qcow2 --out-format=<>%i %n%L /tmp/sandboxes-gpte-OCP4_RHPAM_DMN_AI_DEMO-dev-test-7e17-3910/agnosticd/ansible/roles/ocp-workload-pam7-cc-dispute-dmn-pmml/files/ ec2-user@clientvm.test-7e17.internal:/tmp/test-7e17/", "msg": "ssh_exchange_identification: Connection closed by remote host\r\nrsync: connection unexpectedly closed (0 bytes received so far) [sender]\nrsync error: unexplained error (code 255) at io.c(605) [sender=3.0.9]\n", "rc": 255}