### PR TITLE
Increase AWS instance type to t2.large

### DIFF
--- a/ansible/configs/ansible-tower-advanced/env_vars.yml
+++ b/ansible/configs/ansible-tower-advanced/env_vars.yml
@@ -68,13 +68,13 @@ subdomain_base: "{{subdomain_base_short}}{{subdomain_base_suffix}}"
 bastion_instance_type: "t2.medium"
 
 tower_instance_count: 3
-tower_instance_type: "t2.medium"
+tower_instance_type: "t2.large"
 
 worker_instance_count: 1
-worker_instance_type: "t2.medium"
+worker_instance_type: "t2.large"
 
 support_instance_count: 3
-support_instance_type: "t2.medium"
+support_instance_type: "t2.large"
 isosupport_instance_count: 2
 
 subnets:


### PR DESCRIPTION
##### SUMMARY
The default sizing was too small and needed to be increased for Tower UI to run properly.
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
config ansible-tower-advanced

##### ADDITIONAL INFORMATION
n/a