### PR TITLE
poll_email.py: handle 'too many connections' error at login

### DIFF
--- a/tests/jenkins/downstream/poll_email.py
+++ b/tests/jenkins/downstream/poll_email.py
@@ -50,9 +50,18 @@ else:
 
 
 def connect():
-    M = imaplib.IMAP4_SSL(imap_server)
-    M.login(username, password)
-    return M
+    max_retries = 10
+    retries=0
+    while retries < max_retries:
+        try:
+            M = imaplib.IMAP4_SSL(imap_server)
+            M.login(username, password)
+            return M
+        except imaplib.IMAP4.error as err:
+            print("IMAP4 error: {0}".format(err))
+            print("[%d / %d] retrying to login.. wait %d sec" % (retries, max_retries, 2**retries))
+            sleep(2**retries)
+            retries += 1
 
 def disconnect(M):
     try:


### PR DESCRIPTION
This commit, if applied, adds the logic to retry when the IMAP login fails.

It implements the exponential backoff.

This commit fixes an error that occur when there are a significant number
of concurrent jenkins job running:

Traceback (most recent call last):
  File "./tests/jenkins/downstream/poll_email.py", line 111, in <module>
    args.timeout))
  File "./tests/jenkins/downstream/poll_email.py", line 65, in wait_email
    M = connect()
  File "./tests/jenkins/downstream/poll_email.py", line 54, in connect
    M.login(username, password)
  File "/usr/lib64/python2.7/imaplib.py", line 520, in login
    raise self.error(dat[-1])
imaplib.error: [ALERT] Too many simultaneous connections. (Failure)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
