### PR TITLE
Fix for ansible 2.7, make sure the callback key is present

### DIFF
--- a/ansible/completion_callback.yml
+++ b/ansible/completion_callback.yml
@@ -5,7 +5,7 @@
     - name: Attempt completion callback
       when:
       - __meta__ is defined
-      - 'callback' in __meta__
+      - "'callback' in __meta__"
       - __meta__.callback is defined
       - __meta__.callback.url | default('') != ''
       - __meta__.callback.token | default('') != ''

--- a/ansible/completion_callback.yml
+++ b/ansible/completion_callback.yml
@@ -5,6 +5,7 @@
     - name: Attempt completion callback
       when:
       - __meta__ is defined
+      - 'callback' in __meta__
       - __meta__.callback is defined
       - __meta__.callback.url | default('') != ''
       - __meta__.callback.token | default('') != ''


### PR DESCRIPTION
This commit if applied fixes the following error with ansible 2.7

```
fatal: [localhost]: FAILED! => {"msg": "The conditional check
'__meta__.callback.url
| default('') != ''' failed. The error was: error while evaluating conditional
(__meta__.callback.url | default('') != ''): '__meta__' is undefined
```


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

