### PR TITLE
Don't install cluster logging operator in the workload.

### DIFF
--- a/ansible/roles/ocp4-workload-homeroomlab-starter-guides/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-homeroomlab-starter-guides/tasks/workload.yml
@@ -160,8 +160,8 @@
   - ./files/eo-sub.yml
   - ./files/eo-role.yml
   - ./files/eo-rb.yml
-  - ./files/clo-og.yml
-  - ./files/clo-sub.yml
+ # - ./files/clo-og.yml
+ # - ./files/clo-sub.yml
 
 - name: Wait for Elasticsearch CRD
   k8s_facts:
@@ -178,38 +178,6 @@
   when: not r_elasticsearch_crd.resources | list | length == 1
   debug:
     msg: "user.info: *** Elasticsearch operator could not be installed ***"
-
-- name: Wait for Logging CRD
-  k8s_facts:
-    api_version: apiextensions.k8s.io/v1beta1
-    kind: CustomResourceDefinition
-    name: clusterloggings.logging.openshift.io
-  register: r_logging_crd
-  retries: 20
-  delay: 10
-  ignore_errors: yes
-  until: r_logging_crd.resources | list | length == 1
-
-- name: Notify user if Logging deployment failed
-  when: not r_logging_crd.resources | list | length == 1
-  debug:
-    msg: "user.info: *** Logging operator could not be installed ***"
-
-- name: Deploy Logging
-  when:
-  - r_logging_crd.resources | list | length == 1
-  - r_elasticsearch_crd.resources | list | length == 1
-  block:
-  - name: Create OpenShift Objects for ClusterLogging
-    k8s:
-      state: present
-      merge_type:
-      - strategic-merge
-      - merge
-      definition: "{{ lookup('template', item ) | from_yaml }}"
-    ignore_errors: yes
-    loop:
-    - ./files/cl-instance.yml    
 
 # Leave this as the last task in the playbook.
 - name: workload tasks complete


### PR DESCRIPTION
##### SUMMARY
For ocp4-workload-homeroomlab-starter-guides, don't install the cluster logging operator in the workload.

- Bugfix Pull Request


##### COMPONENT NAME
ocp4-workload-homeroomlab-starter-guides
