### PR TITLE
Clientvm rhel81 and gold

### DIFF
--- a/ansible/configs/ocp-clientvm/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/ocp-clientvm/files/cloud_providers/ec2_cloud_template.j2
@@ -6,6 +6,7 @@ Mappings:
     us-east-1:
       {% if osrelease is version_compare('3.9.25', '>=') %}
       RHELAMI: ami-6871a115
+      RHEL81GOLD: ami-002cdac160d085b42
       {% else %}
       RHELAMI: ami-c998b6b2
       {% endif %}

--- a/ansible/configs/ocp-clientvm/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/ocp-clientvm/files/cloud_providers/ec2_cloud_template.j2
@@ -2,103 +2,8 @@
 ---
 AWSTemplateFormatVersion: "2010-09-09"
 Mappings:
-  RegionMapping:
-    us-east-1:
-      {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-6871a115
-      RHEL81GOLD: ami-002cdac160d085b42
-      {% else %}
-      RHELAMI: ami-c998b6b2
-      {% endif %}
-    us-east-2:
-      {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-03291866
-      {% else %}
-      RHELAMI: ami-cfdafaaa
-      {% endif %}
-    us-west-1:
-      {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-18726478
-      {% else %}
-      RHELAMI: ami-66eec506
-      {% endif %}
-    us-west-2:
-      {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-223f945a
-      {% else %}
-      RHELAMI: ami-9fa343e7
-      {% endif %}
-    eu-west-1:
-      {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-7c491f05
-      {% else %}
-      RHELAMI: ami-bb9a6bc2
-      {% endif %}
-    eu-central-1:
-      {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-c86c3f23
-      {% else %}
-      RHELAMI: ami-d74be5b8
-      {% endif %}
-    ap-northeast-1:
-      {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-6b0d5f0d
-      {% else %}
-      RHELAMI: ami-30ef0556
-      {% endif %}
-    ap-northeast-2:
-      {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-3eee4150
-      {% else %}
-      RHELAMI: ami-0f5a8361
-      {% endif %}
-    ap-southeast-1:
-      {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-76144b0a
-      {% else %}
-      RHELAMI: ami-10bb2373
-      {% endif %}
-    ap-southeast-2:
-      {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-67589505
-      {% else %}
-      RHELAMI: ami-ccecf5af
-      {% endif %}
-    ap-south-1:
-      {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-5b673c34
-      {% else %}
-      RHELAMI: ami-cdbdd7a2
-      {% endif %}
-    sa-east-1:
-      {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-b0b7e3dc
-      {% else %}
-      RHELAMI: ami-a789ffcb
-      {% endif %}
-  DNSMapping:
-    us-east-1:
-      domain: "us-east-1.compute.internal"
-    us-west-1:
-      domain: "us-west-1.compute.internal"
-    us-west-2:
-      domain: "us-west-2.compute.internal"
-    eu-west-1:
-      domain: "eu-west-1.compute.internal"
-    eu-central-1:
-      domain: "eu-central-1.compute.internal"
-    ap-northeast-1:
-      domain: "ap-northeast-1.compute.internal"
-    ap-northeast-2:
-      domain: "ap-northeast-2.compute.internal"
-    ap-southeast-1:
-      domain: "ap-southeast-1.compute.internal"
-    ap-southeast-2:
-      domain: "ap-southeast-2.compute.internal"
-    sa-east-1:
-      domain: "sa-east-1.compute.internal"
-    ap-south-1:
-      domain: "ap-south-1.compute.internal"
+  RegionMapping: {{ aws_ami_region_mapping | to_json }}
+  DNSMapping: {{ aws_dns_mapping | to_json }}
 
 Resources:
   Vpc:
@@ -233,6 +138,7 @@ Resources:
       HostedZoneConfig:
         Comment: "Created By ansible agnostic deployer"
 
+{# if deploying many clientvms #}
 {% if num_users|d(1)|int > 1 %}
 {% for c in range(1,num_users|int+1) %}
 
@@ -249,7 +155,7 @@ Resources:
 {% if 'image_id' in instances[0] %}
         - {{ instances[0].image_id }}
 {% else %}
-        - 'RHELAMI'
+        - 'RHEL81'
 {% endif %}
 {% endif %}
       InstanceType: "{{instances[0]['flavor'][cloud_provider]}}"
@@ -338,6 +244,8 @@ Resources:
               - PublicIp
 {% endfor %}
 
+
+{# deploying just one clientvm #}
 {% else %}
   clientvm:
     Type: "AWS::EC2::Instance"
@@ -349,7 +257,11 @@ Resources:
         Fn::FindInMap:
         - RegionMapping
         - Ref: AWS::Region
-        - 'RHELAMI'
+{% if 'image_id' in instances[0] %}
+        - {{ instances[0].image_id }}
+{% else %}
+        - 'RHEL81'
+{% endif %}
 {% endif %}
       InstanceType: "{{instances[0]['flavor'][cloud_provider]}}"
       KeyName: "{{instances[0]['key_name'] | default(key_name)}}"

--- a/ansible/roles/infra-ec2-template-generate/defaults/main.yml
+++ b/ansible/roles/infra-ec2-template-generate/defaults/main.yml
@@ -259,7 +259,6 @@ aws_ami_region_mapping:
 
 # DNSMapping is unlikely to change.  It's useful to keep env_type CF templates small
 aws_dns_mapping:
-  DNSMapping:
     "us-east-1":
       domain: "us-east-1.compute.internal"
     "us-west-1":

--- a/ansible/roles/infra-ec2-template-generate/defaults/main.yml
+++ b/ansible/roles/infra-ec2-template-generate/defaults/main.yml
@@ -256,3 +256,29 @@ aws_ami_region_mapping:
     RHEL74: ami-1607ba6e # RHEL-7.4_HVM-20180122-x86_64-1-Hourly2-GP2
     WIN2012R2: ami-0f8967b5f815400c0 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2020.02.12
     WIN2019: ami-0d7d80db021ba0d11 # Windows_Server-2019-English-Full-Base-2020.02.12
+
+# DNSMapping is unlikely to change.  It's useful to keep env_type CF templates small
+aws_dns_mapping:
+  DNSMapping:
+    "us-east-1":
+      domain: "us-east-1.compute.internal"
+    "us-west-1":
+      domain: "us-west-1.compute.internal"
+    "us-west-2":
+      domain: "us-west-2.compute.internal"
+    "eu-west-1":
+      domain: "eu-west-1.compute.internal"
+    "eu-central-1":
+      domain: "eu-central-1.compute.internal"
+    "ap-northeast-1":
+      domain: "ap-northeast-1.compute.internal"
+    "ap-northeast-2":
+      domain: "ap-northeast-2.compute.internal"
+    "ap-southeast-1":
+      domain: "ap-southeast-1.compute.internal"
+    "ap-southeast-2":
+      domain: "ap-southeast-2.compute.internal"
+    "sa-east-1":
+      domain: "sa-east-1.compute.internal"
+    "ap-south-1":
+      domain: "ap-south-1.compute.internal"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fixed ocp-clientvm  set `clientvm_image_name=RHEL81GOLD` failed to apply to single-instance clientvm.  Only worked for deploying multiple clientVMs  

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp-clientvm
infra-ec2-template-generate

##### ADDITIONAL INFORMATION
