### PR TITLE
Certbot breaking in python3

### DIFF
--- a/ansible/configs/ocp4-disconnected-osp-lab/destroy_env.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/destroy_env.yml
@@ -19,6 +19,7 @@
         zone: "{{ osp_cluster_dns_zone }}"
         record: "{{ item }}.{{ guid }}"
         type: A
+        port: "{{ osp_cluster_dns_port | d('53') }}"
         key_name: "{{ ddns_key_name }}"
         key_secret: "{{ ddns_key_secret }}"
         state: absent

--- a/ansible/configs/ocp4-disconnected-osp-lab/post_infra.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/post_infra.yml
@@ -37,6 +37,7 @@
         record: "{{ item.dns }}.{{ guid }}"
         type: A
         ttl: 5
+        port: "{{ osp_cluster_dns_port | d('53') }}"
         value: "{{ item.name }}"
         key_name: "{{ ddns_key_name }}"
         key_secret: "{{ ddns_key_secret }}"

--- a/ansible/roles/host-lets-encrypt-certs-certbot/tasks/main.yml
+++ b/ansible/roles/host-lets-encrypt-certs-certbot/tasks/main.yml
@@ -48,7 +48,8 @@
     pip:
       name: virtualenv
       state: present
-      
+    when: not use_python3 | bool
+
   - name: Install certbot pip prerequisites in a VirtualEnv
     become: True
     pip:


### PR DESCRIPTION
##### SUMMARY
Another python2 vs python3 problem.

This [task](https://github.com/redhat-cop/agnosticd/blob/development/ansible/roles/host-lets-encrypt-certs-certbot/tasks/main.yml#L47-L50) was added in #1089 and unfortunately doesn't work in python3 environments since it is not specifying the executable so when we have no pip and no executable defined, it fails.

This PR is a workaround for now. We need a real effort to fix these python2/3 issues, but I need this to unblock for now. Fortunately not all configs have been tagged otherwise all of the OCP4-disconnected deploys would have failed all week.

The PR also has has a small change to add the port option for the DNS tasks similar to what was added to the role.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-disconnected-ha-lab
host-lets-encrypt-certs-certbot