### PR TITLE
Adding extradns for instances

### DIFF
--- a/ansible/configs/osp-migration/instance_loop.yml
+++ b/ansible/configs/osp-migration/instance_loop.yml
@@ -13,3 +13,13 @@
   # safety: Create DNS only when GUID is included in the hostname
   when: guid in _dns
   include_tasks: dns_loop.yml
+
+# support extra DNS
+- loop: "{{ _instance.metadata.extradns|default([]) }}"
+  loop_control:
+    loop_var: _dns
+
+  # safety: Create DNS only when GUID is included in the extradns
+  when:
+   - guid in _dns
+  include_tasks: dns_loop.yml


### PR DESCRIPTION
For some labs we need to add some extradns, for example wildcard. Example on the **stack_user.yaml**:

```
        "extradns": 
           - str_replace:
               template: "*.apps-REPL"
               params:
                 REPL: {get_param: project_guid}
```

