### PR TITLE
add OCS migstorage bucket config option and tasks

### DIFF
--- a/ansible/roles/ocp4-workload-migration/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-migration/defaults/main.yml
@@ -7,6 +7,9 @@ migration_workload_destroy: "{{ False if (ACTION=='create' or ACTION=='provision
 migration_workload_title: "{{ 'Creating' if not migration_workload_destroy else 'Removing' }}"
 migration_workload_state: "{{ 'present' if not migration_workload_destroy else 'absent' }}"     # state of k8s resources
 silent: false
-
+noobaa_s3_endpoint_proto: http
+ocs_migstorage: false
+ocs_migstorage_bucketname: migstorage
+ocs_migstorage_namespace: openshift-migration
 # undefined variables
 # mig_operator_ui_cluster_api_endpoint:

--- a/ansible/roles/ocp4-workload-migration/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-migration/tasks/workload.yml
@@ -32,6 +32,65 @@
     dest: "/home/{{ student_name }}/"
   when: student_name is defined
 
+- when: ocs_migstorage
+  block:
+  - name: Discovering NooBaa S3 endpoint
+    k8s_info:
+      api_version: v1
+      kind: Service
+      name: s3
+      namespace: "{{ ocs_migstorage_namespace }}"
+    register: noobaa_s3_endpoint
+    retries: 10
+    delay: 3
+    until: noobaa_s3_endpoint.resources is defined and
+           noobaa_s3_endpoint.resources[0] is defined and
+           noobaa_s3_endpoint.resources[0].status.loadBalancer is defined and
+           noobaa_s3_endpoint.resources[0].status.loadBalancer.ingress is defined
+
+  - set_fact:
+      noobaa_endpoint: "{{ noobaa_s3_endpoint.resources[0].status.loadBalancer.ingress[0].ip }}"
+    when: noobaa_s3_endpoint.resources[0].status.loadBalancer.ingress[0].ip is defined
+
+  - set_fact:
+      noobaa_endpoint: "{{ noobaa_s3_endpoint.resources[0].status.loadBalancer.ingress[0].hostname }}"
+    when: noobaa_s3_endpoint.resources[0].status.loadBalancer.ingress[0].hostname is defined
+
+  - name: Get MCG PV Pool secret
+    k8s_info:
+      api_version: v1
+      kind: Secret
+      name: "{{ ocs_migstorage_bucketname }}"
+      namespace: "{{ ocs_migstorage_namespace }}"
+    register: ocs_migstorage_secret
+    retries: 20
+    delay: 3
+    until: ocs_migstorage_secret.resources|length > 0
+
+  - set_fact:
+      noobaa_s3_access_key_id: "{{ ocs_migstorage_secret.resources[0].data.AWS_ACCESS_KEY_ID | b64decode }}"
+      noobaa_s3_secret_access_key: "{{ ocs_migstorage_secret.resources[0].data.AWS_SECRET_ACCESS_KEY | b64decode }}"
+
+  - name: Discovering NooBaa CA Bundle
+    shell: "{{ item }}"
+    loop:
+    - openssl s_client -showcerts -verify 5 -connect {{ noobaa_endpoint }}:443 < /dev/null | awk '/BEGIN/,/END/{ if(/BEGIN/){a++}; out="cert"a".crt"; print >out}' && for cert in *.crt; do newname=$(openssl x509 -noout -subject -in $cert | sed -n 's/^.*CN=\(.*\)$/\1/; s/[ ,.*]/_/g; s/__/_/g; s/^_//g;p').pem; mv $cert $newname; done;
+    - cat *.pem
+    - rm *.pem
+    register: noobaa_ca_bundle_raw
+    when: noobaa_s3_endpoint_proto == 'https'
+
+  - set_fact:
+      noobaa_ca_bundle: "{{ noobaa_ca_bundle_raw.results[1].stdout }}"
+    when: noobaa_s3_endpoint_proto == 'https'
+
+  - name: Creating OCS backed migstorage
+    k8s:
+      state: present
+      definition: "{{ lookup('template', 'mig_storage.yml.j2') }}"
+    vars:
+      noobaa_s3_url: "{{ noobaa_s3_endpoint_proto }}://{{ noobaa_endpoint }}/"
+
 # Leave this as the last task in the playbook.
 - name: workload tasks complete
   debug:

--- a/ansible/roles/ocp4-workload-migration/templates/mig_storage.yml.j2
+++ b/ansible/roles/ocp4-workload-migration/templates/mig_storage.yml.j2
@@ -3,33 +3,32 @@ apiVersion: v1
 kind: Secret
 metadata:
   namespace: {{ mig_migration_namespace }}
-  name: migstorage-creds
+  name: migstorage-default-creds
 type: Opaque
 data:
-  aws-access-key-id: {{ noobaa_key|b64encode }}
-  aws-secret-access-key: {{ noobaa_secret|b64encode }}
+  aws-access-key-id: {{ noobaa_s3_access_key_id|b64encode }}
+  aws-secret-access-key: {{ noobaa_s3_secret_access_key|b64encode }}
 ---
 apiVersion: migration.openshift.io/v1alpha1
 kind: MigStorage
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: migstorage-sample
+  name: migstorage-default
   namespace: {{ mig_migration_namespace }}
 spec:
   backupStorageProvider: aws
   volumeSnapshotProvider: aws
 
   backupStorageConfig:
-    awsBucketName: first.bucket
+    awsBucketName: {{ ocs_migstorage_bucketname }}
     awsS3ForcePathStyle: true
     awsS3Url: {{ noobaa_s3_url }}
     credsSecretRef:
       namespace: {{ mig_migration_namespace }}
-      name: migstorage-creds
+      name: migstorage-default-creds
 
   volumeSnapshotConfig:
-    awsRegion: {{ noobaa_region }}
     credsSecretRef:
       namespace: {{ mig_migration_namespace }}
-      name: migstorage-creds
+      name: migstorage-default-creds

--- a/ansible/roles/ocp4-workload-migration/templates/mig_storage.yml.j2
+++ b/ansible/roles/ocp4-workload-migration/templates/mig_storage.yml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   namespace: {{ mig_migration_namespace }}
-  name: migstorage-default-creds
+  name: pvpool-storage-creds
 type: Opaque
 data:
   aws-access-key-id: {{ noobaa_s3_access_key_id|b64encode }}
@@ -14,7 +14,7 @@ kind: MigStorage
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: migstorage-default
+  name: pvpool-storage
   namespace: {{ mig_migration_namespace }}
 spec:
   backupStorageProvider: aws
@@ -26,9 +26,9 @@ spec:
     awsS3Url: {{ noobaa_s3_url }}
     credsSecretRef:
       namespace: {{ mig_migration_namespace }}
-      name: migstorage-default-creds
+      name: pvpool-storage-creds
 
   volumeSnapshotConfig:
     credsSecretRef:
       namespace: {{ mig_migration_namespace }}
-      name: migstorage-default-creds
+      name: pvpool-storage-creds


### PR DESCRIPTION
##### SUMMARY
This PR adds optional automated configuration of an OCS MCG bucket. This is intended primarily to be used in conjunction with the ocp4-workload-ocs-operator role.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4-workload-migration role

##### ADDITIONAL INFORMATION
