### PR TITLE
CHANGE included ddns_key_algorithm variable in all related files

### DIFF
--- a/ansible/cloud_providers/osp_default_vars.yml
+++ b/ansible/cloud_providers/osp_default_vars.yml
@@ -6,6 +6,7 @@ wait_for_dns: true
 
 # Authenticaion for DDNS
 # ddns_key_name:
+# ddns_key_algorithm:                # default value set to: "hmac-md5"
 # ddns_secret_name:
 
 # The name of the project that will be created in OpenStack for the user

--- a/ansible/configs/ocp-clientvm/default_vars_osp.yml
+++ b/ansible/configs/ocp-clientvm/default_vars_osp.yml
@@ -31,6 +31,7 @@ wait_for_dns: true
 
 # Authenticaion for DDNS, Must be set in secrets
 # ddns_key_name:
+# ddns_key_algorithm:                # default value set to: "hmac-md5"
 # ddns_secret_name:
 
 # Set this to true if you want a FIPs provisioned for an OpenShift on OpenStack install

--- a/ansible/configs/ocp4-cluster/destroy_env.yml
+++ b/ansible/configs/ocp4-cluster/destroy_env.yml
@@ -20,6 +20,7 @@
         record: "{{ item }}.{{ guid }}"
         type: A
         key_name: "{{ ddns_key_name }}"
+        key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
         key_secret: "{{ ddns_key_secret }}"
         state: absent
       loop:

--- a/ansible/configs/ocp4-cluster/post_infra.yml
+++ b/ansible/configs/ocp4-cluster/post_infra.yml
@@ -39,6 +39,7 @@
       ttl: 5
       value: "{{ item.name }}"
       key_name: "{{ ddns_key_name }}"
+      key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
       key_secret: "{{ ddns_key_secret }}"
     loop:
       - name: "{{ ocp_api_fip }}"

--- a/ansible/configs/ocp4-disconnected-osp-lab/destroy_env.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/destroy_env.yml
@@ -21,6 +21,7 @@
         type: A
         port: "{{ osp_cluster_dns_port | d('53') }}"
         key_name: "{{ ddns_key_name }}"
+        key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
         key_secret: "{{ ddns_key_secret }}"
         state: absent
       loop:

--- a/ansible/configs/ocp4-disconnected-osp-lab/env_vars.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/env_vars.yml
@@ -156,6 +156,7 @@ wait_for_dns: true
 
 # Authenticaion for DDNS
 # ddns_key_name:
+# ddns_key_algorithm:                # default value set to: "hmac-md5"
 # ddns_secret_name:
 
 # Set this to true if you want a FIPs provisioned for an OpenShift on OpenStack install

--- a/ansible/configs/ocp4-disconnected-osp-lab/files/rfc2136.ini.j2
+++ b/ansible/configs/ocp4-disconnected-osp-lab/files/rfc2136.ini.j2
@@ -7,4 +7,4 @@ dns_rfc2136_name = {{ ddns_key_name }}
 # TSIG key secret
 dns_rfc2136_secret = {{ ddns_key_secret }}
 # TSIG key algorithm
-dns_rfc2136_algorithm = HMAC-MD5
+dns_rfc2136_algorithm = {{ ddns_key_algorithm | d('hmac-md5') }}

--- a/ansible/configs/ocp4-disconnected-osp-lab/post_infra.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/post_infra.yml
@@ -40,6 +40,7 @@
         port: "{{ osp_cluster_dns_port | d('53') }}"
         value: "{{ item.name }}"
         key_name: "{{ ddns_key_name }}"
+        key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
         key_secret: "{{ ddns_key_secret }}"
       loop:
         - name: "{{ ocp_api_fip }}"

--- a/ansible/configs/osp-migration/dns_loop.yml
+++ b/ansible/configs/osp-migration/dns_loop.yml
@@ -16,6 +16,7 @@
         ttl: "{{ _infra_osp_dns_default_ttl }}"
         value: "{{ _instance.public_v4 }}"
         key_name: "{{ ddns_key_name }}"
