### PR TITLE
Improvements to OCS workloads

### DIFF
--- a/ansible/roles/ocp4-workload-ceph/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-ceph/defaults/main.yml
@@ -24,7 +24,17 @@ ceph_mds:
     requests:
       cpu: '0.1'
       memory: 2Gi
-
+noobaa_core:
+  resources:
+    requests:
+      cpu: '0.2'
+      memory: 2Gi
+noobaa_db:
+  resources:
+    requests:
+      cpu: '0.2'
+      memory: 2Gi
+ocs_operator_channel: stable-4.2
 ocs_operator_channel: stable-4.2
 ocs_operator_csv: ocs-operator.v4.2.1
 ocs_source_namespace: openshift-marketplace

--- a/ansible/roles/ocp4-workload-ceph/templates/storagecluster.yml.j2
+++ b/ansible/roles/ocp4-workload-ceph/templates/storagecluster.yml.j2
@@ -18,6 +18,14 @@ spec:
       requests:
         cpu: {{ ceph_mgr.resources.requests.cpu }}
         memory: {{ ceph_mgr.resources.requests.memory }}
+    noobaa-core:
+      requests:
+        cpu: {{ noobaa_core.resources.requests.cpu }}
+        memory: {{ noobaa_core.resources.requests.memory }}
+    noobaa-db:
+      requests:
+        cpu: {{ noobaa_db.resources.requests.cpu }}
+        memory: {{ noobaa_db.resources.requests.memory }}
   storageDeviceSets:
   - name: ocs-deviceset
     count: 1

--- a/ansible/roles/ocp4-workload-ocs-operator/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-ocs-operator/defaults/main.yml
@@ -9,11 +9,20 @@ ocs_mcg_core_cpu: 0.5
 ocs_mcg_core_mem: 500Mi
 ocs_mcg_db_cpu: 0.5
 ocs_mcg_db_mem: 1Gi
+ocs_ceph_mds_cpu: 0.5
+ocs_ceph_mds_mem: 1Gi
+ocs_ceph_mon_cpu: 0.5
+ocs_ceph_mon_mem: 1Gi
+ocs_ceph_mgr_cpu: 0.5
+ocs_ceph_mgr_mem: 1Gi
+ocs_ceph_osd_cpu: 0.5
+ocs_ceph_osd_mem: 1Gi
 ocs_mcg_pv_pool: true
 ocs_mcg_pv_pool_bucket_name: mcg
 ocs_mcg_pv_pool_pv_size: 50Gi
 ocs_mcg_pv_pool_pv_quantity: 3
 ocs_mcg_pv_pool_pv_storageclass: gp2
-ocs_namespace: ocs-storage
+ocs_namespace: openshift-storage
 ocs_release: v4.2.1
+ocs_operator_workload_destroy: "{{ False if (ACTION=='create' or ACTION=='provision') else True }}"
 silent: false

--- a/ansible/roles/ocp4-workload-ocs-operator/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-ocs-operator/tasks/pre_workload.yml
@@ -1,4 +1,23 @@
 ---
+- name: Discovering worker nodes
+  k8s_facts:
+    api_version: v1
+    kind: Node
+    label_selectors:
+    - node-role.kubernetes.io/worker
+  register: worker_nodes
+
+- fail:
+    msg: "Less than 3 worker nodes detected. Cannot install Ceph..."
+  when: worker_nodes | length < 3
+
+- set_fact:
+    ceph_worker_nodes: "{{ worker_nodes | json_query('resources[*].metadata.name') }}"
+
+- name: "Adding Ceph labels to worker nodes"
+  shell: "oc label nodes --overwrite {{ item }} cluster.ocs.openshift.io/openshift-storage=''"
+  loop: "{{ ceph_worker_nodes }}"
+
 # Leave this as the last task in the playbook.
 - name: pre_workload tasks complete
   debug:

