### PR TITLE
Add 10 second delay

### DIFF
--- a/ansible/roles/ocp4-workload-quay-operator/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-quay-operator/tasks/workload.yml
@@ -165,6 +165,10 @@
     retries: 30
     delay: 10
 
+  - name: Pause 10 seconds to give containers a chance to initialize
+    pause:
+      seconds: 10
+
   - name: Wait for Quay App Pod Status to be Ready
     k8s_facts:
       api_version: v1


### PR DESCRIPTION
Prevent a snowflake situation where the pod existed but no container status did yet.