### PR TITLE
OCP4 NFS workload role

### DIFF
--- a/ansible/roles/ocp4-workload-nfs-server/README.md
+++ b/ansible/roles/ocp4-workload-nfs-server/README.md
@@ -1,0 +1,38 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/ansible/roles/ocp4-workload-nfs-server/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-nfs-server/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# defaults file for ocp4-workload-nfs-server
+_nfs_project: nfs-server
+_nfs_pvc_type: standard

--- a/ansible/roles/ocp4-workload-nfs-server/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-nfs-server/defaults/main.yml
@@ -1,5 +1,14 @@
 ---
 # defaults file for ocp4-workload-nfs-server
+_nfs_app: nfs-server
 _nfs_project: nfs-server
+
 _nfs_pvc_type: standard
+_nfs_pvc_size: 20Gi
+
 _nfs_server_image: quay.io/nstephan/nfs-server:v0.0.1
+
+_nfs_provided_storage_class: manual
+_nfs_pv_provided_size: 5Gi
+#TODO: Implement this so you can have a variable number of exports
+#_nfs_provided_exports: 10

--- a/ansible/roles/ocp4-workload-nfs-server/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-nfs-server/defaults/main.yml
@@ -2,3 +2,4 @@
 # defaults file for ocp4-workload-nfs-server
 _nfs_project: nfs-server
 _nfs_pvc_type: standard
+_nfs_server_image: quay.io/nstephan/nfs-server:v0.0.1

--- a/ansible/roles/ocp4-workload-nfs-server/files/Dockerfile
+++ b/ansible/roles/ocp4-workload-nfs-server/files/Dockerfile
@@ -1,0 +1,5 @@
+FROM gcr.io/google_containers/volume-nfs:0.8
+
+COPY run_nfs.sh /usr/local/bin/
+
+RUN chmod 775 /usr/local/bin/run_nfs.sh

--- a/ansible/roles/ocp4-workload-nfs-server/files/run_nfs.sh
+++ b/ansible/roles/ocp4-workload-nfs-server/files/run_nfs.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+NFSROOT=/exports
+
+function start()
+{
+
+    unset gid
+    # accept "-G gid" option
+    while getopts "G:" opt; do
+        case ${opt} in
+            G) gid=${OPTARG};;
+        esac
+    done
+    shift $(($OPTIND - 1))
+
+    # prepare /etc/exports
+    mkdir $NFSROOT
+    chown root:root $NFSROOT
+    if [ -v gid ] ; then
+        chmod 777 $NFSROOT
+        chgrp $gid $NFSROOT
+    fi
+    echo "$NFSROOT *(rw,fsid=0,insecure,no_root_squash,no_wdelay)" >> /etc/exports
+
+    for i in "$@"; do
+        if [ ! -d $NFSROOT/$i ]; then
+            mkdir -p $NFSROOT/$i
+        fi
+        if [ -v gid ] ; then
+            chmod 777 $NFSROOT/$i
+            chgrp $gid $NFSROOT/$i
+        fi
+    done
+  
+    # start rpcbind if it is not started yet
+    /usr/sbin/rpcinfo 127.0.0.1 > /dev/null; s=$?
+    if [ $s -ne 0 ]; then
+       echo "Starting rpcbind"
+       /usr/sbin/rpcbind -w
+    fi
+
+    mount -t nfsd nfsd /proc/fs/nfsd
+
+    # -V 3: enable NFSv3
+    /usr/sbin/rpc.mountd -N 2 -V 3
+
+    /usr/sbin/exportfs -r
+    # -G 10 to reduce grace time to 10 seconds (the lowest allowed)
+    /usr/sbin/rpc.nfsd -G 10 -N 2 -V 3
+    /usr/sbin/rpc.statd --no-notify
+    echo "NFS started"
+}
+
+function stop()
+{
+    echo "Stopping NFS"
+
+    /usr/sbin/rpc.nfsd 0
+    /usr/sbin/exportfs -au
+    /usr/sbin/exportfs -f
+
+    kill $( pidof rpc.mountd )
+    umount /proc/fs/nfsd
+    echo > /etc/exports
+    exit 0
+}
+
+
+trap stop TERM
+
+start "$@"
+
+# Ugly hack to do nothing and wait for SIGTERM
+while true; do
+    sleep 5
+done

