### PR TITLE
ocp4-workload-ceph : Sanitize worker var before calling AWS helper scripts

### DIFF
--- a/ansible/roles/ocp4-workload-ceph/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-ceph/tasks/pre_workload.yml
@@ -63,6 +63,10 @@
       src: "{{ role_path }}/files/aws_helper.yaml"
       dest: "{{ ceph_workload_venv_path.path }}/aws_helper.yaml"
 
+  - name: "Sanitize worker list prior passing to AWS helper script"
+    set_fact:
+      ceph_worker_nodes_sane: "{{ ceph_worker_nodes | to_json }}"
+
   - name: "Running AWS helper scripts"
     shell: |
       ./bin/ansible-playbook aws_helper.yaml \
@@ -71,6 +75,6 @@
       -e aws_region={{ aws_region }} \
       -e ceph_cluster_id={{ ceph_cluster_id }} \
       -e ceph_workload_destroy={{ ceph_workload_destroy }} \
-      --extra-vars '{'ceph_worker_nodes':{{ ceph_worker_nodes }} }' \
+      --extra-vars '{'ceph_worker_nodes':{{ ceph_worker_nodes_sane }} }' \
     args:
       chdir: "{{ ceph_workload_venv_path.path }}"


### PR DESCRIPTION
**SUMMARY**
The worker nodes variable needs to be sanitized before passing to AWS helper script, this is to avoid python structures on values when calling helper script modules

**ISSUE TYPE**

Bugfix Pull Request

**COMPONENT NAME**

ocp4-workload-ceph

**ADDITIONAL INFORMATION**

This can be reproduced by running the ceph workload and inspecting the values passed to ec2_vol module, see sample : 
```
 "ok: [localhost]", "", "TASK [Provisioning new ebs volumes for worker nodes] ***************************", "failed: [localhost] (item={u'name': u'ui-0280e2ccb7ff4f242', u'aZone': u'ueu-west-1a'}) => {\"ansible_loop_var\": \"item\", \"changed\": false, \"item\": {\"aZone\": \"ueu-west-1a\", \"name\": \"ui-0280e2ccb7ff4f242\"}, \"msg\": \"Invalid id: \\\"ui-0280e2ccb7ff4f242\\\"\"}", "failed: [localhost] (item={u'name': u'ui-05c589efb2a7e1799', u'aZone': u'ueu-west-1b'}) => {\"ansible_loop_var\": \"item\", \"changed\": false, \"item\": {\"aZone\": \"ueu-west-1b\", \"name\": \"ui-05c589efb2a7e1799\"}, \"msg\": \"Invalid id: \\\"ui-05c589efb2a7e1799\\\"\"}", "failed: [localhost] (item={u'name': u'ui-01619f97ce5137ce3', u'aZone': u'ueu-west-1c'}) => {\"ansible_loop_var\": \"item\", \"changed\": false, \"item\": {\"aZone\": \"ueu-west-1c\", \"name\": \"ui-01619f97ce5137ce3\"}, \"msg\": \"Invalid id: \\\"ui-01619f97ce5137ce3\\\"\"}", "", "PLAY RECAP *********************************************************************", "localhost                  : ok=1    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   "]}
```
ansible-playbook is called with --extra-vars from a shell module passing worker_nodes_ceph, this is where the list of dicts gets mangled. Note the "u" elements on the values.