### PR TITLE
Change the default flavour for HANA hosts

### DIFF
--- a/ansible/configs/sap-hana/default_vars.yml
+++ b/ansible/configs/sap-hana/default_vars.yml
@@ -60,7 +60,7 @@ bastion_instance_count: 1
 rootfs_size_bastion: "{{ rootfs_size_bastion }}"
 
 hana_instance_image: rhel-8.0-update-3
-hana_instance_type: "8-128"
+hana_instance_type: "4c64gb"
 hana_instance_count: 1
 rootfs_size_hana: "{{ rootfs_size_hana }}"
 pv_size_hana: 500


### PR DESCRIPTION
##### SUMMARY
A new flavour has been created and assigned by default to the HANA instances in order the reduce the total blueprint size and required resources.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
sap-hana config
