### PR TITLE
Wait for RHPAM IS tags to become available in the cluster.

### DIFF
--- a/ansible/roles/ocp-workload-pam7-cc-dispute-dmn-pmml/defaults/main.yml
+++ b/ansible/roles/ocp-workload-pam7-cc-dispute-dmn-pmml/defaults/main.yml
@@ -39,6 +39,7 @@ pv_capacity: 512Mi
 pam_version_tag: 7.5.0.GA
 #pam_imagestreams_yml: https://raw.githubusercontent.com/jboss-container-images/rhpam-7-openshift-image/{{pam_version_tag}}/rhpam75-image-streams.yaml
 pam_imagestreams_yml: https://raw.githubusercontent.com/jboss-container-images/rhpam-7-openshift-image/{{pam_version_tag}}/rhpam75-image-streams.yaml
+pam_imagestreams_tag: 7.5.0
 #pam_template_yml: https://raw.githubusercontent.com/jboss-container-images/rhpam-7-openshift-image/{{pam_version_tag}}/templates/rhpam75-authoring.yaml
 pam_template_yml: https://raw.githubusercontent.com/jboss-container-images/rhpam-7-openshift-image/{{pam_version_tag}}/templates/rhpam75-trial-ephemeral.yaml
 #pam_secrets_template_yml: https://raw.githubusercontent.com/jboss-container-images/rhdm-7-openshift-image/{{pam_version_tag}}/example-app-secret-template.yaml

--- a/ansible/roles/ocp-workload-pam7-cc-dispute-dmn-pmml/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-pam7-cc-dispute-dmn-pmml/tasks/workload.yml
@@ -28,6 +28,13 @@
   when: rhpam_is_exists_result is failed
   ignore_errors: true
 
+- name: Wait for RHPAM ImageStream tags to be available
+  shell: "oc get is -n openshift | grep -i rhpam | grep -i {{pam_imagestreams_tag}}"
+  register: result
+  until: result.stdout != ""
+  retries: 5
+  delay: 10
+
 - name: Import ImageStreams Entando EAP 7.1
   shell: "oc create -f https://raw.githubusercontent.com/entando/entando-ops/credit-card-dispute/Openshift/image-streams/entando-fsi-ccd-demo.json -n {{ OCP_PROJECT }}"
 


### PR DESCRIPTION
##### SUMMARY
Fixes a bug in the RHPAM DMN PMML demo where a Docker build was created based on an IS with a certain tag before that IS tag was available in the cluster.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp-workload-pam7-cc-dispute-dmn-pmml