### PR TITLE
ocp4-workload-ceph: Switch cephcsi to stable image

### DIFF
--- a/ansible/roles/ocp4-workload-ceph/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-ceph/defaults/main.yml
@@ -1,7 +1,7 @@
 ceph_image: "ceph/ceph:v14.2.2-20190722"
 ceph_rook_operator_image: "rook/ceph:v1.0.0-306.g81dde4b"
 ceph_rook_toolbox_image: "rook/ceph:master"
-ceph_csi_image: "quay.io/cephcsi/cephcsi:canary"
+ceph_csi_image: "quay.io/cephcsi/cephcsi:v1.1.0"
 ceph_csi_provisioner_image: "quay.io/k8scsi/csi-provisioner:v1.2.0"
 ceph_csi_registrar_image: "quay.io/k8scsi/csi-node-driver-registrar:v1.1.0"
 ceph_csi_snapshotter_image: "quay.io/k8scsi/csi-snapshotter:v1.1.0"


### PR DESCRIPTION
**SUMMARY**
Ceph rbdplugin crashes when using cephcsi canary images

**ISSUE TYPE**

Bugfix Pull Request

**COMPONENT NAME**

ocp4-workload-ceph

**ADDITIONAL INFORMATION**

This can be reproduced by running the ceph workload and inspecting the pods on the rookio-ceph namespace : 
```
 NAME                                          READY     STATUS             RESTARTS   AGE
csi-cephfsplugin-7cv5b                        2/2       Running            0          5m
csi-cephfsplugin-mb7df                        2/2       Running            0          5m
csi-cephfsplugin-nwtv9                        2/2       Running            0          5m
csi-cephfsplugin-provisioner-0                3/3       Running            0          5m
csi-rbdplugin-j5hxq                           1/2       CrashLoopBackOff   5          5m
csi-rbdplugin-p2fxc                           1/2       CrashLoopBackOff   5          5m
csi-rbdplugin-provisioner-0                   3/4       CrashLoopBackOff   5          5m
csi-rbdplugin-t74dj                           1/2       CrashLoopBackOff   5          5m
rook-ceph-agent-7lhmw                         1/1       Running            0          5m
rook-ceph-agent-cnd5t                         1/1       Running            0          5m
rook-ceph-agent-lqtng                         1/1       Running            0          5m
rook-ceph-mds-myfs-a-754769b5fb-9hhsw         1/1       Running            0          1m
rook-ceph-mds-myfs-b-5fff54b99d-lsndn         1/1       Running            0          1m
rook-ceph-mgr-a-7f9df44477-7rz5q              1/1       Running            0          3m
rook-ceph-mon-a-556bb547f8-ml4s5              1/1       Running            0          4m
rook-ceph-mon-b-559b7bb848-87pp4              1/1       Running            0          4m
rook-ceph-mon-c-7667d765bb-gp4qb              1/1       Running            0          3m
rook-ceph-operator-6d6fc84b7f-49dwj           1/1       Running            0          6m
rook-ceph-osd-0-7b9c9f8ff9-jrcsm              1/1       Running            0          1m
rook-ceph-osd-1-649f89b647-8splb              1/1       Running            0          1m
rook-ceph-osd-2-56b647984f-rvgpk              1/1       Running            0          1m
rook-ceph-osd-prepare-ip-10-0-129-97-rznjv    0/2       Completed          0          2m
rook-ceph-osd-prepare-ip-10-0-135-101-tth5x   0/2       Completed          0          2m
rook-ceph-osd-prepare-ip-10-0-156-30-6d5s5    0/2       Completed          0          2m
rook-ceph-tools-5f5dc75fd5-bgplm              1/1       Running            0          1m
rook-discover-4kg5d                           1/1       Running            0          5m
rook-discover-ltxdc                           1/1       Running            0          5m
rook-discover-mhfp4                           1/1       Running            0          5m
```
The pods logs complain about an old flag "containerized" not being recognized any longer by cephcsi.
