### PR TITLE
remove overwatch annotations for install test

### DIFF
--- a/ansible/configs/ocp4-disconnected-osp-lab/software.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/software.yml
@@ -272,15 +272,6 @@
             dest: "/etc/openstack/clouds.yaml"
             mode: 0644
 
-        - name: Send notice to overwatch for start
-          uri:
-            url: http://overwatch.osp.opentlc.com:3000/api/annotations
-            method: POST
-            body_format: json
-            headers:
-              Authorization: "Bearer {{ test_overwatch }}"
-            body: {"text":"BEGIN ocp4 disconnected install","tags":["ocp4","perftest"]}
-
         - name: Run solver for lab 03
           shell: /usr/local/bin/solve_lab ocp4_advanced_deployment 03_1
           register: r_solve_lab_03
@@ -293,15 +284,6 @@
             INGRESS_FIP: "{{ hostvars['localhost']['ocp_ingress_fip'] }}"
           vars:
             GUID: "{{ guid }}"
-
-        - name: Send notice to overwatch for finish
-          uri:
-            url: http://overwatch.osp.opentlc.com:3000/api/annotations
-            method: POST
-            body_format: json
-            headers:
-              Authorization: "Bearer {{ test_overwatch }}"
-            body: {"text":"END ocp4 disconnected install","tags":["ocp4","perftest"]}
 
     - when: 
         - test_enable


### PR DESCRIPTION
##### SUMMARY
The annotations in grafana were extreme. Removing the install annotations to focus on the actual disk performance once the cluster is running. Still optional to enable the tests.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4-disconnected-osp-lab

