### PR TITLE
Satellite roles enabling libvirt provisioning

### DIFF
--- a/ansible/configs/satellite-vm/README.adoc
+++ b/ansible/configs/satellite-vm/README.adoc
@@ -50,6 +50,26 @@ Config Variables
 |satellite_content: [list] |Required | Main List variable
 |subscription_name: "String" |Required | Subscription name mainly required for manifest role
 | satellite_manifest: {Dictionary} |Required | Where satellite manifest is stored
+|satellite_libvirt_provisioning: "Bool" |Optional(*false*) | Whether configure libvirt provisioning
+|satellite_libvirt_network: {Dictionary}
+!===
+!domain: "String"
+!network: "String"
+!gateway: "String"
+!netmask: "String"
+!range_from: "String"
+!range_to: "String"
+!===
+|Optional
+|Libvrit default network setting
+!===
+!What domain should the subnet belong to
+!Network address
+!Gateway address - this is the hosting system address in this nat network
+!Network mask - full format
+!First IP to be included in the subnet used for provisioning
+!Last IP to be included in the subnet used for provisioning
+!===
 |===
 
 [NOTE]
@@ -77,6 +97,15 @@ org: gpte
 org_label: gpte
 org_description: "Global Partner Training and Enablement"
 subscription_name: "Employee SKU"
+
+satellite_libvirt_provisioning: yes
+satellite_libvirt_network:
+  domain: example.org
+  network: '192.168.122.0'
+  gateway: '192.168.122.1'
+  netmask: '255.255.255.0'
+  range_from: '192.168.122.2'
+  range_to: '192.168.122.254'
 
 lifecycle_environment_path:
     - name: "Dev"
@@ -152,6 +181,8 @@ Roles
 |satellite-public-hostname | link:../../roles/satellite-public-hostname[satellite-public-hostname] | Set public hostname
 |satellite-installation |link:../../roles/satellite-installation[satellite-installation] | Install and configure satellite
 |satellite-hammer-cli |link:../../roles/satellite-hammer-cli[satellite-hammer-cli] | Setup hammer cli
+|satellite-libvirt |link:../../roles/satellite-libvirt[satellite-libvirt] | Install libvirt (kvm) on capsule for provisioning
+|satellite-provisioning |link:../../roles/satellite-provisioning[satellite-provisioning] | Register provisioning resources (compute resource, subnet, domain) to satellite
 |satellite-manage-organization |link:../../roles/satellite-manage-organization[satellite-manage-organization] | Create satellite organization
 |satellite-manage-manifest |link:../../roles/ssatellite-manage-manifest[satellite-manage-manifest] | uploads manifest
 |satellite-manage-repositories |link:../../roles/satellite-manage-repository[satellite-manage-repositories] | Manage subscriptions/repositories and synchronize

--- a/ansible/configs/satellite-vm/default_vars_ec2.yml
+++ b/ansible/configs/satellite-vm/default_vars_ec2.yml
@@ -7,6 +7,7 @@ cloud_provider: ec2                     # Which AgnosticD Cloud Provider to use 
 HostedZoneId: Z3IHLWJZOU9SRT
 aws_region: ap-southeast-2
 
+satellite_libvirt_provisioning: no
 
 # How many do you want for each instance type
 bastion_instance_type: "t3.medium"
@@ -77,7 +78,7 @@ security_groups:
         protocol: tcp
         from_group: DefaultSG
         rule_type: Ingress
- 
+
 # Environment Instances
 instances:
   - name: "bastion"
@@ -102,7 +103,7 @@ instances:
   - name: "satellite"
     count: "{{satellite_instance_count}}"
     public_dns: true
-    security_groups: 
+    security_groups:
       - SatelliteSG
       - DefaultSG
     flavor:

--- a/ansible/configs/satellite-vm/default_vars_osp.yml
+++ b/ansible/configs/satellite-vm/default_vars_osp.yml
@@ -3,7 +3,7 @@
 ################################################################################
 
 
-cloud_provider: osp                               
+cloud_provider: osp
 install_student_user: false
 
 
@@ -20,11 +20,21 @@ admin_user: opentlc-mgr
 bastion_instance_type: 2c2g30d
 satellite_instance_type: 8c32g100d
 
-_image: rhel-server-7.7-update-2 
+_image: rhel-server-7.7-update-2
 bastion_instance_image: "{{ _image }}"
 satellite_instance_image: "{{ _image }}"
 
 satellite_instance_count: 1
