### PR TITLE
rename roles for OCP migration training

### DIFF
--- a/ansible/roles/ocp-workload-migration-training/README.adoc
+++ b/ansible/roles/ocp-workload-migration-training/README.adoc
@@ -1,0 +1,68 @@
+= Cluster Application Migration Workload
+
+== Overview
+
+The workload includes migration operator which deploys migration controller, migration ui and Velero.
+
+== Supported Versions
+
+This workload supports following versions of Cluster Application Migration Tool
+
+- release-1.0
+
+Older version are no longer supported
+
+=== Deploy the workload
+[source,'bash']
+----
+ansible-playbook -i "bastion.${GUID}.${BASE_DOMAIN}", ./ansible/configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=${ANSIBLE_USER_KEY_FILE}" \
+    -e"ansible_user=${ANSIBLE_USER}" \
+    -e"ocp_workload=ocp-workload-migration" \
+    -e"silent=False" \
+    -e"ACTION=create" \
+    -e @./secret.yaml <1> \
+    -e @./workload.yaml <2>
+----
+<1> This is the file you used when deploying your cluster with AgnosticD.
+<2> All variables required by the workload go in this file.
+
+=== Variables
+
+This workload does not require any variables. Following variables can be overridden if you do not want default behaviour.
+
+|===
+| Variable | Default Value | Description
+
+| mig_operator_repo
+| https://github.com/fusor/mig-operator
+| Repository for migration operator
+
+| mig_operator_repo_branch
+| master
+| Branch in operator repo
+
+| mig_operator_version
+| latest
+| Migration operator version 
+
+| mig_ocp_version
+| 4
+| Version of OpenShift cluster
+|===
+
+
+=== Delete the workload
+
+[source,'bash']
+----
+ansible-playbook -i "bastion.${GUID}.${BASE_DOMAIN}", ./ansible/configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=${ANSIBLE_USER_KEY_FILE}" \
+    -e"ansible_user=${ANSIBLE_USER}" \
+    -e"ocp_workload=ocp-workload-migration" \
+    -e"silent=False" \
+    -e"ACTION=delete" \
+    -e @./secret.yaml \
+    -e @./workload.yaml
+----
+

--- a/ansible/roles/ocp-workload-migration-training/defaults/main.yml
+++ b/ansible/roles/ocp-workload-migration-training/defaults/main.yml
@@ -1,0 +1,8 @@
+mig_operator_repo: https://github.com/fusor/mig-operator
+mig_operator_repo_branch: master
+mig_operator_version: latest
+mig_ocp_version: 3
+
+# workload vars
+silent: false
+

--- a/ansible/roles/ocp-workload-migration-training/files/cors.yaml
+++ b/ansible/roles/ocp-workload-migration-training/files/cors.yaml
@@ -1,0 +1,42 @@
+---
+- hosts: masters
+  vars:
+    ansible_user: ec2-user
+    route: "{{ lookup('env', 'ROUTE') }}"
+    corsOrigin: "- (?i)//{{ route | replace('.','\\.') }}(:|\\z)"
+  tasks:
+  - block:
+      - debug:
+          msg: "CORS Origin to add: {{corsOrigin}}"
+
+      - name: "Adding new CORS rules"
+        lineinfile:
+          insertafter: "corsAllowedOrigins:"
+          #line: "- (?i)//migration-mig\\.apps\\.cluster-{{ guid_v4 }}\\.{{ guid_v4 }}\\.{{ subdomain }}"
+          line: "{{ corsOrigin }}"
+          path: /etc/origin/master/master-config.yaml
+        become: yes
+
+      - name: "Checking if atomic-openshift services exist"
+        shell: "systemctl status atomic-openshift-master-api"
+        register: status
+        become: yes
+        ignore_errors: yes
+
+      - name: "Applying new configuration [atomic-openshift services]"
+        service:
+          name: "{{ item }}"
+          state: restarted
+        loop:
+          - atomic-openshift-master-api
+          - atomic-openshift-master-controllers
+        become: yes
+        when: status.rc == 0
+
+      - name: "Applying new configuration [master-restart]"
+        shell: "/usr/local/bin/master-restart {{ item }}"
+        loop:
+          - api
+          - controller
+        when: status.rc != 0
+        become: yes

