### PR TITLE
fix bastion-lite ssh

### DIFF
--- a/ansible/roles/bastion-lite/templates/bastion_ssh_config.j2
+++ b/ansible/roles/bastion-lite/templates/bastion_ssh_config.j2
@@ -13,4 +13,3 @@ Host *.example.com
   StrictHostKeyChecking no
   ConnectTimeout 60
   ConnectionAttempts 10
-{% endif %}	


### PR DESCRIPTION
##### SUMMARY
There is an extra `endif` in the jinja for the ssh config in the `bastion-lite` role. This removes it.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
bastion-lite
