### PR TITLE
sets OC version when deploying labguide

### DIFF
--- a/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/workload.yml
@@ -51,7 +51,7 @@
   shell: |
     oc new-app -n lab-ocp-cns /tmp/production-cluster-admin.json \
     --param TERMINAL_IMAGE="quay.io/openshiftroadshow/lab-ocp-ocs:{{ HOMEROOM_IMAGE }}" --param PROJECT_NAME="lab-ocp-cns" \
-    --param WORKSHOP_ENVVARS="`cat /tmp/workshop-settings.sh`"
+    --param WORKSHOP_ENVVARS="`cat /tmp/workshop-settings.sh`" --param OC_VERSION="4.3"
 
 - name: add kubeadmin to RoleBinding admin enabling route access
   k8s:


### PR DESCRIPTION
Minor tweak to the admin-storage workshop workload for an env var