### PR TITLE
Remove install_dependencies var for ftl-injector task in bastion role

### DIFF
--- a/ansible/roles/bastion/tasks/main.yml
+++ b/ansible/roles/bastion/tasks/main.yml
@@ -117,7 +117,6 @@
       name: ftl-injector
     vars:
       student_login: "{{ student_name }}"
-      install_dependencies: false
 
 - name: Install jq on the bastion
   get_url:


### PR DESCRIPTION
##### SUMMARY
The `bastion` role passes `install_dependencies: false` to the `ftl-injector` role. This causes the conditional check to fail and no virtual envs are set up for FTL. The default in the `ftl_injector` role is true for this.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- bastion
