### PR TITLE
Add completion callback

### DIFF
--- a/ansible/action_plugins/agnosticd_user_info.py
+++ b/ansible/action_plugins/agnosticd_user_info.py
@@ -46,9 +46,11 @@ class ActionModule(ActionBase):
         result['_ansible_verbose_always'] = True
 
         try:
-            output_dir = task_vars.get('output_dir',
-                task_vars['hostvars'].get('localhost',{}).get('output_dir',
-                    task_vars.get('playbook_dir', '.')
+            output_dir = self._templar.template(
+                task_vars.get('output_dir',
+                    task_vars['hostvars'].get('localhost',{}).get('output_dir',
+                        task_vars.get('playbook_dir', '.')
+                    )
                 )
             )
             fh = open(os.path.join(output_dir, 'user-info.yaml'), 'a')

--- a/ansible/completion_callback.yml
+++ b/ansible/completion_callback.yml
@@ -1,0 +1,26 @@
+- name: Completion Callback
+  gather_facts: false
+  hosts: localhost
+  tasks:
+    - name: Attempt completion callback
+      when:
+      - __meta__.callback.url | default('') != ''
+      - __meta__.callback.token | default('') != ''
+      vars:
+        user_info_yaml: "{{ output_dir ~ '/user-info.yaml' }}"
+      uri:
+        url:              "{{ __meta__.callback.url }}"
+        method:           POST
+        body_format:      json
+        body:
+          event: complete
+          messages: >-
+            {%- if user_info_yaml is file -%}
+            {{ lookup('file', user_info_yaml) | from_yaml }}
+            {%- else -%}
+            []
+            {%- endif -%}
+        headers:
+          Authorization: Bearer {{ __meta__.callback.token }}
+      # Best effort
+      ignore_errors: true

--- a/ansible/configs/test-empty-config/post_software.yml
+++ b/ansible/configs/test-empty-config/post_software.yml
@@ -22,9 +22,9 @@
       pause:
         seconds: 30
 
-    - debug:
+    - agnosticd_user_info:
         msg: >-
-          user.info: Some random password
+          Some random string
           {{ lookup('password', '/dev/null length=15 chars=ascii_letters') }}
 
     - name: Print string expected by Cloudforms

--- a/ansible/configs/test-empty-config/software.yml
+++ b/ansible/configs/test-empty-config/software.yml
@@ -22,4 +22,8 @@
       debug:
         msg:
           - Exiting the test-empty-config software.yml
+
+    - name: Add GUID message to user info
+      agnosticd_user_info:
+        msg: GUID is {{ guid }}
 ...

--- a/ansible/destroy.yml
+++ b/ansible/destroy.yml
@@ -24,3 +24,5 @@
          'paths': [ 'configs/' + env_type, 'cloud_providers/' ]
        })
     }}
+
+- import_playbook: completion_callback.yml

--- a/ansible/lifecycle_entry_point.yml
+++ b/ansible/lifecycle_entry_point.yml
@@ -8,3 +8,5 @@
          'paths': ['configs/' + env_type, playbook_dir]
        })
     }}
+
+- import_playbook: completion_callback.yml

--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -95,3 +95,5 @@
     - step005
     - post_software
     - post_software_tasks
+
+- import_playbook: completion_callback.yml

--- a/ansible/setup_runtime.yml
+++ b/ansible/setup_runtime.yml
@@ -30,6 +30,12 @@
         state: directory
       when: not rstat_output_dir.stat.exists
 
+    - name: Create empty user-info.yaml in output dir
+      copy:
+        content: |
+          ---
+        dest: "{{ output_dir }}/user-info.yaml"
+
 # include global vars from the config
 - import_playbook: include_vars.yml
 


### PR DESCRIPTION
##### SUMMARY

Add completion callback and userinfo to agnosticd for babylon integration.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Main entry point playbooks

##### ADDITIONAL INFORMATION

When initially adopted this will result in duplicate completion callbacks from ansible tower and agnosticd. These will not cause any issues with babylon processing.