### PR TITLE
Fix certbot

### DIFF
--- a/ansible/configs/ocp-workloads/ocp-workload.yml
+++ b/ansible/configs/ocp-workloads/ocp-workload.yml
@@ -6,7 +6,12 @@
   become: false
   gather_facts: False
   tags:
-    - step007
-  roles:
-    - role: "{{ocp_workload}}"
-      when: ocp_workload is defined
+  - step007
+  tasks:
+  - name: Set Ansible Python interpreter to k8s virtualenv
+    set_fact:
+      ansible_python_interpreter: /opt/virtualenvs/k8s/bin/python
+  - name: Run workload
+    include_role:
+      name: "{{ ocp_workload }}"
+    when: ocp_workload is defined

--- a/ansible/roles/host-lets-encrypt-certs-certbot/tasks/main.yml
+++ b/ansible/roles/host-lets-encrypt-certs-certbot/tasks/main.yml
@@ -44,125 +44,131 @@
   when:
     - cacert.stat.exists|bool == false or _certbot_force_issue|bool
   block:
-    - name: Install certbot pip prerequisites in a VirtualEnv
-      become: True
-      pip:
-        state: present
-        virtualenv: /opt/virtualenvs/certbot
-        name:
-          - certbot
-          - certbot-dns-{{ _certbot_dns_provider }}
-      when: not use_python3 | bool
+  - name: Ensure virtualenv is installed
+    pip:
+      name: virtualenv
+      state: present
+      
+  - name: Install certbot pip prerequisites in a VirtualEnv
+    become: True
+    pip:
+      state: present
+      virtualenv_command: /usr/local/bin/virtualenv
+      virtualenv: /opt/virtualenvs/certbot
+      name:
+        - certbot
+        - certbot-dns-{{ _certbot_dns_provider }}
+    when: not use_python3 | bool
 
-    - name: Install certbot pip prerequisites in a virtualenv with python3
-      become: True
-      pip:
-        state: present
-        virtualenv_command: /usr/local/bin/virtualenv
-        virtualenv: /opt/virtualenvs/certbot
-        name:
-          - certbot
-          - certbot-dns-{{ _certbot_dns_provider }}
-      when: use_python3 | bool
+  - name: Install certbot pip prerequisites in a virtualenv with python3
+    become: True
+    pip:
+      state: present
+      virtualenv_command: /usr/local/bin/virtualenv
+      virtualenv: /opt/virtualenvs/certbot
+      name:
+        - certbot
+        - certbot-dns-{{ _certbot_dns_provider }}
+    when: use_python3 | bool
 
-    - name: Copy certbot script
-      become: True
-      template:
-        src: ./templates/run-certbot.j2
-        dest: /usr/local/bin/run-certbot
-        owner: "{{ _certbot_user }}"
-        group: "{{ _certbot_remote_dir_group }}"
-        mode: 0755
+  - name: Copy certbot script
+    become: True
+    template:
+      src: ./templates/run-certbot.j2
+      dest: /usr/local/bin/run-certbot
+      owner: "{{ _certbot_user }}"
+      group: "{{ _certbot_remote_dir_group }}"
+      mode: 0755
 
-    - name: Check if cached certificate archive exists
-      become: false
-      stat:
-        path: "{{ _certbot_cache_archive_file }}"
-      delegate_to: localhost
-      register: cache_archive_file
+  - name: Check if cached certificate archive exists
+    become: false
+    stat:
+      path: "{{ _certbot_cache_archive_file }}"
+    delegate_to: localhost
+    register: cache_archive_file
 