--- a/ansible/roles/ocp4-workload-nfs-server/tasks/main.yml
+++ b/ansible/roles/ocp4-workload-nfs-server/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: Running Pre Workload Tasks
+  import_tasks: ./pre_workload.yml
+  become: false
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload Tasks
+  import_tasks: ./workload.yml
+  become: false
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  import_tasks: ./post_workload.yml
+  become: false
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload removal Tasks
+  import_tasks: ./remove_workload.yml
+  become: false
+  when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles/ocp4-workload-nfs-server/tasks/post_workload.yml
+++ b/ansible/roles/ocp4-workload-nfs-server/tasks/post_workload.yml
@@ -1,0 +1,9 @@
+---
+# Implement your Post Workload deployment tasks here
+
+
+# Leave this as the last task in the playbook.
+- name: post_workload tasks complete
+  debug:
+    msg: "Post-Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp4-workload-nfs-server/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-nfs-server/tasks/pre_workload.yml
@@ -1,0 +1,8 @@
+---
+# Implement your Pre Workload deployment tasks here
+
+# Leave this as the last task in the playbook.
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp4-workload-nfs-server/tasks/remove_workload.yml
+++ b/ansible/roles/ocp4-workload-nfs-server/tasks/remove_workload.yml
@@ -1,13 +1,34 @@
 ---
 # Implement your Workload removal tasks here
 
-#TODO: Remove PVs
-
 - name: Remove NFS Storage Project
   k8s:
     name: "{{ _nfs_project }}"
     api_version: v1
     kind: Namespace
+    state: absent
+
+- name: Clean up PVs
+  k8s:
+    api_version: v1
+    kind: PersistentVolume
+    name: "{{ item }}"
+    state: absent
+  loop:
+    - "vol0"
+    - "vol1"
+    - "vol2"
+    - "vol3"
+    - "vol4"
+    - "vol5"
+    - "vol6"
+    - "vol7"
+
+- name: Remove storage class
+  k8s:
+    api_version: storage.k8s.io/v1
+    kind: StorageClass
+    name: "{{ _nfs_provided_storage_class }}"
     state: absent
 
 # Leave this as the last task in the playbook.

--- a/ansible/roles/ocp4-workload-nfs-server/tasks/remove_workload.yml
+++ b/ansible/roles/ocp4-workload-nfs-server/tasks/remove_workload.yml
@@ -1,0 +1,17 @@
+---
+# Implement your Workload removal tasks here
+
+#TODO: Remove PVs
+
+- name: Remove NFS Storage Project
+  k8s:
+    name: "{{ _nfs_project }}"
+    api_version: v1
+    kind: Namespace
+    state: absent
+
+# Leave this as the last task in the playbook.
+- name: remove_workload tasks complete
+  debug:
+    msg: "Remove Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp4-workload-nfs-server/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-nfs-server/tasks/workload.yml
@@ -6,7 +6,7 @@
       apiVersion: storage.k8s.io/v1
       kind: StorageClass
       metadata:
-        name: manual
+        name: "{{ _nfs_provided_storage_class }}"
       provisioner: kubernetes.io/no-provisioner
       reclaimPolicy: Retain
       volumeBindingMode: WaitForFirstConsumer
@@ -20,38 +20,6 @@
       metadata:
         name: "{{ _nfs_project }}"
 
-- name: Create ImageStream for nfs server image
-  k8s:
-    state: present
-    definition:
-      apiVersion: v1
-      kind: ImageStream
-      metadata:
-        labels:
-          app: nfs-server
-        name: nfs-server
-        namespace: "{{ _nfs_project }}"
-      spec: {}
-
-- name: Import image to ImageStream
-  shell: oc import-image --from={{ _nfs_server_image }} --scheduled nfs-server
-
-- name: Create service account
-  k8s:
-    state: present
-    definition:
-      apiVersion: v1
-      kind: ServiceAccount
-      metadata:
-        name: nfs-server
-        namespace: nfs-server
-
-- name: Add anyuid SCC to SA
-  shell: oc adm policy add-scc-to-user anyuid -z nfs-server
-
-- name: Add privileged SCC to SA
-  shell: oc adm policy add-scc-to-user privileged -z nfs-server
-
 - name: Create PVC for NFS server underlying storage
   k8s:
     state: present
@@ -60,8 +28,8 @@
       apiVersion: v1
       metadata:
         labels:
-          app: nfs-server
-        name: nfs-server
+          app: "{{ _nfs_app }}"
+        name: "{{ _nfs_app }}-pvc"
         namespace: "{{ _nfs_project }}"
       spec:
         accessModes:
