### PR TITLE
Satellite role - create organization through foreman-ansible-modules

### DIFF
--- a/ansible/configs/satellite-multi-region/requirements.yml
+++ b/ansible/configs/satellite-multi-region/requirements.yml
@@ -1,0 +1,4 @@
+---
+collections:
+- name: theforeman.foreman
+  version: '0.6.0'

--- a/ansible/configs/satellite-multi-region/software.yml
+++ b/ansible/configs/satellite-multi-region/software.yml
@@ -6,35 +6,51 @@
   tasks:
     - debug:
         msg: "Software tasks Started"
- 
+
 - name: Configuring satellite Hosts
   hosts: satellites
   become: True
   gather_facts: True
-  roles:
-    - { role: "satellite-public-hostname" }
-    - { role: "satellite-installation",                 when: install_satellite   } 
-    # # - { role: "satellite-hammer-cli",                 when: install_satellite   }
-    - { role: "satellite-manage-organization",          when: configure_satellite }  
-    - { role: "satellite-manage-manifest",              when: configure_satellite } 
-    - { role: "satellite-manage-subscription",          when: configure_satellite } 
-    - { role: "satellite-manage-sync",                  when: configure_satellite } 
-    # - { role: "satellite-manage-lifecycle",             when: configure_satellite } 
-    # - { role: "satellite-manage-content-view",          when: configure_satellite } 
-    # - { role: "satellite-manage-activationkey",         when: configure_satellite } 
-    # - { role: "satellite-manage-capsule-certificate",   when: configure_satellite }
-    
- 
+  tasks:
+
+    - import_role:
+        name: satellite-public-hostname
+
+    - when: install_satellite
+      include_role:
+        name: "{{ _role }}"
+      loop_control:
+        loop_var: _role
+      loop:
+        - satellite-installation
+        # - satellite-hammer-cli
+
+    - when: configure_satellite
+      include_role:
+        name: "{{ _role }}"
+      loop_control:
+        loop_var: _role
+      loop:
+        - satellite-manage-organization
+        - satellite-manage-manifest
+        - satellite-manage-subscription
+        - satellite-manage-sync
+        # - satellite-manage-lifecycle
+        # - satellite-manage-content-view
+        # - satellite-manage-activationkey
+        # - satellite-manage-capsule-certificate
+
+
 - name: Configuring capsule Hosts
   hosts: capsules
   become: True
   gather_facts: True
   roles:
     - { role: "satellite-public-hostname" }
-    # - { role: "satellite-capsule-installation",   when: install_capsule }   
-    # - { role: "satellite-capsule-configuration",  when: configure_capsule }  
+    # - { role: "satellite-capsule-installation",   when: install_capsule }
+    # - { role: "satellite-capsule-configuration",  when: configure_capsule }
 
-    
+
 
 - name: Software flight-check
   hosts: localhost

--- a/ansible/configs/satellite-vm/requirements.yml
+++ b/ansible/configs/satellite-vm/requirements.yml
@@ -1,0 +1,4 @@
+---
+collections:
+- name: theforeman.foreman
+  version: '0.6.0'

--- a/ansible/configs/satellite-vm/software.yml
+++ b/ansible/configs/satellite-vm/software.yml
@@ -6,24 +6,40 @@
   tasks:
     - debug:
         msg: "Software tasks Started"
-    
+
 
 - name: Configuring satellite Hosts
   hosts: satellites
   become: True
   gather_facts: True
-  roles:
-    - { role: "satellite-public-hostname" }
-    - { role: "satellite-installation",                 when: install_satellite  } 
-    # # - { role: "satellite-hammer-cli",                 when: install_satellite   }
-    - { role: "satellite-manage-organization",          when: configure_satellite }  
-    - { role: "satellite-manage-manifest",              when: configure_satellite } 
-    - { role: "satellite-manage-subscription",          when: configure_satellite } 
-    - { role: "satellite-manage-sync",                  when: configure_satellite }
-    # - { role: "satellite-manage-lifecycle",             when: configure_satellite }
-    # - { role: "satellite-manage-content-view",          when: configure_satellite } 
-    # - { role: "satellite-manage-activationkey",         when: configure_satellite } 
-    
+  tasks:
+
+    - import_role:
+        name: satellite-public-hostname
+
+    - when: install_satellite
+      include_role:
+        name: "{{ _role }}"
+      loop_control:
+        loop_var: _role
+      loop:
+        - satellite-installation
+        # - satellite-hammer-cli
+
+    - when: configure_satellite
+      include_role:
+        name: "{{ _role }}"
+      loop_control:
+        loop_var: _role
+      loop:
+        - satellite-manage-organization
+        - satellite-manage-manifest
+        - satellite-manage-subscription
+        - satellite-manage-sync
+        # - satellite-manage-lifecycle
+        # - satellite-manage-content-view
+        # - satellite-manage-activationkey
+        # - satellite-manage-capsule-certificate
 
 - name: Software flight-check
   hosts: localhost

--- a/ansible/install_galaxy_roles.yml
+++ b/ansible/install_galaxy_roles.yml
@@ -26,6 +26,20 @@
         ansible-galaxy install
         -r "{{ requirements_path }}"
         -p "{{ ANSIBLE_REPO_PATH | default('.') }}/configs/{{ env_type }}/roles"
