### PR TITLE
destroy: output_dir should be created

### DIFF
--- a/ansible/destroy.yml
+++ b/ansible/destroy.yml
@@ -5,7 +5,7 @@
 ################################################################################
 ################################################################################
 
-- import_playbook: include_vars.yml
+- import_playbook: setup_runtime.yml
 
 - name: Detect in what region the stack is
   hosts: localhost


### PR DESCRIPTION
When running in babylon, the output_dir is created by agnosticd.

Destroy.yml should also include the creation of output_dir, like main.yml.
