### PR TITLE
Fix set-repositories role

### DIFF
--- a/ansible/roles/set-repositories/tasks/main.yml
+++ b/ansible/roles/set-repositories/tasks/main.yml
@@ -2,6 +2,11 @@
 ---
 ######################### Set up Subscription Method (File/Satellite/RHN)
 
+- name: Run setup if gather_facts hasn't been run
+  setup:
+    gather_subset: min
+  when: ansible_date_time is not defined
+
 - when: not hostvars.localhost.skip_packer_tasks | d(false)
   tags:
     - set_repositories

--- a/ansible/roles/set-repositories/tasks/satellite-repos.yml
+++ b/ansible/roles/set-repositories/tasks/satellite-repos.yml
@@ -48,6 +48,16 @@
     - configure_repos
     - remove_existing_repos
 
+# - name: Run setup if gather_facts hasn't been run
+#   setup:
+#     gather_subset: min
+#   when: ansible_date_time is not defined
+
+- name: Randomize hostname for Satellite
+  copy:
+    dest: /etc/rhsm/facts/katello.facts
+    content: {"network.fqdn": "{{ inventory_hostname }}-{{ ansible_date_time.iso8601_basic | lower }}"}
+
 - name: Register with activation-key
   when: satellite_activationkey is defined
   redhat_subscription:

--- a/ansible/roles/set-repositories/tasks/satellite-repos.yml
+++ b/ansible/roles/set-repositories/tasks/satellite-repos.yml
@@ -48,11 +48,6 @@
     - configure_repos
     - remove_existing_repos
 
-# - name: Run setup if gather_facts hasn't been run
-#   setup:
-#     gather_subset: min
-#   when: ansible_date_time is not defined
-
 - name: Randomize hostname for Satellite
   copy:
     dest: /etc/rhsm/facts/katello.facts


### PR DESCRIPTION
##### SUMMARY
The rhel 7 repos were broken in the previous due to gather_facts being disabled. This adds a task to run setup and gather minimal facts for the necessary role.

##### ISSUE TYPE
- Bugfix Pull Request
