### PR TITLE
[WIP] changes to satellite role for rhel8

### DIFF
--- a/ansible/configs/ocp-clientvm/files/repos_template.j2
+++ b/ansible/configs/ocp-clientvm/files/repos_template.j2
@@ -3,7 +3,7 @@
 
 [rhel8baseos]
 name=rhel8-baseos
-baseurl=https://{{ satellite_url }}/pulp/repos/Red_Hat_GPTE/Library/content/dist/rhel8/8/x86_64/baseos/os/
+baseurl=https://{{ satellite_url }}/pulp/repos/{{ satellite_org }}/Library/content/dist/rhel8/8/x86_64/baseos/os/
 enabled=1
 sslverify=1
 sslclientkey=/etc/pki/tls/Red_GPTE.key
@@ -11,7 +11,7 @@ sslclientcert=/etc/pki/tls/Red_GPTE.pem
 
 [rhel8appstream]
 name=rhel8-appstream
-baseurl=https://{{ satellite_url }}/pulp/repos/Red_Hat_GPTE/Library/content/dist/rhel8/8/x86_64/appstream/os/
+baseurl=https://{{ satellite_url }}/pulp/repos/{{ satellite_org }}/Library/content/dist/rhel8/8/x86_64/appstream/os/
 enabled=1
 sslverify=1
 sslclientkey=/etc/pki/tls/Red_GPTE.key
@@ -19,7 +19,7 @@ sslclientcert=/etc/pki/tls/Red_GPTE.pem
 
 [rhel8ansible]
 name=rhel8-ansible-2.8
-baseurl=https://{{ satellite_url }}/pulp/repos/Red_Hat_GPTE/Library/content/dist/layered/rhel8/x86_64/ansible/2.8/os/
+baseurl=https://{{ satellite_url }}/pulp/repos/{{ satellite_org }}/Library/content/dist/layered/rhel8/x86_64/ansible/2/os/
 enabled=1
 sslverify=1
 sslclientkey=/etc/pki/tls/Red_GPTE.key

--- a/ansible/configs/ocp-clientvm/pre_software.yml
+++ b/ansible/configs/ocp-clientvm/pre_software.yml
@@ -31,7 +31,7 @@
   hosts:
   - all:!windows
   become: true
-  gather_facts: True
+  gather_facts: false
   tags:
   - step004
   - common_tasks

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -40,6 +40,11 @@
         - 'virtual'
 
 ######################## Install Basic Packages
+- name: Run setup if gather_facts hasn't been run
+  setup:
+    gather_subset: min
+  when: ansible_distribution_major_version is not defined
+
 - name: Install common packages for RHEL 7
   import_tasks: ./packages_el7.yml
   when: 

--- a/ansible/roles/set-repositories/tasks/satellite-repos.yml
+++ b/ansible/roles/set-repositories/tasks/satellite-repos.yml
@@ -41,12 +41,21 @@
   file:
     path: /etc/yum.repos.d/{{ item }}
     state: absent
-  # TODO: use with_fileglob here
   with_items: "{{ repodircontents.stdout_lines }}"
   ignore_errors: true
   tags:
     - configure_repos
     - remove_existing_repos
+
+- name: Run setup if gather_facts hasn't been run
+  setup:
+    gather_subset: min
+  when: ansible_date_time is not defined
+
+- name: Randomize hostname for Satellite
+  copy:
+    dest: /etc/rhsm/facts/katello.facts
+    content: {"network.fqdn": "{{ inventory_hostname }}-{{ ansible_date_time.iso8601_basic | lower }}"}
 
 - name: Register with activation-key
   when: satellite_activationkey is defined
@@ -56,16 +65,6 @@
     activationkey: "{{ satellite_activationkey }}"
     org_id: "{{ satellite_org }}"
 
-- name: Enable repos for RHEL
-  rhsm_repository:
-    name: "{{ item }}"
-    state: enabled
-  with_items:
-    - '{{ rhel_repos }}'
-  when: 
-  - not use_content_view
-  - rhel_repos is defined
-
 - name: Enable repos
   rhsm_repository:
     name: "*"
@@ -74,6 +73,20 @@
   - use_content_view
   - satellite_activationkey is defined
 
+- name: Enable repos for RHEL
+  rhsm_repository:
+    name: "{{ item }}"
+    state: enabled
+  with_items:
+    - '{{ rhel_repos }}'
+  when: 
+  - not use_content_view
+  - rhel_repos is define
+
+# This would be used to skip registering with Satellite,
+# but still be able to access the repos via certificate auth.
+# This will only run if you have satellite_key and satellite_cert defined,
+# but not satellite_activationkey
 - name: Set up repos to access Satellite using cert
   when:
   - satellite_key is defined


### PR DESCRIPTION
##### SUMMARY
Some additional changes to support agnostic clientVM for RHEL 8 & 7. Mainly changes to satellite-repo role so we can register systems instead of bypassing with certs. Key change was adding a randomization to the hostname so they don't overwrite each other in Satellite.

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
ocp-clientvm
set-repositories
common

