### PR TITLE
Add apipy to openstack virtualenv

### DIFF
--- a/tools/virtualenvs/openstack-ansible-2.9-python3.txt
+++ b/tools/virtualenvs/openstack-ansible-2.9-python3.txt
@@ -1,4 +1,5 @@
 ansible==2.9.4
+apipy==0.5.15
 appdirs==1.4.3
 attrs==19.3.0
 Babel==2.8.0
@@ -14,6 +15,7 @@ distro==1.4.0
 dnspython==1.16.0
 dogpile.cache==0.9.0
 idna==2.8
+importlib-metadata==1.5.0
 iso8601==0.1.12
 Jinja2==2.11.1
 jmespath==0.9.4
@@ -66,3 +68,4 @@ urllib3==1.25.8
 warlock==1.3.3
 wcwidth==0.1.8
 wrapt==1.11.2
+zipp==3.1.0

--- a/tools/virtualenvs/openstack-ansible-latest.txt
+++ b/tools/virtualenvs/openstack-ansible-latest.txt
@@ -1,4 +1,5 @@
 ansible
+apipy
 openstacksdk
 python-cinderclient
 python-dateutil


### PR DESCRIPTION
##### SUMMARY
To use `foreman-ansible-modules` for satellite communication we need `apipy` installed.
I believe it's quite small dependency, so there is no need to create separate environment for it

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- `tools/virtualenvs/openstack-ansible-latest.txt`
- `tools/virtualenvs/openstack-ansible-2.9-python3.txt`
