### PR TITLE
dry-run-osp: simplify heat template

### DIFF
--- a/ansible/roles/infra-osp-dry-run/defaults/main.yml
+++ b/ansible/roles/infra-osp-dry-run/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
 heat_retries: 0
 output_dir: /tmp/output_dir
-infra_osp_dry_run_basic_image: rhel-server-7.7-update-2
 infra_osp_dry_run_project_name: admin

--- a/ansible/roles/infra-osp-dry-run/templates/basic_heat_template.yml.j2
+++ b/ansible/roles/infra-osp-dry-run/templates/basic_heat_template.yml.j2
@@ -1,10 +1,10 @@
 heat_template_version: 2015-04-30
 
-description: Simple template to deploy a single compute instance
+description: Simple template to deploy a single key
 
 resources:
-  my_instance:
-    type: OS::Nova::Server
+  dry-run-{{ 99999 | random }}-infra_key:
+    type: OS::Nova::KeyPair
     properties:
-      image: {{ infra_osp_dry_run_basic_image }}
-      flavor: m1.small
+      name: dry-run-{{ 99999 | random }}-infra_key
+      save_private_key: true


### PR DESCRIPTION
Do not use instance as it has a dependency on the image.
Just create a SSH key in the template.
