### PR TITLE
add stopgap RHEL81GOLD to config ocp-clientvm

### DIFF
--- a/ansible/configs/ocp-clientvm/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/ocp-clientvm/files/cloud_providers/ec2_cloud_template.j2
@@ -6,6 +6,7 @@ Mappings:
     us-east-1:
       {% if osrelease is version_compare('3.9.25', '>=') %}
       RHELAMI: ami-6871a115
+      RHEL81GOLD: ami-002cdac160d085b42
       {% else %}
       RHELAMI: ami-c998b6b2
       {% endif %}


### PR DESCRIPTION
##### SUMMARY
stopgap so Noelia can use RHEL81GOLD on ocp-clientvm 


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp-clientvm

##### ADDITIONAL INFORMATION
aws ami template creation and ami definition and selection process needs to be generalized.  I'm working on it in another workstream.
