### PR TITLE
Remove student name from project name

### DIFF
--- a/ansible/configs/osp-migration/env_vars.yml
+++ b/ansible/configs/osp-migration/env_vars.yml
@@ -44,7 +44,6 @@ project_tag: "{{ env_type }}-{{ guid }}"
 osp_project_name: >-
   {{ project
   | replace('-bp','')
-  | replace('OPTLC', 'OTLC-LAB-' + student_name)
   }}-{{ guid }}
 
 


### PR DESCRIPTION
We need to short the project name as much as possible to avoid errors (max length is 64)