### PR TITLE
OCP4 Disconnected Config update for certificates

### DIFF
--- a/ansible/configs/ocp4-disconnected-osp-lab/env_vars.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/env_vars.yml
@@ -1,6 +1,12 @@
 ###### VARIABLES YOU SHOULD CONFIGURE FOR YOUR DEPLOYEMNT
 ###### OR PASS as "-e" args to ansible-playbook command
 
+# This config was written with the expectation of using python3
+# Several of the roles that it depends on only work with python2,
+# so they had to be modified to handle python3 as well. Use this
+# var so that it is passed along and influences how those roles run.
+all_use_python3: true
+
 # This is an account that must exist in OpenStack.
 # It is used to create projects, access, Heat templates
 admin_user: opentlc-mgr
@@ -80,7 +86,12 @@ install_k8s_modules: false
 
 # FTL is used for grading and solving. It will pull in the external ftl-injector role.
 # This might be enabled when we have solvers to run or graders for ILT
-install_ftl: true
+# install_ftl: true
+
+# This var will set the version of ftl-injector to use.
+# In addition, it implies that FTL should be installed, eventually 
+# removing the need for install_ftl var.
+ftl_injector_tag: v0.16.0
 
 # FTL injector will try to install python-pip and we only have python3-pip available
 # This var will force the ftl-injector role to adapt accordingly
@@ -222,12 +233,12 @@ networks:
 
 # These will influence the bastion if it is being deployed
 bastion_instance_type: 2c2g30d
-bastion_instance_image: rhel-guest-7.7u2
+bastion_instance_image: rhel-server-7.7-update-2
 
 # These will influence the utility VM, which is primarily used for disconnected
 # install, but can be used for anything really.
 utilityvm_instance_type: 2c2g30d
-utilityvm_instance_image: rhel-guest-7.7u2
+utilityvm_instance_image: rhel-server-7.7-update-2
 
 # Instances to be provisioned in new project
 # Provide these as a list.

--- a/ansible/configs/ocp4-disconnected-osp-lab/files/rfc2136.ini.j2
+++ b/ansible/configs/ocp4-disconnected-osp-lab/files/rfc2136.ini.j2
@@ -1,0 +1,10 @@
+# Target DNS server
+dns_rfc2136_server = {{ osp_cluster_dns_server }}
+# Target DNS port
+dns_rfc2136_port = 53
+# TSIG key name
+dns_rfc2136_name = {{ ddns_key_name }}
+# TSIG key secret
+dns_rfc2136_secret = {{ ddns_key_secret }}
+# TSIG key algorithm
+dns_rfc2136_algorithm = HMAC-MD5

--- a/ansible/configs/ocp4-disconnected-osp-lab/software.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/software.yml
@@ -176,7 +176,8 @@
     - name: chmod the user vols
       shell: "chmod -R 777 /srv/nfs"
 
-    - file:
+    - name: create exports file
+      file:
         path: /etc/exports.d/{{ env_type }}-{{ guid }}.exports
         state: touch
         mode: 755
@@ -193,4 +194,44 @@
         state: restarted
         enabled: yes
 
-# something to create the PV files
+- name: Step 004 LE certs
+  hosts: bastions
+  gather_facts: false
+  become: true
+  vars:
+    _certbot_dns_provider: "rfc2136"
+    _certbot_domain: "api.{{ guid }}.{{ osp_cluster_dns_zone }}"
+    _certbot_wildcard_domain: "*.apps.{{ guid }}.{{ osp_cluster_dns_zone }}"
+    _certbot_remote_dir: "/home/{{ student_name }}"
+    _certbot_remote_dir_owner: "{{ student_name }}"
+    _certbot_install_dir: "/home/{{ student_name }}/certificates"
+    _certbot_install_dir_owner: "{{ student_name }}"
+    _certbot_production: False
+    _certbot_user: "{{ student_name }}"
+    _certbot_cache_archive_file: "{{ output_dir|d('/tmp') }}/{{ guid }}-certs.tar.gz"
+    _certbot_use_cache: False
+    use_python3: "{{ all_use_python3 }}"
+  tasks:
+    - name: Copy credentials to host temporarily
+      template:
+        src: ./files/rfc2136.ini.j2
+        dest: /home/{{ _certbot_user }}/.rfc2136.ini
+        owner: "{{ _certbot_user }}"
+
+    - import_role: 
+        name: host-lets-encrypt-certs-certbot
+
+    - name: Remove credentials once LE certs complete
+      file:
+        state: absent
+        path: /home/{{ _certbot_user }}/.rfc2136.ini
+      when: _certbot_setup_complete
+
+    - name: Copy the LE root certs into trusted bundle
+      copy:
+        dest: /etc/pki/ca-trust/source/anchors/le-chain.pem
+        src: /home/{{ student_name }}/certificates/chain.pem
+        remote_src: true
+    
+    - name: Update CA trust
+      command: update-ca-trust


### PR DESCRIPTION
##### SUMMARY
This PR introduces changes to the `ocp4-disconnected-ha-lab` config. Along with #995 it will provision Let's Encrypt certs for both api and wildcard domain using DNS-01 validation with rfc2136 certbot DNS plugin. The certs will be added to the student user directory for use during the labs.

It also updates the `env_vars` to match what is intended as defaults.

The changes in this PR only affect the `ocp4-disconnected-ha-lab` config.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4-disconnected-ha-lab
