### PR TITLE
Fix typo in common galaxy roles playbook

### DIFF
--- a/ansible/install_galaxy_roles.yml
+++ b/ansible/install_galaxy_roles.yml
@@ -31,7 +31,7 @@
         and r_requirements_content | length > 0
         and ( r_requirements_content is mapping
               and 'roles' in r_requirements_content )
-        or r_requirements_contet is sequence
+        or r_requirements_content is sequence
 
     - name: Import collections from requirements.yml
       command: >-


### PR DESCRIPTION
##### SUMMARY
A typo was introduced in #1289 , so the playbook was no longer pulling in galaxy roles - specifically ftl-injector. This would not be noticed when testing locally if you already have the ftl-injector role cached, but it is broken live.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
install_galaxy_roles
