### PR TITLE
Role added to copy tower license

### DIFF
--- a/ansible/configs/ansible-tower-implementation/post_software.yml
+++ b/ansible/configs/ansible-tower-implementation/post_software.yml
@@ -16,6 +16,8 @@
     - import_role:
         name: "bastion-opentlc-ipa"
       when: install_ipa_client|bool
+    - import_role:
+        name: "tower-license-copy"
 
     # sssd bug, fixed by restart
     - name: restart sssd

--- a/ansible/roles/tower-license-copy/tasks/main.yml
+++ b/ansible/roles/tower-license-copy/tasks/main.yml
@@ -1,0 +1,8 @@
+- name: Copy Tower License File
+  copy:
+    content: "{{ tower_license | from_json }}"
+    dest: /root/license.txt
+  tags:
+      - tower-license-copy
+
+


### PR DESCRIPTION
Role `tower-license-copy` created.
Edited configs/ansible-tower-implemetation/post_software.yml to call the role.