### PR TITLE
Increase OptaWeb Employee Rostering build timeout

### DIFF
--- a/ansible/roles/ocp-workload-optaweb-employee-rostering/defaults/main.yml
+++ b/ansible/roles/ocp-workload-optaweb-employee-rostering/defaults/main.yml
@@ -18,7 +18,7 @@ quota_services: 3
 quota_secrets: 1
 quota_requests_storage: 1Gi
 
-build_status_retries: 45
+build_status_retries: 60
 build_status_delay: 30
 
 deploy_status_retries: 15

--- a/ansible/roles/ocp-workload-optaweb-employee-rostering/readme.adoc
+++ b/ansible/roles/ocp-workload-optaweb-employee-rostering/readme.adoc
@@ -65,6 +65,7 @@ WORKLOAD="ocp-workload-optaweb-employee-rostering"
 
 # a TARGET_HOST is specified in the command line, without using an inventory file
 ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+                 -e"ansible_python_interpreter=/usr/bin/python" \
                  -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
                  -e"ansible_user=${SSH_USER}" \
                  -e"ocp_username=${OCP_USERNAME}" \


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I have successfully tested the deployment on DEV cluster but the deployment times out when the GPTE team tries to set up a catalog item for this demo.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp-workload-optaweb-employee-rostering

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Another commit in this PR is related to #1089. When I tested the role today I was surprised that it fails both on my machine on on DEV cluster's bastion with the following:

```
TASK [ocp-workload-optaweb-employee-rostering : Remove user Project] **********
Wednesday 12 February 2020  15:27:16 +0100 (0:00:00.024)       0:00:00.667 **** 
fatal: [bastion.dev.openshift.opentlc.com]: FAILED! => {
  "changed": false,
  "module_stderr": "Shared connection to bastion.dev.openshift.opentlc.com closed.\r\n",
  "module_stdout": "/bin/sh: /opt/virtualenvs/k8s/bin/python: No such file or directory\r\n",
  "msg": "The module failed to execute correctly, you probably need to set the interpreter.\nSee stdout/stderr for the exact error",
  "rc": 127
}
```

This happens not only on my machine where I don't use `virtualenv` but also on bastion so I took the approach where I override the variable (`ansible_python_interpreter=/usr/bin/python`). Please confirm this is OK or propose a better approach.