--- a/ansible/roles/ocp-workload-migration-training/files/lab8/deploy.sh
+++ b/ansible/roles/ocp-workload-migration-training/files/lab8/deploy.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# deploys "Hello, OpenShift" app to random X number of namespaces
+
+echo "Number of namespaces? "; read x
+
+echo $x > .ns
+
+ns_prefix="hello-openshift-"
+app_manifest=https://raw.githubusercontent.com/openshift/origin/master/examples/hello-openshift/hello-pod.json
+
+for i in $(seq 1 $x); do
+	oc create namespace "$ns_prefix""$i"
+        oc apply -f $app_manifest -n "$ns_prefix""$i"
+        oc expose pod hello-openshift -n "$ns_prefix""$i"
+        oc expose svc hello-openshift -n "$ns_prefix""$i"
+done
+
+echo "Finding routes..."
+
+for i in $(seq 1 $x); do
+	oc get route hello-openshift -n "$ns_prefix""$i" -o go-template='{{ .spec.host }}{{ println }}'
+done
+ 

--- a/ansible/roles/ocp-workload-migration-training/files/lab8/destroy.sh
+++ b/ansible/roles/ocp-workload-migration-training/files/lab8/destroy.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# deletes "Hello, OpenShift" app previously deployed to X namespaces using deploy.sh
+
+x=$(cat .ns)
+
+ns_prefix="hello-openshift-"
+app_manifest=https://raw.githubusercontent.com/openshift/origin/master/examples/hello-openshift/hello-pod.json
+
+for i in $(seq 1 $x); do
+	oc delete project "$ns_prefix""$i"
+done
+
+echo "Done..." 

--- a/ansible/roles/ocp-workload-migration-training/files/lab8/probe.sh
+++ b/ansible/roles/ocp-workload-migration-training/files/lab8/probe.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# wgets routes created in previously deployed "Hello,OpenShift" app
+
+GREEN='\033[0;33m'
+NC='\033[0m'
+
+x=$(cat .ns)
+
+ns_prefix="hello-openshift-"
+
+for i in $(seq 1 $x); do
+        echo -e "${GREEN}Probing app in namespace ""$ns_prefix""$i""${NC}"	
+	route=$(oc get route hello-openshift -n "$ns_prefix""$i" -o go-template='{{ .spec.host }}{{ println }}')
+	curl http://${route}
+done
+ 

--- a/ansible/roles/ocp-workload-migration-training/tasks/main.yml
+++ b/ansible/roles/ocp-workload-migration-training/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- name: Running Pre Workload Tasks
+  import_tasks: ./pre_workload.yml
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload Tasks
+  import_tasks: ./workload.yml
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  import_tasks: ./post_workload.yml
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Remove Workload Tasks
+  import_tasks: ./remove_workload.yml
+  when: ACTION == "remove"

--- a/ansible/roles/ocp-workload-migration-training/tasks/post_workload.yml
+++ b/ansible/roles/ocp-workload-migration-training/tasks/post_workload.yml
@@ -1,0 +1,24 @@
+---
+# Implement your Post Workload deployment tasks here
+
+# Leave these as the last tasks in the playbook
+
+# For deployment onto a dedicated cluster (as part of the
+# cluster deployment) set workload_shared_deployment to False
+# This is the default so it does not have to be set explicitely
+- name: pre_workload tasks complete
+  debug:
+    msg: "Post-Workload tasks completed successfully."
+  when:
+  - not silent|bool
+  - not workload_shared_deployment|d(False)
+
+# For RHPDS deployment (onto a shared cluster) set
+# workload_shared_deployment to True
+# (in the deploy script or AgnosticV configuration)
+- name: pre_workload tasks complete
+  debug:
+    msg: "Post-Software checks completed successfully"
+  when:
+  - not silent|bool
+  - workload_shared_deployment|d(False)

--- a/ansible/roles/ocp-workload-migration-training/tasks/pre_workload.yml
+++ b/ansible/roles/ocp-workload-migration-training/tasks/pre_workload.yml
@@ -1,0 +1,47 @@
+---
+# Implement your Pre Workload deployment tasks here
+
+
+- wait_for:
+    port: 22
+    host: "bastion.{{ guid }}.internal"
+    timeout: 5
+  register: status
+  ignore_errors: true
+
+- name: copy lab scripts to bastion
+  delegate_to: "{{ bastion_host | d( groups.bastions | first ) }}"
+  become: true
+  copy:
+    src: "{{ role_path }}/files/"
+    dest: "/root/"
+
+- name: "Downloading CPMA binary to bastion"
+  delegate_to: "{{ bastion_host | d( groups.bastions | first ) }}"
+  become: true
+  get_url:
+    url: "https://cpma.s3.us-east-2.amazonaws.com/cpma"
+    dest: "/root/cpma"
+    mode: "u+rwx"
+
+# Leave these as the last tasks in the playbook
+
+# For deployment onto a dedicated cluster (as part of the
+# cluster deployment) set workload_shared_deployment to False
+# This is the default so it does not have to be set explicitely
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Workload tasks completed successfully."
+  when:
+  - not silent|bool
+  - not workload_shared_deployment|d(False)
+
+# For RHPDS deployment (onto a shared cluster) set
+# workload_shared_deployment to True
+# (in the deploy script or AgnosticV configuration)
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Software checks completed successfully"
+  when:
+  - not silent|bool
+  - workload_shared_deployment|d(False)