+
+satellite_libvirt_provisioning: yes
+
+satellite_libvirt_network:
+  domain: example.org
+  network: '192.168.122.0'
+  gateway: '192.168.122.1'
+  netmask: '255.255.255.0'
+  range_from: '192.168.122.2'
+  range_to: '192.168.122.254'
 
 security_groups:
   - name: SatelliteSG
@@ -50,7 +60,7 @@ security_groups:
         protocol: tcp
         from_group: DefaultSG
         rule_type: Ingress
- 
+
 # Environment Instances
 instances:
   - name: "bastion"
@@ -85,7 +95,7 @@ instances:
       osp: "{{satellite_instance_type}}"
       azure: Standard_A2_V2
     image_id: "{{ satellite_instance_image }}"
-    security_groups: 
+    security_groups:
       - SatelliteSG
       - DefaultSG
     tags:

--- a/ansible/configs/satellite-vm/software.yml
+++ b/ansible/configs/satellite-vm/software.yml
@@ -26,6 +26,12 @@
         - satellite-installation
         # - satellite-hammer-cli
 
+    - import_role:
+        name: satellite-libvirt
+      when:
+        - install_satellite
+        - satellite_libvirt_provisioning | d(false)
+
     - when: configure_satellite
       include_role:
         name: "{{ _role }}"
@@ -33,6 +39,7 @@
         loop_var: _role
       loop:
         - satellite-manage-organization
+        - satellite-provisioning
         - satellite-manage-manifest
         - satellite-manage-repositories
         # - satellite-manage-lifecycle

--- a/ansible/roles/satellite-libvirt/README.adoc
+++ b/ansible/roles/satellite-libvirt/README.adoc
@@ -1,0 +1,120 @@
+:role: satellite-libvirt
+:author: Satellite Team
+:tag1: satellite_provisioning
+:tag2: satellite_provisioning_libvirt
+:defaults_file: defaults/main.yml
+:main_file: tasks/main.yml
+:libvirt_tasks: tasks/libvirt.yml
+:proxy_tasks: tasks/proxy_libvirt.yml
+:network_template: templates/network/default.xml.j2
+:pool_template: templates/pool/default.xml.j2
+
+Role: {role}
+============
+
+This role installs libvirt and prepares it to be used for provisioning.
+It can be installed eigther directly on satellite, or on the capsule.
+
+Requirements
+------------
+
+. libvirt packages needs to be enabled
+
+
+Role Variables
+--------------
+
+* Following are the variable to customize this role
+
+[cols="2a,1,3a"]
+|===
+|satellite_libvirt_provisioning: "Bool" |Optional(*false*) | Whether configure libvirt provisioning
+|satellite_libvirt_network: {Dictionary}
+!===
+!domain: "String"
+!network: "String"
+!gateway: "String"
+!netmask: "String"
+!range_from: "String"
+!range_to: "String"
+!===
+|Optional
+|Libvrit default network setting
+!===
+!What domain should the subnet belong to
+!Network address
+!Gateway address - this is the hosting system address in this nat network
+!Network mask - full format
+!First IP to be included in the subnet used for provisioning
+!Last IP to be included in the subnet used for provisioning
+!===
+|===
+
+* Exammple variables
+
+[source=text]
+----
+satellite_libvirt_provisioning: yes
+satellite_libvirt_network:
+  domain: example.org
+  network: '192.168.122.0'
+  gateway: '192.168.122.1'
+  netmask: '255.255.255.0'
+  range_from: '192.168.122.2'
+  range_to: '192.168.122.254'
+----
+
+Tags
+---
+
+|===
+|{tag1} |Consistent tag for all satellite config roles
+|{tag2} |This tag is specific to this role only
+|{tag3} |This tag is specific to this role and libvirt provisioning
+|===
+
+
+Example Playbook
+----------------
+
+How to use your role (for instance, with variables passed in playbook).
+
+[source=text]
+----
+[user@desktop ~]$ cat sample_vars.yml
+satellite_version: 6.7
+satellite_admin: admin
+satellite_admin_password: 'changeme'
+satellite_libvirt_provisioning: yes
+satellite_libvirt_network:
+  domain: example.org
+  network: '192.168.122.0'
+  gateway: '192.168.122.1'
+  netmask: '255.255.255.0'
+  range_from: '192.168.122.2'
+  range_to: '192.168.122.254'
+
+[user@desktop ~]$ cat playbook.yml
+- hosts: satellites
+  vars_files:
+    - sample_vars.yml
+  roles:
+    - satellite-provisioning
+
+[user@desktop ~]$ ansible-playbook playbook.yml
+----
+
+Tips to update Role
+------------------
+
+The libvirt installation tasks are at link:{libvirt_tasks}[libvirt.yml],
+for resource definition look at network definition link:{network_template}[network/default.xml.j2]
+and storage pool link:{pool_template}[pool/default.xml.j2]
+The enablement of libvirt in the capsule tasks are in link:{proxy_tasks}[proxy_libvirt.yml]
+
+for reference look at link:{main_file}[main.yml] for the variable reference at link:{defaults}[defaults/main.yml].
+
+Author Information
+------------------
+
+{author}

