### PR TITLE
Removed old FTL code from ans-tower-lab config, python 2 issue

### DIFF
--- a/ansible/configs/ans-tower-lab/pre_software.yml
+++ b/ansible/configs/ans-tower-lab/pre_software.yml
@@ -38,16 +38,16 @@
     - step004
     - bastion_tasks
 
-- name: Inject and configure FTL on bastion as grader host
-  hosts: bastions
-  become: true
-  tasks:
-    - name: Setup FTL
-      include_role:
-        name: ftl-injector
-  tags:
-    - step004
-    - ftl-injector  
+#- name: Inject and configure FTL on bastion as grader host
+#  hosts: bastions
+#  become: true
+#  tasks:
+#    - name: Setup FTL
+#      include_role:
+#        name: ftl-injector
+#  tags:
+#    - step004
+#    - ftl-injector  
 
 - name: Place Tower License from env_secret_vars on bastion
   hosts: bastions


### PR DESCRIPTION
##### SUMMARY
Python 2 FTL issue breaking ftl-injector


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ans-tower-lab fails

##### ADDITIONAL INFORMATION
Older FTL implementation commented out.
