### PR TITLE
Change bastion hostname and ansible inventory

### DIFF
--- a/ansible/configs/sap-hana/default_vars.yml
+++ b/ansible/configs/sap-hana/default_vars.yml
@@ -165,7 +165,7 @@ security_groups:
         rule_type: Ingress
 
 instances:
-  - name: "bastion"
+  - name: "sap-bastion"
     count: "{{ bastion_instance_count }}"
     unique: true
     public_dns: true
@@ -276,8 +276,8 @@ common_packages:
 zone_internal_dns: "{{guid}}.internal."
 chomped_zone_internal_dns: "{{guid}}.internal"
 
-bastion_public_dns: "bastion.{{subdomain_base}}."
-bastion_public_dns_chomped: "bastion.{{subdomain_base}}"
+bastion_public_dns: "sap-bastion.{{subdomain_base}}."
+bastion_public_dns_chomped: "sap-bastion.{{subdomain_base}}"
 vpcid_cidr_block: "192.168.0.0/16"
 vpcid_name_tag: "{{subdomain_base}}"
 

--- a/ansible/configs/sap-hana/files/cloud_providers/osp_cloud_template_master.j2
+++ b/ansible/configs/sap-hana/files/cloud_providers/osp_cloud_template_master.j2
@@ -165,7 +165,7 @@ resources:
           delete_on_termination: true
           volume_size: {{ instance['rootfs_size'] | default(osp_default_rootfs_size) }}
           boot_index: 0
-        {% if iname == "bastion" %}
+        {% if iname == "sap-bastion" %}
         - image: {{ instance.sofware_image_id | default("software-sap") }}
           delete_on_termination: true
           volume_size: {{ instance['softwarefs_size'] }}

--- a/ansible/configs/sap-hana/files/hosts_template.j2
+++ b/ansible/configs/sap-hana/files/hosts_template.j2
@@ -1,12 +1,8 @@
 [hanas]
-{% for host in groups['hanas'] %}
 hana
-{% endfor %}
 
 [s4hanas]
-{% for host in groups['s4hanas'] %}
-hana
-{% endfor %}
+s4hana
 
 
 [hana:children]
@@ -19,7 +15,7 @@ s4hanas
 hanas
 s4hanas
 
-[hana:vars]
+[sap:vars]
 timeout=60
 ansible_become=yes
 ansible_user={{remote_user}}

--- a/ansible/configs/sap-hana/software.yml
+++ b/ansible/configs/sap-hana/software.yml
@@ -8,7 +8,7 @@
         msg: "Software tasks Started"
 
 - name: Ensure NFS Server is installed, SAP Software Device Mounted and Ansible Installed
-  hosts: bastion
+  hosts: bastions
   become: True
   gather_facts: True
   tasks:
@@ -83,7 +83,7 @@
     - name: Ensure NFS share is mounted
       mount:
         path: "/software"
-        src: "bastion:/nfs"
+        src: "sap-bastion:/nfs"
         fstype: nfs4
         opts: "rw,bg,hard,_netdev"
         state: mounted


### PR DESCRIPTION
##### SUMMARY
Change bastion hostname to get more sap-specific one and avoid conflicts with others on Satellite. Change how inventory for ansible in the bastion is generated.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
sap-hana config


