### PR TITLE
Fix typo in galaxy requirements + fix  collections  path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@
 *secrets[_-]var.yaml
 ansible/workdir/*
 ansible/judd.sh
+ansible/collections
+ansible/configs/*/roles
 *.swp
 scripts/*.rc
 wk*
@@ -21,7 +23,6 @@ virtualenv/
 .idea
 *.rc
 .tox
-ansible/configs/*/roles
 .pre-commit-config.yaml
 .DS_Store
 my_*_vars.yml

--- a/ansible/install_galaxy_roles.yml
+++ b/ansible/install_galaxy_roles.yml
@@ -37,7 +37,7 @@
       command: >-
         ansible-galaxy collection install
         -r "{{ requirements_path }}"
-        -p "configs/{{ env_type }}/collections"
+        -p collections
       when: >-
         r_requirements_stat.stat.exists
         and r_requirements_content | length > 0

--- a/ansible/install_galaxy_roles.yml
+++ b/ansible/install_galaxy_roles.yml
@@ -31,7 +31,7 @@
         and r_requirements_content | length > 0
         and ( r_requirements_content is mapping
               and 'roles' in r_requirements_content )
-        or r_requirements_contet is sequence
+        or r_requirements_content is sequence
 
     - name: Import collections from requirements.yml
       command: >-

--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -23,7 +23,8 @@ include::Contributing.adoc[]
 
 include::FAQ.adoc[FAQ]
 
+include::How_to_use_galaxy_roles_in_your_config.adoc[Galaxy roles and collections]
+
 == Misc
 
 include::User_stories.adoc[User Stories, leveloffset=1]
-


### PR DESCRIPTION
##### ISSUE TYPE

- Bugfix Pull Request

Galaxy roles in development branch are currently broken because of a typo. This PR includes a fix.

It also fixes path for ansible collections, new feature added in a previous commit.