### PR TITLE
Fix ansible windows 2020 03 02

### DIFF
--- a/ansible/configs/ansible-windows/env_vars.yml
+++ b/ansible/configs/ansible-windows/env_vars.yml
@@ -14,6 +14,8 @@
 ###### VARIABLES YOU SHOULD CONFIGURE FOR YOUR DEPLOYEMNT
 ###### OR PASS as "-e" args to ansible-playbook command
 
+
+
 ### Common Host settings
 
 repo_method: file # Other Options are: file, satellite and rhn
@@ -49,6 +51,11 @@ ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem
 set_env_authorized_key: true
 # Is this running from Red Hat Ansible Tower
 tower_run: false
+
+### FTL settings
+
+install_ftl: false
+
 
 ### AWS EC2 Environment settings
 

--- a/ansible/configs/ansible-windows/pre_software.yml
+++ b/ansible/configs/ansible-windows/pre_software.yml
@@ -40,17 +40,6 @@
     - step004
     - bastion_tasks
 
-- name: Inject and configure FTL on bastion as grader host
-  hosts: bastions
-  become: true
-  tasks:
-    - name: Setup FTL
-      include_role:
-        name: ftl-injector
-  tags:
-    - step004
-    - ftl-injector
-
 - name: Place Tower License from env_secret_vars on bastion
   hosts: bastions
   become: yes

--- a/ansible/configs/ansible-windows/sample_vars.yml
+++ b/ansible/configs/ansible-windows/sample_vars.yml
@@ -5,7 +5,7 @@
 #
 # Ideally keep your copy OUTSIDE your repo, especially if using Cloud Credentials
 
-env_type: ansible-integrations          # Name of config to deploy
+env_type: ansible-windows
 output_dir: /tmp/workdir                # Writable working scratch directory
 email: name@example.com                 # User info for notifications
 


### PR DESCRIPTION
##### SUMMARY
ansible-windows had old style ftl-injection code and incorrect vars

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-windows

##### ADDITIONAL INFORMATION
Simple fix ftl-injection now done in bastion role. Plus sample_vars had an incorrect env_type