@@ -69,7 +37,39 @@
         storageClassName: "{{ _nfs_pvc_type }}"
         resources:
           requests:
-            storage: 6Gi
+            storage: "{{ _nfs_pvc_size }}"
+
+- name: Create ImageStream for nfs server image
+  k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: ImageStream
+      metadata:
+        labels:
+          app: "{{ _nfs_app }}"
+        name: "{{ _nfs_app }}"
+        namespace: "{{ _nfs_project }}"
+      spec: {}
+
+- name: Import image to ImageStream
+  shell: oc import-image --from={{ _nfs_server_image }} --scheduled {{ _nfs_app }} -n {{ _nfs_project }}
+
+- name: Create service account
+  k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: "{{ _nfs_app }}"
+        namespace: "{{ _nfs_project }}"
+
+- name: Add anyuid SCC to SA
+  shell: oc adm policy add-scc-to-user anyuid system:serviceaccount:{{ _nfs_project }}:{{ _nfs_app }}
+
+- name: Add privileged SCC to SA
+  shell: oc adm policy add-scc-to-user privileged system:serviceaccount:{{ _nfs_project }}:{{ _nfs_app }}
 
 - name: Create NFS server StatefulSet
   k8s:
@@ -79,27 +79,28 @@
       kind: StatefulSet
       metadata:
         labels:
-          app: nfs-server
-        name: nfs-server
+          app: "{{ _nfs_app }}"
+        name: "{{ _nfs_app }}"
         namespace: "{{ _nfs_project }}"
       spec:
         replicas: 1
         selector:
           matchLabels:
-            app: nfs-server
-            statefulset: nfs-server
+            app: "{{ _nfs_app }}"
+            statefulset: "{{ _nfs_app }}"
         template:
           metadata:
             labels:
-              app: nfs-server
-              statefulset: nfs-server
+              app: "{{ _nfs_app }}"
+              statefulset: "{{ _nfs_app }}"
           spec:
-            serviceAccountName: nfs-server
+            serviceAccountName: "{{ _nfs_app }}"
             containers:
-            - name: nfs-server
+            - name: "{{ _nfs_app }}"
               command:
               - /usr/local/bin/run_nfs.sh
               - -G
+              - "0"
               - "vol0"
               - "vol1"
               - "vol2"
@@ -120,11 +121,14 @@
                 privileged: true
               volumeMounts:
                 - mountPath: /exports
-                  name: pvc-nfs-server
+                  name: pvc-{{ _nfs_app }}
             volumes:
-              - name: pvc-nfs-server
+              - name: pvc-{{ _nfs_app }}
                 persistentVolumeClaim:
-                  claimName: nfs-server
+                  claimName: "{{ _nfs_app }}-pvc"
+
+#TODO: Add health check to statefulset
+#TODO: Add check to make sure Pod comes up
 
 - name: Create NFS server service
   k8s:
@@ -134,8 +138,8 @@
       kind: Service
       metadata:
         labels:
-          app: nfs-server
-        name: nfs-server
+          app: "{{ _nfs_app }}"
+        name: "{{ _nfs_app }}"
         namespace: "{{ _nfs_project }}"
       spec:
         ports:
@@ -165,12 +169,12 @@
       kind: PersistentVolume
       metadata:
         labels:
-          app: nfs-server
+          app: "{{ _nfs_app }}"
         name: "{{ item }}"
       spec:
-        storageClassName: manual
+        storageClassName: "{{ _nfs_provided_storage_class }}"
         capacity:
-          storage: 1Gi
+          storage: "{{ _nfs_pv_provided_size }}"
         accessModes:
           - ReadWriteOnce
           - ReadOnlyMany
@@ -190,9 +194,6 @@
     - "vol5"
     - "vol6"
     - "vol7"
-
-
-
 
 # Leave this as the last task in the playbook.
 - name: workload tasks complete

