### PR TITLE
increase codeready keycloak token lifespan

### DIFF
--- a/ansible/roles/ocp4-workload-ccnrd/tasks/install-codeready.yaml
+++ b/ansible/roles/ocp4-workload-ccnrd/tasks/install-codeready.yaml
@@ -171,9 +171,9 @@
   shell: |
     oc import-image --all quarkus-stack -n openshift
 
-- name: wait a minute and let the image download and be registered so workspaces start up
+- name: wait 2 minutes and let the image download and be registered so workspaces start up
   pause:
-      minutes: 1
+      minutes: 2
 
 - name: Pre-create and warm user workspaces
   include_tasks: create_che_workspace.yaml

--- a/ansible/roles/ocp4-workload-ccnrd/tasks/install-codeready.yaml
+++ b/ansible/roles/ocp4-workload-ccnrd/tasks/install-codeready.yaml
@@ -116,18 +116,35 @@
     user: "{{ item }}"
   with_list: "{{ users }}"
 
-- name: Get Codeready admin token
+- name: Get codeready SSO admin token
   uri:
-    url: http://keycloak-labs-infra.{{ route_subdomain }}/auth/realms/codeready/protocol/openid-connect/token
+    url: http://keycloak-labs-infra.{{ route_subdomain }}/auth/realms/master/protocol/openid-connect/token
     method: POST
     body:
-      username: admin
-      password: admin
+      username: "{{ codeready_sso_admin_username }}"
+      password: "{{ codeready_sso_admin_password }}"
       grant_type: "password"
       client_id: "admin-cli"
     body_format: form-urlencoded
     status_code: 200,201,204
-  register: che_admin_token
+  register: codeready_sso_admin_token
+
+- name: Increase codeready access token lifespans
+  uri:
+    url: http://keycloak-labs-infra.{{ route_subdomain }}/auth/admin/realms/codeready
+    method: PUT
+    headers:
+      Content-Type: application/json
+      Authorization: "Bearer {{ codeready_sso_admin_token.json.access_token }}"
+    body:
+      accessTokenLifespan: 28800
+      accessTokenLifespanForImplicitFlow: 28800
+      actionTokenGeneratedByUserLifespan: 28800
+      ssoSessionIdleTimeout: 28800
+      ssoSessionMaxLifespan: 28800
+    body_format: json
+    status_code: 204
+
 
 - name: Import stack imagestream
   k8s:

--- a/ansible/roles/ocp4-workload-ccnrd/templates/devfile.json.j2
+++ b/ansible/roles/ocp4-workload-ccnrd/templates/devfile.json.j2
@@ -10,7 +10,7 @@
     },
     {
       "mountSources": true,
-      "memoryLimit": "4Gi",
+      "memoryLimit": "3Gi",
       "type": "dockerimage",
       "volumes": [
         {
@@ -50,18 +50,6 @@
           }
         }
       ]
-    },
-    {
-      "id": "redhat/vscode-yaml/latest",
-      "type": "chePlugin"
-    },
-    {
-      "id": "redhat/vscode-openshift-connector/latest",
-      "type": "chePlugin"
-    },
-    {
-      "id": "ms-kubernetes-tools/vscode-kubernetes-tools/latest",
-      "type": "chePlugin"
     }
   ],
   "commands": [


### PR DESCRIPTION
##### SUMMARY

CodeReady's default token lifespan of 5 minutes is insufficient for day-long workshops, so this increases the timeout to 8 hours. Otherwise users constantly get logged out and have to log back in to continue.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-workload-ccnrd

