### PR TITLE
Support ansible_python_interpreter tag  / metadata

### DIFF
--- a/ansible/include_vars.yml
+++ b/ansible/include_vars.yml
@@ -1,16 +1,9 @@
 ---
-- hosts:
-    - localhost
-    - all
+- hosts: localhost
   connection: local
   gather_facts: no
   tags: include_vars
   tasks:
-    - name: Set output_dir for all hosts
-      set_fact:
-        output_dir: "{{ hostvars.localhost.output_dir }}"
-      when: hostvars.localhost.output_dir is defined
-
     - name: Stat default variables files (both yaml/yml extensions)
       vars:
         find_me:
@@ -43,13 +36,26 @@
       loop: "{{ find_me }}"
       register: rstat2_varfiles
 
+
+- hosts:
+    - localhost
+    - all
+  connection: local
+  gather_facts: no
+  tags: include_vars
+  tasks:
+    - name: Set output_dir for all hosts
+      set_fact:
+        output_dir: "{{ hostvars.localhost.output_dir }}"
+      when: hostvars.localhost.output_dir is defined
+
     - name: Include variables files
       include_vars:
         file: "{{ item.stat.path }}"
       when:
         - item is not skipped
         - item.stat.exists
-      loop: "{{ rstat_varfiles.results + rstat2_varfiles.results }}"
+      loop: "{{ hostvars.localhost.rstat_varfiles.results + hostvars.localhost.rstat2_varfiles.results }}"
       loop_control:
         label: >-
           {{ (

--- a/ansible/roles/infra-ec2-create-inventory/tasks/main.yml
+++ b/ansible/roles/infra-ec2-create-inventory/tasks/main.yml
@@ -71,6 +71,7 @@
     placement: "{{item['placement']['availability_zone']}}"
     image_id: "{{item['image_id']}}"
     ansible_ssh_extra_args: "-o StrictHostKeyChecking=no"
+    ansible_python_interpreter: "{{ item.tags.ansible_python_interpreter | default(omit) }}"
     bastion: "{{ local_bastion | default('') }}"
   when: item.state.name != 'terminated'
   with_items: "{{ec2_facts['instances']}}"

--- a/ansible/roles/infra-osp-create-inventory/tasks/main.yml
+++ b/ansible/roles/infra-osp-create-inventory/tasks/main.yml
@@ -47,6 +47,7 @@
         public_ip_address: "{{ server.public_v4 | default('') }}"
         image_id: "{{ server.image.id | default('') }}"
         ansible_ssh_extra_args: "-o StrictHostKeyChecking=no"
+        ansible_python_interpreter: "{{ server.metadata.ansible_python_interpreter | default(omit) }}"
         bastion: "{{ local_bastion | default('') }}"
       loop: "{{ r_osp_facts.ansible_facts.openstack_servers }}"
       loop_control:


### PR DESCRIPTION
- include_vars.yml: don't stats files on all hosts but only on localhost
