### PR TITLE
Tkummer

### DIFF
--- a/ansible/configs/ocp4-cluster/default_vars_osp.yml
+++ b/ansible/configs/ocp4-cluster/default_vars_osp.yml
@@ -17,6 +17,9 @@ admin_user: opentlc-mgr
 # The name of the project that will be created in OpenStack for the user
 osp_project_name: "{{ guid }}-project"
 
+# The name of the cloud where ocp-cluster will be created
+osp_cloud_name: "{{ osp_project_name }}"
+
 # Set this to true if you need to create a new project in OpenStack
 # This should almost always be set to true for OpenShift installations
 # If it is set to false, the {{ osp_project_name }} must already exist and

--- a/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
+++ b/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
@@ -51,7 +51,7 @@ platform:
 {% endif %}
 {% if cloud_provider == 'osp' %}
   openstack:
-    cloud: {{ osp_project_name }}
+    cloud: {{ osp_cloud_name }}
     computeFlavor: 4c16g30d
     externalNetwork: external
     lbFloatingIP: {{ hostvars.localhost.ocp_api_fip }}

--- a/ansible/roles/host-ocp4-provisioner/tasks/osp_prereqs.yml
+++ b/ansible/roles/host-ocp4-provisioner/tasks/osp_prereqs.yml
@@ -64,7 +64,7 @@
   lineinfile:
     path: "/home/{{ ansible_user }}/.bashrc"
     regexp: "^export OS_CLOUD"
-    line: "export OS_CLOUD={{ osp_project_name }}"
+    line: "export OS_CLOUD={{ osp_cloud_name }}"
 
 - name: Create resources directory
   file:
@@ -76,6 +76,6 @@
 
 - name: Set OpenStack Object Store Account
   command: >-
-    openstack --os-cloud={{ osp_project_name }} object store account set
+    openstack --os-cloud={{ osp_cloud_name }} object store account set
     --property Temp-URL-Key=somename
   become: no

--- a/ansible/roles/host-ocp4-provisioner/templates/clouds.yaml.j2
+++ b/ansible/roles/host-ocp4-provisioner/templates/clouds.yaml.j2
@@ -1,5 +1,5 @@
 clouds:
-  {{ osp_project_name }}:
+  {{ osp_cloud_name }}:
     auth:
       auth_url: "{{ osp_auth_url }}"
 {% if osp_project_create | bool %}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add support for custom cloud name in ocp4-cluster. We needed to change this in order to deploy on non-openTLC openstacks where project names are not matching the cloud names.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
N/A

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
1. when we deployed OCP4 cluster we run couple of times into an issue with incorrect cloud names in autogenerated clouds.yaml as well as wrong OS_CLOUD var with wrong value
2. After change the cloud name is configurable in config file. Still defaults to the project name. 

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
