### PR TITLE
ocp-workshop - set default AMI to RH Cloud Access

### DIFF
--- a/ansible/configs/ocp-workshop/README.adoc
+++ b/ansible/configs/ocp-workshop/README.adoc
@@ -1,5 +1,7 @@
 = ocp-workshop standard config
 
+NOTE: AWS Instance Types of m5.* are known to fail.  Use m4.*
+
 
 == Running Ansible Playbook
 

--- a/ansible/configs/ocp-workshop/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/ocp-workshop/files/cloud_providers/ec2_cloud_template.j2
@@ -5,77 +5,77 @@ Mappings:
   RegionMapping:
     us-east-1:
       {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-6871a115
+      RHELAMI: ami-0456c465f72bd0c95  # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
       {% else %}
-      RHELAMI: ami-c998b6b2
+      RHELAMI: ami-c5a094bf # RHEL-7.4_HVM-20180122-x86_64-1-Access2-GP2
       {% endif %}
     us-east-2:
       {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-03291866
+      RHELAMI: ami-04268981d7c33264d  # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
       {% else %}
-      RHELAMI: ami-cfdafaaa
+      RHELAMI: ami-9db09af8 # RHEL-7.4_HVM-20180122-x86_64-1-Access2-GP2
       {% endif %}
     us-west-1:
       {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-18726478
+      RHELAMI: ami-02574210e91c38419  # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
       {% else %}
-      RHELAMI: ami-66eec506
+      RHELAMI: ami-9db09af8  # RHEL-7.4_HVM-20180122-x86_64-1-Access2-GP2
       {% endif %}
     us-west-2:
       {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-28e07e50
+      RHELAMI: ami-0e6bab6682ec471c0 # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
       {% else %}
-      RHELAMI: ami-223f945a
+      RHELAMI: ami-c405b8bc # RHEL-7.4_HVM-20180122-x86_64-1-Access2-GP2
       {% endif %}
     eu-west-2:
-      RHELAMI: ami-032a151c5ec1cece8
+      RHELAMI: ami-01f010afd559615b9 # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
     eu-west-1:
       {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-7c491f05
+      RHELAMI: ami-01f010afd559615b9  # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
       {% else %}
-      RHELAMI: ami-bb9a6bc2
+      RHELAMI: ami-b7b6d3ce # RHEL-7.4_HVM-20180122-x86_64-1-Access2-GP2
       {% endif %}
     eu-central-1:
       {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-c86c3f23
+      RHELAMI: ami-07d3f0705bebac978 # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
       {% else %}
-      RHELAMI: ami-d74be5b8
+      RHELAMI: ami-b3d841dc # RHEL-7.4_HVM-20180122-x86_64-1-Access2-GP2
       {% endif %}
     ap-northeast-1:
       {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-6b0d5f0d
+      RHELAMI: ami-0bf9ecb88f5719e17 # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
       {% else %}
-      RHELAMI: ami-30ef0556
+      RHELAMI: ami-ccf695aa # RHEL-7.4_HVM-20180122-x86_64-1-Access2-GP2
       {% endif %}
     ap-northeast-2:
       {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-3eee4150
+      RHELAMI: ami-031161cd3182e012a # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
       {% else %}
-      RHELAMI: ami-0f5a8361
+      RHELAMI: ami-9fa201f1 # RHEL-7.4_HVM-20180122-x86_64-1-Access2-GP2
       {% endif %}
     ap-southeast-1:
       {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-76144b0a
+      RHELAMI: ami-0f44e46fa59e902b6 # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
       {% else %}
-      RHELAMI: ami-10bb2373
+      RHELAMI: ami-8193eafd # RHEL-7.4_HVM-20180122-x86_64-1-Access2-GP2
       {% endif %}
     ap-southeast-2:
       {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-67589505
+      RHELAMI: ami-0066ef2f9c72fad96 # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
       {% else %}
-      RHELAMI: ami-ccecf5af
+      RHELAMI: ami-dd9668bf # RHEL-7.4_HVM-20180122-x86_64-1-Access2-GP2
       {% endif %}
     ap-south-1:
       {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-5b673c34
+      RHELAMI: ami-0c6ec6988a8df3acc # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
       {% else %}
-      RHELAMI: ami-cdbdd7a2
+      RHELAMI: ami-952879fa # RHEL-7.4_HVM-20180122-x86_64-1-Access2-GP2
       {% endif %}
     sa-east-1:
       {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-b0b7e3dc
+      RHELAMI: ami-0a419d7f7b8b07b64 # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
       {% else %}
-      RHELAMI: ami-a789ffcb
+      RHELAMI: ami-dc014db0 # RHEL-7.4_HVM-20180122-x86_64-1-Access2-GP2
       {% endif %}
   DNSMapping:
     us-east-1:

--- a/ansible/roles/infra-ec2-template-generate/defaults/main.yml
+++ b/ansible/roles/infra-ec2-template-generate/defaults/main.yml
@@ -91,7 +91,8 @@ aws_default_volume_type: gp2
 # Images
 #################################################################
 
-aws_default_image: RHEL75
+# changed to GOLD to save money via Red Hat Cloud Access program
+aws_default_image: RHEL75GOLD
 
 aws_ami_region_mapping:
   ap-south-1:


### PR DESCRIPTION
##### SUMMARY
DO NOT MERGE

This is an initial test of changing the default AWS AMI image to the less expensive AMIs for ocp-workshop (OCP3) based workloads.

Please checkout this PR and test with your workloads ASAP.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp-workshop

##### ADDITIONAL INFORMATION
RHEL AWS AMIs with the string *Hourly* in the name are to be avoided because they cause a support fee with AWS.  RHEL AWS AMIs with the string *Access* in the name MUST be used to avoid the AWS support fee.  All of these images belong to the AWS AMI OwnerId: 309956199498

