### PR TITLE
Revert "ssh_config template update for bastion and set_env_authorized_key roles"

### DIFF
--- a/ansible/roles/bastion/files/bastion_ssh_config.j2
+++ b/ansible/roles/bastion/files/bastion_ssh_config.j2
@@ -1,4 +1,3 @@
-{% if cloud_provider == 'ec2' %}
 Host ec2* *.internal *.example.com
   User {{remote_user}}
 {% if use_own_key|bool %}
@@ -10,18 +9,3 @@ Host ec2* *.internal *.example.com
   StrictHostKeyChecking no
   ConnectTimeout 60
   ConnectionAttempts 10
-{% endif %}
-{% if cloud_provider == 'osp' %}
-{% set ip_octet = hostvars['bastion'].private_ip_address.split('.') %}
-Host {{ ip_octet[0]+'.'+ip_octet[1] }}.*
-  User {{remote_user}}
-{% if use_own_key|bool %}
-  IdentityFile ~/.ssh/{{env_authorized_key}}.pem
-{% else %}
-  IdentityFile ~/.ssh/{{key_name}}.pem
-{% endif %}
-  ForwardAgent yes
-  StrictHostKeyChecking no
-  ConnectTimeout 60
-  ConnectionAttempts 10
-{% endif %}

--- a/ansible/roles/set_env_authorized_key/files/host_ssh_config.j2
+++ b/ansible/roles/set_env_authorized_key/files/host_ssh_config.j2
@@ -1,4 +1,3 @@
-{% if cloud_provider == 'ec2' %}
 Host ec2* *.internal *.example.com
    User {{remote_user}}
    IdentityFile ~/.ssh/{{env_authorized_key}}.pem
@@ -6,15 +5,3 @@ Host ec2* *.internal *.example.com
    StrictHostKeyChecking no
    ConnectTimeout 60
    ConnectionAttempts 10
-{% endif %}
-
-{% if cloud_provider == 'osp' %}
-{% set ip_octet = hostvars['bastion'].private_ip_address.split('.') %}
-Host {{ ip_octet[0]+'.'+ip_octet[1] }}.*
-   User {{remote_user}}
-   IdentityFile ~/.ssh/{{env_authorized_key}}.pem
-   ForwardAgent yes
-   StrictHostKeyChecking no
-   ConnectTimeout 60
-   ConnectionAttempts 10
-{% endif %}


### PR DESCRIPTION
Reverts redhat-cop/agnosticd#1000

@miteshrh 
I think we should iterate over the hosts and just use the private ip address, instead of a wildcard 192.168.*. Something in the tone of

```
Host {{ host.name }}
Hostname {{ host.private_ip_address }}
...
```