### PR TITLE
Update CRW password; increase robustness of pre-warming of workspaces

### DIFF
--- a/ansible/roles/ocp4-workload-quarkus-workshop/tasks/add_che_user.yaml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/tasks/add_che_user.yaml
@@ -28,7 +28,7 @@
       email: "{{ user }}@no-reply.com"
       credentials:
         - type: password
-          value: "{{ user | replace('user', 'pass') }}"
+          value: "{{ workshop_che_user_password }}"
           temporary: false
     body_format: json
     status_code: 201,409

--- a/ansible/roles/ocp4-workload-quarkus-workshop/tasks/create_che_workspace.yaml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/tasks/create_che_workspace.yaml
@@ -5,7 +5,7 @@
     method: POST
     body:
       username: "{{ user }}"
-      password: "{{ user | replace('user', 'pass') }}"
+      password: "{{ workshop_che_user_password }}"
       grant_type: "password"
       client_id: "admin-cli"
     body_format: form-urlencoded

--- a/ansible/roles/ocp4-workload-quarkus-workshop/tasks/install-codeready.yaml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/tasks/install-codeready.yaml
@@ -208,12 +208,19 @@
   shell: |
     oc import-image --all quarkus-stack -n openshift
 
-- name: wait a minute and let the image download and be registered so workspaces start up
-  pause:
-      minutes: 5
-
 - name: Pre-create and warm user workspaces
   include_tasks: create_che_workspace.yaml
   vars:
     user: "{{ item }}"
   with_list: "{{ users }}"
+
+- name: wait a minute and let the image download and be registered
+  pause:
+      minutes: 2
+
+- name: Attempt to warm workspaces which failed to start
+  include_tasks: verify_che_workspace.yaml
+  vars:
+    user: "{{ item }}"
+  with_list: "{{ users }}"
+

--- a/ansible/roles/ocp4-workload-quarkus-workshop/tasks/verify_che_workspace.yaml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/tasks/verify_che_workspace.yaml
@@ -1,0 +1,35 @@
+---
+- name: "Get Che {{ user }} token"
+  uri:
+    url: http://keycloak-codeready.{{ route_subdomain }}/auth/realms/codeready/protocol/openid-connect/token
+    method: POST
+    body:
+      username: "{{ user }}"
+      password: "{{ workshop_che_user_password }}"
+      grant_type: "password"
+      client_id: "admin-cli"
+    body_format: form-urlencoded
+    status_code: 200
+  register: user_token
+
+- name: Get workspace for {{ user }}
+  uri:
+    url: "http://codeready-codeready.{{ route_subdomain }}/api/workspace"
+    method: GET
+    headers:
+      Accept: application/json
+      Authorization: "Bearer {{ user_token.json.access_token }}"
+    status_code: 200
+  register: workspace_def
+
+- name: Verify and start workspace for {{ user }} again if stopped
+  when: workspace_def.json[0].status == "STOPPED"
+  uri:
+    url: "http://codeready-codeready.{{ route_subdomain }}/api/workspace/{{ workspace_def.json[0].id }}/runtime"
+    method: POST
+    headers:
+      Accept: application/json
+      Authorization: "Bearer {{ user_token.json.access_token }}"
+    status_code: 200
+
+


### PR DESCRIPTION
##### SUMMARY
Use default RHPDS password for CRW accounts to match OCP password.

Add an extra attempt to pre-start workspaces for those that tried to start before their container images were pulled down.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`ocp4-workload-quarkus-workshop`

