### PR TITLE
Pre-install the NooBaa CLI on the bastion host

### DIFF
--- a/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/post_workload.yml
+++ b/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/post_workload.yml
@@ -1,6 +1,24 @@
 ---
 # Implement your Post Workload deployment tasks here
 
+- name: Get latest NooBaa CLI info from Github
+  uri:
+    url: https://api.github.com/repos/noobaa/noobaa-operator/releases/latest
+  register: noobaa_releases
+
+- name: Determine download URL for latest Noobaa CLI for Linux
+  set_fact:
+      noobaa_linux_download: "{{ item.browser_download_url }}"
+  with_items:
+    - "{{ noobaa_releases.json.assets }}"
+  when: "'linux' in item.browser_download_url"
+
+- name: Download latest NooBaa CLI
+  get_url:
+    url: "{{ noobaa_linux_download }}"
+    dest: /usr/bin/noobaa
+    mode: 'o=rx'
+
 # Leave this as the last task in the playbook.
 - name: post_workload tasks complete
   debug:


### PR DESCRIPTION
##### SUMMARY
Since the OC client is pre-installed, we should also pre-install this client.
This is used in the OCS4 module of the ocp4-workload-workshop-admin-storage workshop

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
NooBaa-CLI-installer
