### PR TITLE
Introduce default_vars.yml

### DIFF
--- a/ansible/include_vars.yml
+++ b/ansible/include_vars.yml
@@ -11,23 +11,45 @@
         output_dir: "{{ hostvars.localhost.output_dir }}"
       when: hostvars.localhost.output_dir is defined
 
-    - name: stats env_vars.yml and (legacy) env_secret_vars.yml
+    - name: Stat default variables files (both yaml/yml extensions)
+      vars:
+        find_me:
+          # Global default vars related to the cloud provider
+          - cloud_providers/{{ cloud_provider }}_default_vars
+          # Legacy env_vars.yml (replaced by default_vars.yml)
+          - configs/{{ env_type }}/env_vars
+          # Default vars of the config
+          - configs/{{ env_type }}/default_vars
+          # Default vars of the config, specific to a cloud provider
+          - configs/{{ env_type }}/default_vars.{{ cloud_provider }}
+          - configs/{{ env_type }}/default_vars_{{ cloud_provider }}
+          # Lecacy secret vars file.
+          - configs/{{ env_type }}/env_secret_vars
+        extensions:
+          - yaml
+          - yml
       stat:
-        path: "{{ item }}"
-      loop:
-        - cloud_providers/{{ cloud_provider }}_default_vars.yml
-        - configs/{{ env_type }}/env_vars.yml
-        - configs/{{ env_type }}/env_secret_vars.yml
-        - "{{ secret_file | d('/secret/file/not/passed') }}"
+        path: "{{ item[0] ~ '.' ~ item[1] }}"
+      loop: "{{ find_me | product(extensions) | list }}"
       register: rstat_varfiles
 
-    - name: Include vars files
+    - name: Stat variables files
+      vars:
+        find_me:
+          # secret file path passed as extra-var
+          - "{{ secret_file | d('/secret/file/not/passed') }}"
+      stat:
+        path: "{{ item }}"
+      loop: "{{ find_me }}"
+      register: rstat2_varfiles
+
+    - name: Include variables files
       include_vars:
         file: "{{ item.stat.path }}"
       when:
         - item is not skipped
         - item.stat.exists
-      loop: "{{ rstat_varfiles.results }}"
+      loop: "{{ rstat_varfiles.results + rstat2_varfiles.results }}"
       loop_control:
         label: >-
           {{ (


### PR DESCRIPTION
`env_vars.yml` is a bad name and should be renamed to `default_vars.yml`.

This commit if applied, will update the `include_vars.yml` play so it looks
for the following files and include them if they exist:

- `cloud_providers/{{ cloud_provider }}_default_vars.yml`
  Global default vars related to the cloud provider
- `configs/{{ env_type }}/env_vars.yml`
  Legacy env_vars.yml (replaced by default_vars.yml)
- `configs/{{ env_type }}/default_vars.yml`
  Default vars of the config
- `configs/{{ env_type }}/default_vars.{{ cloud_provider }}.yml`
  `configs/{{ env_type }}/default_vars_{{ cloud_provider }}.yml`
  Default vars of the config, specific to a cloud provider
-  `configs/{{ env_type }}/env_secret_vars.yml`
  Lecacy secret vars file.

In order not to break current configs, `env_vars.yml` files are still included as
before.

This commit also makes it possible to have default vars for each cloud provider,
for example, it is now possible to have those files in a config:

```yaml
default_vars.yml
default_vars_osp.yml
default_vars_ec2.yml
```


##### ISSUE TYPE
 Feature Pull Request

##### COMPONENT NAME
Core: `include_vars.yml`
##### ADDITIONAL INFORMATION
tested with ansible 2.9.1
