### PR TITLE
Work around for oddjobd needing messagebus service restart

### DIFF
--- a/ansible/configs/three-tier-app/post_software.yml
+++ b/ansible/configs/three-tier-app/post_software.yml
@@ -12,17 +12,25 @@
   become: yes
   tags:
     - opentlc_bastion_tasks
-  tasks:
-    - import_role:
-        name: "bastion-opentlc-ipa"
-      when: install_ipa_client|bool
 
-    # sssd bug, fixed by restart
-    - name: restart sssd
+  tasks:
+
+    - when: install_ipa_client | bool
+      name: Install IPA Clinet on bastions
+      import_role:
+        name: "bastion-opentlc-ipa"
+
+    - when: install_ipa_client | bool
+      name: Restart IPA related services 
       service:
-        name: sssd
+        name: "{{ service }}"
         state: restarted
-      when: install_ipa_client
+      loop:
+        - sssd              # sssd bug, fixed by restart
+        - messagebus        # oddjobd failing without messagebus restart
+        - oddjobd
+      loop_control:
+        loop_var: service  
 
 - name: PostSoftware flight-check
   hosts: localhost


### PR DESCRIPTION
##### SUMMARY
Bringing config `three-tier-app` up to date with much more recent rpms breaks ipa code, this issue has also been seen elsewhere. Fixed by restarting both key services in the correct order.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
config three-tier-app

##### ADDITIONAL INFORMATION
Should perhaps migrate into the `bastion-opentlc-ipa` role
