### PR TITLE
Allowed port 80 in SG

### DIFF
--- a/ansible/configs/ansible-tower-implementation/default_vars_osp.yml
+++ b/ansible/configs/ansible-tower-implementation/default_vars_osp.yml
@@ -35,10 +35,17 @@ rootfs_size_bastion: 50
 security_groups:
   - name: TowerSG
     rules:
-      - name: SatHTTPSPorts
+      - name: TowerHTTPSPorts
         description: "HTTPS Public"
         from_port: 443
         to_port: 443
+        protocol: tcp
+        cidr: "0.0.0.0/0"
+        rule_type: Ingress
+      - name: TowerHTTPPorts
+        description: "HTTP Public"
+        from_port: 80 
+        to_port: 80
         protocol: tcp
         cidr: "0.0.0.0/0"
         rule_type: Ingress


### PR DESCRIPTION
Edited default_vars_osp.yaml to open port 80 for tower instance.