--- a/ansible/roles/ocp4-workload-nfs-server/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-nfs-server/tasks/workload.yml
@@ -1,0 +1,200 @@
+---
+- name: Create or update storage class
+  k8s:
+    state: present
+    definition:
+      apiVersion: "storage.k8s.io/v1"
+      kind: "StorageClass"
+      metadata:
+        name: manual
+      provisioner: kubernetes.io/no-provisioner
+      reclaimPolicy: Retain
+      volumeBindingMode: WaitForFirstConsumer
+
+- name: Create project for NFS server
+  k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ _nfs_project }}"
+
+- name: Create new build config for NFS server container image
+  k8s:
+    state: present
+    definition:
+      apiVersion: build.openshift.io/v1
+      kind: BuildConfig
+      metadata:
+        labels:
+          app: nfs-server
+        name: nfs-server
+        namespace: "{{ _nfs_project }}"
+      spec:
+        failedBuildsHistoryLimit: 5
+        output:
+          to:
+            kind: ImageStreamTag
+            name: nfs-server:latest
+        runPolicy: Serial
+        source:
+          binary: {}
+          type: Binary
+        strategy:
+          dockerStrategy: {}
+          type: Docker
+        successfulBuildsHistoryLimit: 5
+
+- name: Start build for NFS server container image and push to imagestream
+  shell: oc start build nfs-server --from-dir
+
+- name: Create service account
+  shell: oc create sa nfs-server
+
+- name: Add anyuid SCC to SA
+  shell: oc adm policy add-scc-to-user anyuid -z nfs-server
+
+- name: Add privileged SCC to SA
+  shell: oc adm policy add-scc-to-user privileged -z nfs-server
+
+- name: Create PVC for NFS server underlying storage
+  k8s:
+    state: present
+    definition:
+      kind: PersistentVolumeClaim
+      apiVersion: v1
+      metadata:
+        labels:
+          app: nfs-server
+        name: nfs-server
+        namespace: "{{ _nfs_project }}"
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: "{{ _nfs_pvc_type }}"
+        resources:
+          requests:
+            storage: 6Gi
+
+- name: Create NFS server StatefulSet
+  k8s:
+    state: present
+    definition:
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        labels:
+          app: nfs-server
+        name: nfs-server
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app: nfs-server
+            statefulset: nfs-server
+        template:
+          metadata:
+            labels:
+              app: nfs-server
+              statefulset: nfs-server
+          spec:
+            serviceAccountName: nfs-server
+            containers:
+            - name: nfs-server
+              command:
+              - /usr/local/bin/run_nfs.sh
+              - -G
+              - "0"
+              - "0"
+              - "1"
+              - "2"
+              - "3"
+              - "4"
+              - "5"
+              - "6"
+              - "7"
+              image: ""
+              ports:
+                - name: nfs
+                  containerPort: 2049
+                - name: mountd
+                  containerPort: 20048
+                - name: rpcbind
+                  containerPort: 111
+              securityContext:
+                privileged: true
+              volumeMounts:
+                - mountPath: /exports
+                  name: pvc-nfs-server
+            volumes:
+              - name: pvc-nfs-server
+                persistentVolumeClaim:
+                  claimName: nfs-server
+
+- name: Create NFS server service
+  k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        labels:
+          app: nfs-server
+        name: nfs-server
+      spec:
+        ports:
+          - name: nfs
+            port: 2049
+          - name: mountd
+            port: 20048
+          - name: rpcbind
+            port: 111
+        selector:
+          app: nfs-server
+  register: r_nfs_service
+
+- name: Dump r_nfs_service
+    var: r_nfs_service
+
+- name: Set trigger to point SS to imagestream
+# TODO: can't we just set this in the SS?
+
+- name: Get NFS server service clusterIP
+  set_fact:
+    nfs_ip: r_nfs_service.
+
+- name: Create PVs pointing to NFS
+  k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: PersistentVolume
+      metadata:
+        labels:
+          app: nfs-server
+        name: "{{ item }}"
+      spec:
+        storageClassName: manual
+        capacity:
+          storage: 1Gi
+        accessModes:
+          - ReadWriteOnce
+          - ReadOnlyMany
+          - ReadWriteMany
+        persistentVolumeReclaimPolicy: Recycle
+        nfs:
+          server: "{{ r_nfs_server_ip.something }}"
+          path: TBD
+        mountOptions:
+          - vers=4
+  loop:
+    something
+
+
+
+# Leave this as the last task in the playbook.
+- name: workload tasks complete
+  debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp4-workload-nfs-server/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-nfs-server/tasks/workload.yml
@@ -3,8 +3,8 @@
   k8s:
     state: present
     definition:
-      apiVersion: "storage.k8s.io/v1"
-      kind: "StorageClass"
+      apiVersion: storage.k8s.io/v1
+      kind: StorageClass
       metadata:
         name: manual
       provisioner: kubernetes.io/no-provisioner
@@ -20,37 +20,31 @@
       metadata:
         name: "{{ _nfs_project }}"
 
