### PR TITLE
ocp4-cluster: use include_role because gcp role don't exist yet

### DIFF
--- a/ansible/configs/ocp4-cluster/destroy_env.yml
+++ b/ansible/configs/ocp4-cluster/destroy_env.yml
@@ -54,13 +54,13 @@
     - cloud_provider != 'osp'
 
   - name: Run infra-azure-create-inventory Role
-    import_role:
+    include_role:
       name: infra-azure-create-inventory
     when:
     - cloud_provider == 'azure'
 
   - name: Run infra-gcp-create-inventory Role
-    import_role:
+    include_role:
       name: infra-gcp-create-inventory
     when:
     - cloud_provider == 'gcp'
@@ -71,7 +71,7 @@
   import_playbook: ../../cloud_providers/azure_ssh_config_setup.yml
   when:
     - cloud_provider != 'osp'
-    - groups["bastions"] is defined 
+    - groups["bastions"] is defined
     - (groups["bastions"]|length>0)
   tags:
     - must
@@ -91,4 +91,3 @@
   when:
   - cloud_provider == 'azure' or
     cloud_provider == 'gcp'
-


### PR DESCRIPTION
This commit, if applied, fixed the following error:

```
ERROR! the role 'infra-gcp-create-inventory' was not found in /home/travis/build/redhat-cop/agnosticd/ansible/configs/ocp4-cluster/roles:/home/travis/build/redhat-cop/agnosticd/roles:/home/travis/build/redhat-cop/agnosticd/ansible/roles:/home/travis/build/redhat-cop/agnosticd/ansible/configs/ocp4-cluster
The error appears to be in '/home/travis/build/redhat-cop/agnosticd/ansible/configs/ocp4-cluster/destroy_env.yml': line 64, column 13
```



##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
