### PR TITLE
Add rhel 7/8 conditional for clientvm role

### DIFF
--- a/ansible/roles/ocp-client-vm/tasks/main.yml
+++ b/ansible/roles/ocp-client-vm/tasks/main.yml
@@ -29,7 +29,7 @@
 
 - name: Install OpenShift Client VM packages for RHEL 8
   when: ansible_distribution_major_version == "8"
-   yum:
+  yum:
     state: present
     name:
     - java-1.8.0-openjdk-devel

--- a/ansible/roles/ocp-client-vm/tasks/main.yml
+++ b/ansible/roles/ocp-client-vm/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
-- name: Get OS version
-  
 - name: Install Openshift Client VM packages for RHEL 7
   when: ansible_distribution_major_version == "7"
   block:

--- a/ansible/roles/ocp-client-vm/tasks/main.yml
+++ b/ansible/roles/ocp-client-vm/tasks/main.yml
@@ -1,28 +1,44 @@
 ---
-- name: Install Openshift Client VM packages
-  yum:
+- name: Get OS version
+  
+- name: Install Openshift Client VM packages for RHEL 7
+  when: ansible_distribution_major_version == "7"
+  block:
+  - name: Install Openshift Client VM packages for RHEL 7
+    yum:
+      state: present
+      name:
+      - java-1.8.0-openjdk-devel
+      - java-11-openjdk-devel
+      - docker
+      - podman
+      - skopeo
+      - buildah
+    tags:
+    - install_openshift_client_vm_packages
+
+  - name: Create docker group
+    become: yes
+    group:
+      name: docker
+      state: present
+
+  - name: Create users group
+    become: yes
+    group:
+      name: users
+      state: present
+
+- name: Install OpenShift Client VM packages for RHEL 8
+  when: ansible_distribution_major_version == "8"
+   yum:
     state: present
     name:
     - java-1.8.0-openjdk-devel
     - java-11-openjdk-devel
-    - docker
     - podman
     - skopeo
     - buildah
-  tags:
-  - install_openshift_client_vm_packages
-
-- name: Create docker group
-  become: yes
-  group:
-    name: docker
-    state: present
-
-- name: Create users group
-  become: yes
-  group:
-    name: users
-    state: present
 
 - when:
   - student_name is defined


### PR DESCRIPTION
##### SUMMARY
The ocp-client-vm role was trying to install packages on RHEL 8 that were causing problems or should no longer be necessary in RHEL 8 - specifically docker. This adds a conditional to differentiate between the list of packages for RHEL 8 vs RHEL 7

##### ISSUE TYPE
- Bugfix Pull Request