--- a/ansible/roles/satellite-libvirt/defaults/main.yml
+++ b/ansible/roles/satellite-libvirt/defaults/main.yml
@@ -1,0 +1,7 @@
+satellite_libvirt_network:
+  domain: example.org
+  network: '192.168.122.0'
+  gateway: '192.168.122.1'
+  netmask: '255.255.255.0'
+  range_from: '192.168.122.2'
+  range_to: '192.168.122.254'

--- a/ansible/roles/satellite-libvirt/handlers/main.yml
+++ b/ansible/roles/satellite-libvirt/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: restart capsule
+  service: name=foreman-proxy state=restarted

--- a/ansible/roles/satellite-libvirt/tasks/libvirt.yml
+++ b/ansible/roles/satellite-libvirt/tasks/libvirt.yml
@@ -1,0 +1,82 @@
+---
+- name: Unlock packages install
+  command: foreman-maintain packages unlock
+
+- name: Install libvirt
+  package:
+    name:
+    - qemu-kvm
+    - libvirt
+    - libvirt-python
+    - libguestfs-tools
+    - virt-install
+    state: latest
+  async: 3600
+  poll: 36
+  register: libvirt_install
+
+- name: Unlock packages install
+  command: foreman-maintain packages lock
+
+- name: Start and enable libvirt service
+  service:
+    name: libvirtd
+    state: started
+    enabled: yes
+
+- name: Add foreman users to libvirt group
+  user:
+    name: "{{ item }}"
+    groups: libvirt
+    append: yes
+  with_items:
+    - foreman
+    - foreman-proxy
+
+- name: Get facts of default network
+  virt_net:
+    command: facts
+
+- virt_net:
+    command: destroy
+    name: default
+
+- virt_net:
+    command: undefine
+    name: default
+
+- name: Add tftp to default network
+  virt_net:
+    command: define
+    name: default
+    xml: '{{ lookup("template", "network/default.xml.j2") }}'
+
+- virt_net:
+    command: start
+    name: default
+
+# Define a new storage pool
+- name: Get facts of pools
+  virt_pool:
+    command: facts
+
+- name: Ensure images directory
+  file:
+    path: /var/lib/libvirt/images
+    state: directory
+    mode: '0755'
+    owner: root
+    group: root
+
+- virt_pool:
+    command: define
+    name: default
+    xml: '{{ lookup("template", "pool/default.xml.j2") }}'
+  when: '"default" not in ansible_libvirt_pools'
+
+- virt_pool:
+    command: create
+    name: default
+  when: '"default" not in ansible_libvirt_pools'
+
+# - name: refresh capsule features

--- a/ansible/roles/satellite-libvirt/tasks/main.yml
+++ b/ansible/roles/satellite-libvirt/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+- set_fact:
+    satellite_hostname: "{{ publicname }}"
+
+- import_tasks: libvirt.yml
+  tags:
+    - configure_satellite
+    - satellite_provisioning
+    - satellite_provisioning_libvirt
+
+- import_tasks: proxy_libvirt.yml
+  tags:
+    - configure_satellite
+    - satellite_provisioning
+    - satellite_provisioning_libvirt

--- a/ansible/roles/satellite-libvirt/tasks/proxy_libvirt.yml
+++ b/ansible/roles/satellite-libvirt/tasks/proxy_libvirt.yml
@@ -1,0 +1,27 @@
+- name: Enable libvirt dhcp
+  lineinfile:
+    path: /etc/foreman-proxy/settings.d/dhcp.yml
+    regexp: '^:enabled:'
+    line: ':enabled: true'
+  notify: restart capsule
+
+- name: Set dhcp provider to libvirt
+  lineinfile:
+    path: /etc/foreman-proxy/settings.d/dhcp.yml
+    regexp: '^:use_provider:'
+    line: ':use_provider: dhcp_libvirt'
+  notify: restart capsule
+
+- name: Enable libvirt dns
+  lineinfile:
+    path: /etc/foreman-proxy/settings.d/dns.yml
+    regexp: '^:enabled:'
+    line: ':enabled: true'
+  notify: restart capsule
+
+- name: Set dns provider to libvirt
+  lineinfile:
+    path: /etc/foreman-proxy/settings.d/dns.yml
+    regexp: '^:use_provider:'
+    line: ':use_provider: dns_libvirt'
+  notify: restart capsule