-      when:
-        - r_requirements_stat.stat.exists
-        - r_requirements_content | length > 0
+      when: >-
+        r_requirements_stat.stat.exists
+        and r_requirements_content | length > 0
+        and ( r_requirements_content is mapping
+              and 'roles' in r_requirements_content )
+        or r_requirements_contet is sequence
+
+    - name: Import collections from requirements.yml
+      command: >-
+        ansible-galaxy collection install
+        -r "{{ requirements_path }}"
+        -p "configs/{{ env_type }}/collections"
+      when: >-
+        r_requirements_stat.stat.exists
+        and r_requirements_content | length > 0
+        and r_requirements_content is mapping
+        and "collections" in r_requirements_content

--- a/ansible/roles/satellite-manage-organization/README.adoc
+++ b/ansible/roles/satellite-manage-organization/README.adoc
@@ -9,19 +9,21 @@
 Role: {role}
 ============
 
-This role creates organization. 
+This role creates organization.
 
 Requirements
 ------------
 
-. Satellite must be install and setup. 
-. Hammer cli config must be configured/updated with privileged user and password to run the satellite cli.
+. Satellite must be install and setup.
+. `satellite-public-hostname` needs to run first, to set the `publicname` fact.
 
 Role Variables
 --------------
 
 |===
 |satellite_version: "Digit" |Required |satellite version
+|satellite_admin: "String"  |Required |Sattelite account to use
+|satellite_admin_password: "String" |Required |Password for sattelite user account
 |org: "String" |Required |Organization name
 |org_label: "String" |Required | Organization label in string without space
 |org_description: "String" |Required | Organization description
@@ -31,7 +33,9 @@ Role Variables
 
 [source=text]
 ----
-satellite_version: 6.4
+satellite_version: 6.7
+satellite_admin: 'admin'
+satellite_admin_password: 'changeme'
 org: "gpte"
 org_label: "gpte"
 org_description: "Global Partner Training and Enablement"
@@ -73,7 +77,7 @@ How to use your role (for instance, with variables passed in playbook).
     org_label: "gpte"
     org_description: "Global Partner Training and Enablement"
   roles:
-    - satellite-manage-organization 
+    - satellite-manage-organization
 
 [user@desktop ~]$ ansible-playbook playbook.yml
 ----

--- a/ansible/roles/satellite-manage-organization/tasks/main.yml
+++ b/ansible/roles/satellite-manage-organization/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 
 ## Import for version satellite 6.4 ##
-- import_tasks: version_6.4.yml
-  when: satellite_version == 6.4
+- import_tasks: version_6.x.yml
+  when: satellite_version >= 6.4
   tags:
     - configure_satellite
     - configure_satellite_organization

--- a/ansible/roles/satellite-manage-organization/tasks/version_6.x.yml
+++ b/ansible/roles/satellite-manage-organization/tasks/version_6.x.yml
@@ -1,0 +1,10 @@
+---
+- name: "Create CI Organization"
+  theforeman.foreman.foreman_organization:
+    username: "{{ satellite_admin }}"
+    password: "{{ satellite_admin_password }}"
+    server_url: "https://{{ publicname }}"
+    name: "{{ org }}"
+    label: "{{ org_label }}"
+    description: "{{ org_description }}"
+    state: present

--- a/tests/static/requirements.txt
+++ b/tests/static/requirements.txt
@@ -1,3 +1,4 @@
 # Versions are pinned to prevent pypi releases arbitrarily breaking
 # tests with new APIs/semantics. We want to update versions deliberately.
 ansible==2.9.5
+apipy==0.5.15

--- a/tests/static/syntax-check.sh
+++ b/tests/static/syntax-check.sh
@@ -38,17 +38,18 @@ for i in \
         )
     fi
 
-    if [ "${env_type}" = satellite-vm ] || [ "${env_type}" = satellite-multi-region ]; then
-        pip install apypie
-        ansible-galaxy collection install theforeman.foreman
-    fi
-
-
     if [ -e "${ansible_path}/configs/${env_type}/hosts" ]; then
         inventory=(-i "${ansible_path}/configs/${env_type}/hosts")
     else
         inventory=(-i "${static}/tox-inventory.txt")
     fi
+
+    # Setup galaxy roles and collections, make sure it works
+    ansible-playbook --tags galaxy_roles \
+                     "${inventory[@]}" \
+                     ${ansible_path}/main.yml \
+                     ${extra_args[@]} \
+                     -e @${i}
 
     for playbook in \
         ${ansible_path}/main.yml \

--- a/tests/static/syntax-check.sh
+++ b/tests/static/syntax-check.sh
@@ -38,6 +38,11 @@ for i in \
         )
     fi
 
+    if [ "${env_type}" = satellite-vm ] || [ "${env_type}" = satellite-multi-region ]; then
+        pip install apypie
+        ansible-galaxy collection install theforeman.foreman
+    fi
+
 
     if [ -e "${ansible_path}/configs/${env_type}/hosts" ]; then
         inventory=(-i "${ansible_path}/configs/${env_type}/hosts")


### PR DESCRIPTION
##### SUMMARY
This is switching the organization creation for satellite to be done through 'foreman-ansible-modules'

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
satellite-manage-organization

##### ADDITIONAL INFORMATION
The satellite team provides sets of ansible modules. It only makes sense to use them. This is a first PR with this change, others will follow after we set course in this one.

The PR needs to have the collection of foreman modules installed locally with it's dependencies.

I've opened PR for them to get taken care of automatically
- [ ] Dependencies - #1288
- [ ] Collection installation - #1282

###### To test manually in meantime

```bash
pip install apypie
ansible-galaxy collection install theforeman.foreman
```
