### PR TITLE
Increase OptaWeb Employee Rostering memory to 4 Gi

### DIFF
--- a/ansible/roles/ocp-workload-optaweb-employee-rostering/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-optaweb-employee-rostering/tasks/workload.yml
@@ -20,7 +20,7 @@
   shell: "oc new-app --name employee-rostering \
       --strategy=docker \
       java:8~{{optaweb_git_repository}}#{{optaweb_git_branch}} \
-      -e JAVA_TOOL_OPTIONS=\"-XX:MaxHeapSize=2g -XX:InitialHeapSize=2g\" \
+      -e JAVA_TOOL_OPTIONS=\"-XX:InitialHeapSize=4g -XX:MaxHeapSize=8g\" \
       -n {{ocp_project}}"
 
 - name: "Share PostgreSQL secret with OptaWeb app"


### PR DESCRIPTION
##### SUMMARY
The application becomes unresponsive and runs out of memory if user loads and uses all of the available tenants. Increasing initial JVM heap from 2 to 4 Gi and allowing max heap of 8 Gi should allow the user to work with all of the tenants that are available in the app out of the box.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
DM7 OptaWeb Employee Rostering Demo

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Discovered in the TEST stage by testing the demo more thoroughly.