--- a/ansible/roles/satellite-libvirt/templates/network/default.xml.j2
+++ b/ansible/roles/satellite-libvirt/templates/network/default.xml.j2
@@ -1,0 +1,20 @@
+<network ipv6="yes">
+  <name>default</name>
+  <uuid>{{ ansible_libvirt_networks.default.uuid }}</uuid>
+  <forward mode="nat" />
+  <bridge name="{{ ansible_libvirt_networks.default.bridge }}" stp="on" delay="0"/>
+  <mac address="{{ ansible_libvirt_networks.default.macaddress }}"/>
+  <domain name="{{ satellite_libvirt_network.domain }}"/>
+  <dns>
+    <host ip='{{ satellite_libvirt_network.gateway }}'>
+      <hostname>{{ satellite_hostname }}</hostname>
+    </host>
+  </dns>
+  <ip address="{{ satellite_libvirt_network.gateway }}" netmask="{{ satellite_libvirt_network.netmask }}">
+    <tftp root="/var/lib/tftpboot"/>
+    <dhcp>
+      <range start="{{ satellite_libvirt_network.range_from }}" end="{{ satellite_libvirt_network.range_to }}"/>
+      <bootp file="pxelinux.0"/>
+    </dhcp>
+  </ip>
+</network>

--- a/ansible/roles/satellite-libvirt/templates/pool/default.xml.j2
+++ b/ansible/roles/satellite-libvirt/templates/pool/default.xml.j2
@@ -1,0 +1,6 @@
+<pool type="dir">
+  <name>default</name>
+  <target>
+    <path>/var/lib/libvirt/images</path>
+  </target>
+</pool>

--- a/ansible/roles/satellite-provisioning/README.adoc
+++ b/ansible/roles/satellite-provisioning/README.adoc
@@ -1,0 +1,120 @@
+:role: satellite-provisioning
+:author: Satellite Team
+:tag1: configure_satellite
+:tag2: satellite_provisioning
+:tag3: satellite_provisioning_libvirt
+:main_file: tasks/main.yml
+:resources_file: tasks/provisioning_resources.yml
+
+Role: {role}
+============
+
+This role prepares satellite network based provisioning.
+As of now, it handles only internal libvirt.
+
+Requirements
+------------
+
+. Satellite must be installed and setted up.
+. For libvirt, libvirt must be installed and it's service running.
+
+
+Role Variables
+--------------
+
+* Following are the variable to customize this role
+
+[cols="2a,1,3a"]
+|===
+|satellite_version: "Digit" |Required |satellite version
+|satellite_admin: "String" |Required |Satellite admin username
+|satellite_admin_password: "String" |Required |Satellite admin password
+|satellite_libvirt_provisioning: "Bool" |Optional(*false*) | Whether configure libvirt provisioning
+|satellite_libvirt_network: {Dictionary}
+!===
+!domain: "String"
+!network: "String"
+!gateway: "String"
+!netmask: "String"
+!range_from: "String"
+!range_to: "String"
+!===
+|Optional
+|Libvrit default network setting
+!===
+!What domain should the subnet belong to
+!Network address
+!Gateway address - this is the hosting system address in this nat network
+!Network mask - full format
+!First IP to be included in the subnet used for provisioning
+!Last IP to be included in the subnet used for provisioning
+!===
+|===
+
+* Exammple variables
+
+[source=text]
+----
+satellite_version: 6.7
+satellite_admin: admin
+satellite_admin_password: 'changeme'
+satellite_libvirt_provisioning: yes
+satellite_libvirt_network:
+  domain: example.org
+  network: '192.168.122.0'
+  gateway: '192.168.122.1'
+  netmask: '255.255.255.0'
+  range_from: '192.168.122.2'
+  range_to: '192.168.122.254'
+----
+
+Tags
+---
+
+|===
+|{tag1} |Consistent tag for all satellite config roles
+|{tag2} |This tag is specific to this role only
+|{tag3} |This tag is specific to this role and libvirt provisioning
+|===
+
+
+Example Playbook
+----------------
+
+How to use your role (for instance, with variables passed in playbook).
+
+[source=text]
+----
+[user@desktop ~]$ cat sample_vars.yml
+satellite_version: 6.7
+satellite_admin: admin
+satellite_admin_password: 'changeme'
+satellite_libvirt_provisioning: yes
+satellite_libvirt_network:
+  domain: example.org
+  network: '192.168.122.0'
+  gateway: '192.168.122.1'
+  netmask: '255.255.255.0'
+  range_from: '192.168.122.2'
+  range_to: '192.168.122.254'
+
+[user@desktop ~]$ cat playbook.yml
+- hosts: satellites
+  vars_files:
+    - sample_vars.yml
+  roles:
+    - satellite-provisioning
+
+[user@desktop ~]$ ansible-playbook playbook.yml
+----
+
+
+Tips to update Role
+------------------
+
+for reference look at link:{main_file}[main.yml] and provisioning resources registration ling:{resources_file}[provisioning_resources.yml]
+
+Author Information
+------------------
+
+{author}

