### PR TITLE
Fix typo in set-repositories/satellite-repos.yml

### DIFF
--- a/ansible/roles/set-repositories/tasks/satellite-repos.yml
+++ b/ansible/roles/set-repositories/tasks/satellite-repos.yml
@@ -69,7 +69,7 @@
   rhsm_repository:
     name: "*"
     state: enabled
-  when: 
+  when:
   - use_content_view
   - satellite_activationkey is defined
 
@@ -79,9 +79,9 @@
     state: enabled
   with_items:
     - '{{ rhel_repos }}'
-  when: 
+  when:
   - not use_content_view
-  - rhel_repos is define
+  - rhel_repos is defined
 
 # This would be used to skip registering with Satellite,
 # but still be able to access the repos via certificate auth.


### PR DESCRIPTION
##### SUMMARY
In #1344 was introduced a typo. It fails to register to the satellite now.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Role `set-repositories`
