### PR TITLE
removed dns_nameservers var see: bugzilla 1748015

### DIFF
--- a/ansible/configs/osp-sandbox/env_vars.yml
+++ b/ansible/configs/osp-sandbox/env_vars.yml
@@ -171,9 +171,6 @@ networks:
     gateway_ip: 192.168.0.1
     allocation_start: 192.168.0.20
     allocation_end: 192.168.0.254
-    dns_nameservers:
-      - 8.8.8.8
-      - 1.1.1.1
     create_router: true
 
 # These will influence the bastion if it is being deployed


### PR DESCRIPTION
##### SUMMARY
removed the dns_nameservers parameter from env_vars.yaml
see https://bugzilla.redhat.com/show_bug.cgi?id=1748015 for more info

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
osp-sandbox config

