### PR TITLE
Add ansible_python_interpreter to ensure cluster recovery works.

### DIFF
--- a/ansible/configs/ocp4-workshop/lifecycle.yml
+++ b/ansible/configs/ocp4-workshop/lifecycle.yml
@@ -98,6 +98,9 @@
   become: false
   gather_facts: false
   tasks:
+  - name: Set Ansible Python interpreter to k8s virtualenv
+    set_fact:
+      ansible_python_interpreter: /opt/virtualenvs/k8s/bin/python
   - name: Recover cluster if it missed cert rotation
     delegate_to: "{{ groups['bastions'] | first }}"
     when: ACTION == 'start'


### PR DESCRIPTION
We didn't set the k8s virtualenv. Therefore the cluster start logic never approved CSRs. :-( Resulting in broken RHPDS clusters.