--- a/ansible/roles/satellite-provisioning/defaults/main.yml
+++ b/ansible/roles/satellite-provisioning/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+satellite_libvirt_provisioning: false
+satellite_libvirt_network:
+  domain: example.org
+  network: '192.168.122.0'
+  gateway: '192.168.122.1'
+  netmask: '255.255.255.0'
+  range_from: '192.168.122.2'
+  range_to: '192.168.122.254'

--- a/ansible/roles/satellite-provisioning/tasks/main.yml
+++ b/ansible/roles/satellite-provisioning/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+- import_tasks: provisioning_resources.yml
+  when: satellite_libvirt_provisioning
+  tags:
+    - configure_satellite
+    - satellite_provisioning
+    - satellite_provisioning_libvirt

--- a/ansible/roles/satellite-provisioning/tasks/provisioning_resources.yml
+++ b/ansible/roles/satellite-provisioning/tasks/provisioning_resources.yml
@@ -1,0 +1,62 @@
+---
+- name: Setting up libvirt compute resource
+  theforeman.foreman.foreman_compute_resource:
+    name: LibvirtLocal
+    locations:
+      - Default Location
+    organizations:
+      - "{{ org }}"
+    provider: libvirt
+    provider_params:
+      url: "qemu:///system"
+      display_type: vnc
+    server_url: "https://{{ publicname }}"
+    username: "{{ satellite_admin }}"
+    password: "{{ satellite_admin_password }}"
+    state: present
+
+- name: Create libvirt domain
+  theforeman.foreman.foreman_domain:
+    name: "summit.example.org"
+    description: "Domain for summit provisioning"
+    organizations:
+      - "{{ org }}"
+    locations:
+      - "Default Location"
+    server_url: "https://{{ publicname }}"
+    username: "{{ satellite_admin }}"
+    password: "{{ satellite_admin_password }}"
+    state: present
+
+- name: Create libvirt subnet
+  theforeman.foreman.foreman_subnet:
+    name: "SummitLocal"
+    description: "Network for summit provisioning"
+    network: "{{ satellite_libvirt_network.network }}"
+    mask: "{{ satellite_libvirt_network.netmask }}"
+    gateway: "{{ satellite_libvirt_network.gateway }}"
+    from_ip: "{{ satellite_libvirt_network.range_from }}"
+    to_ip: "{{ satellite_libvirt_network.range_to }}"
+    boot_mode: "Static"
+    dhcp_proxy: "{{ publicname }}"
+    tftp_proxy: "{{ publicname }}"
+    dns_proxy: "{{ publicname }}"
+    mtu: 9000
+    domains:
+      - "summit.example.org"
+    organizations:
+      - "{{ org }}"
+    locations:
+      - "Default Location"
+    server_url: "https://{{ publicname }}"
+    username: "{{ satellite_admin }}"
+    password: "{{ satellite_admin_password }}"
+    state: present
+
+- name: "Set a Setting"
+  foreman_setting:
+    server_url: "https://{{ publicname }}"
+    username: "{{ satellite_admin }}"
+    password: "{{ satellite_admin_password }}"
+    name: "unattended_url"
+    value: "http://{{ satellite_libvirt_network.gateway }}"


### PR DESCRIPTION
##### SUMMARY
For OpenStack the most convenient method of provisioning is nested libvirt provisioning.
This PR adds ability to install libvirt and enables the provisioning on it. 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- config `satellite-vm`
- new role `satellite-libvirt`
- new role `satellite-provisioning`

##### ADDITIONAL INFORMATION
Role `satellite-libvirt` installs libvirt eighter on satellite itself, or it's capsule, role `satellite-provisioning` set up the satellite to be able to provision on this resource.
