### PR TITLE
ocp4-workload-ceph: Fix rbd secret name for stable images

### DIFF
--- a/ansible/roles/ocp4-workload-ceph/templates/cephfs.yaml.j2
+++ b/ansible/roles/ocp4-workload-ceph/templates/cephfs.yaml.j2
@@ -45,8 +45,8 @@ parameters:
     # The secrets have to contain user and/or Ceph admin credentials.
     csi.storage.k8s.io/provisioner-secret-name: csi-cephfs-secret
     csi.storage.k8s.io/provisioner-secret-namespace: default
-    csi.storage.k8s.io/node-stage-secret-name: csi-cephfs-secret
-    csi.storage.k8s.io/node-stage-secret-namespace: default
+    csi.storage.k8s.io/node-publish-secret-name: csi-cephfs-secret
+    csi.storage.k8s.io/node-publish-secret-namespace: default
 
     # (optional) The driver can use either ceph-fuse (fuse) or ceph kernel client (kernel)
     # If omitted, default volume mounter will be used - this is determined by probing for ceph-fuse

--- a/ansible/roles/ocp4-workload-ceph/templates/cephfs.yaml.j2
+++ b/ansible/roles/ocp4-workload-ceph/templates/cephfs.yaml.j2
@@ -45,8 +45,8 @@ parameters:
     # The secrets have to contain user and/or Ceph admin credentials.
     csi.storage.k8s.io/provisioner-secret-name: csi-cephfs-secret
     csi.storage.k8s.io/provisioner-secret-namespace: default
-    csi.storage.k8s.io/node-publish-secret-name: csi-cephfs-secret
-    csi.storage.k8s.io/node-publish-secret-namespace: default
+    csi.storage.k8s.io/node-stage-secret-name: csi-cephfs-secret
+    csi.storage.k8s.io/node-stage-secret-namespace: default
 
     # (optional) The driver can use either ceph-fuse (fuse) or ceph kernel client (kernel)
     # If omitted, default volume mounter will be used - this is determined by probing for ceph-fuse

--- a/ansible/roles/ocp4-workload-ceph/templates/rbd.yaml.j2
+++ b/ansible/roles/ocp4-workload-ceph/templates/rbd.yaml.j2
@@ -42,8 +42,8 @@ parameters:
     # The secrets have to contain Ceph admin credentials.
     csi.storage.k8s.io/provisioner-secret-name: csi-rbd-secret
     csi.storage.k8s.io/provisioner-secret-namespace: default
-    csi.storage.k8s.io/node-stage-secret-name: csi-rbd-secret
-    csi.storage.k8s.io/node-stage-secret-namespace: default
+    csi.storage.k8s.io/node-publish-secret-name: csi-rbd-secret
+    csi.storage.k8s.io/node-publish-secret-namespace: default
     # Ceph users for operating RBD
     adminid: admin
     


### PR DESCRIPTION
**SUMMARY**
Stable images must use proper secret name for rbd storage class, see : 
https://github.com/ceph/ceph-csi/issues/543

**ISSUE TYPE**

Bugfix Pull Request

**COMPONENT NAME**

ocp4-workload-ceph

**ADDITIONAL INFORMATION**