### PR TITLE
Add *.pyc files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ my_*_vars.yml
 
 .vscode/settings.json
 __pycache__
+*.pyc


### PR DESCRIPTION
##### SUMMARY
After running the example config, `git status` reported that `action_plugins/agnosticd_user_info.pyc` is not tracked. The `.pyc` files shouldn't be versioned as they are generated at runtime.

##### ISSUE TYPE
- Bugfix Pull Request

##### ADDITIONAL INFORMATION
The change is pretty simple as it only adds `*.pyc` to `.gitignore`.