### PR TITLE
Fix deletion in osp-migration config

### DIFF
--- a/ansible/configs/osp-migration/destroy_env.yml
+++ b/ansible/configs/osp-migration/destroy_env.yml
@@ -50,11 +50,13 @@
       os_stack:
         name: "create-objects-{{ osp_project_name }}"
         state: absent
+        wait: true
 
     - name: Delete project and unassign permission
       os_stack:
         name: "create-project-{{ osp_project_name }}"
         state: absent
+        wait: true
 
     - name: Iterate over all instances and delete DNS entries
       loop: "{{ r_osp_facts.ansible_facts.openstack_servers }}"

--- a/ansible/configs/osp-migration/destroy_env.yml
+++ b/ansible/configs/osp-migration/destroy_env.yml
@@ -47,6 +47,8 @@
       register: r_osp_facts
 
     - name: Delete objects inside the project
+      environment:
+        OS_PROJECT_NAME: "{{ osp_project_name }}"
       os_stack:
         name: "create-objects-{{ osp_project_name }}"
         state: absent

--- a/ansible/configs/osp-migration/env_vars.yml
+++ b/ansible/configs/osp-migration/env_vars.yml
@@ -58,7 +58,7 @@ install_student_user: true
 install_ipa_client: false
 
 # TODO: What does this really do besides run the role?
-set_env_authorized_key: true
+set_env_authorized_key: false
 env_authorized_key: "{{guid}}key"
 key_name: "default_key_name"
 

--- a/ansible/configs/osp-migration/infra.yml
+++ b/ansible/configs/osp-migration/infra.yml
@@ -7,6 +7,8 @@
     - set_fact:
         api_pass: "{{ lookup('password', '/dev/null length=20 chars=ascii_letters') }}"
 
+    - import_tasks: pull_repo.yml
+
     - name: Check if project exists
       environment:
         OS_AUTH_URL: "{{ osp_auth_url }}"
@@ -34,7 +36,7 @@
         OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"
       os_stack:
         name: "create-project-{{osp_project_name}}"
-        template: "files/templates/{{ project }}/stack_admin.yaml"
+        template: "{{ output_dir }}/imported-templates/heat-templates/{{ project }}/stack_admin.yaml"
         parameters:
           project_name: "{{ osp_project_name }}"
           project_guid: "{{ guid }}"
@@ -69,7 +71,7 @@
         OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"
       os_stack:
         name: "create-objects-{{osp_project_name}}"
-        template: "files/templates/{{ project }}/stack_user.yaml"
+        template: "{{ output_dir }}/imported-templates/heat-templates/{{ project }}/stack_user.yaml"
         parameters:
           project_name: "{{ osp_project_name }}"
           public_net_id: "{{ external_network }}"

--- a/ansible/configs/osp-migration/instance_loop.yml
+++ b/ansible/configs/osp-migration/instance_loop.yml
@@ -9,4 +9,7 @@
     - "{{ _instance.metadata.hostname | regex_replace('-' ~ guid ~ '$', '-' ~ guid ~ '.' + guid) }}"
   loop_control:
     loop_var: _dns
+
+  # safety: Create DNS only when GUID is included in the hostname
+  when: guid in _dns
   include_tasks: dns_loop.yml

--- a/ansible/configs/osp-migration/pull_repo.yml
+++ b/ansible/configs/osp-migration/pull_repo.yml
@@ -1,0 +1,31 @@
+---
+- name: Ensure secret directory exists in output_dir
+  file:
+    path: "{{ output_dir }}/secrets"
+    state: directory
+
+- fail:
+    msg: >-
+      You must define heat_templates_private_repo
+  when: heat_templates_private_repo is not defined
+
+- fail:
+    msg: >-
+      You must define heat_templates_private_key_content in
+      order to pull the templates from the private repository.
+  when: heat_templates_private_key_content is not defined
+
+- name: Copy content of the SSH key file
+  copy:
+    content: "{{ heat_templates_private_key_content }}"
+    dest: "{{ output_dir }}/secrets/heat_templates_private_key"
+    mode: 0600
+
+- name: Download the templates
+  git:
+    repo: "{{ heat_templates_private_repo }}"
+    version: master
+    accept_hostkey: true
+    depth: 1
+    dest: "{{ output_dir }}/imported-templates"
+    key_file: "{{ output_dir }}/secrets/heat_templates_private_key"

--- a/ansible/configs/osp-migration/pull_repo.yml
+++ b/ansible/configs/osp-migration/pull_repo.yml
@@ -21,7 +21,7 @@
     dest: "{{ output_dir }}/secrets/heat_templates_private_key"
     mode: 0600
 
-- name: Download the templates
+- name: Download the templates from the private repository
   git:
     repo: "{{ heat_templates_private_repo }}"
     version: master

--- a/ansible/configs/osp-migration/requirements.yml
+++ b/ansible/configs/osp-migration/requirements.yml
@@ -1,6 +1,0 @@
----
-# External role to setup grader host virtualenv and FTL grading infra
-
-- src: https://github.com/redhat-gpte-devopsautomation/ftl-injector
-  name: ftl-injector
-  version: v0.15

--- a/ansible/configs/osp-migration/sample_vars.yml
+++ b/ansible/configs/osp-migration/sample_vars.yml
@@ -2,7 +2,8 @@
 guid: testgucore
 env_type: osp-migration
 
-project: dev-ansible-tower-implementation-3.3-v6
+#project: dev-ansible-tower-implementation-3.3-v6
+project: EMEA-PC-azure-gold-image-bp
 
 
 # For this config we don't use any *common* agnosticd cloud-provider

--- a/ansible/configs/osp-migration/sample_vars.yml
+++ b/ansible/configs/osp-migration/sample_vars.yml
@@ -2,8 +2,8 @@
 guid: gucore3
 env_type: osp-migration
 
-#project: dev-ansible-tower-implementation-3.3-v6
-project: EMEA-PC-azure-gold-image-bp
+project: dev-ansible-tower-implementation-3.3-v6
+#project: EMEA-PC-azure-gold-image-bp
 
 cloud_provider: osp
 

--- a/ansible/configs/osp-migration/sample_vars.yml
+++ b/ansible/configs/osp-migration/sample_vars.yml
@@ -1,16 +1,13 @@
 ---
-guid: testgucore
+guid: gucore3
 env_type: osp-migration
 
 #project: dev-ansible-tower-implementation-3.3-v6
 project: EMEA-PC-azure-gold-image-bp
 
-
-# For this config we don't use any *common* agnosticd cloud-provider
-# instead, the infrastructure part is done in infra.yml
 cloud_provider: osp
 
-admin_user: guillaume
+admin_user: gucore
 
 student_name: guillaume
 

--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -79,7 +79,7 @@
     - step004
     - deploy_software
 
-- import_playbook: "./software_playbooks/{{ software_to_deploy | d('none')}}.yml"
+- import_playbook: "./software_playbooks/{{ software_to_deploy | d('none') }}.yml"
   tags:
     - step004
     - deploy_software


### PR DESCRIPTION
##### SUMMARY
OS PROJECT NAME was missing in the task responsible of the deletion of the user stack.

This PR if applied will fix that.

The PR also contains minor changes:

- Do not create DNS names if the name doesn't include the GUID (failsafe)
- wait for the stack to be deleted, do not fire & forget
- remove unused comments
- add space in jinja2 anchors (style)
- automatically import templates from the redhat-gpe private repo

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
