### PR TITLE
osp-migration: register hostname directly too

### DIFF
--- a/ansible/configs/osp-migration/instance_loop.yml
+++ b/ansible/configs/osp-migration/instance_loop.yml
@@ -4,7 +4,7 @@
 # host.GUID.zone.com
 # host-GUID.GUID.zone.com
 - loop:
-    - "{{ _instance.metadata.hostname | regex_replace('-' ~ guid ~ '$', '.' + guid) }}"
+    - "{{ _instance.metadata.hostname }}"
     - "{{ _instance.metadata.hostname | regex_replace('-' ~ guid ~ '$', '.' + guid) }}"
     - "{{ _instance.metadata.hostname | regex_replace('-' ~ guid ~ '$', '-' ~ guid ~ '.' + guid) }}"
   loop_control:


### PR DESCRIPTION
when `metadata.hostname` = `bastion-GUID` for example, register:

- bastion-GUID.CLUSTER.osp.opentlc.com
- bastion.GUID.CLUSTER.osp.opentlc.com
- bastion-GUID.GUID.CLUSTER.osp.opentlc.com

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
