### PR TITLE
infra-aws-sandbox: Add new AWS accounts to aws-nuke blacklist

### DIFF
--- a/ansible/roles/infra-aws-sandbox/defaults/main.yml
+++ b/ansible/roles/infra-aws-sandbox/defaults/main.yml
@@ -34,9 +34,14 @@ aws_nuke_binary_url: https://github.com/rebuy-de/aws-nuke/releases/download/v2.1
 
 aws_nuke_account_blacklist:
   - 017310218799 # Master account
-  - 627202319003 # OPENTLC infrastructure
-  - 719622469867 # GPE
+  - 627202319003 # OPENTLC Events
+  - 962799139175 # OPENTLC
+  - 719622469867 # GPE (RHPDS prod)
   - 550201621713 # openshift BU
+  - 124572886817 # AWS dev/test
+  - 809721187735 # GPTE infrastructure
+  - 384299329206 # GPTE ILT
+  -
 
 aws_nuke_retries: 3
 


### PR DESCRIPTION
The infra-aws-sandbox role should never be run against a non-sandbox AWS account.

BUT, just in case, we blacklist our known accounts as a failsafe.

if an account is in `aws_nuke_account_blacklist`, aws-nuke will just won't do
anything.
