### PR TITLE
OpenShift Migration Workload:  Upgrade to use CAM 1.1 in both OCP 3 and 4 workloads

### DIFF
--- a/ansible/roles/ocp-workload-migration/templates/operator.yml.j2
+++ b/ansible/roles/ocp-workload-migration/templates/operator.yml.j2
@@ -7,7 +7,7 @@ metadata:
   labels:
     control-plane: controller-manager
     controller-tools.k8s.io: "1.0"
-  name: {{ mig_migration_namespace }}
+  name: "{{ mig_migration_namespace }}"
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
@@ -27,7 +27,7 @@ subjects:
   name: deployer
   namespace: {{ mig_migration_namespace }}
 userNames:
-- system:serviceaccount:openshift-migration:deployer
+- system:serviceaccount:{{ mig_migration_namespace }}:deployer
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
@@ -46,11 +46,11 @@ subjects:
   name: builder
   namespace: {{ mig_migration_namespace }}
 userNames:
-- system:serviceaccount:openshift-migration:builder
+- system:serviceaccount:{{ mig_migration_namespace }}:builder
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 groupNames:
-- system:serviceaccounts:openshift-migration
+- system:serviceaccounts:{{ mig_migration_namespace }}
 kind: RoleBinding
 metadata:
   annotations:
@@ -65,13 +65,13 @@ roleRef:
   name: system:image-puller
 subjects:
 - kind: Group