-    - name: Restore entire certificate archive
+  - name: Restore entire certificate archive
+    when:
+    - _certbot_use_cache|bool
+    - cache_archive_file.stat.exists|bool
+    - not _certbot_force_issue|bool
+    block:
+    - name: Upload certificate archive
+      unarchive:
+        src: "{{ _certbot_cache_archive_file }}"
+        dest: "{{ _certbot_remote_dir }}"
+        owner: "{{ _certbot_install_dir_owner }}"
+        keep_newer: yes
+    - name: Set _certbot_setup_complete=true
+      set_fact:
+        _certbot_setup_complete: true
+
+  - name: Ensure Certbot Directories are present
+    file:
+      name: "{{ item }}"
+      state: directory
+      owner: "{{ _certbot_remote_dir_owner }}"
+      mode: 0775
+    loop:
+    - "{{ _certbot_dir }}"
+    - "{{ _certbot_dir }}/config"
+    - "{{ _certbot_dir }}/work"
+    - "{{ _certbot_dir }}/logs"
+    - "{{ _certbot_dir }}/renewal-hooks"
+    - "{{ _certbot_dir }}/renewal-hooks/deploy"
+
+  - name: Request Certificates from Let's Encrypt (force or no cache)
+    when:
+    - _certbot_force_issue|bool or not _certbot_setup_complete|bool
+    block:
+    # Get Intermediary CA Certificate.
+    # This is also used in the SSO configuration!
+    - name: Get Let's Encrypt Intermediary CA Certificate
+      get_url:
+        url: https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem.txt
+        dest: "{{ _certbot_dir }}/lets-encrypt-x3-cross-signed.pem"
+    - name: Print Shell Command
+      debug:
+        msg: >-
+          About to request certificates using the following command:
+          certbot certonly -n --agree-tos --email {{ _certbot_le_email }}
+          -d {{ _certbot_domain }}
+          {{ (_certbot_wildcard_domain|length>0)|ternary('-d','')}} {{ (_certbot_wildcard_domain|length>0)|ternary(_certbot_wildcard_domain,'')}}
+          {{ (_certbot_wildcard_certs|bool)|ternary('--dns-'+_certbot_dns_provider, '') }}
+          --config-dir={{ _certbot_dir }}/config
+          --work-dir={{ _certbot_dir }}/work
+          --logs-dir={{ _certbot_dir }}/logs
+          {{ (_certbot_production|bool)|ternary('','--test-cert') }}
+          {{ _certbot_additional_args|d(_certbot_args)|d('') }}
+
+    - name: Request API and Wildcard Certificates
+      # become: false
+      become_user: "{{ _certbot_user }} "
+      command: /usr/local/bin/run-certbot
+      retries: 5
+      delay: 30
+      register: r_request_le
+      until: r_request_le is succeeded
+
+    - name: Save certificates to cache
       when:
       - _certbot_use_cache|bool
-      - cache_archive_file.stat.exists|bool
-      - not _certbot_force_issue|bool
+      - _certbot_cache_archive_file is defined
+      - _certbot_cache_archive_file|trim != ""
       block:
-      - name: Upload certificate archive
-        unarchive:
-          src: "{{ _certbot_cache_archive_file }}"
-          dest: "{{ _certbot_remote_dir }}"
-          owner: "{{ _certbot_install_dir_owner }}"
-          keep_newer: yes
-      - name: Set _certbot_setup_complete=true
-        set_fact:
-          _certbot_setup_complete: true
-
-    - name: Ensure Certbot Directories are present
-      file:
-        name: "{{ item }}"
-        state: directory
-        owner: "{{ _certbot_remote_dir_owner }}"
-        mode: 0775
-      loop:
-      - "{{ _certbot_dir }}"
-      - "{{ _certbot_dir }}/config"
-      - "{{ _certbot_dir }}/work"
-      - "{{ _certbot_dir }}/logs"
-      - "{{ _certbot_dir }}/renewal-hooks"
-      - "{{ _certbot_dir }}/renewal-hooks/deploy"
-
-    - name: Request Certificates from Let's Encrypt (force or no cache)
-      when:
-      - _certbot_force_issue|bool or not _certbot_setup_complete|bool
-      block:
-      # Get Intermediary CA Certificate.
-      # This is also used in the SSO configuration!
-      - name: Get Let's Encrypt Intermediary CA Certificate
-        get_url:
-          url: https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem.txt
-          dest: "{{ _certbot_dir }}/lets-encrypt-x3-cross-signed.pem"
-      - name: Print Shell Command
-        debug:
-          msg: >-
-            About to request certificates using the following command:
-            certbot certonly -n --agree-tos --email {{ _certbot_le_email }}
-            -d {{ _certbot_domain }}
-            {{ (_certbot_wildcard_domain|length>0)|ternary('-d','')}} {{ (_certbot_wildcard_domain|length>0)|ternary(_certbot_wildcard_domain,'')}}
-            {{ (_certbot_wildcard_certs|bool)|ternary('--dns-'+_certbot_dns_provider, '') }}
-            --config-dir={{ _certbot_dir }}/config
-            --work-dir={{ _certbot_dir }}/work
-            --logs-dir={{ _certbot_dir }}/logs
-            {{ (_certbot_production|bool)|ternary('','--test-cert') }}
-            {{ _certbot_additional_args|d(_certbot_args)|d('') }}
-
-      - name: Request API and Wildcard Certificates
-        # become: false
-        become_user: "{{ _certbot_user }} "
-        command: /usr/local/bin/run-certbot
-        retries: 5
-        delay: 30
-        register: r_request_le
-        until: r_request_le is succeeded
-
-      - name: Save certificates to cache
-        when:
-        - _certbot_use_cache|bool
-        - _certbot_cache_archive_file is defined
-        - _certbot_cache_archive_file|trim != ""
-        block:
-        - name: Create archive of certbot directory for cache
-          archive:
-            path: "{{ _certbot_dir }}"
-            dest: "/tmp/certbot.tgz"
-        - name: Save certbot archive to cache
-          fetch:
-            src: "/tmp/certbot.tgz"
-            dest: "{{ _certbot_cache_archive_file }}"
-            flat: yes
-        - name: Remove archive from server
-          file:
-            name: "/tmp/certbot.tgz"
-            state: absent
+      - name: Create archive of certbot directory for cache
+        archive:
+          path: "{{ _certbot_dir }}"
+          dest: "/tmp/certbot.tgz"
+      - name: Save certbot archive to cache
+        fetch:
+          src: "/tmp/certbot.tgz"
+          dest: "{{ _certbot_cache_archive_file }}"
+          flat: yes
+      - name: Remove archive from server
+        file:
+          name: "/tmp/certbot.tgz"
+          state: absent
 
 - name: Install the certificates into {{ _certbot_install_dir }}
   block:

--- a/ansible/roles/ocp4-workload-aws-jumpbox/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-aws-jumpbox/tasks/workload.yml
@@ -5,11 +5,17 @@
   debug:
     msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
 
+- name: Ensure virtualenv is installed
+  pip:
+    name: virtualenv
+    state: present
+
 - name: Install Ansible and selinux python library into ocp-jumpbox virtualenv
   become: yes
   pip:
     state: present
-    virtualenv: /opt/virtualenvs/ocp-jumpbox
+    virtualenv_command: /usr/local/bin/virtualenv
+    virtualenv: /opt/virtualenvs/aws-jumpbox
     name:
     - ansible
     - selinux

--- a/ansible/roles/ocp4-workload-aws-jumpbox/templates/create_jumpbox.j2
+++ b/ansible/roles/ocp4-workload-aws-jumpbox/templates/create_jumpbox.j2
@@ -1,4 +1,4 @@
 #!/bin/bash
-source /opt/virtualenvs/ocp-jumpbox/bin/activate
+source /opt/virtualenvs/aws-jumpbox/bin/activate
 
 ansible-playbook /opt/aws-jumpbox/create_jumpbox.yml -e guid={{ guid }} -e cluster_name={{ cluster_name }} -e aws_region={{ aws_region }}

--- a/ansible/roles/ocp4-workload-aws-jumpbox/templates/delete_jumpbox.j2
+++ b/ansible/roles/ocp4-workload-aws-jumpbox/templates/delete_jumpbox.j2
@@ -1,4 +1,4 @@
 #!/bin/bash
-source /opt/virtualenvs/ocp-jumpbox/bin/activate
+source /opt/virtualenvs/aws-jumpbox/bin/activate
 
 ansible-playbook /opt/aws-jumpbox/delete_jumpbox.yml -e guid={{ guid }} -e cluster_name={{ cluster_name }} -e aws_region={{ aws_region }}

--- a/ansible/roles/ocp4-workload-enable-lets-encrypt-certificates/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-enable-lets-encrypt-certificates/tasks/workload.yml
@@ -49,6 +49,7 @@
       - _certbot_force_issue: False
       - _certbot_production: True
       - _certbot_cron_job_name: LETS_ENCRYPT_RENEW
+      - use_python3:  "{{ all_use_python3 | d(True) | bool }}"
       # production false results in unusable certificates
       # (not possible to login to OCP)
       # - _certbot_production: "{{ lets_encrypt_production|d(False)|bool}}"
@@ -79,7 +80,7 @@
       - _certbot_force_issue: False
       - _certbot_production: True
       - _certbot_cron_job_name: LETS_ENCRYPT_RENEW
-      - use_python3:  "{{ all_use_python3 | d(True) }}"
+      - use_python3:  "{{ all_use_python3 | d(True) | bool }}"
       # production false results in unusable certificates
       # (not possible to login to OCP)
       # - _certbot_production: "{{ lets_encrypt_production|d(False)|bool}}"


### PR DESCRIPTION
This PR fixes the Certbot (and aws jumpbox) roles by specifying the virtualenv binary. It also changes the default for the certbot role to use Python3 instead of Python2.