--- a/ansible/roles/ocp-workload-migration-training/tasks/remove_workload.yml
+++ b/ansible/roles/ocp-workload-migration-training/tasks/remove_workload.yml
@@ -1,0 +1,9 @@
+---
+- name: "Removing controller and operator"
+  debug: msg="Not Implemented"
+
+# Leave this as the last task in the playbook.
+- name: remove_workload tasks complete
+  debug:
+    msg: "Remove Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp-workload-migration-training/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-migration-training/tasks/workload.yml
@@ -1,0 +1,15 @@
+---
+# Implement your Workload deployment tasks here
+
+- name: Setting up workload for user
+  debug:
+    msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
+
+- name: "Creating controller and operator"
+  debug: msg="Student creates the workload"
+
+# Leave this as the last task in the playbook.
+- name: workload tasks complete
+  debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp4-workload-migration-training/README.adoc
+++ b/ansible/roles/ocp4-workload-migration-training/README.adoc
@@ -1,0 +1,68 @@
+= Cluster Application Migration Workload
+
+== Overview
+
+The workload includes migration operator which deploys migration controller, migration ui and Velero.
+
+== Supported Versions
+
+This workload supports following versions of Cluster Application Migration Tool
+
+- release-1.0
+
+Older version are no longer supported
+
+=== Deploy the workload
+[source,'bash']
+----
+ansible-playbook -i "bastion.${GUID}.${BASE_DOMAIN}", ./ansible/configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=${ANSIBLE_USER_KEY_FILE}" \
+    -e"ansible_user=${ANSIBLE_USER}" \
+    -e"ocp_workload=ocp-workload-migration" \
+    -e"silent=False" \
+    -e"ACTION=create" \
+    -e @./secret.yaml <1> \
+    -e @./workload.yaml <2>
+----
+<1> This is the file you used when deploying your cluster with AgnosticD.
+<2> All variables required by the workload go in this file.
+
+=== Variables
+
+This workload does not require any variables. Following variables can be overridden if you do not want default behaviour.
+
+|===
+| Variable | Default Value | Description
+
+| mig_operator_repo
+| https://github.com/fusor/mig-operator
+| Repository for migration operator
+
+| mig_operator_repo_branch
+| master
+| Branch in operator repo
+
+| mig_operator_version
+| latest
+| Migration operator version 
+
+| mig_ocp_version
+| 4
+| Version of OpenShift cluster
+|===
+
+
+=== Delete the workload
+
+[source,'bash']
+----
+ansible-playbook -i "bastion.${GUID}.${BASE_DOMAIN}", ./ansible/configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=${ANSIBLE_USER_KEY_FILE}" \
+    -e"ansible_user=${ANSIBLE_USER}" \
+    -e"ocp_workload=ocp-workload-migration" \
+    -e"silent=False" \
+    -e"ACTION=delete" \
+    -e @./secret.yaml \
+    -e @./workload.yaml
+----
+

--- a/ansible/roles/ocp4-workload-migration-training/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-migration-training/defaults/main.yml
@@ -1,0 +1,7 @@
+mig_operator_repo: https://github.com/fusor/mig-operator
+mig_operator_repo_branch: master
+mig_operator_version: release-1.0
+mig_ocp_version: 4
+
+# workload vars
+silent: false

--- a/ansible/roles/ocp4-workload-migration-training/files/probe.sh
+++ b/ansible/roles/ocp4-workload-migration-training/files/probe.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# wgets routes created in previously deployed "Hello,OpenShift" app
+
+GREEN='\033[0;33m'
+NC='\033[0m'
+
+x=5
+
+ns_prefix="hello-openshift-"
+
+for i in $(seq 1 $x); do
+        echo -e "${GREEN}Probing app in namespace ""$ns_prefix""$i""${NC}"	
+	route=$(oc get route hello-openshift -n "$ns_prefix""$i" -o go-template='{{ .spec.host }}{{ println }}')
+	curl http://${route}
+done
+ 

