### PR TITLE
Small change to support Python2

### DIFF
--- a/ansible/roles/infra-osp-template-generate/templates/cloud_template_master.j2
+++ b/ansible/roles/infra-osp-template-generate/templates/cloud_template_master.j2
@@ -47,7 +47,7 @@ resources:
       name: "{{ guid }}-{{ network['name'] }}-subnet"
       network_id: {get_resource: {{ network['name'] }}-network}
 {% if network['dns_nameservers'] is defined %}
-      dns_nameservers: {{ network['dns_nameservers'] }}
+      dns_nameservers: [{{ network['dns_nameservers'] | list | join(",") }}]
 {% endif %}
       cidr: {{ network['subnet_cidr'] }}
       gateway_ip: {{ network['gateway_ip'] }}

--- a/ansible/roles/infra-osp-template-generate/templates/nested_version/cloud_template_master.j2
+++ b/ansible/roles/infra-osp-template-generate/templates/nested_version/cloud_template_master.j2
@@ -42,7 +42,7 @@ resources:
       name: "{{ guid }}-{{ network['name'] }}-subnet"
       network_id: { get_resource: {{ network['name'] }}-network }
 {% if network['dns_nameservers'] is defined %}
-      dns_nameservers: {{ network['dns_nameservers'] }}
+      dns_nameservers: [{{ network['dns_nameservers'] | list | join(",") }}]
 {% endif %}
       cidr: {{ network['subnet_cidr'] }}
       gateway_ip: {{ network['gateway_ip'] }}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Using Python2 generates the strings from an array with module template with u"TEST" instead TEST

Playbook:

> - hosts: localhost
>   gather_facts: false
>   vars:
>     servers: 
>      - "8.8.8.8"
>      - "1.1.1.1"
>   tasks:
>   - template:
>      src: templates/test.j2
>      dest: /tmp/test

Template:

> Original: {{ servers }}
> After PR: [{{ servers | list | join(",") }}]

File generated using Python 2:

> Original: [u'8.8.8.8', u'1.1.1.1']
> After PR: [8.8.8.8,1.1.1.1]



