### PR TITLE
Remove duplicate line tower_license content parameter

### DIFF
--- a/ansible/roles/tower-license-injector/tasks/main.yml
+++ b/ansible/roles/tower-license-injector/tasks/main.yml
@@ -1,7 +1,6 @@
 - name: Copy Tower License File
   copy:
     content: "{{ tower_license | from_json }}"
-    content: "{{ tower_license | from_json }}"
     dest: /root/license.txt
   tags:
       - tower-license-injector
@@ -11,4 +10,3 @@
   tags:
       - tower-license-injector
 
-      


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
```
[WARNING]: While constructing a mapping from [...]/agnosticd/ansible/roles/tower-license-injector/tasks/main.yml, line 3, column 5, found a duplicate dict key (content). Using last defined value only.
```

Indeed the line is duplicate and needed one to be removed.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
roles/tower-license-injector

##### ADDITIONAL INFORMATION
only a warning...
