### PR TITLE
Added role to install 3scale toolbox and ruby.

### DIFF
--- a/ansible/configs/ocp-clientvm/README.adoc
+++ b/ansible/configs/ocp-clientvm/README.adoc
@@ -16,12 +16,13 @@ CLOUDPROVIDER=ec2
 HOSTZONEID='Z3IHLWJZOU9SRT'
 BASESUFFIX='.example.opentlc.com'
 
+
 # OCP Vars
 
 REPO_VERSION=3.11
 OSRELEASE=3.11.16
 
-ansible-playbook ansible/main.yml \
+ansible-playbook main.yml \
   -e "guid=${GUID}" \
   -e "env_type=${ENVTYPE}" \
   -e "osrelease=${OSRELEASE}" \
@@ -33,7 +34,10 @@ ansible-playbook ansible/main.yml \
   -e "key_name=${KEYNAME}" \
   -e "subdomain_base_suffix=${BASESUFFIX}" \
   -e "clientvm_instance_type=t2.large" \
-  -e "email=name@example.com" -e"output_dir=/opt/workdir" -e"output_dir=/opt/workdir" -e@../secret.yml -vvvv
+  -e "requirements_path=ansible/configs/ocp-clientvm/requirements_ruby.yml" \
+  -e "email=name@example.com"  \
+  -e "output_dir=/tmp/output" \
+  -e "install_ruby=true"    -e "install_3scale=true" -vvvv
 ----
 
 === Satellite version

--- a/ansible/configs/ocp-clientvm/default_vars.yml
+++ b/ansible/configs/ocp-clientvm/default_vars.yml
@@ -15,6 +15,11 @@ project_tag: "{{ env_type }}-{{ guid }}"
 osrelease: '4.3.0'
 repo_version: '4.3'
 
+# Ruby and 3scale ToolBox gem is installed. 
+install_ruby: false
+install_3scale: false
+
+
 # Software Versions:
 # Specified in ocp-client-vm role defaults. Can be overridden with specific
 # versions if necessary

--- a/ansible/configs/ocp-clientvm/pre_software.yml
+++ b/ansible/configs/ocp-clientvm/pre_software.yml
@@ -43,13 +43,39 @@
 - name: Configuring Bastion Hosts
   hosts: bastions
   become: true
+  tags:
+  - step004
+  - bastion_tasks
   roles:
   - { role: "bastion-lite",         when: 'install_bastion | bool' }
   - { role: "bastion-student-user", when: 'install_student_user | bool' }
   - { role: "bastion-opentlc-ipa",  when: 'install_ipa_client | bool' }
+
+- name: Configuring Ruby on Bastion Hosts
+  hosts: bastions
+  become: true
+  gather_facts: False
+  tasks:
+  - when: (install_ruby | bool) or (install_3scale | bool)
+    include_role:
+      name: ruby
+    vars:
+      rvm1_rubies: ['ruby-2.6.3']
+      rvm1_install_flags: '--auto-dotfiles'  # Remove --user-install from defaults
+      rvm1_install_path: /usr/local/rvm         # Set to system location
+      rvm1_user: root                            # Need root account to access system location
   tags:
   - step004
-  - bastion_tasks
+  - ruby_tasks
+
+- name: Configuring 3scale toolbox 
+  hosts: bastions
+  become: true
+  tags:
+  - step004
+  - 3scale_toolbox_tasks
+  roles:
+  - { role: "bastion-3scale",         when: 'install_3scale | bool' }
 
 - name: PreSoftware flight-check
   hosts: localhost

--- a/ansible/configs/ocp-clientvm/requirements-ruby.yml
+++ b/ansible/configs/ocp-clientvm/requirements-ruby.yml
@@ -1,0 +1,6 @@
+---
+# External role to setup RVM and Ruby 
+
+- src: rvm.ruby
+  name: ruby 
+  version: v2.1.2

--- a/ansible/roles/bastion-3scale/defaults/main.yml
+++ b/ansible/roles/bastion-3scale/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+ruby_path: /usr/local/rvm/gems/ruby-2.6.3/bin:/usr/local/rvm/gems/ruby-2.6.3@global/bin:/usr/local/rvm/rubies/ruby-2.6.3/bin:/usr/local/bin:/usr/bin:/usr/local/rvm/bin

--- a/ansible/roles/bastion-3scale/tasks/main.yml
+++ b/ansible/roles/bastion-3scale/tasks/main.yml
@@ -1,0 +1,16 @@
+#vim: set ft=ansible:
+---
+# tasks file for bastion
+
+######################### Setting up a bastion host to use 3scale toolbox
+
+
+- name: Install 3scale toolbox gem 
+  become: true
+  environment:
+    PATH: "{{ruby_path}}"  
+  gem: 
+    name: 3scale_toolbox
+    version: 0.16.0
+    state: present
+    user_install: no


### PR DESCRIPTION
Added changes to the ocp-clientvm to install ruby and 3scale toolbox.
default vars are false so these are not installed.

These tools are needed for 3scale API Lifecycle labs.