### PR TITLE
Add data support to agnosticd_user_info

### DIFF
--- a/ansible/action_plugins/agnosticd_user_info.py
+++ b/ansible/action_plugins/agnosticd_user_info.py
@@ -31,7 +31,7 @@ class ActionModule(ActionBase):
     '''Print statements during execution and save user info to file'''
 
     TRANSFERS_FILES = False
-    _VALID_ARGS = frozenset(('msg',))
+    _VALID_ARGS = frozenset(('msg','data'))
 
     def run(self, tmp=None, task_vars=None):
         self._supports_check_mode = True
@@ -42,7 +42,19 @@ class ActionModule(ActionBase):
         result = super(ActionModule, self).run(tmp, task_vars)
         del tmp # tmp no longer has any effect
 
-        result['msg'] = 'user.info: ' + self._task.args['msg']
+        msg = self._task.args.get('msg')
+        data = self._task.args.get('data')
+
+        if msg:
+            result['msg'] = 'user.info: ' + msg
+        if data:
+            result['data'] = data
+            if not isinstance(data, dict):
+                result['failed'] = True
+                result['error'] = 'data must be a dictionary of name/value pairs'
+                return result
+
+        # Force display of result like debug
         result['_ansible_verbose_always'] = True
 
         try:
@@ -53,9 +65,15 @@ class ActionModule(ActionBase):
                     )
                 )
             )
-            fh = open(os.path.join(output_dir, 'user-info.yaml'), 'a')
-            fh.write('- ' + json.dumps(self._task.args['msg']) + "\n")
-            fh.close()
+            if msg:
+                fh = open(os.path.join(output_dir, 'user-info.yaml'), 'a')
+                fh.write('- ' + json.dumps(msg) + "\n")
+                fh.close()
+            if data:
+                fh = open(os.path.join(output_dir, 'user-data.yaml'), 'a')
+                for k, v in data.items():
+                    fh.write("{0}: {1}\n".format(k, json.dumps(v)))
+                fh.close()
             result['failed'] = False
         except Exception as e:
             result['failed'] = True

--- a/ansible/completion_callback.yml
+++ b/ansible/completion_callback.yml
@@ -7,6 +7,7 @@
       - __meta__.callback.url | default('') != ''
       - __meta__.callback.token | default('') != ''
       vars:
+        user_data_yaml: "{{ output_dir ~ '/user-data.yaml' }}"
         user_info_yaml: "{{ output_dir ~ '/user-info.yaml' }}"
       uri:
         url:              "{{ __meta__.callback.url }}"
@@ -16,9 +17,15 @@
           event: complete
           messages: >-
             {%- if user_info_yaml is file -%}
-            {{ lookup('file', user_info_yaml) | from_yaml }}
+            {{ lookup('file', user_info_yaml) | from_yaml | default([], true) }}
             {%- else -%}
             []
+            {%- endif -%}
+          data: >-
+            {%- if user_data_yaml is file -%}
+            {{ lookup('file', user_data_yaml) | from_yaml | default({}, true) }}
+            {%- else -%}
+            {}
             {%- endif -%}
         headers:
           Authorization: Bearer {{ __meta__.callback.token }}

--- a/ansible/configs/test-empty-config/post_software.yml
+++ b/ansible/configs/test-empty-config/post_software.yml
@@ -22,9 +22,13 @@
       pause:
         seconds: 30
 
-    - agnosticd_user_info:
-        msg: >-
-          Some random string
+    - name: Test agnosticd_user_info from post_software with random string
+      agnosticd_user_info:
+        msg: Some random string {{ random_string }}
+        data:
+          random_string: "{{ random_string }}"
+      vars:
+        random_string: >-
           {{ lookup('password', '/dev/null length=15 chars=ascii_letters') }}
 
     - name: Print string expected by Cloudforms

--- a/ansible/configs/test-empty-config/software.yml
+++ b/ansible/configs/test-empty-config/software.yml
@@ -23,7 +23,9 @@
         msg:
           - Exiting the test-empty-config software.yml
 
-    - name: Add GUID message to user info
+    - name: Test agnosticd_user_info with GUID message and data
       agnosticd_user_info:
         msg: GUID is {{ guid }}
+        data:
+          GUID: "{{ guid }}"
 ...

--- a/ansible/setup_runtime.yml
+++ b/ansible/setup_runtime.yml
@@ -30,11 +30,14 @@
         state: directory
       when: not rstat_output_dir.stat.exists
 
-    - name: Create empty user-info.yaml in output dir
+    - name: Create empty user-info.yaml and user-data.yaml in output dir
       copy:
         content: |
           ---
-        dest: "{{ output_dir }}/user-info.yaml"
+        dest: "{{ output_dir }}/{{ item }}"
+      loop:
+      - user-info.yaml
+      - user-data.yaml
 
 # include global vars from the config
 - import_playbook: include_vars.yml


### PR DESCRIPTION
##### SUMMARY

Add ability to collect data in the output directory and pass the data in job completion callback.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

agnosticd_user_info

##### ADDITIONAL INFORMATION

Usage example:
```
    - name: Return user info data:
      agnosticd_user_info:
        msg: Generated password is {{ generated_password }}
        data:
          generated_password: "{{ generated_password }}"
```