### PR TITLE
Added owners for ocp4-workload-pam-fraudmanagement-workshop

### DIFF
--- a/ansible/roles/ocp4-workload-pam-fraudmanagement-workshop-verification/OWNERS
+++ b/ansible/roles/ocp4-workload-pam-fraudmanagement-workshop-verification/OWNERS
@@ -1,0 +1,9 @@
+reviewers:
+  - garethahealy
+  - ally-jarrett
+  - cluppi
+  - dmarrazzo
+  - pauljamesbrown
+
+approvers:
+  - garethahealy

--- a/ansible/roles/ocp4-workload-pam-fraudmanagement-workshop/OWNERS
+++ b/ansible/roles/ocp4-workload-pam-fraudmanagement-workshop/OWNERS
@@ -1,0 +1,9 @@
+reviewers:
+  - garethahealy
+  - ally-jarrett
+  - cluppi
+  - dmarrazzo
+  - pauljamesbrown
+
+approvers:
+  - garethahealy


### PR DESCRIPTION
##### SUMMARY
Not sure if there is an official policy to describe who owns each role, but I've adopted owners file for this purpose. Maybe something that should be done by default for each role?

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- ocp4-workload-pam-fraudmanagement-workshop

##### ADDITIONAL INFORMATION
Summit 2020
