### PR TITLE
FTL injector fixes for OCP4 disconnected config

### DIFF
--- a/ansible/configs/ocp4-disconnected-osp-lab/env_vars.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/env_vars.yml
@@ -82,6 +82,10 @@ install_k8s_modules: false
 # This might be enabled when we have solvers to run or graders for ILT
 install_ftl: true
 
+# FTL injector will try to install python-pip and we only have python3-pip available
+# This var will force the ftl-injector role to adapt accordingly
+ftl_use_python3: true
+
 # TODO: Decide on whether to use sat or give access to repos directly with key
 # This will tell Agnosticd to use either:
 # sattelite, rhn, or file for repos

--- a/ansible/configs/ocp4-disconnected-osp-lab/requirements.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/requirements.yml
@@ -3,4 +3,4 @@
 
 - src: https://github.com/redhat-gpte-devopsautomation/ftl-injector
   name: ftl-injector
-  version: v0.14
+  version: v0.15

--- a/ansible/configs/ocp4-disconnected-osp-lab/requirements.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/requirements.yml
@@ -3,4 +3,4 @@
 
 - src: https://github.com/redhat-gpte-devopsautomation/ftl-injector
   name: ftl-injector
-  version: v0.13
+  version: v0.14

--- a/ansible/roles/bastion-lite/tasks/main.yml
+++ b/ansible/roles/bastion-lite/tasks/main.yml
@@ -73,7 +73,7 @@
       name: ftl-injector
     vars:
       student_login: "{{ student_name }}"
-      use_python3: "{{ ftl_use_python3 }} | default(true)"
+      use_python3: "{{ ftl_use_python3 | default(true) }}"
 
 - name: Install jq on the bastion
   get_url:

--- a/ansible/roles/bastion-lite/tasks/main.yml
+++ b/ansible/roles/bastion-lite/tasks/main.yml
@@ -73,6 +73,7 @@
       name: ftl-injector
     vars:
       student_login: "{{ student_name }}"
+      use_python3: "{{ ftl_use_python3 }} | default(true)"
 
 - name: Install jq on the bastion
   get_url:


### PR DESCRIPTION
- add new env var for defining whether it will use python3
- rev ftl-injector to latest tag
- fix use_python3 var in bastion-lite role