### PR TITLE
dont hide .m2

### DIFF
--- a/ansible/roles/ocp4-workload-ccnrd/templates/devfile.json.j2
+++ b/ansible/roles/ocp4-workload-ccnrd/templates/devfile.json.j2
@@ -12,12 +12,6 @@
       "mountSources": true,
       "memoryLimit": "3Gi",
       "type": "dockerimage",
-      "volumes": [
-        {
-          "name": "m2",
-          "containerPath": "/home/jboss/.m2"
-        }
-      ],
       "alias": "quarkus-tools",
       "image": "image-registry.openshift-image-registry.svc:5000/openshift/quarkus-stack:1.5",
       "env": [


### PR DESCRIPTION
##### SUMMARY
By declaring `~/.m2` as a volume in the Che devfile, the pre-cached artifacts in the underlying container image are hidden. This fixes that so that builds go faster and take less network to do so.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`ocp4-workload-quarkus-workshop`

