### PR TITLE
Fix links and add Fedora specifics to preparing workstation

### DIFF
--- a/docs/Preparing_your_workstation.adoc
+++ b/docs/Preparing_your_workstation.adoc
@@ -23,15 +23,18 @@ NOTE: Red Hat employee subscriptions can be used
 
 === Software required for deployment
 
-* [Python](https://www.python.org) version 2.7.x (3.x untested and may not work)
-* [Python Boto](http://docs.pythonboto.org) version 2.41 or greater
-* [Git](http://github.com) any version would do.
-* [Ansible](https://github.com/ansible/ansible) version 2.1.2 or greater
-* [awscli bundle](https://s3.amazonaws.com/aws-cli/awscli-bundle.zip) tested with version 1.11.32
+* https://www.python.org[Python]
+* http://docs.pythonboto.org[Python Boto] version 2.41 or greater
+* http://github.com[Git] any version would do.
+* https://github.com/ansible/ansible[Ansible] version 2.1.2 or greater
+* https://s3.amazonaws.com/aws-cli/awscli-bundle.zip[awscli bundle] tested with version 1.11.32
 Python and the Python dependencies may be installed via your OS' package manager
-(eg: python2-boto on Fedora/CentOS/RHEL) or via
-[pip](https://pypi.python.org/pypi/pip). [Python
-virtualenv](https://pypi.python.org/pypi/virtualenv) can also work.
+(eg: python2-boto on Fedora/CentOS/RHEL) or via https://pypi.python.org/pypi/pip[pip]. https://pypi.python.org/pypi/virtualenv[Python virtualenv] can also work.
+
+NOTE: on Fedora, all dependencies are packaged and can be easily installed via
+`dnf install wget git awscli python3-boto3 ansible ansible-lint yamllint`
+(botocore and python will be pulled automatically through dependencies).
+The lint tools are optional but are recommended tools to check the quality of your code.
 
 .Example script to install required software
 [source,bash]
@@ -206,6 +209,8 @@ sudo pip install openstacksdk
 # Install openstack CLIs
 sudo pip install python-openstackclient python-heatclient
 ----
+
+NOTE: on Fedora `dnf install python3-openstacksdk python3-openstackclient python-openstackclient-doc python-openstackclient-lang python3-heatclient python-heatclient-doc python3-dns` will do the job (you may choose to skip doc and lang packages).
 
 === Azure
 


### PR DESCRIPTION
##### SUMMARY
Only documentation changes done during the AgnosticD training:
The links were still markdown style and not rendering properly.
Added the necessary dnf commands for Fedora where all dependencies
are properly packaged.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

docs/Preparing_your_workstation.adoc

##### ADDITIONAL INFORMATION

The existing instructions were far too complex for Fedora. It can be so easy as a one liner :smirk: 
