### PR TITLE
ocp-workshop: simplify ec2 cloudformations templ

### DIFF
--- a/ansible/configs/ocp-workshop/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/ocp-workshop/files/cloud_providers/ec2_cloud_template.j2
@@ -2,104 +2,8 @@
 ---
 AWSTemplateFormatVersion: "2010-09-09"
 Mappings:
-  RegionMapping:
-    us-east-1:
-      {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-0456c465f72bd0c95  # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
-      {% else %}
-      RHELAMI: ami-c5a094bf # RHEL-7.4_HVM-20180122-x86_64-1-Access2-GP2
-      {% endif %}
-    us-east-2:
-      {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-04268981d7c33264d  # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
-      {% else %}
-      RHELAMI: ami-9db09af8 # RHEL-7.4_HVM-20180122-x86_64-1-Access2-GP2
-      {% endif %}
-    us-west-1:
-      {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-02574210e91c38419  # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
-      {% else %}
-      RHELAMI: ami-9db09af8  # RHEL-7.4_HVM-20180122-x86_64-1-Access2-GP2
-      {% endif %}
-    us-west-2:
-      {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-0e6bab6682ec471c0 # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
-      {% else %}
-      RHELAMI: ami-c405b8bc # RHEL-7.4_HVM-20180122-x86_64-1-Access2-GP2
-      {% endif %}
-    eu-west-2:
-      RHELAMI: ami-01f010afd559615b9 # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
-    eu-west-1:
-      {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-01f010afd559615b9  # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
-      {% else %}
-      RHELAMI: ami-b7b6d3ce # RHEL-7.4_HVM-20180122-x86_64-1-Access2-GP2
-      {% endif %}
-    eu-central-1:
-      {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-07d3f0705bebac978 # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
-      {% else %}
-      RHELAMI: ami-b3d841dc # RHEL-7.4_HVM-20180122-x86_64-1-Access2-GP2
-      {% endif %}
-    ap-northeast-1:
-      {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-0bf9ecb88f5719e17 # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
-      {% else %}
-      RHELAMI: ami-ccf695aa # RHEL-7.4_HVM-20180122-x86_64-1-Access2-GP2
-      {% endif %}
-    ap-northeast-2:
-      {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-031161cd3182e012a # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
-      {% else %}
-      RHELAMI: ami-9fa201f1 # RHEL-7.4_HVM-20180122-x86_64-1-Access2-GP2
-      {% endif %}
-    ap-southeast-1:
-      {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-0f44e46fa59e902b6 # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
-      {% else %}
-      RHELAMI: ami-8193eafd # RHEL-7.4_HVM-20180122-x86_64-1-Access2-GP2
-      {% endif %}
-    ap-southeast-2:
-      {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-0066ef2f9c72fad96 # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
-      {% else %}
-      RHELAMI: ami-dd9668bf # RHEL-7.4_HVM-20180122-x86_64-1-Access2-GP2
-      {% endif %}
-    ap-south-1:
-      {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-0c6ec6988a8df3acc # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
-      {% else %}
-      RHELAMI: ami-952879fa # RHEL-7.4_HVM-20180122-x86_64-1-Access2-GP2
-      {% endif %}
-    sa-east-1:
-      {% if osrelease is version_compare('3.9.25', '>=') %}
-      RHELAMI: ami-0a419d7f7b8b07b64 # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
-      {% else %}
-      RHELAMI: ami-dc014db0 # RHEL-7.4_HVM-20180122-x86_64-1-Access2-GP2
-      {% endif %}
-  DNSMapping:
-    us-east-1:
-      domain: "us-east-1.compute.internal"
-    us-west-1:
-      domain: "us-west-1.compute.internal"
-    us-west-2:
-      domain: "us-west-2.compute.internal"
-    eu-west-1:
-      domain: "eu-west-1.compute.internal"
-    eu-central-1:
-      domain: "eu-central-1.compute.internal"
-    ap-northeast-1:
-      domain: "ap-northeast-1.compute.internal"
-    ap-northeast-2:
-      domain: "ap-northeast-2.compute.internal"
-    ap-southeast-1:
-      domain: "ap-southeast-1.compute.internal"
-    ap-southeast-2:
-      domain: "ap-southeast-2.compute.internal"
-    sa-east-1:
-      domain: "sa-east-1.compute.internal"
-    ap-south-1:
-      domain: "ap-south-1.compute.internal"
+  RegionMapping: {{ aws_ami_region_mapping | to_json }}
+  DNSMapping: {{ aws_dns_mapping | to_json }}
 
 Resources:
   Vpc:
@@ -279,7 +183,13 @@ Resources:
         Fn::FindInMap:
         - RegionMapping
         - Ref: AWS::Region
-        - {{ instance['image_id'] | default('RHELAMI') }}
+{% if instance['image_id'] is defined %}
+        - {{ instance['image_id'] }}
+{% elif osrelease is version_compare('3.9.25', '>=') %}
+        - "RHEL75GOLD"
+{% else %}
+        - "RHEL74GOLD"
+{% endif %}
       InstanceType: "{{instance['flavor'][cloud_provider]}}"
       KeyName: "{{instance['key_name'] | default(key_name)}}"
 {% if instance['UserData'] is defined %}


### PR DESCRIPTION
##### SUMMARY
There was a bug in the ocp-workshop template: the same image_id was being used in two regions.

This fixes that by using the agnosticd var aws_image_region_mapping in the ocp-workshop cloudformations template.  var aws_dns_mapping added for more template clarity and brevity.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp-workshop

##### ADDITIONAL INFORMATION
