### PR TITLE
OCP4 Disconnected DNS & Trunks

### DIFF
--- a/ansible/configs/ocp4-disconnected-osp-lab/destroy_env.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/destroy_env.yml
@@ -7,9 +7,11 @@
   gather_facts: false
   become: false
   tasks:
-    - name: Run infra-osp-resources-destroy role
+    - name: Run infra-osp-dns
       include_role:
-        name: infra-osp-resources-destroy
+        name: infra-osp-dns
+      vars:
+        _dns_state: absent
 
     - name: Remove DNS entry for OpenShift API and ingress
       nsupdate:
@@ -26,3 +28,7 @@
       when:
         - openshift_fip_provision
         - use_dynamic_dns
+
+    - name: Run infra-osp-resources-destroy role
+      include_role:
+        name: infra-osp-resources-destroy

--- a/ansible/configs/ocp4-disconnected-osp-lab/files/general-ms.yaml.j2
+++ b/ansible/configs/ocp4-disconnected-osp-lab/files/general-ms.yaml.j2
@@ -50,6 +50,6 @@ spec:
             openshiftClusterID: {{ lookup('env', 'INFRA_ID') }}
           tags:
           - openshiftClusterID={{ lookup('env', 'INFRA_ID') }}
-          trunk: true
+          trunk: false
           userDataSecret:
             name: worker-user-data


### PR DESCRIPTION
The `destroy_env` was missing the role to clean up bastion DNS entry. This adds that.

This PR also includes a change to disable trunk ports in the template machineset file provided for the labs using this config.