+        key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
         key_secret: "{{ ddns_key_secret }}"
 
 # When state == absent, don't use r_osp_facts (should not be needed)
@@ -30,5 +31,6 @@
         type: A
         ttl: "{{ _infra_osp_dns_default_ttl }}"
         key_name: "{{ ddns_key_name }}"
+        key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
         key_secret: "{{ ddns_key_secret }}"
         state: absent

--- a/ansible/configs/osp-migration/env_vars.yml
+++ b/ansible/configs/osp-migration/env_vars.yml
@@ -104,4 +104,5 @@ wait_for_dns: true
 
 # Authenticaion for DDNS
 # ddns_key_name:
+# ddns_key_algorithm:                # default value set to: "hmac-md5"
 # ddns_secret_name:

--- a/ansible/configs/osp-sandbox/env_vars.yml
+++ b/ansible/configs/osp-sandbox/env_vars.yml
@@ -143,6 +143,7 @@ openshift_fip_provision: False
 
 # Authenticaion for DDNS
 # ddns_key_name:
+# ddns_key_algorithm:                # default value set to: "hmac-md5"
 # ddns_secret_name:
 
 # Quotas to set for new project that is created

--- a/ansible/configs/osp-sandbox/files/secret.yaml.j2
+++ b/ansible/configs/osp-sandbox/files/secret.yaml.j2
@@ -3,6 +3,7 @@ osp_auth_user_domain: default
 
 # dynamic DNS
 ddns_key_name: {{ student_ddns_key_name }}
+ddns_key_algorithm: {{ student_ddns_key_algorithm | d('hmac-md5') }}
 ddns_key_secret: {{ student_ddns_key_secret }}
 osp_cluster_dns_server: {{ student_dns_server }}
 osp_cluster_dns_zone: {{ student_dns_zone }}

--- a/ansible/roles/infra-osp-dns/tasks/nested_loop.yml
+++ b/ansible/roles/infra-osp-dns/tasks/nested_loop.yml
@@ -19,6 +19,7 @@
         value: "{{ r_osp_facts | json_query(find_ip_query) }}"
         port: "{{ osp_cluster_dns_port | d('53') }}"
         key_name: "{{ ddns_key_name }}"
+        key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
         key_secret: "{{ ddns_key_secret }}"
 
 # When state == absent, don't use r_osp_facts (should not be needed)

--- a/ansible/roles/ocp4-workload-enable-lets-encrypt-certificates/templates/rfc2136.ini.j2
+++ b/ansible/roles/ocp4-workload-enable-lets-encrypt-certificates/templates/rfc2136.ini.j2
@@ -7,4 +7,4 @@ dns_rfc2136_name = {{ ddns_key_name }}
 # TSIG key secret
 dns_rfc2136_secret = {{ ddns_key_secret }}
 # TSIG key algorithm
-dns_rfc2136_algorithm = HMAC-MD5
+dns_rfc2136_algorithm = {{ ddns_key_algorithm | d('hmac-md5') }}

--- a/docs/First_OSP_Env_walkthrough.adoc
+++ b/docs/First_OSP_Env_walkthrough.adoc
@@ -150,6 +150,7 @@ osp_auth_user_domain: default
 osp_cluster_dns_server: ddns01.opentlc.com
 osp_cluster_dns_zone: students.osp.opentlc.com
 ddns_key_name: opentlc_students
+ddns_key_name: PROVIDED_BY_ADMIN          # default value is set to "hmac-dm5"
 ddns_key_secret: PROVIDED_BY_ADMIN
 
 # Repo


### PR DESCRIPTION
##### SUMMARY
Deploying on an existing OSP infrastructure with own DNS server and an already existing key, there is no user variable to specify your own value of "key_algorithm" for nsupdate module of Ansible. Only key with the default value "hmac-md5" can be used.
Proposed changes allow user to define their own "ddns_key_algorithm". The default value "hmac-md5" is used in case the new "ddns_key_algorithm" user definable variable is not used.

Fixes #1216

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
n/a

##### ADDITIONAL INFORMATION
n/a