### PR TITLE
Add logging curator configuration to enable log cleanup

### DIFF
--- a/ansible/roles/ocp4-workload-logging/files/curator_configmap.yaml
+++ b/ansible/roles/ocp4-workload-logging/files/curator_configmap.yaml
@@ -1,0 +1,68 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: curator
+  namespace: openshift-logging
+data:
+  actions.yaml: |
+    # ---
+    # Remember, leave a key empty if there is no value.  None will be a string,
+    # not a Python "NoneType"
+    #
+    # Also remember that all examples have 'disable_action' set to True.  If you
+    # want to use this action as a template, be sure to set this to False after
+    # copying it.
+    # actions:
+    #   1:
+    #     action: delete_indices
+    #     description: >-
+    #       Delete .operations indices older than 30 days.
+    #       Ignore the error if the filter does not
+    #       result in an actionable list of indices (ignore_empty_list).
+    #       See https://www.elastic.co/guide/en/elasticsearch/client/curator/5.2/ex_delete_indices.html
+    #     options:
+    #       # Swallow curator.exception.NoIndices exception
+    #       ignore_empty_list: True
+    #       # In seconds, default is 300
+    #       timeout_override: ${CURATOR_TIMEOUT}
+    #       # Don't swallow any other exceptions
+    #       continue_if_exception: False
+    #       # Optionally disable action, useful for debugging
+    #       disable_action: False
+    #     # All filters are bound by logical AND
+    #     filters:
+    #     - filtertype: pattern
+    #       kind: regex
+    #       value: '^\.operations\..*$'
+    #       exclude: False
+    #     - filtertype: age
+    #       # Parse timestamp from index name
+    #       source: name
+    #       direction: older
+    #       timestring: '%Y.%m.%d'
+    #       unit: days
+    #       unit_count: 30
+    #       exclude: False
+  config.yaml: |
+    # Logging curator configuration for Red Hat GPTE Clustgers
+
+    # Delete all non-specifiec projects after 1 week
+    .defaults:
+      delete:
+        days: 7
+
+    # Delete operators logs after 4 weeks
+    .operations:
+      delete:
+        weeks: 4
+
+    # Delete logs for pods in 'openshift-*' projects after 2 weeks
+    .regex:
+    - pattern: 'openshift-$'
+      delete:
+        weeks: 2
+  curator5.yaml: "---\nclient:\n  hosts:\n  - ${ES_HOST}\n  port: ${ES_PORT}\n  use_ssl:
+    True\n  certificate: ${ES_CA}\n  client_cert: ${ES_CLIENT_CERT}\n  client_key:
+    ${ES_CLIENT_KEY}\n  ssl_no_validate: False\n  timeout: ${CURATOR_TIMEOUT}\n  master_only:
+    False\nlogging:\n  loglevel: ${CURATOR_LOG_LEVEL}\n  logformat: default\n  blacklist:
+    ['elasticsearch', 'urllib3']\n  \n"

--- a/ansible/roles/ocp4-workload-logging/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-logging/tasks/workload.yml
@@ -89,6 +89,17 @@
     until: 
     - r_logging.resources[0].status.logStore.elasticsearchStatus[0].clusterHealth == "green"
 
+  - name: Update Logging Curator configuration
+    k8s:
+      state: present
+      merge_type:
+      - strategic-merge
+      - merge
+      definition: "{{ lookup('file', item ) | from_yaml }}"
+    ignore_errors: yes
+    loop:
+    - ./files/curator_configmap.yaml
+
 # Leave this as the last task in the playbook.
 - name: workload tasks complete
   debug:


### PR DESCRIPTION
Add logging curation defaults to the logging role to prevent disks from filling up.