### PR TITLE
Enable FTL by default in ocp4-disco config

### DIFF
--- a/ansible/configs/ocp4-disconnected-osp-lab/env_vars.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/env_vars.yml
@@ -80,7 +80,7 @@ install_k8s_modules: false
 
 # FTL is used for grading and solving. It will pull in the external ftl-injector role.
 # This might be enabled when we have solvers to run or graders for ILT
-install_ftl: false
+install_ftl: true
 
 # TODO: Decide on whether to use sat or give access to repos directly with key
 # This will tell Agnosticd to use either:


### PR DESCRIPTION
Since we are beginning to add solvers and resets to FTL for labs that rely on this config, changing the env var to true by default for FTL.