### PR TITLE
multiple cloud support added

### DIFF
--- a/ansible/roles/satellite-public-hostname/tasks/main.yml
+++ b/ansible/roles/satellite-public-hostname/tasks/main.yml
@@ -3,6 +3,14 @@
 - name: Setting up facts for public hostname
   set_fact:
       publicname: "{{ inventory_hostname | regex_replace('.internal',subdomain_base_suffix) }}"
+  when: cloud_provider == 'ec2'
+  tags:
+    - public_hostname
+
+- name: Setting up facts for public hostname
+  set_fact:
+      publicname: "{{ inventory_hostname}}.{{guid}}.{{osp_cluster_dns_zone}}"
+  when: cloud_provider == 'osp'
   tags:
     - public_hostname
 


### PR DESCRIPTION
SUMMARY

Role: satellite-public-hostname can add public hostname for both cloud aws and osp

 ISSUE TYPE
- Feature enhanced 

