### PR TITLE
OSP-Sandbox separate DNS vars

### DIFF
--- a/ansible/configs/osp-sandbox/env_vars.yml
+++ b/ansible/configs/osp-sandbox/env_vars.yml
@@ -134,6 +134,9 @@ osp_cluster_dns_server: ddns01.opentlc.com
 # Whether to wait for an ack from the DNS servers before continuing
 wait_for_dns: true
 
+student_dns_zone: students.osp.opentlc.com
+student_dns_server: ddns01.opentlc.com
+
 # Set this to true if you want a FIPs provisioned for an OpenShift on OpenStack install
 # This will provision an API and Ingress FIP
 openshift_fip_provision: False

--- a/ansible/configs/osp-sandbox/files/secret.yaml.j2
+++ b/ansible/configs/osp-sandbox/files/secret.yaml.j2
@@ -3,7 +3,7 @@ osp_auth_user_domain: default
 
 # dynamic DNS
 ddns_key_name: {{ student_ddns_key_name }}
-ddns_key_secret: {{ student_ddns_key_secret}}
+ddns_key_secret: {{ student_ddns_key_secret }}
 osp_cluster_dns_server: {{ student_dns_server }}
 osp_cluster_dns_zone: {{ student_dns_zone }}
 

--- a/ansible/configs/osp-sandbox/files/secret.yaml.j2
+++ b/ansible/configs/osp-sandbox/files/secret.yaml.j2
@@ -2,10 +2,10 @@ osp_auth_project_domain: default
 osp_auth_user_domain: default
 
 # dynamic DNS
-ddns_key_name: {{ ddns_key_name }}
-ddns_key_secret: {{ ddns_key_secret}}
-osp_cluster_dns_server: {{ osp_cluster_dns_server }}
-osp_cluster_dns_zone: {{ osp_cluster_dns_zone }}
+ddns_key_name: {{ student_ddns_key_name }}
+ddns_key_secret: {{ student_ddns_key_secret}}
+osp_cluster_dns_server: {{ student_dns_server }}
+osp_cluster_dns_zone: {{ student_dns_zone }}
 
 osp_auth_username: "{{ guid }}-user"
 osp_auth_password: "{{ hostvars['localhost']['heat_user_password'] }}"


### PR DESCRIPTION
##### SUMMARY
The original version of this config used the same DNS server and zone for both the provisioned project and what is provided to the user for further use. This will break those apart and allow a new DNS zone, server, (and keys) to be defined.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
osp-sandbox
