### PR TITLE
Move debug statement up in the play

### DIFF
--- a/ansible/configs/test-empty-config/post_software.yml
+++ b/ansible/configs/test-empty-config/post_software.yml
@@ -27,11 +27,12 @@
           user.info: Some random password
           {{ lookup('password', '/dev/null length=15 chars=ascii_letters') }}
 
+    - name: Print string expected by Cloudforms
+      debug:
+        msg: "Post-Software checks completed successfully"
+
     - name: Exiting the test-empty-config post_software.yml
       debug:
         msg:
           - Exiting the test-empty-config post_software.yml
-
-    - debug:
-        msg: "Post-Software checks completed successfully"
 ...


### PR DESCRIPTION
Sometimes, the last debug statement is not printed in the logs fetch by

  tower-cli job monitor

To fix that, move up the debug task required by Cloudforms so the whole deployment
doesn't fail.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
