### PR TITLE
OptaWeb Employee Rostering: Increase JVM heap memory

### DIFF
--- a/ansible/roles/ocp-workload-optaweb-employee-rostering/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-optaweb-employee-rostering/tasks/workload.yml
@@ -20,6 +20,7 @@
   shell: "oc new-app --name employee-rostering \
       --strategy=docker \
       java:8~{{optaweb_git_repository}}#{{optaweb_git_branch}} \
+      -e JAVA_TOOL_OPTIONS=\"-XX:MaxHeapSize=2g -XX:InitialHeapSize=2g\" \
       -n {{ocp_project}}"
 
 - name: "Share PostgreSQL secret with OptaWeb app"


### PR DESCRIPTION
##### SUMMARY
The application becomes unresponsive after being used for a short time
when relying on the default memory settings. I even saw it crash with
OutOfMemoryError once.

Increasing the heap memory size addresses these issues. I used the
application with increased JVM memory settings for some time and the memory consumption
settled down on 1.4 Gi so I assume 2 Gi should be enough (unless there's
a memory leak).

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
DM7 OptaWeb Employee Rostering Demo

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

The demo is not yet in production. It has passed DEV onboarding during which I have identified the memory issue. I'd like to get this merged before I request moving the demo from DEV to TEST stage.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