--- a/ansible/roles/ocp4-workload-migration-training/tasks/main.yml
+++ b/ansible/roles/ocp4-workload-migration-training/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- name: Running Pre Workload Tasks
+  import_tasks: ./pre_workload.yml
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload Tasks
+  import_tasks: ./workload.yml
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  import_tasks: ./post_workload.yml
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Remove Workload Tasks
+  import_tasks: ./remove_workload.yml
+  when: ACTION == "remove"

--- a/ansible/roles/ocp4-workload-migration-training/tasks/post_workload.yml
+++ b/ansible/roles/ocp4-workload-migration-training/tasks/post_workload.yml
@@ -1,0 +1,24 @@
+---
+# Implement your Post Workload deployment tasks here
+
+# Leave these as the last tasks in the playbook
+
+# For deployment onto a dedicated cluster (as part of the
+# cluster deployment) set workload_shared_deployment to False
+# This is the default so it does not have to be set explicitely
+- name: pre_workload tasks complete
+  debug:
+    msg: "Post-Workload tasks completed successfully."
+  when:
+  - not silent|bool
+  - not workload_shared_deployment|d(False)
+
+# For RHPDS deployment (onto a shared cluster) set
+# workload_shared_deployment to True
+# (in the deploy script or AgnosticV configuration)
+- name: pre_workload tasks complete
+  debug:
+    msg: "Post-Software checks completed successfully"
+  when:
+  - not silent|bool
+  - workload_shared_deployment|d(False)

--- a/ansible/roles/ocp4-workload-migration-training/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-migration-training/tasks/pre_workload.yml
@@ -1,0 +1,24 @@
+---
+# Implement your Pre Workload deployment tasks here
+
+# Leave these as the last tasks in the playbook
+
+# For deployment onto a dedicated cluster (as part of the
+# cluster deployment) set workload_shared_deployment to False
+# This is the default so it does not have to be set explicitely
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Workload tasks completed successfully."
+  when:
+  - not silent|bool
+  - not workload_shared_deployment|d(False)
+
+# For RHPDS deployment (onto a shared cluster) set
+# workload_shared_deployment to True
+# (in the deploy script or AgnosticV configuration)
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Software checks completed successfully"
+  when:
+  - not silent|bool
+  - workload_shared_deployment|d(False)

--- a/ansible/roles/ocp4-workload-migration-training/tasks/remove_workload.yml
+++ b/ansible/roles/ocp4-workload-migration-training/tasks/remove_workload.yml
@@ -1,0 +1,12 @@
+---
+# Implement your Workload removal tasks here
+
+- name: "Removing controller and operator"
+  debug:
+    msg: "Not implemented"
+
+# Leave this as the last task in the playbook.
+- name: remove_workload tasks complete
+  debug:
+    msg: "Remove Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp4-workload-migration-training/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-migration-training/tasks/workload.yml
@@ -1,0 +1,19 @@
+---
+# Implement your Workload deployment tasks here
+
+- name: Setting up workload for user
+  debug:
+    msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
+
+
+- name: copy lab scripts to bastion
+  become: true
+  copy:
+    src: "{{ role_path }}/files/"
+    dest: "/home/{{ student_name }}/"
+
+# Leave this as the last task in the playbook.
+- name: workload tasks complete
+  debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp4-workload-migration-training/templates/migstorage.yaml.j2
+++ b/ansible/roles/ocp4-workload-migration-training/templates/migstorage.yaml.j2
@@ -1,0 +1,35 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: openshift-migration
+  name: migstorage-creds
+type: Opaque
+data:
+  aws-access-key-id: {{ noobaa_key|b64encode }}
+  aws-secret-access-key: {{ noobaa_secret|b64encode }}
+---
+apiVersion: migration.openshift.io/v1alpha1
+kind: MigStorage
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: migstorage-sample
+  namespace: openshift-migration
+spec:
+  backupStorageProvider: aws
+  volumeSnapshotProvider: aws
+
+  backupStorageConfig:
+    awsBucketName: first.bucket
+    awsS3ForcePathStyle: true
+    awsS3Url: {{ noobaa_s3_url }}
+    credsSecretRef:
+      namespace: openshift-migration
+      name: migstorage-creds
+
+  volumeSnapshotConfig:
+    awsRegion: {{ noobaa_region }}
+    credsSecretRef:
+      namespace: openshift-migration
+      name: migstorage-creds


### PR DESCRIPTION
##### SUMMARY
OCP migration team requested forking to a new name of (very simple) roles dedicated to training because they are SO DIFFERENT from Engineering's roles that they use for hack-fests, RHTE, Summit, CI, etc.

##### ISSUE TYPE
- New role Pull Request

##### COMPONENT NAME
ocp-workload-migration -> ocp-workload-migration-training

##### ADDITIONAL INFORMATION
No significant changes.
