### PR TITLE
Checking if generated key were created or not before deployment

### DIFF
--- a/ansible/cloud_providers/azure_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/azure_infrastructure_deployment.yml
@@ -64,6 +64,13 @@
         name: "{{ az_resource_group }}"
         location: "{{ azure_region }}"
 
+    - name: Check for auto-generated SSH Key
+      stat:
+        path: "{{output_dir}}/{{env_authorized_key}}"
+      register: env_authorized_key_status
+      tags:
+        - check_for_env_keys
+
     - name: Get SSH public key
       set_fact:
         ssh_key: "~/.ssh/{{key_name}}.pem"
@@ -72,7 +79,7 @@
         - set_existing_ssh_key
         - must
         - create_inventory
-      when: not set_env_authorized_key | bool
+      when: not env_authorized_key_status.stat.exists
 
     - name: Get SSH public key
       set_fact:
@@ -82,7 +89,7 @@
         - set_generated_ssh_key
         - must
         - create_inventory
-      when: set_env_authorized_key | bool
+      when: env_authorized_key_status.stat.exists
 
     - name: Setting windows_password variable
       set_fact:
@@ -90,6 +97,11 @@
       when:
         - windows_password is not defined
         - generated_windows_password is defined
+
+    - name: Check if the parameter file exists
+      stat:
+        path: "{{params_dest}}"
+      register: params_dest_status
 
     - name: Build parameter file
       copy:
@@ -101,6 +113,7 @@
             "guid": { "value": "{{guid}}"},
           }
         dest: "{{params_dest}}"
+      when: not params_dest_status.stat.exists
       tags:
         - azure_infrastructure_deployment
         - validate_azure_template

--- a/ansible/cloud_providers/gcp_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/gcp_infrastructure_deployment.yml
@@ -19,6 +19,13 @@
         msg: you need Google Cloud SDK installed
       when: gcloud_result is failed
 
+    - name: Check for auto-generated SSH Key
+      stat:
+        path: "{{output_dir}}/{{env_authorized_key}}"
+      register: env_authorized_key_status
+      tags:
+        - check_for_env_keys
+
     - name: Get SSH public key
       set_fact:
         ssh_key: "~/.ssh/{{key_name}}.pem"
@@ -27,7 +34,7 @@
         - set_existing_ssh_key
         - must
         - create_inventory
-      when: not set_env_authorized_key | bool
+      when: not env_authorized_key_status.stat.exists
 
     - name: Get SSH public key
       set_fact:
@@ -37,7 +44,7 @@
         - set_generated_ssh_key
         - must
         - create_inventory
-      when: set_env_authorized_key | bool
+      when: env_authorized_key_status.stat.exists
 
     - name: Set the destination for the template
       set_fact:

--- a/ansible/configs/aro/env_vars.yml
+++ b/ansible/configs/aro/env_vars.yml
@@ -6,6 +6,10 @@ project_tag: "{{ env_type }}-{{ guid }}"
 az_destroy_method: resource_group
 az_resource_group: "{{ project_tag }}"
 
+# Will not autogenerate SSH Keys
+set_env_authorized_key: false
+env_authorized_key: "{{guid}}key"
+
 # Setting the key_name and ssh_keyfile
 key_name: id_rsa
 


### PR DESCRIPTION
##### SUMMARY
the various ocp-workshop configs when using Azure generate the keys in pre_software.yml where ocp4-cluster does it in pre_infra.yml (most of my testing), so I updated the infrastructure deployment for azure and gcp to check if the files exist instead of if the variable is set.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
gcp_infrastructure_deployment.yml
azure_infrastructure_deployment.yml
config/aro

##### ADDITIONAL INFORMATION
Also added the variable env_authorized_keys variable to config/aro so it doesn't cause any errors in case anything decides to look for the value in the future too.