### PR TITLE
Allow delete all resource when developing from a sandbox

### DIFF
--- a/ansible/roles/infra-osp-resources-destroy/defaults/main.yaml
+++ b/ansible/roles/infra-osp-resources-destroy/defaults/main.yaml
@@ -1,2 +1,8 @@
 ---
 osp_stack_delete_retries: 3
+
+# This is useful if you're working with osp_project_create = false but
+# still want to cleanup your project *and* because you're the only one
+# working in the project.
+# by default, the cleanup of resource only occurs when osp_project_create is true
+osp_force_delete_all_resources: false

--- a/ansible/roles/infra-osp-resources-destroy/tasks/main.yml
+++ b/ansible/roles/infra-osp-resources-destroy/tasks/main.yml
@@ -7,7 +7,9 @@
     osp_project_info | default([]) | length > 0
     or osp_project_id is defined
   block:
-    - when: osp_project_create | bool
+    - when: >-
+        osp_project_create | bool
+        or osp_force_delete_all_resources
       include_tasks: project_resources.yml
 
     # Delete the heat stack **after** resources:

--- a/ansible/roles/infra-osp-resources-destroy/tasks/project_resources.yml
+++ b/ansible/roles/infra-osp-resources-destroy/tasks/project_resources.yml
@@ -7,7 +7,9 @@
     OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
     OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"
   # Delete resources only if the project was created for this environment
-  when: osp_project_create | bool
+  when: >-
+    osp_project_create | bool
+    or osp_force_delete_all_resources
   block:
     - name: Cleanup OpenStack resources
       environment:
@@ -15,12 +17,14 @@
       block:
         - name: Do dry-run of compute and storage purge
           command: |
-            openstack project purge --dry-run --keep-project --project {{ osp_project_name }}
+            openstack project purge --dry-run --keep-project
+            --project {{ osp_project_id | default(osp_project_name) }}
           register: project_purge_out
 
         - name: Purge compute and storage
           command: |
-            openstack project purge --keep-project --project {{ osp_project_name }}
+            openstack project purge --keep-project
+            --project {{ osp_project_id | default(osp_project_name) }}
           when: project_purge_out is succeeded
 
         - pause:
@@ -28,7 +32,9 @@
 
         - name: Get all remaining volumes in project
           command: >-
-            openstack volume list --project {{ osp_project_name }} -f json -c ID
+            openstack volume list
+            --project {{ osp_project_id | default(osp_project_name) }}
+            -f json -c ID
           register: r_volumes
 
         - set_fact:
@@ -49,7 +55,7 @@
         - name: Get all remaining trunk ports in project
           command: >-
             openstack port list
-            --project {{ osp_project_name }}
+            --project {{ osp_project_id | default(osp_project_name) }}
             -f json -c trunk_details
           register: r_ports
 
@@ -66,7 +72,8 @@
 
         - name: Purge network resources
           command: |
-            neutron purge --project {{ osp_project_info[0].id }}
+            neutron purge
+            --project {{ osp_project_info[0].id | default(osp_project_id) }}
 
         - name: Cleanup the keypairs
           debug:


### PR DESCRIPTION
Introduce `osp_force_delete_all_resource` variable. Defaults to false.

If the user is using `osp_project_create = false` and working with an existing project, he/she cannot delete the resources inside the project.

If the user is alone in that project, he might want to just delete everything and start fresh.

This commit introduces a new variable that allows that.

Also: prefer the osp_project_id when possible because that doesn't requirement
privileged access to list all the project.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request
