### PR TITLE
Fill agnosticd_user_info with OSP information for bookbag+ospvnc

### DIFF
--- a/ansible/configs/osp-migration/post_software.yml
+++ b/ansible/configs/osp-migration/post_software.yml
@@ -6,5 +6,12 @@
   tags:
     - step005
   tasks:
+    - name: Save user info
+      agnosticd_user_info:
+        data:
+          BOOKBAG_OS_AUTH_URL: "{{ osp_auth_url }}"
+          BOOKBAG_OS_USERNAME: "{{ guid }}"
+          BOOKBAG_OS_PASSWORD: "{{ api_pass }}"
+          BOOKBAG_OS_PROJECT_NAME: "{{ osp_project_name }}"
     - debug:
         msg: "Post-Software checks completed successfully"


### PR DESCRIPTION
For deploy bookbag with OSP+VNC we require information of OSP (user, password, auth url)