### PR TITLE
Migration of Ravello Blueprint to AgnosticD - 3scale Implementation course

### DIFF
--- a/ansible/roles/ocp-workload-3scale-ocp-vm-ai/defaults/main.yml
+++ b/ansible/roles/ocp-workload-3scale-ocp-vm-ai/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+become_override: false
+ocp_username: user1
+
+ocp_user_groups:
+  - OPENTLC-PROJECT-PROVISIONERS

--- a/ansible/roles/ocp-workload-3scale-ocp-vm-ai/readme.adoc
+++ b/ansible/roles/ocp-workload-3scale-ocp-vm-ai/readme.adoc
@@ -1,0 +1,22 @@
+= ocp-workload-3scale-ocp-vm-ai
+
+== NOTES
+
+. This workload provisions a dedicated OCP cluster with a bastion node that runs on RHEL 7, for use in the *3scale Implementation* course
+. The bastion node contains an `oc` client that will be used as part of the labs in the course.
+
+== Execution using localhost oc client
+
+-----
+WORKLOAD="ocp-workload-3scale-ocp-vm-ai"
+OCP_USERNAME="user1"
+ansible-playbook -i localhost, -c local ./configs/ocp-workloads/ocp-workload.yml \
+                    -e"ocp_username=${OCP_USERNAME}" \
+                    -e"ocp_workload=${WORKLOAD}" \
+                    -e"ACTION=create"
+
+ansible-playbook -i localhost, -c local ./configs/ocp-workloads/ocp-workload.yml \
+                    -e"ocp_username=${OCP_USERNAME}" \
+                    -e"ocp_workload=${WORKLOAD}" \
+                    -e"ACTION=remove"
+-----

--- a/ansible/roles/ocp-workload-3scale-ocp-vm-ai/tasks/main.yml
+++ b/ansible/roles/ocp-workload-3scale-ocp-vm-ai/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: Running Pre Workload Tasks
+  import_tasks: ./pre_workload.yml
+  become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload Tasks
+  import_tasks: ./workload.yml
+  become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  import_tasks: ./post_workload.yml
+  become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload removal Tasks
+  import_tasks: ./remove_workload.yml
+  become: "{{ become_override | bool }}"
+  when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles/ocp-workload-3scale-ocp-vm-ai/tasks/post_workload.yml
+++ b/ansible/roles/ocp-workload-3scale-ocp-vm-ai/tasks/post_workload.yml
@@ -1,0 +1,4 @@
+---
+- name: post_workload Tasks Complete
+  debug:
+    msg: "Post-Software checks completed successfully"

--- a/ansible/roles/ocp-workload-3scale-ocp-vm-ai/tasks/pre_workload.yml
+++ b/ansible/roles/ocp-workload-3scale-ocp-vm-ai/tasks/pre_workload.yml
@@ -1,0 +1,4 @@
+---
+- name: pre_workload Tasks Complete
+  debug:
+    msg: "Pre-Software checks completed successfully"

--- a/ansible/roles/ocp-workload-3scale-ocp-vm-ai/tasks/remove_workload.yml
+++ b/ansible/roles/ocp-workload-3scale-ocp-vm-ai/tasks/remove_workload.yml
@@ -1,0 +1,4 @@
+---
+- name: post_workload Tasks Complete
+  debug:
+    msg: "Post-Software checks completed successfully - Removed"

--- a/ansible/roles/ocp-workload-3scale-ocp-vm-ai/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-3scale-ocp-vm-ai/tasks/workload.yml
@@ -1,0 +1,8 @@
+---
+- name: Provide user with ability to impersonate system admin so as to be able to run cluster-admin commands
+  shell: "oc adm policy add-cluster-role-to-user sudoer {{ocp_username}} --as=system:admin"
+
+
+- name: workload Tasks Complete
+  debug:
+    msg: workload Tasks Complete


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Migration of Ravello Blueprint to AgnosticD - 3scale Implementation course
https://github.com/redhat-gpe/3scale_implementation/issues/191

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp-workload-3scale-ocp-vm-ai
