### PR TITLE
disable gitea

### DIFF
--- a/ansible/roles/ocp-workload-integreatly/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-integreatly/tasks/workload.yml
@@ -23,6 +23,7 @@
           -e rhsso_seed_users_password={{ evals_password }} \
           -e rhsso_evals_admin_password={{ customer_admin_password }} \
           -e rhsso_cluster_admin_password={{ cluster_admin_password }}" \
+          -e gitea=false \
           | tee -a "{{ integreatly_logs }}"
   args:
     chdir: "{{ install_dir }}"


### PR DESCRIPTION
This PR disables the gitea installation for current Integreatly workshops. This is because the image that the gitea operator is deployment no longer exists. A fixed version of Gitea will be included in the next release again.