-  name: system:serviceaccounts:openshift-migration
+  name: system:serviceaccounts:{{ mig_migration_namespace }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: migration-operator
-  namespace: {{ mig_migration_namespace }}
+  namespace: "{{ mig_migration_namespace }}"
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -98,7 +98,7 @@ kind: Role
 metadata:
   creationTimestamp: null
   name: migration-operator
-  namespace: {{ mig_migration_namespace }}
+  namespace: "{{ mig_migration_namespace }}"
 rules:
 - apiGroups:
   - ""
@@ -147,7 +147,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: migration-operator
-  namespace: {{ mig_migration_namespace }}
+  namespace: "{{ mig_migration_namespace }}"
 subjects:
 - kind: ServiceAccount
   name: migration-operator
@@ -167,24 +167,24 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: migration-operator
-    namespace: {{ mig_migration_namespace }}
-namespace: {{ mig_migration_namespace }}
+    namespace: "{{ mig_migration_namespace }}"
+namespace: "{{ mig_migration_namespace }}"
 ---
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: migration-operator
-  namespace: {{ mig_migration_namespace }}
+  namespace: "{{ mig_migration_namespace }}"
   labels:
-    app: migration-operator
+    app: migration
 spec:
   selector:
     matchLabels:
-      app: migration-operator
+      app: migration
   template:
     metadata:
       labels:
-        app: migration-operator
+        app: migration
     spec:
       serviceAccountName: migration-operator
       containers:
@@ -193,14 +193,14 @@ spec:
         - /usr/local/bin/ao-logs
         - /tmp/ansible-operator/runner
         - stdout
-        image: registry.redhat.io/rhcam-1-0/openshift-migration-rhel7-operator:v1.0
+        image: registry.redhat.io/rhcam-1-1/{{ mig_migration_namespace }}-rhel7-operator:v1.1
         imagePullPolicy: Always
         volumeMounts:
         - mountPath: /tmp/ansible-operator/runner
           name: runner
           readOnly: true
       - name: operator
-        image: registry.redhat.io/rhcam-1-0/openshift-migration-rhel7-operator:v1.0
+        image: registry.redhat.io/rhcam-1-1/{{ mig_migration_namespace }}-rhel7-operator:v1.1
         imagePullPolicy: Always
         volumeMounts:
         - mountPath: /tmp/ansible-operator/runner
@@ -219,27 +219,43 @@ spec:
         - name: REGISTRY
           value: registry.redhat.io
         - name: PROJECT
-          value: rhcam-1-0
+          value: rhcam-1-1
         - name: MIG_CONTROLLER_REPO
-          value: openshift-migration-controller-rhel8@sha256
-        - name: MIG_CONTROLLER_TAG
-          value: f5cdf3c0d3da45243b3e98441f0486b29aa8683b09dd936dfb32fda3ff10c2c1
+          value: {{ mig_migration_namespace }}-controller-rhel8@sha256
         - name: MIG_UI_REPO
-          value: openshift-migration-ui-rhel8@sha256
-        - name: MIG_UI_TAG
-          value: a196fa9d9af4262641a740823a8b3343c59a352fb3a48a409538554bd1fa88a9
+          value: {{ mig_migration_namespace }}-ui-rhel8@sha256
+        - name: MIGRATION_REGISTRY_REPO
+          value: {{ mig_migration_namespace }}-registry-rhel8@sha256
+        - name: MIGRATION_REGISTRY_TAG
+          value: 0ae610db4f73b6a5353c4821165bd60a8c4e86ac5ba5f1d60cd532f5bcd814bd
         - name: VELERO_REPO
-          value: openshift-migration-velero-rhel8@sha256
-        - name: VELERO_TAG
-          value: d4423442db8618e4c96faadd96b053572ecf278f07461c8f8709af8094e8a5da
+          value: {{ mig_migration_namespace }}-velero-rhel8@sha256
         - name: VELERO_PLUGIN_REPO
-          value: openshift-migration-plugin-rhel8@sha256
-        - name: VELERO_PLUGIN_TAG
-          value: ffdea2b8e467ab7a8e1b9f718e7e3700abbfa3cb9539a09b4dc7a5cb6ea9e0bb
+          value: {{ mig_migration_namespace }}-plugin-rhel8@sha256
         - name: VELERO_RESTIC_RESTORE_HELPER_REPO
-          value: openshift-migration-velero-restic-restore-helper-rhel8@sha256
+          value: {{ mig_migration_namespace }}-velero-restic-restore-helper-rhel8@sha256
+        - name: VELERO_AWS_PLUGIN_REPO
+          value: {{ mig_migration_namespace }}-velero-plugin-for-aws-rhel8@sha256
+        - name: VELERO_GCP_PLUGIN_REPO
+          value: {{ mig_migration_namespace }}-velero-plugin-for-gcp-rhel8@sha256
+        - name: VELERO_AZURE_PLUGIN_REPO
+          value: {{ mig_migration_namespace }}-velero-plugin-for-microsoft-azure-rhel8@sha256
+        - name: VELERO_TAG
+          value: db2997115d8a0767d61038e14f48170dc53d3c54b977184e7ecb37ead2f131da
         - name: VELERO_RESTIC_RESTORE_HELPER_TAG
-          value: 0ec6d5e6f3446490d7cb54a2443c2869936fc7650e19740e4b10aed71ff4f863
+          value: 44f0362c8570d707582bd428aaf18f390ce915ef72cdeb60cf2699171dbda3c8
+        - name: VELERO_PLUGIN_TAG
+          value: 94d5f45f5e8236614e124d2753da7165b913b0e2d8199f164d8f2d208339e85e
+        - name: VELERO_AWS_PLUGIN_TAG
+          value: 460dfc455de7ee6a2e49d17d5227c5d653340197b7ad9ed430576c35f4651f4d
+        - name: VELERO_GCP_PLUGIN_TAG
+          value: 44f40ff5a3c8ad9b76105e2b8fc5bd04692464cc4aa683da2cf83b3336200863
+        - name: VELERO_AZURE_PLUGIN_TAG
+          value: 9e69f2af712452218cde0c3325c60f9e1eb4624bcaff67770822b60f2e19ac60
+        - name: MIG_UI_TAG
+          value: ed16db50ffd6614d8f654449bf29003b82d4d5da420419add00fd5ec5b1fd79b
+        - name: MIG_CONTROLLER_TAG
+          value: db3247ffbaaace242cfd3d530994ccdeb0a39f4e3b46e43f7f3870279cf65d1a
       volumes:
         - name: runner
           emptyDir: {}

--- a/ansible/roles/ocp4-workload-migration/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-migration/defaults/main.yml
@@ -1,5 +1,5 @@
 # workload vars
-mig_operator_release: "v1.0.1"
+mig_operator_release: "v1.1.0"
 
 mig_state: "present"
 mig_migration_namespace: "openshift-migration"

--- a/ansible/roles/ocp4-workload-migration/templates/mig-operator-subscription-downstream.yml.j2
+++ b/ansible/roles/ocp4-workload-migration/templates/mig-operator-subscription-downstream.yml.j2
@@ -4,7 +4,7 @@ metadata:
   name: cam-operator
   namespace: {{ mig_migration_namespace }}
 spec:
-  channel: release-v1
+  channel: release-v1.1
   installPlanApproval: Automatic
   name: cam-operator
   source: redhat-operators


### PR DESCRIPTION
##### SUMMARY
Upgrade CAM Operator to version 1.1 for both OCP 3 and 4 workloads.
Part of Summit 2020 Lab for OpenShift Migrations

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp-workload-migration
ocp4-workload-migration


cc @pranavgaikwad @djwhatle @jmontleon 
