### PR TITLE
[WIP]Update config to optionally run solver

### DIFF
--- a/ansible/configs/ocp4-disconnected-osp-lab/env_vars.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/env_vars.yml
@@ -199,6 +199,13 @@ user_vols_size: 20G
 # The external network in OpenStack where the floating IPs (FIPs) come from
 provider_network: external
 
+# Testing:
+# Enabling these vars will influence whether or not the FTL solver is run
+# This can be used for function or load testing
+
+test_enable: false
+test_pull_secret: FROM_SECRET
+
 # If you are deploying OpenShift, this should be set to the network that you
 # want to use and will be used to create security groups.
 # It will pull the subnet CIDR from the defined network below, based on the

--- a/ansible/configs/ocp4-disconnected-osp-lab/software.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/software.yml
@@ -235,3 +235,82 @@
     
     - name: Update CA trust
       command: update-ca-trust
+  
+- name: Step 005 Prep for FTL solver
+  hosts: bastions
+  gather_facts: false
+  become: true
+  tasks:
+    - when: test_enable
+      block:
+        - name: Set python3
+          set_fact:
+            ansible_python_interpreter: /usr/bin/python3
+
+        - name: Create pull secret file
+          file:
+            state: touch
+            path: "/home/{{ student_name }}/ocp_pullsecret.json"
+            mode: 0644
+            owner: "{{ student_name }}"
+
+        - name: Add pull secret to bastion
+          copy:
+            dest: "/home/{{ student_name }}/ocp_pullsecret.json"
+            content: "{{ test_pull_secret }}"
+
+        - name: Create neutral clouds.yaml directory
+          file:
+            path: /etc/openstack
+            state: directory
+            mode: 0644
+
+        - name: copy clouds.yaml to neutral location
+          copy:
+            remote_src: true
+            src: "/home/{{ student_name }}/.config/openstack/clouds.yaml"
+            dest: "/etc/openstack/clouds.yaml"
+            mode: 0644
+
+        - name: Check if metadata.json exists
+          stat:
+            path: /home/{{ student_name }}/openstack-upi/metadata.json
+          register: r_metadata
+
+        - name: Get the infra ID
+          shell: jq -r .infraID $HOME/openstack-upi/metadata.json
+          register: r_infra_id
+          when: r_metadata.stat.exists
+
+        - name: Run solver for lab 03
+          shell: /usr/local/bin/solve_lab ocp4_advanced_deployment 03_1
+          register: r_solve_lab_03
+          become_user: "{{ student_name }}"
+          environment:
+            OS_CLOUD: "{{ guid }}-project"
+            GUID: "{{ guid }}"
+            OPENSHIFT_DNS_ZONE: "{{ osp_cluster_dns_zone }}"
+            API_FIP: "{{ hostvars['localhost']['ocp_api_fip'] }}"
+            INGRESS_FIP: "{{ hostvars['localhost']['ocp_ingress_fip'] }}"
+            # INFRA_ID: "{{ r_infra_id.stdout }}"
+          vars:
+            GUID: "{{ guid }}"
+
+        - name: dump r_solve_lab_03
+          debug:
+            var: r_solve_lab_03
+        
+        - name: Run solver for lab 04
+          shell: /usr/local/bin/solve_lab ocp4_advanced_deployment 04_1
+          register: r_solve_lab_04
+          become_user: "{{ student_name }}"
+          environment:
+            OS_CLOUD: "{{ guid }}-project"
+            GUID: "{{ guid }}"
+          vars:
+            GUID: "{{ guid }}"
+
+        - name: dump r_solve_lab_04
+          debug:
+            var: r_solve_lab_04
+        


### PR DESCRIPTION
##### SUMMARY
This PR will extend the ocp4-disconnected config to optionally run the FTL solvers in the software phase. This is accomplished by setting `test_enable: true` and providing the `test_pull_secret`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4-disconnected-osp-lab
