### PR TITLE
Update SG rules to allow SSH in network

### DIFF
--- a/ansible/configs/ocp4-disconnected-osp-lab/env_vars.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/env_vars.yml
@@ -354,7 +354,7 @@ security_groups:
       direction: ingress
       port_range_min: 22
       port_range_max: 22
-      remote_group: "bastion_sg"
+      remote_ip_prefix: "{{ ocp_network_subnet_cidr }}"
       description: "SSH"
     - protocol: tcp
       direction: ingress
@@ -508,7 +508,7 @@ security_groups:
       direction: ingress
       port_range_min: 22
       port_range_max: 22
-      remote_group: "bastion_sg"
+      remote_ip_prefix: "{{ ocp_network_subnet_cidr }}"
       description: "SSH"
     - protocol: udp
       direction: ingress


### PR DESCRIPTION
##### SUMMARY
When writing the authentication and security lab, it was discovered that the `node-ssh` Pod could not SSH to nodes in the cluster other than the one it was running on. This was due to the `master_sg` and `worker_sg` security groups limiting ingress SSH to the bastion. 

This change makes it so that SSH works between all workers and masters within the tenant. You still cannot SSH in from the outside, except to the bastion.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-disconnected-osp-lab
