### PR TITLE
Added a sample vars file for a private three-tier-app on OSP

### DIFF
--- a/ansible/configs/three-tier-app/sample_vars/private-dns-osp.yml
+++ b/ansible/configs/three-tier-app/sample_vars/private-dns-osp.yml
@@ -1,0 +1,161 @@
+# sample vars configuration file to deploy three-tier-app to OSP
+#
+# Only the bastion is exposed and the other hosts do not have public DNS or
+# Floating IPs
+# Consider exposing Frontends via public_dns: true in the instance dictionary
+#
+# Usage: ansible-playbook main.yml -e @configs/three-tier-app/sample_vars/private-dns-osp.yml
+# 
+# Ideally make and keep a copy OUTSIDE your repo, especially if using Cloud Credentials
+# Credentials can also be set seperately i.e. ~/secrets.yml and passed in with
+# a 2nd `-e` argument i.e. -e ~/secrets.yml
+# You may also need to pass other secret vars like `own_repo_path`
+
+env_type: three-tier-app        # Name of config to deploy
+output_dir: /tmp/output_dir     # Writable working scratch directory
+email: name@example.com         # User info for notifications
+
+guid: tok01                     # Your Global UNIQUE Identifier, change
+
+repo_method: file
+own_repo_path:                  # Move this var and set into your secrets.yml
+
+# Cloud specfic settings - example given here for OSP
+# ec2 example typically in ../sample_vars.yml
+
+cloud_provider: osp             # Which AgnosticD Cloud Provider to use
+ansible_user: cloud-user        # Default user in an OSP environment
+remote_user: cloud-user         # Default user in an OSP environment
+
+# The domain that you want to add DNS entries to
+osp_cluster_dns_zone: blue.osp.opentlc.com
+
+# The dynamic DNS server you will add entries to.
+# NOTE: This is only applicable when {{ use_dynamic_dns}} is true
+osp_cluster_dns_server: ddns01.opentlc.com
+
+# Instance type - you can list these with `openstack image list`
+
+bastion_instance_type: 2c2g30d
+app_instance_type: 2c2g30d
+appdb_instance_type: 2c2g30d
+frontend_instance_type: 2c2g30d
+support_instance_type: 2c2g30d
+
+#___image: rhel-guest-7.7u2    # blue
+___image: rhel-server-7.7-update-2  # red
+
+bastion_instancbastion_instance_image: "{{ ___image }}"
+bastion_instance_image: "{{ ___image }}"
+e_image: "{{ ___image }}"
+app_instance_image: "{{ ___image }}"
+appdb_instance_image: "{{ ___image }}"
+frontend_instance_image: "{{ ___image }}"
+support_instance_image: "{{ ___image }}"
+
+student_name: 3257-user #change to your GUID
+#admin_user: opentlc-mgr
+admin_user: 3257-user #change to your GUID
+
+update_all_packages: false
+
+#osp_project_create: true
+
+instances:
+  - name: bastion
+    count: 1
+    unique: true
+    public_dns: true
+    dns_loadbalancer: true
+    floating_ip: true
+    image_id: "{{ bastion_instance_image }}"
+    flavor:
+      ec2: "{{bastion_instance_type}}"
+      osp: "{{bastion_instance_type}}"
+      azure: Standard_A2_V2
+    tags:
+      - key: "AnsibleGroup"
+        value: "bastions"
+      - key: "ostype"
+        value: "linux"
+      - key: "instance_filter"
+        value: "{{ env_type }}-{{ email }}"
+    rootfs_size: "{{ rootfs_size_bastion }}"
+    security_groups:
+      - BastionSG
+
+  - name: "frontend"
+    count: "{{frontend_instance_count}}"
+    public_dns: false
+    dns_loadbalancer: true
+    image_id: "{{ frontend_instance_image }}"
+    flavor:
+      ec2: "{{frontend_instance_type}}"
+      osp: "{{frontend_instance_type}}"
+      azure: "Standard_A2_V2"
+    tags:
+      - key: "AnsibleGroup"
+        value: "frontends"
+      - key: "ostype"
+        value: "linux"
+      - key: "instance_filter"
+        value: "{{ env_type }}-{{ email }}"
+    security_groups:
+      - DefaultSG
+
+  - name: "app"
+    count: "{{app_instance_count}}"
+    public_dns: false
+    image_id: "{{ app_instance_image }}"
+    flavor:
+      ec2: "{{app_instance_type}}"
+      osp: "{{app_instance_type}}"
+      azure: "Standard_A2_V2"
+    tags:
+      - key: "AnsibleGroup"
+        value: "apps"
+      - key: "ostype"
+        value: "rhel"
+      - key: "instance_filter"
+        value: "{{ env_type }}-{{ email }}"
+    key_name: "{{key_name}}"
+    security_groups:
+      - DefaultSG
+
+  - name: "appdb"
+    count: "{{appdb_instance_count}}"
+    public_dns: false
+    image_id: "{{ appdb_instance_image }}"
+    flavor:
+      ec2: "{{appdb_instance_type}}"
+      azure: "Standard_A2_V2"
+      osp: "{{appdb_instance_type}}"
+    tags:
+      - key: "AnsibleGroup"
+        value: "appdbs"
+      - key: "ostype"
+        value: "rhel"
+      - key: "instance_filter"
+        value: "{{ env_type }}-{{ email }}"
+    key_name: "{{key_name}}"
+    security_groups:
+      - DefaultSG
+
+  - name: "support"
+    count: "{{support_instance_count}}"
+    public_dns: false
+    image_id: "{{ support_instance_image }}"
+    flavor:
+      ec2: "{{support_instance_type}}"
+      osp: "{{support_instance_type}}"
+      azure: "Standard_A2_V2"
+    tags:
+      - key: "AnsibleGroup"
+        value: "support"
+      - key: "ostype"
+        value: "rhel"
+      - key: "instance_filter"
+        value: "{{ env_type }}-{{ email }}"
+    key_name: "{{key_name}}"
+    security_groups:
+      - DefaultSG


### PR DESCRIPTION
##### SUMMARY
Added a sample vars file for three-tier-app using a new pattern of config/<config-name>/sample_vars/ directory as a form of blueprints to allow users to start a particular customized config quickly.

This one allows three-tier-app to deploy onto an OSP cluster with all but the bastion private and not exposed.


##### ISSUE TYPE

- New config Pull Request

##### COMPONENT NAME
three-tier-app enhancement
 
##### ADDITIONAL INFORMATION

No change to the code base, just an optional vars files 