### PR TITLE
Clean up intly vars

### DIFF
--- a/ansible/roles/ocp-workload-integreatly/defaults/main.yml
+++ b/ansible/roles/ocp-workload-integreatly/defaults/main.yml
@@ -8,7 +8,6 @@ inventory_hosts_file: inventories/pds.template
 release_tag: "release-{{ ig_version }}"
 webapp_namespace: webapp
 self_signed_certs_enabled: True
-amq_streams: True
 openshift_master_config_path: /etc/origin/master/master-config.yaml
 cluster_admin_username: admin@example.com
 cluster_admin_password: ""

--- a/ansible/roles/ocp-workload-integreatly/tasks/remove_workload.yml
+++ b/ansible/roles/ocp-workload-integreatly/tasks/remove_workload.yml
@@ -1,9 +1,7 @@
 ---
 
 - name: Uninstall Integreatly
-  shell: |
-          ansible-playbook -i "{{ inventory_hosts_file }}" \
-          playbooks/uninstall.yml -e amq_streams="{{ amq_streams }}"
+  shell: ansible-playbook -i "{{ inventory_hosts_file }}" playbooks/uninstall.yml
   args:
     chdir: "{{ install_dir }}"
 

--- a/ansible/roles/ocp-workload-integreatly/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-integreatly/tasks/workload.yml
@@ -19,7 +19,6 @@
           playbooks/install.yml \
           -e eval_self_signed_certs="{{ self_signed_certs_enabled }} \
           -e rhsso_identity_provider_ca_cert_path={{ rhsso_identity_provider_ca_cert_path }} \
-          -e amq_streams={{ amq_streams }} \
           -e rhsso_seed_users_password={{ evals_password }} \
           -e rhsso_evals_admin_password={{ customer_admin_password }} \
           -e rhsso_cluster_admin_password={{ cluster_admin_password }}" \

--- a/ansible/roles/ocp-workload-integreatly/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-integreatly/tasks/workload.yml
@@ -7,7 +7,7 @@
   when: lets_encrypt_production|bool
 
 - name: Generate passwords
-  set_fact: 
+  set_fact:
     cluster_admin_password: "{{ lookup('password', '/tmp/cluster_{{ ansible_date_time.iso8601_micro | to_uuid }} length=15 chars=ascii_letters,digits') }}"
     evals_password: "{{ lookup('password', '/tmp/evals_{{ ansible_date_time.iso8601_micro | to_uuid }} length=15 chars=ascii_letters,digits') }}"
     customer_admin_password: "{{ lookup('password', '/tmp/customer_{{ ansible_date_time.iso8601_micro | to_uuid }} length=15 chars=ascii_letters,digits') }}"
@@ -23,7 +23,6 @@
           -e rhsso_seed_users_password={{ evals_password }} \
           -e rhsso_evals_admin_password={{ customer_admin_password }} \
           -e rhsso_cluster_admin_password={{ cluster_admin_password }}" \
-          -e gitea=false \
           | tee -a "{{ integreatly_logs }}"
   args:
     chdir: "{{ install_dir }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

In the integreatly ansible installation repo, we've just changed the default for Gitea to be "false", so there shouldn't be a need to override that here.

Additionally, the default for amq_streams is already "true" in the group vars for the "PDS" flavour of integreatly (which is used here), so that also shouldn't need to be overridden.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New config Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
integreatly
