### PR TITLE
Ensure generated passwords are not repeated

### DIFF
--- a/ansible/roles/ocp-workload-integreatly/defaults/main.yml
+++ b/ansible/roles/ocp-workload-integreatly/defaults/main.yml
@@ -11,10 +11,10 @@ self_signed_certs_enabled: True
 amq_streams: True
 openshift_master_config_path: /etc/origin/master/master-config.yaml
 cluster_admin_username: admin@example.com
-cluster_admin_password: "{{ lookup('password', '/tmp/cluster_admin_password length=15 chars=ascii_letters,digits') }}"
-evals_password: "{{ lookup('password', '/tmp/evals_password length=15 chars=ascii_letters,digits') }}"
+cluster_admin_password: ""
+evals_password: ""
 customer_admin_username: customer-admin
-customer_admin_password: "{{ lookup('password', '/tmp/customer_admin_password length=15 chars=ascii_letters,digits') }}"
+customer_admin_password: ""
 letsencrypt_staging_root_cert_url: https://letsencrypt.org/certs/fakelerootx1.pem
 letsencrypt_staging_root_cert_path: /etc/origin/master/fakelerootx1.pem
 rhsso_identity_provider_ca_cert_path: "{{ letsencrypt_staging_root_cert_path }}"

--- a/ansible/roles/ocp-workload-integreatly/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-integreatly/tasks/workload.yml
@@ -6,6 +6,12 @@
     self_signed_certs_enabled: False
   when: lets_encrypt_production|bool
 
+- name: Generate passwords
+  set_fact: 
+    cluster_admin_password: "{{ lookup('password', '/tmp/cluster_{{ ansible_date_time.iso8601_micro | to_uuid }} length=15 chars=ascii_letters,digits') }}"
+    evals_password: "{{ lookup('password', '/tmp/evals_{{ ansible_date_time.iso8601_micro | to_uuid }} length=15 chars=ascii_letters,digits') }}"
+    customer_admin_password: "{{ lookup('password', '/tmp/customer_{{ ansible_date_time.iso8601_micro | to_uuid }} length=15 chars=ascii_letters,digits') }}"
+
 - name: Run Integreatly installer
   shell: |
           set -o pipefail


### PR DESCRIPTION
##### SUMMARY
Ensures that generated passwords for integreatly users are never repeated.

Fixes: https://issues.redhat.com/browse/INTLY-4211

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`ocp-workload-integreatly` role 

##### VERIFICATION
- Provision a plain RHPDS OCP3 cluster
- Clone this repo and checkout this branch 
- Export the following variables: (change `HOUST_GUID` and `GUID` accordingly)
```sh
HOST_GUID=dimitra-667d                                                
DOMAIN="$HOST_GUID.open.redhat.com"
TARGET_HOST="master.$DOMAIN"
SSH_USER="ec2-user"
SSH_PRIVATE_KEY="ocpkey.pem"
GUID=dimitra-667d
```
- Run the ocp integreatly workload to kick off the integreatly installation: 
```sh
WORKLOAD="ocp-workload-integreatly"                                   

# a TARGET_HOST is specified in the command line, without using an inventory file
ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
                 -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
                 -e"ansible_user=${SSH_USER}" \
                 -e"ocp_workload=${WORKLOAD}" \
                 -e"guid=${GUID}" \
                 -e"ocp_user_needs_quota=false" \
                 -e"ACTION=create" \
                 -e"self_signed_certs_enabled=true"  \
                 -e"lets_encrypt_production=false" \
                 -e"ig_version=1.6.0"
```

- Wait for the playbook to run and integreatly to install. To check the progress of the integreatly install, ssh onto the master node of the cluster and tail the install logs: `tail /tmp/integreatly.log` 

- Once the installation is complete, ensure that the generated passwords for customer admin, cluster admin and evals users are unique (instead of running the playbook twice you can ensure they are different to the following):
```sh
rhsso_seed_users_password=Rn8ICW4Ta4zKeJw 
rhsso_evals_admin_password=GVZgBdQzsELYLdp
rhsso_cluster_admin_password=Q0AfuEX5cgUeAvd

rhsso_seed_users_password=ZJYHXStmRpW9UKv
rhsso_evals_admin_password=m5xxPVYCp7SLscm
rhsso_cluster_admin_password=4URwIAXaBsyjSIz
```
