### PR TITLE
Fix env_type to osp-sandbox in its sample_vars.yml

### DIFF
--- a/ansible/configs/osp-sandbox/sample_vars.yml
+++ b/ansible/configs/osp-sandbox/sample_vars.yml
@@ -1,6 +1,6 @@
 ---
 guid: testgucore
-env_type: ocp4-disconnected-osp-lab
+env_type: osp-sandbox
 cloud_provider: osp
 #key_name: opentlc_admin_backdoor
 #key_name: gucore


### PR DESCRIPTION
##### SUMMARY
Fix incorrect setting for env_type in osp-sandbox sample_vars.yml


##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
env_type set incorrectly in sample_vars.yml

##### ADDITIONAL INFORMATION
