### PR TITLE
Add agnosticd_user_info module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ ansible/configs/*/roles
 my_*_vars.yml
 
 .vscode/settings.json
+__pycache__

--- a/ansible/action_plugins/agnosticd_user_info.py
+++ b/ansible/action_plugins/agnosticd_user_info.py
@@ -52,7 +52,7 @@ class ActionModule(ActionBase):
                 )
             )
             fh = open(os.path.join(output_dir, 'user-info.yaml'), 'a')
-            fh.write('- ' + json.dumps(result['msg']) + "\n")
+            fh.write('- ' + json.dumps(self._task.args['msg']) + "\n")
             fh.close()
             result['failed'] = False
         except Exception as e:

--- a/ansible/action_plugins/agnosticd_user_info.py
+++ b/ansible/action_plugins/agnosticd_user_info.py
@@ -1,0 +1,57 @@
+#!/usr/bin/python
+# 
+# Copyright: (c) 2020, Johnathan Kupferer <jkupfere@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# This plugin is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+import os
+
+from ansible.errors import AnsibleUndefinedVariable
+from ansible.module_utils.six import string_types
+from ansible.module_utils._text import to_text
+from ansible.plugins.action import ActionBase
+
+class ActionModule(ActionBase):
+    '''Print statements during execution and save user info to file'''
+
+    TRANSFERS_FILES = False
+
+    def run(self, tmp=None, task_vars=None):
+        self._supports_check_mode = True
+
+        if task_vars is None:
+            task_vars = dict()
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+        del tmp # tmp no longer has any effect
+
+        result['msg'] = 'user.info: ' + self._task.args['msg']
+        result['_ansible_verbose_always'] = True
+
+        try:
+            output_dir = task_vars.get('output_dir', task_vars.get('playbook_dir', '.'))
+            fh = open(os.path.join(output_dir, 'user-info.yaml'), 'a')
+            fh.write('- ' + json.dumps(result['msg']) + "\n")
+            fh.close()
+            result['failed'] = False
+        except Exception as e:
+            result['failed'] = True
+            result['error'] = str(e)
+
+        return result

--- a/ansible/library/agnosticd_user_info.py
+++ b/ansible/library/agnosticd_user_info.py
@@ -1,0 +1,59 @@
+#!/usr/bin/python
+#
+# Copyright: (c) 2020, Johnathan Kupferer <jkupfere@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: agnosticd_user_info
+
+short_description: Display user information for agnosticd deployment and save in output directory
+
+version_added: "2.9"
+
+description:
+- This module provides the capability of displaying user information in agnosticd processing while saving the output as a YAML list in the output directory.
+- The string "user.info: " is prepended to the displayed output for compatibility with the prior practice of using the debug module with this special prefix string.
+
+options:
+  msg:
+    description:
+    - This is the message or data to display.
+    - It may be of any datatype.
+  required: true
+
+author:
+- Johnathan Kupferer
+'''
+
+RETURN = '''
+msg:
+  description: The message displayed.
+  type: str
+  returned: always
+error:
+  description: Error message on failure
+  type: str
+  returned: failed
+'''
+
+# Module is implemented as an action plugin


### PR DESCRIPTION
##### SUMMARY

Add agnostid_user_info module implemented as action plugin.

This module is proposed as a replacement for using debug statements.
Switching to this module allows us to more easily programatically
capture output by putting user info directly into the output dir.

##### ISSUE TYPE


- Feature Pull Request

##### COMPONENT NAME

agnosticd user info

##### ADDITIONAL INFORMATION

This PR only adds the `agnosticd_user_info` module. Configs and workloads will need to be adapted to use it. In order to convert to `agnosticd_user_info`:

Go from this:

```
- name: Show generated password
  debug:
    msg: "user.info: generated password {{ generated_password }}"
```

To this:

```
- name: Show generated password
  agnosticd_user_info:
    msg: "generated password {{ generated_password }}"
```

This module also supports outputing structured data, so the following may be preferred to allow the value to be picked up by automation more easily:

```
- name: Show generated password
  agnosticd_user_info:
    msg:
      generated_password: "{{ generated_password }}"
```