### PR TITLE
Set memory request and limit

### DIFF
--- a/ansible/roles/ocp-workload-optaweb-employee-rostering/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-optaweb-employee-rostering/tasks/workload.yml
@@ -20,11 +20,26 @@
   shell: "oc new-app --name employee-rostering \
       --strategy=docker \
       java:8~{{optaweb_git_repository}}#{{optaweb_git_branch}} \
-      -e JAVA_TOOL_OPTIONS=\"-XX:InitialHeapSize=4g -XX:MaxHeapSize=8g\" \
+      -e JAVA_TOOL_OPTIONS=\"-XX:InitialHeapSize=1g -XX:MaxHeapSize=4g\" \
       -n {{ocp_project}}"
 
 - name: "Share PostgreSQL secret with OptaWeb app"
   shell: "oc set env dc/employee-rostering --from=secret/postgresql -n {{ocp_project}}"
+
+# The memory limit needs to be higher than actual maximum JVM memory consumption.
+# Recommendation: set the memory limit to MaxHeapSize + 1 GiB.
+#
+# If JVM memory consumption exceeds container memory limit, the JVM process will be killed by OOM killer.
+# More info:
+# - https://docs.openshift.com/container-platform/3.11/dev_guide/application_memory_sizing.html
+# - https://docs.openshift.com/container-platform/3.11/dev_guide/compute_resources.html
+# Also note that cluster has a Limit Range defining maximum resource limits containers/pods can ask.
+# Verify the max memory limit at Administration > Limit Ranges before increasing the limit.
+- name: "Set OptaWeb's resource requests and limits"
+  shell: "oc set resources dc employee-rostering \
+      --limits=cpu=2,memory=5Gi \
+      --requests=cpu=1,memory=1Gi \
+      -n {{ocp_project}}"
 
 - name: "Expose the service"
   shell: "oc expose svc/employee-rostering -n {{ocp_project}}"


### PR DESCRIPTION
##### SUMMARY
#1279 didn't fix the application instability. I didn't know about resource [requests and limits](https://docs.openshift.com/container-platform/3.11/dev_guide/compute_resources.html#dev-requests-vs-limits). What I observed after giving JVM more memory was that the process exceeded the container memory limit after some time and was killed by OOM killer. I have educated myself on this topic and I am now setting memory limit to a number higher than the JVM's max heap size to avoid being killed by OOM killer.

Fix verified by solving all built-in data sets several times.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
DM7 OptaWeb Employee Rostering Demo

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