-- name: Create new build config for NFS server container image
+- name: Create ImageStream for nfs server image
   k8s:
     state: present
     definition:
-      apiVersion: build.openshift.io/v1
-      kind: BuildConfig
+      apiVersion: v1
+      kind: ImageStream
       metadata:
         labels:
           app: nfs-server
         name: nfs-server
         namespace: "{{ _nfs_project }}"
-      spec:
-        failedBuildsHistoryLimit: 5
-        output:
-          to:
-            kind: ImageStreamTag
-            name: nfs-server:latest
-        runPolicy: Serial
-        source:
-          binary: {}
-          type: Binary
-        strategy:
-          dockerStrategy: {}
-          type: Docker
-        successfulBuildsHistoryLimit: 5
+      spec: {}
 
-- name: Start build for NFS server container image and push to imagestream
-  shell: oc start build nfs-server --from-dir
+- name: Import image to ImageStream
+  shell: oc import-image --from={{ _nfs_server_image }} --scheduled nfs-server
 
 - name: Create service account
-  shell: oc create sa nfs-server
+  k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: nfs-server
+        namespace: nfs-server
 
 - name: Add anyuid SCC to SA
   shell: oc adm policy add-scc-to-user anyuid -z nfs-server
@@ -87,6 +81,7 @@
         labels:
           app: nfs-server
         name: nfs-server
+        namespace: "{{ _nfs_project }}"
       spec:
         replicas: 1
         selector:
@@ -105,16 +100,15 @@
               command:
               - /usr/local/bin/run_nfs.sh
               - -G
-              - "0"
-              - "0"
-              - "1"
-              - "2"
-              - "3"
-              - "4"
-              - "5"
-              - "6"
-              - "7"
-              image: ""
+              - "vol0"
+              - "vol1"
+              - "vol2"
+              - "vol3"
+              - "vol4"
+              - "vol5"
+              - "vol6"
+              - "vol7"
+              image: "{{ _nfs_server_image }}"
               ports:
                 - name: nfs
                   containerPort: 2049
@@ -142,6 +136,7 @@
         labels:
           app: nfs-server
         name: nfs-server
+        namespace: "{{ _nfs_project }}"
       spec:
         ports:
           - name: nfs
@@ -154,15 +149,13 @@
           app: nfs-server
   register: r_nfs_service
 
-- name: Dump r_nfs_service
-    var: r_nfs_service
-
-- name: Set trigger to point SS to imagestream
-# TODO: can't we just set this in the SS?
-
 - name: Get NFS server service clusterIP
   set_fact:
-    nfs_ip: r_nfs_service.
+    nfs_ip: "{{ r_nfs_service.result.spec.clusterIP }}"
+
+- name: Dump nfs_ip
+  debug:
+    var: nfs_ip
 
 - name: Create PVs pointing to NFS
   k8s:
@@ -184,12 +177,20 @@
           - ReadWriteMany
         persistentVolumeReclaimPolicy: Recycle
         nfs:
-          server: "{{ r_nfs_server_ip.something }}"
-          path: TBD
+          server: "{{ nfs_ip }}"
+          path: "/{{ item }}"
         mountOptions:
           - vers=4
   loop:
-    something
+    - "vol0"
+    - "vol1"
+    - "vol2"
+    - "vol3"
+    - "vol4"
+    - "vol5"
+    - "vol6"
+    - "vol7"
+
 
 
 

--- a/ansible/roles/ocp4-workload-nfs-server/vars/main.yml
+++ b/ansible/roles/ocp4-workload-nfs-server/vars/main.yml
@@ -1,2 +1,0 @@
----
-# vars file for ocp4-workload-nfs-server

--- a/ansible/roles/ocp4-workload-nfs-server/vars/main.yml
+++ b/ansible/roles/ocp4-workload-nfs-server/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for ocp4-workload-nfs-server


### PR DESCRIPTION
##### SUMMARY
This role can be used to deploy an NFS server pod inside an OpenShift cluster. It is helpful when you need more than RWO that is provided with AWS & OpenStack.

A PV will be provisioned for the NFS server pod
A new storage class will be created
A project and associated objects will be created to run the NFS server pod
A statefulset will be created to deploy the NFS server pod
The script that runs will set up a finite number of exports (to be variablized)
PVs will be created

##### ISSUE TYPE
- New role Pull Request

##### COMPONENT NAME
ocp4-workload-nfs-server