--- a/ansible/roles/ocp4-workload-ocs-operator/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-ocs-operator/tasks/workload.yml
@@ -37,17 +37,26 @@
   retries: 30
   delay: 10
 
+- name: "Create OCS Storage cluster"
+  k8s:
+    state: "{{ state }}"
+    definition: "{{ lookup('template', 'storagecluster.yml.j2') }}"
+  
+- name: "Waiting for MCG to become ready"
+  k8s_info:
+    api_version: "noobaa.io/v1alpha1"
+    kind: NooBaa
+    namespace: "{{ ocs_namespace }}"
+  register: noobaa_system_status
+  until: noobaa_system_status.resources|length > 0 and
+         noobaa_system_status.resources[0].status is defined and 
+         noobaa_system_status.resources[0].status.phase == 'Ready'
+  ignore_errors: true
+
 - when: ocs_install_mcg
   block:
-
-  - name: "Create NooBaa system"
-    k8s:
-      state: "{{ state }}"
-      definition: "{{ lookup('template', 'noobaa_system.yml.j2') }}"
-
   - when: ocs_mcg_pv_pool
     block:
-
     - name: "Create PV Pool BackingStore"
       k8s:
         state: "{{ state }}"
@@ -93,7 +102,7 @@
         namespace: "{{ ocs_namespace }}"
       register: bucket
       until: (bucket.resources|first).status.phase == "Bound"
-      retries: 60
+      retries: 75
       delay: 10
 
 # Leave this as the last task in the playbook.

--- a/ansible/roles/ocp4-workload-ocs-operator/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-ocs-operator/tasks/workload.yml
@@ -48,6 +48,8 @@
     kind: NooBaa
     namespace: "{{ ocs_namespace }}"
   register: noobaa_system_status
+  retries: 60
+  delay: 10
   until: noobaa_system_status.resources|length > 0 and
          noobaa_system_status.resources[0].status is defined and 
          noobaa_system_status.resources[0].status.phase == 'Ready'

--- a/ansible/roles/ocp4-workload-ocs-operator/templates/storagecluster.yml.j2
+++ b/ansible/roles/ocp4-workload-ocs-operator/templates/storagecluster.yml.j2
@@ -1,0 +1,47 @@
+apiVersion: ocs.openshift.io/v1
+kind: StorageCluster
+metadata:
+  namespace: {{ ocs_namespace }}
+  name: ocs-storagecluster
+spec:
+  manageNodes: false
+  resources:
+    mon:
+      requests:
+        cpu: {{ ocs_ceph_mon_cpu }}
+        memory: {{ ocs_ceph_mon_mem }}
+    mds:
+      requests:
+        cpu: {{ ocs_ceph_mds_cpu }}
+        memory: {{ ocs_ceph_mds_mem }}
+    mgr:
+      requests:
+        cpu: {{ ocs_ceph_mgr_cpu }}
+        memory: {{ ocs_ceph_mgr_mem }}
+    noobaa-core:
+      requests:
+        cpu: {{ ocs_mcg_core_cpu }}
+        memory: {{ ocs_mcg_core_mem }}
+    noobaa-db:
+      requests:
+        cpu: {{ ocs_mcg_db_cpu }}
+        memory: {{ ocs_mcg_db_mem }}
+  storageDeviceSets:
+  - name: ocs-deviceset
+    count: 1
+    replica: 3
+    resources:
+      requests:
+        cpu: {{ ocs_ceph_osd_cpu }}
+        memory: {{ ocs_ceph_osd_mem }}
+    placement: {}
+    dataPVCTemplate:
+      spec:
+        storageClassName: gp2
+        accessModes:
+        - ReadWriteOnce
+        volumeMode: Block
+        resources:
+          requests:
+            storage: 2Ti
+    portable: true


### PR DESCRIPTION
##### SUMMARY
- adds new resource limits on Ceph to allow running on smaller clusters
- replaces NooBaa System CR with StorageCluster CR in ocs-operator workload

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
ocp4-workload-ocs-operator
ocp4-workload-ceph

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
