### PR TITLE
Fix callback error warning for Ansible 2.7

### DIFF
--- a/ansible/completion_callback.yml
+++ b/ansible/completion_callback.yml
@@ -4,6 +4,8 @@
   tasks:
     - name: Attempt completion callback
       when:
+      - __meta__ is defined
+      - __meta__.callback is defined
       - __meta__.callback.url | default('') != ''
       - __meta__.callback.token | default('') != ''
       vars:


### PR DESCRIPTION
##### SUMMARY

Fix for Ansible 2.7 completion callback error when `__meta__` not defined.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Completion callback playbook.

##### ADDITIONAL INFORMATION

Prior to Ansible 2.8, default handling behaved differently as describe here:

https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.8.html

This caused the check in the `when` condition in the callback playbook to show noisy errors with Ansible 2.7.