### PR TITLE
Deactivate localhost warning

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -10,6 +10,7 @@ callback_whitelist      = profile_tasks
 #stdout_callback         = yaml
 # Use the stdout_callback when running ad-hoc commands.
 bin_ansible_callbacks   = True
+localhost_warning       = False
 
 [privilege_escalation]
 become                  = False


### PR DESCRIPTION
hide this:

```
[WARNING]: provided hosts list is empty, only localhost is available. Note that
the implicit localhost does not match 'all'
```