### PR TITLE
Workaround OOMKilled issues with knative-serving and knative-eventing

### DIFF
--- a/ansible/roles/ocp4-workload-ccnrd/files/eventing-operator.v0.12.0.csv.yaml
+++ b/ansible/roles/ocp4-workload-ccnrd/files/eventing-operator.v0.12.0.csv.yaml
@@ -1,0 +1,189 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    certified: 'false'
+    olm.targetNamespaces: ''
+    repository: 'https://github.com/openshift-knative/knative-eventing-operator'
+    support: Red Hat
+    alm-examples: >-
+      [{"apiVersion":"eventing.knative.dev/v1alpha1","kind":"KnativeEventing","metadata":{"name":"knative-eventing"},"spec":{}}]
+    capabilities: Basic Install
+    olm.operatorNamespace: openshift-operators
+    containerImage: 'quay.io/openshift-knative/knative-eventing-operator:v0.12.0'
+    categories: 'Networking,Integration & Delivery,Cloud Provider,Developer Tools'
+    description: |-
+      Knative Eventing is a system that is designed to address a
+      common need for cloud native development and provides composable
+      primitives to enable late-binding event sources and event
+      consumers.
+    olm.operatorGroup: global-operators
+  name: knative-eventing-operator.v0.12.0
+  namespace: openshift-operators
+  labels:
+    olm.api.f71952e065303dbe: provided
+spec:
+  customresourcedefinitions:
+    owned:
+      - description: Represents an installation of a particular version of Knative Eventing
+        displayName: Knative Eventing
+        kind: KnativeEventing
+        name: knativeeventings.eventing.knative.dev
+        statusDescriptors:
+          - description: The version of Knative Eventing installed
+            displayName: Version
+            path: version
+        version: v1alpha1
+  apiservicedefinitions: {}
+  keywords:
+    - serverless
+    - eventing
+    - camel
+    - kafka
+  displayName: Knative Eventing Operator
+  provider:
+    name: Red Hat
+  maturity: alpha
+  installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+  version: 0.12.0
+  icon:
+    - base64data: >-
+        iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAYAAACtWK6eAAAd1ElEQVR4nOzdCXhU5b0/8O/vTPZlsu8BQhYhJEAIsgQEBRRcLxZqBbdaKu5Vr7Wuf+1f5a/W/rXVW+uCFfetiIqsgoIsgmwJhDUJCSE72ffMZOb87jODWgQyzEnmzMyZeT/Pc5/7tJ1zzstkvuc973k3CYIg9EkERBBsEAERBBtEQATBBhEQQbBBBEQQbBABEQQbREAEwQYREEGwQQREEGwQAREEG0RABMEGERBBsEEERBBsEAERBBtEQATBBhEQQbBBBEQQbBABEQQbREAEwQYREEGwQQREEGwQAREEG0RABMEGERBBsEEERBBsEAERBBtEQATBBhEQQbBBBEQQbBABEQQbREAEwQYfVxfA4wQFgcJSfQD2YUOAEU27ZVcXSeg/ERBHGpoXJc168G7I5rkEigQ4X/btfp0//NsaNO8xubp4rhA7NFs3eursMUPHXjmfAaquKPhy69ol37fs29Hr6rLZg1xdAI+QPVtPIy+bK4VEPwyijNO+114GVnHT0UW86oM96Nrr8TWKXp+MjMmXDhpz5V1zydwzH8BIEAVa/0eGkcG7ult83ize9/ba/d98Vt3VXOvqIvdJBKS/AvTAiHlZNGLCAgoK+xWBhths0zG6GLyd+cRHvOnTZSja2OTU8qosMjaJUkb/Ji1hePqs2PTcS3REFxAhqu8jWAaoWQbvqSva/UVd0YnVRfnvH289UWp2ZrnPRQREqYA0ogsvy0HyRXeSDr8hkF7ZCRgMHOX2xudRsWkp7/m8CV1dapVWZckYc8WVkQkZuZcmpo68jkBTQFD4ffysHcCumqL8N0oPblldlr+6tbvJ9fcQERB7BUYCGXlJUt6ND0D2WUCkNBhnkBlcjIaqRXL+x0tRtq3HQSVVXcrYy3xjkocNyxg77dfBEXHzGZxOIIe8EWWGpQYpAbBi984v3q7dtvJgTUmhyx5LRUDOJXFiAGWNn0ZDpt5AEs0EI9rB35oM5kLual8qF3/3Dg6srERnPTv0CgPkGxSG6MS0wJF5szIj08bNDo1MvAqETEt9qvKluxjYY2yr+6a4YMu6svLd+bVlhV2or1f5sv8hAtKXmPN8aeKN0ylhxBME5Dnlu2I0MvNSufCrZ1Cw6jgMzvshnE1wRASyJl03aNikK64LCI38LQgZrnvzyTIzDunM3e/s37r8y927Vxf3lB1R/UYiAnK64BwJl11/oRSR+gQIkwjwc24BGGBqYOJ35fKDL2HtE8ede31g5OQF+qwLr7gkJD5pPgEXWdrgILf5rbC1vcK8tvZo+xtV+z7ctmfD251qXcxd/tGuFxUv0ajrxlFa3h9AdDURBbu6SADKua3hb1y27WMu/LRO7cZ87pw/xaSPuuDmsKjY3wI0TAP9ZEYAxU3mtiX133742qbljg+KCEhKXiglZV1A2ZffQbJ88c/v692GtUap5nbDB1y05V98dHkxWisd3mgdnDkldOYdz68hokmOPrcTyGDzByv+566FNcUFBkee2HsDkj09jLKuvY70UXcTWe+WOlcX6dy4g4HV3HTo7/zNsh/QnO+wPoNfP7L+9ojEkH9q+DdhCg8N+P1fb85515En1cCPwsFihvvRJS9cJWVOflMKCF5IRDHaGbRJfgTKosCY62nEhansF3wQjeVNMHUP6KyxQ0f651wy9w0QxTusqM4ndRtMWYG+0scVR3Y77FlUq3cLhWKA1LQYacJvr6fQmFvANBzkCTcHbgfTt3L9ntd54451aFmneLzX4KEZuPCWlx8O0Ecs0v4N0/I4yq99/tz1dzVUlznkMdSzAxIQAuRckyaNuvw2YroJhDiP/CczTADvkDtaX+It/1qOiu/t7nSc8ttFY4aff/EGAGHqFtI5GDCV79k0dd2SB7c54nwav2P0JRmYfGU0Tbn7ASlp5BsEugREIR4ZDlhvcxKIBpFfwNWUPikPkZNK0Xm0Fp1NNu+iianZPnlz7vsnEUY7r7DqIkAKj0/xrzmw4YuO1uYBn8/zApI9I5Jm/OEOKXnMq5JPwBwC3OF1rXMQdERIo4iweTRsxngkj6lBR1UV2hvOGpTsGTfmxaVkPa2B17mKMPFQn+CYL8ry1zUM9FyeEZCQWInSfzWMZt57l5Q25R+Sf+A8AkV5/CNk33yJ6DwKibqBMqZfgIjcHlB7FdpbeiCfnIaRnDrBd9K8+18hUKarC+toBPKPjB+cYfTnL04czjcO7FxaFhwB5MxLkbIufoyYr3e/Pgy3cowN7c/La75dgrp3e2bf//qc2KGjP/G02uMUckdr3YPLnr/xBUNbW79Pos2A+IcCY+7NpOwxt5PE1/9YWwjncnKk7L6YYJ/XrkiN/YNElO3qIqmJgar8H1aM2/3+opr+nkNbAQkf5Efjrp2IhOxbyT/0KiLWa+2f4A7Gx+vlrOgQicjzvzudufuZt//PnMd6OvrXYNfGNxSX6UMX/n6mFJ7yBBi5IPJ1dZG0KjHYHxenRMFH0saffsAYjUf3rZ747ZtPlvTncPd+/oyb7ktT8yZQeO79RLjMOv/AS/6uarBkIicu1HvCAWsVEJU+6tIHfwj/6vbOlj2KOw/d75sKCgIScvTInDVXSsy6HaAxBIgawwHSwgMxNTkC3vBodZoef7nrusWPX/u5oU3ZHBv3qkFGzoiQLlh4G0y+txAhzdXF8SQ6AkbFhHpjOCwCeijwhYzcGd/v3/hxnZID3ePbGjkrmLLmzJb00Y8CGOE25fIgwyODkJcYrkpAhiXrERv2n9m3PUYz9pY1w2g6+USjkwjpiaHIGRqB+IgABPn7oLPHhOrGLuwvb0VxTTvMshNmGTP9ddmiXz3UeKLa7ou59ocYk+FL02+7QtKn/BknXzm6V43mIYJ8JFyRFoNQP3W+3lsuScP4YdE//2fLr+/j745hQ2EdBkUHYfbEQcgcpIev7sxB0yazjJ3Fjfhkczm6DOqu+MNA8+FN743b8u9Xjtp7jPN/kH6JhNETUmjItKsoIuk6Is4FxFsptVjugGPj9Qjxdd6f2nLNUSnhCAn0wYzR8dYaoy8+Ogl5w2MQFx6If31dgvo2h853Or1cEWnn/9cfD3739V1NJ4rtqkWcO9QkfVwQXfrgn6XkcW9KQfpfESEZIM8Y7uKmEoL9MC4hDJKKbY/ctEgkRQf94r+LDgvA8GQ9fH3sm2oTEeKH5Kgga22i5tOWzjdgeOiglDUl21fatZyj8yYKBUfqpOkPvSYFhj9CRBFOu66XGx4VrGo4+nL6m2RLm6O2uRvNHcY+A3Besh6DY1QfWxqanDrmifNGTbLrqcVp9S5d8dhcAs3Xzuw97UsM9segULWXruqbJQhHq9usbZHDlW3oNpqtfTCZg8Nw07RU6yPYqSyZGpkSjtLaDnULxrhi8Ngr5hXt+/69c33UOQGxbgkw5GrRCHeuwfoA+Eiuux+t2V2FFTurYDL/p8owy4yC0mZEh1bhN1OGnHHMkGj1ZycQkS+TdTmjcwbEOd+ePsUPhLFOuZbws26T69aBlmVgf3nLL8JxqoMVLTD2nlk+S63ipI7+Vns+5JyABA+NASjZKdcSftZsMIHZrVYx/Vlnjxm95jNHfvj7Sk7pzGRGqT2fc05A4uNGEjjIKdcSftZi6IXZTQNikhlnyYdzwgE2EeGAPZ91SkAoYshYV/dJeqOuXhk9Jo/fr0c5ptbOEL9iez7qnIAkjMxyxnWEX7LcpbtEQM5AhKraTasb7fms+gFJmOYDYo9ZNUNrWg2a2ArQqZj5QM2hXXattqd+QGJTkwicovp1hLNqNXjl3qE21fW27TIY7JunrnpAKCZsFECige4i7Ua32vLPLXTt37nf3s+qH5CEkTPUvobQtzaDCbKbvslyDW43S2xXAx2qByRjnB8C9VNVvYZgU2fv2fsbvBUzThzfs9HufafVDUjMyHgChqp6DcEmoyyLN1m/VNXWVm332sWqBoSCwkcBCFXzGoJtMlvaIaKh/hOScKzh6CG7nznVrUGSZk3zmOVNNay+S7zq/UlTeelhJZ9XLyBRgyXy65im2vkFuzX2GN12TJazVR8vOKLk8+oFRJ8YRQTR/+EG2g1mmERALLinralMyQGqzc+g+MxMS0zUOr9gv06TGV29ZoT5q3M/3FfegtbTHuMsbZ/mjr4XVu81yfiusA4Bfr98Am/r7lXvtTRzk458q5Qcot4EpsiUMaL94R5MMlt71MP81VkbY0dRo/X/lDCaZHy1U9FvdcAYKK8q/qFFyTGqPWJR0FCPXjlca5p7REMdQElLTbmi/UJUCkgyEB4kRvC6keYe95085Sw6Sdrf3dGk6Bh1HrGyh0cSIUOVc6vEV0eK5m9bnpMNA+yA8/eR+r3iiEmW0dvHdNazaerptbYLdF48Ladk97qdSo9RJSAUnzMaoHA1zq2Wx6/MxI0TB9v9+aP1nbjspS2KfqSnGhQRiGV35iE6xE/xsZYf+qOf78cnOyvtPqbDaLb2qgdKXtss7GyoKjqo9CB1apCM88fBrK0VTCKD/TAo0v5Bx11G84/TQ5UHxEciPDc3G2MG9+8e8u3hE/hqr7JNk0zM1jdZgT7eGRAGqtvqq5S9SVClDRIzAmTyucTh5/Ug145Lxtyx/VvDYntpIxYs2W0NqFLePDeEGAd6Q3R2TZI6leMDEhoaAaJch5/XQ8TrA/D07BH92sSmuK4DN7y5E5Utiv/OVnVdXtujbvbh7pWVm79W3Gh0eEBoyAXZxCwGKJ6FTiI8+V+ZGBylfHG0LqMJd36Qj2ONXf2+fklzF0pbu71rfgjDCMJf1r6z6JyLxJ2Nw9sJlJw9TewheCZLfXHnRam4Me/M1QTPxdIof2bVYWw4omx3pNP1yozNlc2o6TAgN06PIF9Pb49wc1Nl0YPr1/7PW617d/XrlaNjAxJ3sYTAUDFA8SwuGhaDp6/Ogp+dq52fasXeary4rl97UJ7BErai5i7UdRoxfUgkIgI89F7GONJbX7dg9ev3fN/Vatciimfl2EesoM4wOrlDlHAKfYAPXvzNKITY2CejL4dq2nDPRwU/79bkKK1GEzYcb0KrB/awM5BfVLjhsreX3D2gcMDhAYmZPgJMkQ49pwe4eXIKspPDFB/X3tOLuz4oQGWL3RPgFGkxmLD2WKP1kctTGu/MXFiZv3Led4sfKUOl/f1EfXFoQGhIzEUgbfV/qC0zIRQPXXqe4nUlzTLw9MrD2FTcoFLJTuroNWN9eSMON3VqvPHO3SGBun/uXv3uxWveerrIUWd13I85MJQoPFm0P04RFuiLxTflIk6vfI+Oz/ZU4pVv7d5Kb0Asjfft1a3W3vac2NCz7iXozhjc1NFQc9t3ny1aVrRf+V7otjguIIkj9UTIdNj5NM5SY/xxZgYmpEYpPrawshX3f7J3wGO9lLDUHYUNHdb565OTIqzjxLSAgbYm2XDb+r/dtrRN4R7o9nDctxCWnApQjMPOp3HTh8fgvoszFD9aVTR1Yf7iH1Cr4maWthxr67E+crUZevsxiMaJ2FpzbDt+eM/MFQ/doEo44MgahALzcgB46DtDZYL8dHh2brb1/yvR1GnEn5YW4rDaW5CdQ12XEStLGzA5Kdy6hZsztiRQhsFE/y76+rUFm756R9Uvy3E1SLIkJkj96J4ZachJVr5P6cvflODLgmpVyqRUt0nGxopmHGp0r8Y7A2Zm+vfmz567Ve1wwGE1SEAISJ8kxl8BmD06AQ9dOhxKtwZcXlCNv68v7vfweTWYZMYPNa1oM5owNk7vDo33po6O9sc3fvnCW7Xb16jz7vs0jglI4vRgENIcci4Niwn1w1OzsxAaoOxr3V/VioeX7UeHwf0WmrbE9bC1FgFy4kIR5LLh8txa397w6I4lzy2uLd7qtLcXjglI6nnDiCnO2zeRenDWMGQlKVvIpbHDaB2hW1Tn2naHLZZf4+GmTtR2GqzDU8JVWvyhLwwc7W6qXrD6hVs2GdqanXpth9SZxEm5ICifGudBRiSEYsFk5cuAvbCuCPur7durwtVaDCeHp7Q5cVMeBm8t3bXusg8W3+v0cMBRNQgNHeTVE6Qignzx6g1jEBak7M66dHcV/uGkzkBHae4xYVVpAzKjQhAe4KNoTr3eT7crzN/XrqmQDHBPZ1tB/solLx7Y/NHABlQNwMADkjIxGBImOKQ0GiQR8OerMjE5PVrRcd8dqcdt7/VvZqCrdZlk7K5TXuvJMi/jN3/9rCqFUsnAH7GGjU8nUKxDSqNBUzOirYMRlahrM+DOD/PR2u1dU2BJQh5CIjXVUh1wQCh6zBQAgY4pjrZEB/vh5fk5ioaxG00yHly6D0dc3BnoEowxlH6x8rE3LjTwgASFTndMUbTntguHYkSisrdWKwtr8NGOCtXK5M4IFI/k0ZpaUHBgAQnP9QFhnMNKoyGRwX5YOCVV8XETUyP7NbrXIxB8kDB8oquLocTAAhIfM4hAylqnHiIm1B+xen/FxyWEBeJ3k5XPS/cUEmEiosa7uhh2G1BAKDZ9FODd/R/9cedFaUiPDXF1MVzlfOihmX/8wGqQmPRcZ2wl7WniwwLwwjUj4ef6sU0uwPGIPF8zG7sOrAaJHCxG8PbTrOx4XD0m0dXFcAHyoaRYzSzs0f+A6AdLBOQ4tDRexEciPP/rkdZFrL0NDRmjmZHf/Q/I4JGpIPbGW6DDJEcE4r8v0dQuEY5hMI1FnDa2r+x3QGjo5LGigf5LdW3KpyhcN2EwUqLsX1XeIzBnIDheE1Vn/wLirwfFZ0yzDh4QrLaWNODyl7aiqlnZwtLRIX548dpRCFY4PVfTiOIoYVS6q4thj/79wBOG+4OkKQ4vjUbtrWjB/MU7sLeyFU+tOASTwlmBV45KxMKpmnmxM2AE+CNz5gWuLoc9+hUQIl0Sgb23t+sUNa3duOXdPaj+cfXDD3+owM5jyvbBkwh4YGYGEsO9p4fdOnAxJsPtBy72rwZJy8sBSPka/h7G0GvG3R8WIP/4f3YW7u41Y9GKwzCalA1jjw8LtE646se2IdrENAYhOW5/R+hfDZI+4WLHF0VbZADPrj6C5WfZCm39oTqsLKxVfM47LkrFzKw4B5XQvRE4gzIS3f5VlvKADJ3iD7NOE8+Paipv6MTf1hXjbCviWJogf11ThJ5eZbVInD4AT1yZqZlVDQeEyJ/is9y+Hav4L0FxKYlE5PXtD6NJtq5p25fd5S1YuU95LTJ2SCTm5iYNsHQa4R85CSHuvRmy8oAEx14AsGYGm7mKmRmPfb7fupSoEjoJeG5ONobHe8EudoTxSLnKrf+hyutyQpbo/7BPSX0nnvzqkHUrAyUSIwKtG+70ZzcqTWGKo5ho5UtQOlF//gLaWobDxT7eWYFDNcoX5ZiRGWtdANvDNXFvrctWLLGH4oDI5voVYJSqUxzP09MrY/HmY4qP00mEe6an92u7aG1ggPljFKx160XBlNcgG1bXyLUFN4FRpUqJPND728ute34oNW14DK6bMEiVMrkUW1/+vSdvfP8v6Ghyn8WIz6Ifj1j14K+e3mrurbgRQKcahfI0rd0mPPRZobUTUQlfnYRn52TjvDjPeifCwHZ53Sd3oOQLt1/apf+twLfv28A9/q85tDQebP2hE1i1z65FBX8hTh+Ax6/MhM5TnrSYu+Ta/Q+h7N+auLkO6DWJ/PUzTzFjveOK47lkBh5ZdgDljcpe+1pcMzYJs7LiVSmXUzF3yj2t92DtXza7uij2Gth7xNrv2+Qdb8xn8C6HlciDlTZ04s/LDyh+7eujk/D4VRrvYWeY5M6Ax3jZn96CUflNwlUG/o3vXdvAx7ctYIa6+xV7iM92V6OwqkXxcWMHR+DaccmqlMkZGLyatz77Kjrdu1F+OofcknjNu4XcVPEAA0ZHnM+TWRrq/39tkeJaRJKARVdnKV7J0S0wjsgHv7wP5Vs19/twUJ1dD974l/dYMr7840BXwYbP86vx/VHlFW5i+MkedqWbg7oSg2vNpRXzsPU9TfadOe6htrFG5vVf/F8Gr3XYOT2UwSTj6RWHFI/2tZg2LAbzx2vmUaubuxrvwc7/V+DqgvSXY1t9JZ90yvtLFgJ8xKHn9UAbj9Tjy3zlO9rqJMKjl2da90N0czKz7q/8+SufQaU9zJ3B8a9Fvn+4ynx841wGe+cS5naSGXj0iwOobVW+EsqQqCDcO8ON1zxggA2+n8orHnsGnfs0/citznvDNf84wJUH7gfgvM3sNKi8sQuLN5f169jbL0xDZoLbjhQ/JO97/79Rc8Dg6oIMlGN2uT0LLlz+BSdmvUcS/e7kQhbu7cuCahxX0InX2GmE2QF7mi/eVIYOgwk6BXv94cftmcMDnbvbrF2Ym+Tu+juQ/6ny2WJuSN0f7ogZodLUW18n2We+qtcR3AIDHVxVewN/+8iX6HbrQbp2U/d9YX2ZkblrLSXkXkIEL5lH6sW6mhfxqkffQLfyjlB3pf7Yhd2rOuRj5X8CoGzJQUFbmLfLW5b/Hd3K1gRzd87pcaredhy5l/sQ66aI/UQ8EHOFXLr9GuQv8bg5Qs4JiMkAVB3ZRoPHhpOv3/liTrsHYa6Xqw9dw2vf2ANoZxCivZw3ZqHjhJk7qr6llAvGE5Ebv8QX7MYwy11tD/Bn933uieGA0x93SncZ5aqtDwNodup1BVUweCVvePcdV5dDTc4f9VZZUIeUnCPkHzELRJrYI0I4EzPWyvs+vBmHV3vG+9w+uKwDj65//1opONBy91G+l7LgWsw7zNvWXY79rze6uihqc9246aMbD1HOZQHEusla6GkXTmKgnsu2zsH2f5S7uizO4LqA9HYzVx/ZQkPGZZGPn2Z2PfVqDCM3ld7L6/++DmbND7Oyi2tft1YXGuVDS+9msCYn03gVhpkJL/PX774Lg0c3O37B9f0RO5bXsuHEQoA9Z3yCB2LwannH4ifRXqjp4etKucfczb17yzAsr538Ama5RWiF05XJFZuvwZYPvG5hDvcICNqAxoo9NOT8BPLxPd/VpRFOweiSawsWYNWSXZ7aGWiLmwQEQHstM9q3UPK46QQx8tctMJvkjuYHeeVTH8DknX277vU4s3d9i1y27RYGe9ygNw1iBr3N37/1GnraNLWWlSO5Tw3yk9qCE4gYtgP6mNlEFOTq4ngl6+rr8kfyhvfuRtl6r56m4H4B6e0FSjYcx4iZneQbeKnoRHQ+BnbIPyz+DQ6tdPvV19XmfgH5SX3JPjpv2jgx8tfpuuXawzdj8xvFri6IO3CvNsipag4a5KItt4Jx0NVF8SJmWWd8Huve2uTqgrgL961BLMq3t3FU4maKGDKNgGhXF8ejMWS5p/UlXv3ck2guMrm6OO7CvQNiUbr9BIcN3kKRg64hQDTaVcKE1bzhlYWo2KO5BabV5P4Bsag9XIfhF/mQzn+GaLKrolk+lH8D9n2gfAssD6eNgJi6gRMlu+i8GWlEnCXebDlUi9zS8Tt88/gmmMVCmKfTRkAsOupN3Fa1mobmjSMgzdXF8QgMI7cHLeTlty71phG6SrjvW6yzKdnSJR/ZshDAcVcXxROwRB/JXz38iaetZeVI2qlBflK+vRVJI0opOHY2iNxwcVptYMZOefvS36Nyfbury+LOtBcQi2O7jyBtSi/5B03TXC3oHoq4dMscbF8stqg4B20GxGwEOpp2UcqkoSRhtKuLozGtckvDTbzi1T3WaQaCTdoMiEVLhZnNPd9R8uipBBrk6uJoA5tknekBXvrHpeitc3VhNEG7AbGoO9LDOnxNcVmXE5HoaT8HNvi/zqsWLUJTqVdNmx0IbQfEoupAG8dmH5DCYq9Vc0MgzWP8IO/6580o2erVw9eV0n5ALCp3lSP76hCSkCca7Wdi5kourZyH7a+I1+MKeUZATEag7sBmGpQbSb7+5wMK9zPzbA184sA8/u6pHda5NoIinhEQi/Z6M3c2fEupk8cRI10MRrEyy92tD/GnLyxFr8evEqoKz/sZ5cxNlsbPfxFMFxIhwNXFcRFm5hr2Mb3Knz/9KmoPiKqjnzwvIBZhyRIFhenZexfGZjC3obGqB72tri6LIAieSrzxEQQbREAEwQYREEGwQQREEGwQAREEG0RABMEGERBBsEEERBBsEAERBBtEQATBBhEQQbBBBEQQbBABEQQbREAEwQYREEGwQQREEGwQAREEG0RABMEGERBBsEEERBBsEAERBBv+NwAA///vaBYk9bJb5QAAAABJRU5ErkJggg==
+      mediatype: image/png
+  minKubeVersion: 1.15.0
+  links:
+    - name: Website
+      url: 'https://www.knative.dev/docs/eventing/'
+    - name: Documentation
+      url: 'https://www.knative.dev/docs/'
+  install:
+    spec:
+      clusterPermissions:
+        - rules:
+            - apiGroups:
+                - '*'
+              resources:
+                - '*'
+              verbs:
+                - '*'
+          serviceAccountName: knative-eventing-operator
+      deployments:
+        - name: knative-eventing-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: knative-eventing-operator
+            strategy: {}
+            template:
+              metadata:
+                labels:
+                  name: knative-eventing-operator
+              spec:
+                containers:
+                  - args:
+                      - >-
+                        --filename=https://raw.githubusercontent.com/RedHat-Middleware-Workshops/cloud-native-workshop-v2m4-labs/ocp-4.3/payment-service/knative/operator/knative-eventing-v0.12.0.yaml,https://raw.githubusercontent.com/openshift-knative/knative-eventing-operator/master/deploy/resources/networkpolicies.yaml
+                    command:
+                      - knative-eventing-operator
+                    env:
+                      - name: WATCH_NAMESPACE
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: knative-eventing-operator
+                    image: >-
+                      quay.io/openshift-knative/knative-eventing-operator:v0.12.0
+                    imagePullPolicy: Always
+                    name: knative-eventing-operator
+                    resources: {}
+                serviceAccountName: knative-eventing-operator
+      permissions:
+        - rules:
+            - apiGroups:
+                - ''
+              resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+              verbs:
+                - '*'
+            - apiGroups:
+                - ''
+              resources:
+                - namespaces
+              verbs:
+                - get
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+                - daemonsets
+                - replicasets
+                - statefulsets
+              verbs:
+                - '*'
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - servicemonitors
+              verbs:
+                - get
+                - create
+            - apiGroups:
+                - apps
+              resourceNames:
+                - knative-eventing-operator
+              resources:
+                - deployments/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - eventing.knative.dev
+              resources:
+                - '*'
+              verbs:
+                - '*'
+          serviceAccountName: knative-eventing-operator
+    strategy: deployment
+  maintainers:
+    - email: knative@redhat.com
+      name: Knative team
+  description: >
+    Knative Eventing is designed to address a common need for cloud
+
+    native development:
+
+
+    1. Services are loosely coupled during development and deployed
+    independently
+
+    1. A producer can generate events before a consumer is listening, and a
+    consumer
+       can express an interest in an event or class of events that is not yet being
+       produced.
+    1. Services can be connected to create new applications
+       - without modifying producer or consumer, and
+       - with the ability to select a specific subset of events from a particular
+         producer.
+
+    For complete Knative Eventing documentation, see
+
+    [Knative eventing](https://www.knative.dev/docs/eventing/) or
+
+    [Knative docs](https://www.knative.dev/docs/) to learn about Knative.
+  replaces: knative-eventing-operator.v0.11.0

--- a/ansible/roles/ocp4-workload-ccnrd/files/knative-serving-cm.yaml
+++ b/ansible/roles/ocp4-workload-ccnrd/files/knative-serving-cm.yaml
@@ -1,0 +1,1395 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: ko-data
+  namespace: openshift-operators
+data:
+  knative-serving-v0.11.1.yaml: |
+    ---
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: knative-serving
+      labels:
+        istio-injection: enabled
+        serving.knative.dev/release: devel
+    ---
+    kind: ClusterRole
+    apiVersion: rbac.authorization.k8s.io/v1
+    metadata:
+      name: knative-serving-addressable-resolver
+      labels:
+        serving.knative.dev/release: devel
+        duck.knative.dev/addressable: "true"
+    rules:
+    - apiGroups:
+      - serving.knative.dev
+      resources:
+      - routes
+      - routes/status
+      - services
+      - services/status
+      verbs:
+      - get
+      - list
+      - watch
+    ---
+    kind: ClusterRole
+    apiVersion: rbac.authorization.k8s.io/v1
+    metadata:
+      name: knative-serving-istio
+      labels:
+        serving.knative.dev/release: devel
+        serving.knative.dev/controller: "true"
+        networking.knative.dev/ingress-provider: istio
+    rules:
+      - apiGroups: ["networking.istio.io"]
+        resources: ["virtualservices", "gateways"]
+        verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: custom-metrics-server-resources
+      labels:
+        serving.knative.dev/release: devel
+        autoscaling.knative.dev/metric-provider: custom-metrics
+    rules:
+      - apiGroups: ["custom.metrics.k8s.io"]
+        resources: ["*"]
+        verbs: ["*"]
+    ---
+    kind: ClusterRole
+    apiVersion: rbac.authorization.k8s.io/v1
+    metadata:
+      name: knative-serving-namespaced-admin
+      labels:
+        rbac.authorization.k8s.io/aggregate-to-admin: "true"
+        serving.knative.dev/release: devel
+    rules:
+      - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
+        resources: ["*"]
+        verbs: ["*"]
+    ---
+    kind: ClusterRole
+    apiVersion: rbac.authorization.k8s.io/v1
+    metadata:
+      name: knative-serving-namespaced-edit
+      labels:
+        rbac.authorization.k8s.io/aggregate-to-edit: "true"
+        serving.knative.dev/release: devel
+    rules:
+      - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
+        resources: ["*"]
+        verbs: ["create", "update", "patch", "delete"]
+    ---
+    kind: ClusterRole
+    apiVersion: rbac.authorization.k8s.io/v1
+    metadata:
+      name: knative-serving-namespaced-view
+      labels:
+        rbac.authorization.k8s.io/aggregate-to-view: "true"
+        serving.knative.dev/release: devel
+    rules:
+      - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
+        resources: ["*"]
+        verbs: ["get", "list", "watch"]
+    ---
+    kind: ClusterRole
+    apiVersion: rbac.authorization.k8s.io/v1
+    metadata:
+      name: knative-serving-admin
+      labels:
+        serving.knative.dev/release: devel
+    aggregationRule:
+      clusterRoleSelectors:
+      - matchLabels:
+          serving.knative.dev/controller: "true"
+    rules: [] # Rules are automatically filled in by the controller manager.
+    ---
+    kind: ClusterRole
+    apiVersion: rbac.authorization.k8s.io/v1
+    metadata:
+      name: knative-serving-core
+      labels:
+        serving.knative.dev/release: devel
+        serving.knative.dev/controller: "true"
+    rules:
+      - apiGroups: [""]
+        resources: ["pods", "namespaces", "secrets", "configmaps", "endpoints", "services", "events", "serviceaccounts"]
+        verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+      - apiGroups: [""]
+        resources: ["endpoints/restricted"] # Permission for RestrictedEndpointsAdmission
+        verbs: ["create"]
+      - apiGroups: ["apps"]
+        resources: ["deployments", "deployments/finalizers"] # finalizers are needed for the owner reference of the webhook
+        verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+      - apiGroups: ["admissionregistration.k8s.io"]
+        resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+        verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+      - apiGroups: ["apiextensions.k8s.io"]
+        resources: ["customresourcedefinitions"]
+        verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+      - apiGroups: ["autoscaling"]
+        resources: ["horizontalpodautoscalers"]
+        verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+      - apiGroups: ["serving.knative.dev", "autoscaling.internal.knative.dev", "networking.internal.knative.dev"]
+        resources: ["*", "*/status", "*/finalizers"]
+        verbs: ["get", "list", "create", "update", "delete", "deletecollection", "patch", "watch"]
+      - apiGroups: ["caching.internal.knative.dev"]
+        resources: ["images"]
+        verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+    ---
+    kind: ClusterRole
+    apiVersion: rbac.authorization.k8s.io/v1
+    metadata:
+      name: knative-serving-podspecable-binding
+      labels:
+        serving.knative.dev/release: devel
+        duck.knative.dev/podspecable: "true"
+    rules:
+    - apiGroups:
+      - serving.knative.dev
+      resources:
+      - configurations
+      - services
+      verbs:
+      - list
+      - watch
+      - patch
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: controller
+      namespace: knative-serving
+      labels:
+        serving.knative.dev/release: devel
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: custom-metrics:system:auth-delegator
+      labels:
+        serving.knative.dev/release: devel
+        autoscaling.knative.dev/metric-provider: custom-metrics
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: system:auth-delegator
+    subjects:
+    - kind: ServiceAccount
+      name: controller
+      namespace: knative-serving
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: hpa-controller-custom-metrics
+      labels:
+        serving.knative.dev/release: devel
+        autoscaling.knative.dev/metric-provider: custom-metrics
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: custom-metrics-server-resources
+    subjects:
+    - kind: ServiceAccount
+      name: horizontal-pod-autoscaler
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: knative-serving-controller-admin
+      labels:
+        serving.knative.dev/release: devel
+    subjects:
+      - kind: ServiceAccount
+        name: controller
+        namespace: knative-serving
+    roleRef:
+      kind: ClusterRole
+      name: knative-serving-admin
+      apiGroup: rbac.authorization.k8s.io
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: custom-metrics-auth-reader
+      namespace: kube-system
+      labels:
+        serving.knative.dev/release: devel
+        autoscaling.knative.dev/metric-provider: custom-metrics
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: extension-apiserver-authentication-reader
+    subjects:
+    - kind: ServiceAccount
+      name: controller
+      namespace: knative-serving
+    ---
+    apiVersion: networking.istio.io/v1alpha3
+    kind: Gateway
+    metadata:
+      name: knative-ingress-gateway
+      namespace: knative-serving
+      labels:
+        serving.knative.dev/release: devel
+        networking.knative.dev/ingress-provider: istio
+    spec:
+      selector:
+        istio: ingressgateway
+      servers:
+      - port:
+          number: 80
+          name: http
+          protocol: HTTP
+        hosts:
+        - "*"
+    ---
+    apiVersion: networking.istio.io/v1alpha3
+    kind: Gateway
+    metadata:
+      name: cluster-local-gateway
+      namespace: knative-serving
+      labels:
+        serving.knative.dev/release: devel
+        networking.knative.dev/ingress-provider: istio
+    spec:
+      selector:
+        istio: cluster-local-gateway
+      servers:
+      - port:
+          number: 80
+          name: http
+          protocol: HTTP
+        hosts:
+        - "*"
+    ---
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      name: certificates.networking.internal.knative.dev
+      labels:
+        serving.knative.dev/release: devel
+        knative.dev/crd-install: "true"
+    spec:
+      group: networking.internal.knative.dev
+      version: v1alpha1
+      names:
+        kind: Certificate
+        plural: certificates
+        singular: certificate
+        categories:
+        - knative-internal
+        - networking
+        shortNames:
+        - kcert
+      scope: Namespaced
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+      - name: Ready
+        type: string
+        JSONPath: ".status.conditions[?(@.type==\"Ready\")].status"
+      - name: Reason
+        type: string
+        JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+    ---
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      name: configurations.serving.knative.dev
+      labels:
+        serving.knative.dev/release: devel
+        knative.dev/crd-install: "true"
+        duck.knative.dev/podspecable: "true"
+    spec:
+      group: serving.knative.dev
+      versions:
+      - name: v1alpha1
+        served: true
+        storage: true
+      - name: v1beta1
+        served: true
+        storage: false
+      - name: v1
+        served: true
+        storage: false
+      names:
+        kind: Configuration
+        plural: configurations
+        singular: configuration
+        categories:
+        - all
+        - knative
+        - serving
+        shortNames:
+        - config
+        - cfg
+      scope: Namespaced
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+      - name: LatestCreated
+        type: string
+        JSONPath: .status.latestCreatedRevisionName
+      - name: LatestReady
+        type: string
+        JSONPath: .status.latestReadyRevisionName
+      - name: Ready
+        type: string
+        JSONPath: ".status.conditions[?(@.type=='Ready')].status"
+      - name: Reason
+        type: string
+        JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
+    ---
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      name: images.caching.internal.knative.dev
+      labels:
+        knative.dev/crd-install: "true"
+    spec:
+      group: caching.internal.knative.dev
+      version: v1alpha1
+      names:
+        kind: Image
+        plural: images
+        singular: image
+        categories:
+        - knative-internal
+        - caching
+        shortNames:
+        - img
+      scope: Namespaced
+      subresources:
+        status: {}
+    ---
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ingresses.networking.internal.knative.dev
+      labels:
+        serving.knative.dev/release: devel
+        knative.dev/crd-install: "true"
+    spec:
+      group: networking.internal.knative.dev
+      versions:
+      - name: v1alpha1
+        served: true
+        storage: true
+      names:
+        kind: Ingress
+        plural: ingresses
+        singular: ingress
+        categories:
+        - knative-internal
+        - networking
+        shortNames:
+        - ing
+      scope: Namespaced
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+      - name: Ready
+        type: string
+        JSONPath: ".status.conditions[?(@.type=='Ready')].status"
+      - name: Reason
+        type: string
+        JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
+    ---
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      name: metrics.autoscaling.internal.knative.dev
+      labels:
+        serving.knative.dev/release: devel
+        knative.dev/crd-install: "true"
+    spec:
+      group: autoscaling.internal.knative.dev
+      version: v1alpha1
+      names:
+        kind: Metric
+        plural: metrics
+        singular: metric
+        categories:
+        - knative-internal
+        - autoscaling
+      scope: Namespaced
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+      - name: Ready
+        type: string
+        JSONPath: ".status.conditions[?(@.type=='Ready')].status"
+      - name: Reason
+        type: string
+        JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
+    ---
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      name: podautoscalers.autoscaling.internal.knative.dev
+      labels:
+        serving.knative.dev/release: devel
+        knative.dev/crd-install: "true"
+    spec:
+      group: autoscaling.internal.knative.dev
+      versions:
+      - name: v1alpha1
+        served: true
+        storage: true
+      names:
+        kind: PodAutoscaler
+        plural: podautoscalers
+        singular: podautoscaler
+        categories:
+        - knative-internal
+        - autoscaling
+        shortNames:
+        - kpa
+        - pa
+      scope: Namespaced
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+      - name: DesiredScale
+        type: integer
+        JSONPath: ".status.desiredScale"
+      - name: ActualScale
+        type: integer
+        JSONPath: ".status.actualScale"
+      - name: Ready
+        type: string
+        JSONPath: ".status.conditions[?(@.type=='Ready')].status"
+      - name: Reason
+        type: string
+        JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
+    ---
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      name: revisions.serving.knative.dev
+      labels:
+        serving.knative.dev/release: devel
+        knative.dev/crd-install: "true"
+    spec:
+      group: serving.knative.dev
+      versions:
+      - name: v1alpha1
+        served: true
+        storage: true
+      - name: v1beta1
+        served: true
+        storage: false
+      - name: v1
+        served: true
+        storage: false
+      names:
+        kind: Revision
+        plural: revisions
+        singular: revision
+        categories:
+        - all
+        - knative
+        - serving
+        shortNames:
+        - rev
+      scope: Namespaced
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+      - name: Config Name
+        type: string
+        JSONPath: ".metadata.labels['serving\\.knative\\.dev/configuration']"
+      - name: K8s Service Name
+        type: string
+        JSONPath: ".status.serviceName"
+      - name: Generation
+        type: string # int in string form :(
+        JSONPath: ".metadata.labels['serving\\.knative\\.dev/configurationGeneration']"
+      - name: Ready
+        type: string
+        JSONPath: ".status.conditions[?(@.type=='Ready')].status"
+      - name: Reason
+        type: string
+        JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
+    ---
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      name: routes.serving.knative.dev
+      labels:
+        serving.knative.dev/release: devel
+        knative.dev/crd-install: "true"
+        duck.knative.dev/addressable: "true"
+    spec:
+      group: serving.knative.dev
+      versions:
+      - name: v1alpha1
+        served: true
+        storage: true
+      - name: v1beta1
+        served: true
+        storage: false
+      - name: v1
+        served: true
+        storage: false
+      names:
+        kind: Route
+        plural: routes
+        singular: route
+        categories:
+        - all
+        - knative
+        - serving
+        shortNames:
+        - rt
+      scope: Namespaced
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+      - name: URL
+        type: string
+        JSONPath: .status.url
+      - name: Ready
+        type: string
+        JSONPath: ".status.conditions[?(@.type=='Ready')].status"
+      - name: Reason
+        type: string
+        JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
+    ---
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      name: services.serving.knative.dev
+      labels:
+        serving.knative.dev/release: devel
+        knative.dev/crd-install: "true"
+        duck.knative.dev/addressable: "true"
+        duck.knative.dev/podspecable: "true"
+    spec:
+      group: serving.knative.dev
+      versions:
+      - name: v1alpha1
+        served: true
+        storage: true
+      - name: v1beta1
+        served: true
+        storage: false
+      - name: v1
+        served: true
+        storage: false
+      names:
+        kind: Service
+        plural: services
+        singular: service
+        categories:
+        - all
+        - knative
+        - serving
+        shortNames:
+        - kservice
+        - ksvc
+      scope: Namespaced
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+      - name: URL
+        type: string
+        JSONPath: .status.url
+      - name: LatestCreated
+        type: string
+        JSONPath: .status.latestCreatedRevisionName
+      - name: LatestReady
+        type: string
+        JSONPath: .status.latestReadyRevisionName
+      - name: Ready
+        type: string
+        JSONPath: ".status.conditions[?(@.type=='Ready')].status"
+      - name: Reason
+        type: string
+        JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
+    ---
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      name: serverlessservices.networking.internal.knative.dev
+      labels:
+        serving.knative.dev/release: devel
+        knative.dev/crd-install: "true"
+    spec:
+      group: networking.internal.knative.dev
+      versions:
+      - name: v1alpha1
+        served: true
+        storage: true
+      names:
+        kind: ServerlessService
+        plural: serverlessservices
+        singular: serverlessservice
+        categories:
+        - knative-internal
+        - networking
+        shortNames:
+        - sks
+      scope: Namespaced
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+      - name: Mode
+        type: string
+        JSONPath: ".spec.mode"
+      - name: ServiceName
+        type: string
+        JSONPath: ".status.serviceName"
+      - name: PrivateServiceName
+        type: string
+        JSONPath: ".status.privateServiceName"
+      - name: Ready
+        type: string
+        JSONPath: ".status.conditions[?(@.type=='Ready')].status"
+      - name: Reason
+        type: string
+        JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: activator-service
+      namespace: knative-serving
+      labels:
+        app: activator
+        serving.knative.dev/release: devel
+    spec:
+      selector:
+        app: activator
+      ports:
+      - name: http
+        protocol: TCP
+        port: 80
+        targetPort: 8012
+      - name: http2
+        protocol: TCP
+        port: 81
+        targetPort: 8013
+      - name: http-metrics
+        protocol: TCP
+        port: 9090
+        targetPort: 9090
+      type: ClusterIP
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app: controller
+        serving.knative.dev/release: devel
+      name: controller
+      namespace: knative-serving
+    spec:
+      ports:
+      - name: http-metrics
+        port: 9090
+        protocol: TCP
+        targetPort: 9090
+      selector:
+        app: controller
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        role: webhook
+        serving.knative.dev/release: devel
+      name: webhook
+      namespace: knative-serving
+    spec:
+      ports:
+        - name: https-webhook
+          port: 443
+          targetPort: 8443
+      selector:
+        role: webhook
+    ---
+    apiVersion: admissionregistration.k8s.io/v1beta1
+    kind: MutatingWebhookConfiguration
+    metadata:
+      name: webhook.serving.knative.dev
+      labels:
+        serving.knative.dev/release: devel
+    webhooks:
+    - admissionReviewVersions:
+      - v1beta1
+      clientConfig:
+        service:
+          name: webhook
+          namespace: knative-serving
+      failurePolicy: Fail
+      name: webhook.serving.knative.dev
+    ---
+    apiVersion: admissionregistration.k8s.io/v1beta1
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      name: validation.webhook.serving.knative.dev
+      labels:
+        serving.knative.dev/release: devel
+    webhooks:
+    - admissionReviewVersions:
+      - v1beta1
+      clientConfig:
+        service:
+          name: webhook
+          namespace: knative-serving
+      failurePolicy: Fail
+      name: validation.webhook.serving.knative.dev
+    ---
+    apiVersion: admissionregistration.k8s.io/v1beta1
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      name: config.webhook.serving.knative.dev
+      labels:
+        serving.knative.dev/release: devel
+    webhooks:
+    - admissionReviewVersions:
+      - v1beta1
+      clientConfig:
+        service:
+          name: webhook
+          namespace: knative-serving
+      failurePolicy: Fail
+      name: config.webhook.serving.knative.dev
+      namespaceSelector:
+        matchExpressions:
+        - key: serving.knative.dev/release
+          operator: Exists
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: webhook-certs
+      namespace: knative-serving
+      labels:
+        serving.knative.dev/release: devel
+    ---
+    apiVersion: caching.internal.knative.dev/v1alpha1
+    kind: Image
+    metadata:
+      name: queue-proxy
+      namespace: knative-serving
+      labels:
+        serving.knative.dev/release: devel
+    spec:
+      image: quay.io/openshift-knative/knative-serving-queue:v0.11.1
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: activator
+      namespace: knative-serving
+      labels:
+        serving.knative.dev/release: devel
+    spec:
+      selector:
+        matchLabels:
+          app: activator
+          role: activator
+      template:
+        metadata:
+          annotations:
+            cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+            sidecar.istio.io/inject: "true"
+          labels:
+            app: activator
+            role: activator
+            serving.knative.dev/release: devel
+        spec:
+          serviceAccountName: controller
+          terminationGracePeriodSeconds: 300
+          containers:
+          - name: activator
+            image: quay.io/openshift-knative/knative-serving-activator:v0.11.1
+            env:
+              - name: GOGC
+                value: 500
+            ports:
+            - name: http1
+              containerPort: 8012
+            - name: h2c
+              containerPort: 8013
+            - name: metrics
+              containerPort: 9090
+            - name: profiling
+              containerPort: 8008
+            readinessProbe:
+              httpGet:
+                path: /healthz
+                port: 8012
+                httpHeaders:
+                - name: k-kubelet-probe
+                  value: "activator"
+            livenessProbe:
+              httpGet:
+                path: /healthz
+                port: 8012
+                httpHeaders:
+                - name: k-kubelet-probe
+                  value: "activator"
+            resources:
+              requests:
+                cpu: 300m
+                memory: 60Mi
+              limits:
+                cpu: 1000m
+                memory: 600Mi
+            env:
+              - name: POD_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.name
+              - name: POD_IP
+                valueFrom:
+                  fieldRef:
+                    fieldPath: status.podIP
+              - name: SYSTEM_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+              - name: CONFIG_LOGGING_NAME
+                value: config-logging
+              - name: CONFIG_OBSERVABILITY_NAME
+                value: config-observability
+              - name: METRICS_DOMAIN
+                value: knative.dev/internal/serving
+            securityContext:
+              allowPrivilegeEscalation: false
+    ---
+    apiVersion: autoscaling/v2beta1
+    kind: HorizontalPodAutoscaler
+    metadata:
+      name: activator
+      namespace: knative-serving
+      labels:
+        serving.knative.dev/release: devel
+    spec:
+        minReplicas: 1
+        maxReplicas: 20
+        scaleTargetRef:
+          apiVersion: apps/v1
+          kind: Deployment
+          name: activator
+        metrics:
+        - type: Resource
+          resource:
+            name: cpu
+            targetAverageUtilization: 100
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: autoscaler-hpa
+      namespace: knative-serving
+      labels:
+        serving.knative.dev/release: devel
+        autoscaling.knative.dev/autoscaler-provider: hpa
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: autoscaler-hpa
+      template:
+        metadata:
+          annotations:
+            sidecar.istio.io/inject: "false"
+          labels:
+            app: autoscaler-hpa
+            serving.knative.dev/release: devel
+        spec:
+          serviceAccountName: controller
+          containers:
+          - name: autoscaler-hpa
+            image: quay.io/openshift-knative/knative-serving-autoscaler-hpa:v0.11.1
+            resources:
+              requests:
+                cpu: 100m
+                memory: 100Mi
+              limits:
+                cpu: 1000m
+                memory: 1000Mi
+            ports:
+            - name: metrics
+              containerPort: 9090
+            - name: profiling
+              containerPort: 8008
+            env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_LOGGING_NAME
+              value: config-logging
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: config-observability
+            - name: METRICS_DOMAIN
+              value: knative.dev/serving
+            securityContext:
+              allowPrivilegeEscalation: false
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app: autoscaler
+        serving.knative.dev/release: devel
+      name: autoscaler
+      namespace: knative-serving
+    spec:
+      ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: 8080
+      - name: http-metrics
+        port: 9090
+        protocol: TCP
+        targetPort: 9090
+      - name: https-custom-metrics
+        port: 443
+        protocol: TCP
+        targetPort: 8443
+      selector:
+        app: autoscaler
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: autoscaler
+      namespace: knative-serving
+      labels:
+        serving.knative.dev/release: devel
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: autoscaler
+      template:
+        metadata:
+          annotations:
+            cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+            sidecar.istio.io/inject: "true"
+            traffic.sidecar.istio.io/includeInboundPorts: "8080,9090"
+          labels:
+            app: autoscaler
+            serving.knative.dev/release: devel
+        spec:
+          serviceAccountName: controller
+          containers:
+          - name: autoscaler
+            image: quay.io/openshift-knative/knative-serving-autoscaler:v0.11.1
+            readinessProbe:
+              httpGet:
+                path: /healthz
+                port: 8080
+                httpHeaders:
+                - name: k-kubelet-probe
+                  value: "autoscaler"
+            livenessProbe:
+              httpGet:
+                path: /healthz
+                port: 8080
+                httpHeaders:
+                - name: k-kubelet-probe
+                  value: "autoscaler"
+            resources:
+              requests:
+                cpu: 30m
+                memory: 40Mi
+              limits:
+                cpu: 300m
+                memory: 400Mi
+            ports:
+            - name: websocket
+              containerPort: 8080
+            - name: metrics
+              containerPort: 9090
+            - name: custom-metrics
+              containerPort: 8443
+            - name: profiling
+              containerPort: 8008
+            args:
+            - "--secure-port=8443"
+            - "--cert-dir=/tmp"
+            env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_LOGGING_NAME
+              value: config-logging
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: config-observability
+            - name: METRICS_DOMAIN
+              value: knative.dev/serving
+            securityContext:
+              allowPrivilegeEscalation: false
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: config-autoscaler
+      namespace: knative-serving
+      labels:
+        serving.knative.dev/release: devel
+    data:
+      _example: |
+        container-concurrency-target-percentage: "70"
+        container-concurrency-target-default: "100"
+        requests-per-second-target-default: "200"
+        target-burst-capacity: "200"
+        stable-window: "60s"
+        panic-window-percentage: "10.0"
+        panic-threshold-percentage: "200.0"
+        max-scale-up-rate: "1000.0"
+        max-scale-down-rate: "2.0"
+        enable-scale-to-zero: "true"
+        tick-interval: "2s"
+        scale-to-zero-grace-period: "30s"
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: config-defaults
+      namespace: knative-serving
+      labels:
+        serving.knative.dev/release: devel
+    data:
+      _example: |
+        revision-timeout-seconds: "300"  # 5 minutes
+        max-revision-timeout-seconds: "600"  # 10 minutes
+        revision-cpu-request: "400m"  # 0.4 of a CPU (aka 400 milli-CPU)
+        revision-memory-request: "100M"  # 100 megabytes of memory
+        revision-cpu-limit: "1000m"  # 1 CPU (aka 1000 milli-CPU)
+        revision-memory-limit: "200M"  # 200 megabytes of memory
+        container-name-template: "user-container"
+        container-concurrency: "0"
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: config-deployment
+      namespace: knative-serving
+      labels:
+        serving.knative.dev/release: devel
+    data:
+      queueSidecarImage: quay.io/openshift-knative/knative-serving-queue:v0.11.1
+      _example: |
+        registriesSkippingTagResolving: "ko.local,dev.local"
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: config-domain
+      namespace: knative-serving
+      labels:
+        serving.knative.dev/release: devel
+    data:
+      _example: |
+        example.com: |
+        example.org: |
+          selector:
+            app: nonprofit
+        svc.cluster.local: |
+          selector:
+            app: secret
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: config-gc
+      namespace: knative-serving
+      labels:
+        serving.knative.dev/release: devel
+    data:
+      _example: |
+        stale-revision-create-delay: "24h"
+        stale-revision-timeout: "15h"
+        stale-revision-minimum-generations: "1"
+        stale-revision-lastpinned-debounce: "5h"
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: config-istio
+      namespace: knative-serving
+      labels:
+        serving.knative.dev/release: devel
+        networking.knative.dev/ingress-provider: istio
+    data:
+      _example: |
+        gateway.knative-serving.knative-ingress-gateway: "istio-ingressgateway.istio-system.svc.cluster.local"
+        local-gateway.knative-serving.cluster-local-gateway: "cluster-local-gateway.istio-system.svc.cluster.local"
+        local-gateway.mesh: "mesh"
+        reconcileExternalGateway: "false"
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: config-logging
+      namespace: knative-serving
+      labels:
+        serving.knative.dev/release: devel
+    data:
+      _example: |
+        zap-logger-config: |
+          {
+            "level": "info",
+            "development": false,
+            "outputPaths": ["stdout"],
+            "errorOutputPaths": ["stderr"],
+            "encoding": "json",
+            "encoderConfig": {
+              "timeKey": "ts",
+              "levelKey": "level",
+              "nameKey": "logger",
+              "callerKey": "caller",
+              "messageKey": "msg",
+              "stacktraceKey": "stacktrace",
+              "lineEnding": "",
+              "levelEncoder": "",
+              "timeEncoder": "iso8601",
+              "durationEncoder": "",
+              "callerEncoder": ""
+            }
+          }
+        loglevel.controller: "info"
+        loglevel.autoscaler: "info"
+        loglevel.queueproxy: "info"
+        loglevel.webhook: "info"
+        loglevel.activator: "info"
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: config-network
+      namespace: knative-serving
+      labels:
+        serving.knative.dev/release: devel
+    data:
+      _example: |
+        istio.sidecar.includeOutboundIPRanges: "*"
+        clusteringress.class: "istio.ingress.networking.knative.dev"
+        ingress.class: "istio.ingress.networking.knative.dev"
+        certificate.class: "cert-manager.certificate.networking.internal.knative.dev"
+        domainTemplate: "{{.Name}}.{{.Namespace}}.{{.Domain}}"
+        tagTemplate: "{{.Tag}}-{{.Name}}"
+        autoTLS: "Disabled"
+        httpProtocol: "Enabled"
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: config-observability
+      namespace: knative-serving
+      labels:
+        serving.knative.dev/release: devel
+    data:
+      _example: |
+        logging.enable-var-log-collection: "false"
+        logging.revision-url-template: |
+          http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana#/discover?_a=(query:(match:(kubernetes.labels.serving-knative-dev%2FrevisionUID:(query:'${REVISION_UID}',type:phrase))))
+        logging.request-log-template: '{"httpRequest": {"requestMethod": "{{.Request.Method}}", "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}", "status": {{.Response.Code}}, "responseSize": "{{.Response.Size}}", "userAgent": "{{js .Request.UserAgent}}", "remoteIp": "{{js .Request.RemoteAddr}}", "serverIp": "{{.Revision.PodIP}}", "referer": "{{js .Request.Referer}}", "latency": "{{.Response.Latency}}s", "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "X-B3-Traceid"}}"}'
+        logging.enable-probe-request-log: "false"
+        metrics.backend-destination: prometheus
+        metrics.request-metrics-backend-destination: prometheus
+        metrics.stackdriver-project-id: "<your stackdriver project id>"
+        metrics.allow-stackdriver-custom-metrics: "false"
+        profiling.enable: "false"
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: config-tracing
+      namespace: knative-serving
+      labels:
+        serving.knative.dev/release: devel
+    data:
+      _example: |
+        backend: "none"
+        zipkin-endpoint: "http://zipkin.istio-system.svc.cluster.local:9411/api/v2/spans"
+        stackdriver-project-id: "my-project"
+        debug: "false"
+        sample-rate: "0.1"
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: controller
+      namespace: knative-serving
+      labels:
+        serving.knative.dev/release: devel
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: controller
+      template:
+        metadata:
+          annotations:
+            sidecar.istio.io/inject: "false"
+          labels:
+            app: controller
+            serving.knative.dev/release: devel
+        spec:
+          serviceAccountName: controller
+          containers:
+          - name: controller
+            image: quay.io/openshift-knative/knative-serving-controller:v0.11.1
+            resources:
+              requests:
+                cpu: 100m
+                memory: 100Mi
+              limits:
+                cpu: 1000m
+                memory: 1000Mi
+            ports:
+            - name: metrics
+              containerPort: 9090
+            - name: profiling
+              containerPort: 8008
+            env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_LOGGING_NAME
+              value: config-logging
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: config-observability
+            - name: METRICS_DOMAIN
+              value: knative.dev/internal/serving
+            securityContext:
+              allowPrivilegeEscalation: false
+    ---
+    apiVersion: apiregistration.k8s.io/v1beta1
+    kind: APIService
+    metadata:
+      name: v1beta1.custom.metrics.k8s.io
+      labels:
+        serving.knative.dev/release: devel
+        autoscaling.knative.dev/metric-provider: custom-metrics
+    spec:
+      service:
+        name: autoscaler
+        namespace: knative-serving
+      group: custom.metrics.k8s.io
+      version: v1beta1
+      insecureSkipTLSVerify: true
+      groupPriorityMinimum: 100
+      versionPriority: 100
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: networking-istio
+      namespace: knative-serving
+      labels:
+        serving.knative.dev/release: devel
+        networking.knative.dev/ingress-provider: istio
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: networking-istio
+      template:
+        metadata:
+          annotations:
+            sidecar.istio.io/inject: "false"
+          labels:
+            app: networking-istio
+            serving.knative.dev/release: devel
+        spec:
+          serviceAccountName: controller
+          containers:
+          - name: networking-istio
+            image: quay.io/openshift-knative/knative-serving-istio:v0.11.1
+            resources:
+              requests:
+                cpu: 100m
+                memory: 100Mi
+              limits:
+                cpu: 1000m
+                memory: 1000Mi
+            ports:
+            - name: metrics
+              containerPort: 9090
+            - name: profiling
+              containerPort: 8008
+            env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_LOGGING_NAME
+              value: config-logging
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: config-observability
+            - name: METRICS_DOMAIN
+              value: knative.dev/serving
+            securityContext:
+              allowPrivilegeEscalation: false
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: webhook
+      namespace: knative-serving
+      labels:
+        serving.knative.dev/release: devel
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: webhook
+          role: webhook
+      template:
+        metadata:
+          annotations:
+            cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+            sidecar.istio.io/inject: "false"
+          labels:
+            app: webhook
+            role: webhook
+            serving.knative.dev/release: devel
+        spec:
+          serviceAccountName: controller
+          containers:
+          - name: webhook
+            image: quay.io/openshift-knative/knative-serving-webhook:v0.11.1
+            ports:
+            - name: metrics
+              containerPort: 9090
+            - name: profiling
+              containerPort: 8008
+            resources:
+              requests:
+                cpu: 20m
+                memory: 20Mi
+              limits:
+                cpu: 200m
+                memory: 2Gi
+            env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_LOGGING_NAME
+              value: config-logging
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: config-observability
+            - name: METRICS_DOMAIN
+              value: knative.dev/serving
+            securityContext:
+              allowPrivilegeEscalation: false

--- a/ansible/roles/ocp4-workload-ccnrd/files/serverless-operator.v1.4.1.csv.yaml
+++ b/ansible/roles/ocp4-workload-ccnrd/files/serverless-operator.v1.4.1.csv.yaml
@@ -1,0 +1,488 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    certified: 'false'
+    olm.targetNamespaces: ''
+    repository: 'https://github.com/openshift-knative/serverless-operator'
+    support: 'Red Hat, Inc.'
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "operator.knative.dev/v1alpha1",
+          "kind": "KnativeServing",
+          "metadata": {
+            "name": "knative-serving"
+          },
+          "spec": {
+            "config": {
+              "autoscaler": {
+                "container-concurrency-target-default": "100",
+                "container-concurrency-target-percentage": "1.0",
+                "enable-scale-to-zero": "true",
+                "max-scale-up-rate": "10",
+                "panic-threshold-percentage": "200.0",
+                "panic-window": "6s",
+                "panic-window-percentage": "10.0",
+                "scale-to-zero-grace-period": "30s",
+                "stable-window": "60s",
+                "tick-interval": "2s"
+              },
+              "defaults": {
+                "revision-cpu-limit": "1000m",
+                "revision-cpu-request": "400m",
+                "revision-memory-limit": "200M",
+                "revision-memory-request": "100M",
+                "revision-timeout-seconds": "300"
+              },
+              "deployment": {
+                "registriesSkippingTagResolving": "ko.local,dev.local"
+              },
+              "gc": {
+                "stale-revision-create-delay": "24h",
+                "stale-revision-lastpinned-debounce": "5h",
+                "stale-revision-minimum-generations": "1",
+                "stale-revision-timeout": "15h"
+              },
+              "logging": {
+                "loglevel.activator": "info",
+                "loglevel.autoscaler": "info",
+                "loglevel.controller": "info",
+                "loglevel.queueproxy": "info",
+                "loglevel.webhook": "info"
+              },
+              "observability": {
+                "logging.enable-var-log-collection": "false",
+                "metrics.backend-destination": "prometheus"
+              },
+              "tracing": {
+                "backend": "none",
+                "sample-rate": "0.1"
+              }
+            }
+          }
+        }
+      ]
+    capabilities: Seamless Upgrades
+    olm.operatorNamespace: openshift-operators
+    containerImage: >-
+      registry.redhat.io/openshift-serverless-1-tech-preview/knative-rhel8-operator@sha256:4a20e629496ef5c693614a600c05a8cf6712d5cf3443aa991fa556338568438e
+    categories: 'Networking,Integration & Delivery,Cloud Provider,Developer Tools'
+    description: >-
+      Provides a collection of API's based on Knative to support deploying and
+      serving
+      of serverless applications and functions.
+    olm.operatorGroup: global-operators
+  name: serverless-operator.v1.4.1
+  namespace: openshift-operators
+  labels:
+    olm.api.1d316f16185c2e24: required
+    olm.api.362f21bbb2de66a0: required
+    olm.api.75423c66e1c26296: provided
+    olm.api.fceaacb4e1c6ac8c: provided
+spec:
+  customresourcedefinitions:
+    owned:
+      - description: Represents an installation of a particular version of Knative Serving
+        displayName: Knative Serving
+        kind: KnativeServing
+        name: knativeservings.operator.knative.dev
+        statusDescriptors:
+          - description: The version of Knative Serving installed
+            displayName: Version
+            path: version
+          - description: Conditions of Knative Serving installed
+            displayName: Conditions
+            path: conditions
+            x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes.conditions'
+        version: v1alpha1
+      - description: Represents an installation of a particular version of Knative Serving
+        displayName: Knative Serving (obsolete)
+        kind: KnativeServing
+        name: knativeservings.serving.knative.dev
+        statusDescriptors:
+          - description: The version of Knative Serving installed
+            displayName: Version
+            path: version
+          - description: Conditions of Knative Serving installed
+            displayName: Conditions
+            path: conditions
+            x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes.conditions'
+        version: v1alpha1
+    required:
+      - description: A list of namespaces in Service Mesh
+        displayName: Istio Service Mesh Member Roll
+        kind: ServiceMeshMemberRoll
+        name: servicemeshmemberrolls.maistra.io
+        version: v1
+      - description: An Istio control plane installation
+        displayName: Istio Service Mesh Control Plane
+        kind: ServiceMeshControlPlane
+        name: servicemeshcontrolplanes.maistra.io
+        version: v1
+  apiservicedefinitions: {}
+  keywords:
+    - serverless
+    - FaaS
+    - microservices
+    - scale to zero
+    - knative
+    - serving
+  displayName: OpenShift Serverless Operator
+  provider:
+    name: 'Red Hat, Inc.'
+  maturity: alpha
+  installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+  version: 1.4.1
+  icon:
+    - base64data: >-
+        PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMzQwMDt9LmNscy0ye2ZpbGw6I2NlMmUwMDt9LmNscy0ze2ZpbGw6bm9uZTt9LmNscy00e2ZpbGw6I2ZmZjt9LmNscy01e2ZpbGw6I2RjZGNkYzt9LmNscy02e2ZpbGw6I2FhYTt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZF9IYXQtT3BlbnNoaWZ0NC1DYXRhbG9nX0ljb25zLVNlcnZlcmxlc3M8L3RpdGxlPjxjaXJjbGUgY2xhc3M9ImNscy0xIiBjeD0iNTAiIGN5PSI1MCIgcj0iNTAiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik04NS4zNiwxNC42NEE1MCw1MCwwLDAsMSwxNC42NCw4NS4zNloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik00MC41Nyw0Ny40MmEzLjg5LDMuODksMCwxLDAsMy44OCwzLjg4QTMuODksMy44OSwwLDAsMCw0MC41Nyw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik0yMS40Miw0Ny40MkEzLjg5LDMuODksMCwxLDAsMjUuMyw1MS4zLDMuODksMy44OSwwLDAsMCwyMS40Miw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTQiIGQ9Ik01MC4wOSw0OC44NmgtLjE4YTQuMTEsNC4xMSwwLDAsMS0zLjI2LTEuNjMsNy42OSw3LjY5LDAsMCwwLTEyLjE2LDAsNC4xMyw0LjEzLDAsMCwxLTMuMjYsMS42M0gzMWE0LjA5LDQuMDksMCwwLDEtMy4yNS0xLjYzQTcuNjksNy42OSwwLDAsMCwxNCw1MS45M2gwVjY0LjZhMi43OSwyLjc5LDAsMCwwLDIuNzksMi43OWgxNS44TDUxLjM0LDQ4LjY2QTQsNCwwLDAsMSw1MC4wOSw0OC44NloiLz48cGF0aCBjbGFzcz0iY2xzLTUiIGQ9Ik03OC4wNSw0NC4yNWE3LjY1LDcuNjUsMCwwLDAtNS44NSwzQTQuMSw0LjEsMCwwLDEsNjksNDguODZoLS4xOWE0LjEzLDQuMTMsMCwwLDEtMy4yNi0xLjYzLDcuNjksNy42OSwwLDAsMC0xMi4xNiwwLDQuMTYsNC4xNiwwLDAsMS0yLDEuNDNMMzIuNjEsNjcuMzlIODMuMTlBMi43OSwyLjc5LDAsMCwwLDg2LDY0LjZWNTIuMDdBNy43Nyw3Ljc3LDAsMCwwLDc4LjA1LDQ0LjI1WiIvPjxwYXRoIGNsYXNzPSJjbHMtNiIgZD0iTTIxLjEsNjNoMTBhMS44MywxLjgzLDAsMSwwLDAtMy42NmgtMTBhMS44MywxLjgzLDAsMCwwLDAsMy42NloiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjIxLjQyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjY4Ljg5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjMxLjA5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9Ijc3Ljk0IiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9IjY4LjkxIiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9Ijc3Ljk0IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iMzMuMSIgcj0iMy4wMSIvPjxjaXJjbGUgY2xhc3M9ImNscy00IiBjeD0iMzEuMDkiIGN5PSIzMy4xIiByPSIzLjAxIi8+PGNpcmNsZSBjbGFzcz0iY2xzLTQiIGN4PSI2OC44OSIgY3k9IjMzLjEiIHI9IjMuMDEiLz48L3N2Zz4=
+      mediatype: image/svg+xml
+  minKubeVersion: 1.14.0
+  links:
+    - name: Documentation
+      url: >-
+        https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index
+    - name: Source Repository
+      url: 'https://github.com/openshift-knative/serverless-operator'
+  install:
+    spec:
+      clusterPermissions:
+        - rules:
+            - apiGroups:
+                - '*'
+              resources:
+                - '*'
+              verbs:
+                - '*'
+          serviceAccountName: knative-serving-operator
+        - rules:
+            - apiGroups:
+                - ''
+              resources:
+                - pods
+                - services
+                - events
+                - configmaps
+              verbs:
+                - '*'
+            - apiGroups:
+                - ''
+              resources:
+                - namespaces
+              verbs:
+                - get
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+                - replicasets
+              verbs:
+                - '*'
+            - apiGroups:
+                - apiextensions.k8s.io
+              resources:
+                - customresourcedefinitions
+              verbs:
+                - '*'
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - '*'
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - servicemonitors
+              verbs:
+                - get
+                - create
+            - apiGroups:
+                - networking.internal.knative.dev
+              resources:
+                - clusteringresses
+                - clusteringresses/status
+                - clusteringresses/finalizers
+                - ingresses
+                - ingresses/status
+                - ingresses/finalizers
+              verbs:
+                - '*'
+            - apiGroups:
+                - route.openshift.io
+              resources:
+                - routes
+                - routes/custom-host
+                - routes/status
+                - routes/finalizers
+              verbs:
+                - '*'
+            - apiGroups:
+                - operator.knative.dev
+              resources:
+                - knativeservings
+                - knativeservings/finalizers
+              verbs:
+                - '*'
+            - apiGroups:
+                - maistra.io
+              resources:
+                - servicemeshmemberrolls
+              verbs:
+                - '*'
+          serviceAccountName: knative-openshift-ingress
+      deployments:
+        - name: knative-serving-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: knative-serving-operator
+            template:
+              metadata:
+                annotations:
+                  sidecar.istio.io/inject: 'false'
+                labels:
+                  name: knative-serving-operator
+              spec:
+                containers:
+                  - env:
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: knative-serving-operator
+                      - name: SYSTEM_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: METRICS_DOMAIN
+                        value: knative.dev/serving-operator
+                      - name: KO_DATA_PATH
+                        value: /tmp/
+                    image: >-
+                      registry.redhat.io/openshift-serverless-1-tech-preview/knative-serving-rhel8-operator@sha256:dc004a3fe9b1bd2f8b3721b0bcbe4e35b4a96e92a5f306b14c8e18dd51e51225
+                    imagePullPolicy: IfNotPresent
+                    name: knative-serving-operator
+                    ports:
+                      - containerPort: 9090
+                        name: metrics
+                    volumeMounts:
+                      - mountPath: /tmp/knative-serving
+                        name: release-manifest
+                serviceAccountName: knative-serving-operator
+                volumes:
+                  - configMap:
+                      items:
+                        - key: knative-serving-v0.11.1.yaml
+                          path: knative-serving-v0.11.1.yaml
+                      name: ko-data
+                    name: release-manifest
+        - name: knative-serving-openshift
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: knative-serving-openshift
+            template:
+              metadata:
+                labels:
+                  app: openshift-admission-server
+                  name: knative-serving-openshift
+              spec:
+                containers:
+                  - command:
+                      - knative-serving-openshift
+                    env:
+                      - name: WATCH_NAMESPACE
+                        value: ''
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: knative-serving-openshift
+                      - name: MIN_OPENSHIFT_VERSION
+                        value: 4.1.13
+                      - name: REQUIRED_NAMESPACE
+                        value: knative-serving
+                      - name: IMAGE_queue-proxy
+                        value: >-
+                          registry.redhat.io/openshift-serverless-1-tech-preview/serving-queue-rhel8@sha256:f9ea8bd70789e67ff00cc134cd966fda8d9e7a764926551d650acc71776db73c
+                      - name: IMAGE_networking-istio
+                        value: >-
+                          registry.redhat.io/openshift-serverless-1-tech-preview/serving-networking-istio-rhel8@sha256:4e19f90b1aea1b7f4ba04f5d6b659f33a27904b37ca3f500e4aa982a9730b48b
+                      - name: IMAGE_activator
+                        value: >-
+                          registry.redhat.io/openshift-serverless-1-tech-preview/serving-activator-rhel8@sha256:529b5c5f27caea6ab664fbc47b74fafa1edf4913e652d02c64ace21829da4cfe
+                      - name: IMAGE_autoscaler
+                        value: >-
+                          registry.redhat.io/openshift-serverless-1-tech-preview/serving-autoscaler-rhel8@sha256:b2e1337b701a831e5832c71cc759c8bea959bc275c03aaf11a047cfc17779ae0
+                      - name: IMAGE_autoscaler-hpa
+                        value: >-
+                          registry.redhat.io/openshift-serverless-1-tech-preview/serving-autoscaler-hpa-rhel8@sha256:e400785e44de44655aa1c6419362f5c8f23fce2f775e4ebc4cc62487356238b7
+                      - name: IMAGE_controller
+                        value: >-
+                          registry.redhat.io/openshift-serverless-1-tech-preview/serving-controller-rhel8@sha256:342bd8de71721eab64bf842453a701cfe82e99954f5fa29095821f84ea61388e
+                      - name: IMAGE_webhook
+                        value: >-
+                          registry.redhat.io/openshift-serverless-1-tech-preview/serving-webhook-rhel8@sha256:8b966f57f45923465316f63eed438d094a4c64deeb07344048f3e7a8b5a88d3a
+                    image: >-
+                      registry.redhat.io/openshift-serverless-1-tech-preview/knative-rhel8-operator@sha256:4a20e629496ef5c693614a600c05a8cf6712d5cf3443aa991fa556338568438e
+                    imagePullPolicy: Always
+                    name: knative-serving-openshift
+                serviceAccountName: knative-serving-operator
+        - name: knative-openshift-ingress
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: knative-openshift-ingress
+            template:
+              metadata:
+                labels:
+                  name: knative-openshift-ingress
+              spec:
+                containers:
+                  - command:
+                      - knative-openshift-ingress
+                    env:
+                      - name: WATCH_NAMESPACE
+                        value: ''
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: knative-openshift-ingress
+                    image: >-
+                      registry.redhat.io/openshift-serverless-1-tech-preview/ingress-rhel8-operator@sha256:43abf91f54a4679acc5d29bcfd6420d882b0eaddea5ed4a906bd25f8a54b8f4f
+                    imagePullPolicy: Always
+                    name: knative-openshift-ingress
+                serviceAccountName: knative-openshift-ingress
+      permissions:
+        - rules:
+            - apiGroups:
+                - ''
+              resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+              verbs:
+                - '*'
+            - apiGroups:
+                - ''
+              resources:
+                - namespaces
+              verbs:
+                - get
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+                - daemonsets
+                - replicasets
+                - statefulsets
+              verbs:
+                - '*'
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - servicemonitors
+              verbs:
+                - get
+                - create
+            - apiGroups:
+                - apps
+              resourceNames:
+                - knative-serving-operator
+              resources:
+                - deployments/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - operator.knative.dev
+              resources:
+                - '*'
+              verbs:
+                - '*'
+          serviceAccountName: knative-serving-operator
+    strategy: deployment
+  maintainers:
+    - email: serverless-support@redhat.com
+      name: Serverless Team
+  description: >-
+    The Red Hat Serverless Operator provides a collection of API's to
+
+    install various "serverless" services.
+
+
+    This is a **[Tech Preview
+    release](https://access.redhat.com/support/offerings/techpreview)!**
+
+
+    # Knative Serving
+
+
+    Knative Serving builds on Kubernetes to support deploying and
+
+    serving of serverless applications and functions. Serving is easy
+
+    to get started with and scales to support advanced scenarios. The
+
+    Knative Serving project provides middleware primitives that
+
+    enable:
+
+
+    - Rapid deployment of serverless containers
+
+    - Automatic scaling up and down to zero
+
+    - Routing and network programming for Istio components
+
+    - Point-in-time snapshots of deployed code and configurations
+
+
+    ## Prerequisites
+
+
+    The Serverless Operator's provided APIs such as Knative Serving
+
+    have certain requirements with regards to the size of the underlying
+
+    cluster and a working installation of Service Mesh. See the [installation
+
+    section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index#installing-openshift-serverless)
+
+    of the Serverless documentation for more info.
+
+
+    ## Further Information
+
+
+    For documentation on using Knative Serving, see the
+
+    [serving
+    section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index#knative-serving_serverless-architecture)
+    of the
+
+    [Serverless documentation
+    site](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index).
+  replaces: serverless-operator.v1.4.0

--- a/ansible/roles/ocp4-workload-ccnrd/files/serverless_eventing_subscription.yaml
+++ b/ansible/roles/ocp4-workload-ccnrd/files/serverless_eventing_subscription.yaml
@@ -10,4 +10,4 @@ spec:
   name: knative-eventing-operator
   source: community-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: knative-eventing-operator.v0.11.0
+  startingCSV: knative-eventing-operator.v0.12.0

--- a/ansible/roles/ocp4-workload-ccnrd/files/serverless_subscription.yaml
+++ b/ansible/roles/ocp4-workload-ccnrd/files/serverless_subscription.yaml
@@ -10,4 +10,4 @@ spec:
   name: serverless-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: serverless-operator.v1.3.0
+  startingCSV: serverless-operator.v1.4.1

--- a/ansible/roles/ocp4-workload-ccnrd/tasks/add_role.yaml
+++ b/ansible/roles/ocp4-workload-ccnrd/tasks/add_role.yaml
@@ -16,3 +16,7 @@
       - apiGroup: rbac.authorization.k8s.io
         kind: User
         name: "{{ user }}"
+  register: r_rb
+  retries: 200
+  delay: 10
+  until: r_rb is succeeded

--- a/ansible/roles/ocp4-workload-ccnrd/tasks/install-serverless.yaml
+++ b/ansible/roles/ocp4-workload-ccnrd/tasks/install-serverless.yaml
@@ -20,13 +20,7 @@
   register: r_knserving_crd
   retries: 200
   delay: 10
-  ignore_errors: yes
   until: r_knserving_crd.resources | list | length == 1
-
-- name: Notify user if serverless deployment failed
-  when: not r_knserving_crd.resources | list | length == 1
-  debug:
-    msg: "user.info: *** Knative-serving could not be installed ***"
 
 - name: create knative projects
   k8s:
@@ -48,8 +42,42 @@
   register: r_serving_proj
   retries: 200
   delay: 10
-  ignore_errors: yes
   until: r_serving_proj.resources | list | length == 1
+
+# workaround for OOMKilled bug in knative-serving webhook https://github.com/knative/serving/issues/7195
+- name: add ConfigMap with updated memory limits for knative-serving webhook
+  k8s:
+    api_version: v1
+    kind: ConfigMap
+    name: ko-data
+    namespace: openshift-operators
+    state: present
+    merge_type:
+    - strategic-merge
+    - merge
+    definition: "{{ lookup('file', './files/knative-serving-cm.yaml' ) | from_yaml }}"
+  register: r_serving_cm
+  retries: 200
+  delay: 10
+  until: r_serving_cm is succeeded
+
+- name: replace knative CSV
+  k8s:
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    name: serverless-operator.v1.4.1
+    namespace: openshift-operators
+    state: present
+    merge_type:
+    - strategic-merge
+    - merge
+    definition: "{{ lookup('file', './files/serverless-operator.v1.4.1.csv.yaml' ) | from_yaml }}"
+  register: r_serving_crd_update
+  retries: 200
+  delay: 10
+  until: r_serving_crd_update is succeeded
+
+# End workaround
 
 - name: create knative serving CR
   k8s:
@@ -69,13 +97,26 @@
   register: r_kneventing_crd
   retries: 200
   delay: 10
-  ignore_errors: yes
   until: r_kneventing_crd.resources | list | length == 1
 
-- name: Notify user if serverless eventing deployment failed
-  when: not r_kneventing_crd.resources | list | length == 1
-  debug:
-    msg: "user.info: *** Knative-eventing could not be installed ***"
+# workaround for OOMKilled bug in knative-eventing webhook https://github.com/knative/serving/issues/7195
+- name: replace knative eventing CSV
+  k8s:
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    name: knative-eventing-operator.v0.12.0
+    namespace: openshift-operators
+    state: present
+    merge_type:
+    - strategic-merge
+    - merge
+    definition: "{{ lookup('file', './files/eventing-operator.v0.12.0.csv.yaml' ) | from_yaml }}"
+  register: r_eventing_crd_update
+  retries: 200
+  delay: 10
+  until: r_eventing_crd_update is succeeded
+
+# End workaround
 
 - name: Wait for knative-eventing project to exist
   k8s_facts:
@@ -85,13 +126,7 @@
   register: r_kneventing_project
   retries: 200
   delay: 10
-  ignore_errors: yes
   until: r_kneventing_project.resources | list | length == 1
-
-- name: Notify user if serverless eventing project deployment failed
-  when: not r_kneventing_project.resources | list | length == 1
-  debug:
-    msg: "user.info: *** knative-eventing project not created by operator ***"
 
 - name: Add view role for users to knative-serving project
   include_tasks: add_role.yaml


### PR DESCRIPTION
##### SUMMARY
Override hard-coded memory settings of knative-eventing and knative-serving to support large deployments. Also update to latest versions of each.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`ocp4-workload-ccnrd`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

The knative-eventing and knative-serving operators create hard-coded, and small memory limits for their webhooks. For large clusters, this easily overwhelms the webhooks and they go into crash loops with OOMKilled (out of memory - killed). This causes some exercises in this workshop to fail that deal with serverless and Knative eventing with Kafka.

There is no easy way to override these values as they are hard-coded into the manifests of the operator, so this bugfix overrides that by providing customized manifests for the operator. @danieloh30 and I have been consulting with the serverless eng team on the best workaround, other than simply removing this highly-sought after content from the workshop.

Once the underlying bug is fixed this workaround can be removed. Alternatively, when https://github.com/jcrossley3/serving-operator/commit/39b3d751f4cf0196e9cd4f9fe49909ce3193f016 finds its way into downstream OpenShift operators we can use that.
