### PR TITLE
Upgrade Knative serving/eventing/kafka/istio operators to latest

### DIFF
--- a/ansible/roles/ocp4-workload-ccnrd/files/kafka_knative_subscription.yaml
+++ b/ansible/roles/ocp4-workload-ccnrd/files/kafka_knative_subscription.yaml
@@ -10,4 +10,4 @@ spec:
   name: knative-kafka-operator
   source: community-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: knative-kafka-operator.v0.11.2
+  startingCSV: knative-kafka-operator.v0.12.1

--- a/ansible/roles/ocp4-workload-ccnrd/files/knative-serving-cm.yaml
+++ b/ansible/roles/ocp4-workload-ccnrd/files/knative-serving-cm.yaml
@@ -4,1116 +4,380 @@ metadata:
   name: ko-data
   namespace: openshift-operators
 data:
-  knative-serving-v0.12.1.yaml: |
+  0.12.1.yaml: |
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        knative.dev/crd-install: "true"
+      name: images.caching.internal.knative.dev
+    spec:
+      group: caching.internal.knative.dev
+      names:
+        categories:
+        - knative-internal
+        - caching
+        kind: Image
+        plural: images
+        shortNames:
+        - img
+        singular: image
+      scope: Namespaced
+      subresources:
+        status: {}
+      version: v1alpha1
+
     ---
     apiVersion: v1
     kind: Namespace
     metadata:
-      name: knative-serving
       labels:
         istio-injection: enabled
-        serving.knative.dev/release: devel
-    ---
-    kind: ClusterRole
-    apiVersion: rbac.authorization.k8s.io/v1
-    metadata:
-      name: knative-serving-addressable-resolver
-      labels:
-        serving.knative.dev/release: devel
-        duck.knative.dev/addressable: "true"
-    rules:
-    - apiGroups:
-      - serving.knative.dev
-      resources:
-      - routes
-      - routes/status
-      - services
-      - services/status
-      verbs:
-      - get
-      - list
-      - watch
-    ---
-    kind: ClusterRole
-    apiVersion: rbac.authorization.k8s.io/v1
-    metadata:
-      name: knative-serving-istio
-      labels:
-        serving.knative.dev/release: devel
-        serving.knative.dev/controller: "true"
-        networking.knative.dev/ingress-provider: istio
-    rules:
-      - apiGroups: ["networking.istio.io"]
-        resources: ["virtualservices", "gateways"]
-        verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
-    ---
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-      name: custom-metrics-server-resources
-      labels:
-        serving.knative.dev/release: devel
-        autoscaling.knative.dev/metric-provider: custom-metrics
-    rules:
-      - apiGroups: ["custom.metrics.k8s.io"]
-        resources: ["*"]
-        verbs: ["*"]
-    ---
-    kind: ClusterRole
-    apiVersion: rbac.authorization.k8s.io/v1
-    metadata:
-      name: knative-serving-namespaced-admin
-      labels:
-        rbac.authorization.k8s.io/aggregate-to-admin: "true"
-        serving.knative.dev/release: devel
-    rules:
-      - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
-        resources: ["*"]
-        verbs: ["*"]
-    ---
-    kind: ClusterRole
-    apiVersion: rbac.authorization.k8s.io/v1
-    metadata:
-      name: knative-serving-namespaced-edit
-      labels:
-        rbac.authorization.k8s.io/aggregate-to-edit: "true"
-        serving.knative.dev/release: devel
-    rules:
-      - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
-        resources: ["*"]
-        verbs: ["create", "update", "patch", "delete"]
-    ---
-    kind: ClusterRole
-    apiVersion: rbac.authorization.k8s.io/v1
-    metadata:
-      name: knative-serving-namespaced-view
-      labels:
-        rbac.authorization.k8s.io/aggregate-to-view: "true"
-        serving.knative.dev/release: devel
-    rules:
-      - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
-        resources: ["*"]
-        verbs: ["get", "list", "watch"]
-    ---
-    kind: ClusterRole
-    apiVersion: rbac.authorization.k8s.io/v1
-    metadata:
-      name: knative-serving-admin
-      labels:
-        serving.knative.dev/release: devel
-    aggregationRule:
-      clusterRoleSelectors:
-      - matchLabels:
-          serving.knative.dev/controller: "true"
-    rules: [] # Rules are automatically filled in by the controller manager.
-    ---
-    kind: ClusterRole
-    apiVersion: rbac.authorization.k8s.io/v1
-    metadata:
-      name: knative-serving-core
-      labels:
-        serving.knative.dev/release: devel
-        serving.knative.dev/controller: "true"
-    rules:
-      - apiGroups: [""]
-        resources: ["pods", "namespaces", "secrets", "configmaps", "endpoints", "services", "events", "serviceaccounts"]
-        verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
-      - apiGroups: [""]
-        resources: ["endpoints/restricted"] # Permission for RestrictedEndpointsAdmission
-        verbs: ["create"]
-      - apiGroups: ["apps"]
-        resources: ["deployments", "deployments/finalizers"] # finalizers are needed for the owner reference of the webhook
-        verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
-      - apiGroups: ["admissionregistration.k8s.io"]
-        resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
-        verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
-      - apiGroups: ["apiextensions.k8s.io"]
-        resources: ["customresourcedefinitions"]
-        verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
-      - apiGroups: ["autoscaling"]
-        resources: ["horizontalpodautoscalers"]
-        verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
-      - apiGroups: ["serving.knative.dev", "autoscaling.internal.knative.dev", "networking.internal.knative.dev"]
-        resources: ["*", "*/status", "*/finalizers"]
-        verbs: ["get", "list", "create", "update", "delete", "deletecollection", "patch", "watch"]
-      - apiGroups: ["caching.internal.knative.dev"]
-        resources: ["images"]
-        verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
-    ---
-    kind: ClusterRole
-    apiVersion: rbac.authorization.k8s.io/v1
-    metadata:
-      name: knative-serving-podspecable-binding
-      labels:
-        serving.knative.dev/release: devel
-        duck.knative.dev/podspecable: "true"
-    rules:
-    - apiGroups:
-      - serving.knative.dev
-      resources:
-      - configurations
-      - services
-      verbs:
-      - list
-      - watch
-      - patch
-    ---
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-      name: controller
-      namespace: knative-serving
-      labels:
-        serving.knative.dev/release: devel
-    ---
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-      name: custom-metrics:system:auth-delegator
-      labels:
-        serving.knative.dev/release: devel
-        autoscaling.knative.dev/metric-provider: custom-metrics
-    roleRef:
-      apiGroup: rbac.authorization.k8s.io
-      kind: ClusterRole
-      name: system:auth-delegator
-    subjects:
-    - kind: ServiceAccount
-      name: controller
-      namespace: knative-serving
-    ---
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-      name: hpa-controller-custom-metrics
-      labels:
-        serving.knative.dev/release: devel
-        autoscaling.knative.dev/metric-provider: custom-metrics
-    roleRef:
-      apiGroup: rbac.authorization.k8s.io
-      kind: ClusterRole
-      name: custom-metrics-server-resources
-    subjects:
-    - kind: ServiceAccount
-      name: horizontal-pod-autoscaler
-      namespace: kube-system
-    ---
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-      name: knative-serving-controller-admin
-      labels:
-        serving.knative.dev/release: devel
-    subjects:
-      - kind: ServiceAccount
-        name: controller
-        namespace: knative-serving
-    roleRef:
-      kind: ClusterRole
-      name: knative-serving-admin
-      apiGroup: rbac.authorization.k8s.io
-    ---
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: RoleBinding
-    metadata:
-      name: custom-metrics-auth-reader
-      namespace: kube-system
-      labels:
-        serving.knative.dev/release: devel
-        autoscaling.knative.dev/metric-provider: custom-metrics
-    roleRef:
-      apiGroup: rbac.authorization.k8s.io
-      kind: Role
-      name: extension-apiserver-authentication-reader
-    subjects:
-    - kind: ServiceAccount
-      name: controller
-      namespace: knative-serving
-    ---
-    apiVersion: networking.istio.io/v1alpha3
-    kind: Gateway
-    metadata:
-      name: knative-ingress-gateway
-      namespace: knative-serving
-      labels:
-        serving.knative.dev/release: devel
-        networking.knative.dev/ingress-provider: istio
-    spec:
-      selector:
-        istio: ingressgateway
-      servers:
-      - port:
-          number: 80
-          name: http
-          protocol: HTTP
-        hosts:
-        - "*"
-    ---
-    apiVersion: networking.istio.io/v1alpha3
-    kind: Gateway
-    metadata:
-      name: cluster-local-gateway
-      namespace: knative-serving
-      labels:
-        serving.knative.dev/release: devel
-        networking.knative.dev/ingress-provider: istio
-    spec:
-      selector:
-        istio: cluster-local-gateway
-      servers:
-      - port:
-          number: 80
-          name: http
-          protocol: HTTP
-        hosts:
-        - "*"
-    ---
-    apiVersion: apiextensions.k8s.io/v1beta1
-    kind: CustomResourceDefinition
-    metadata:
-      name: certificates.networking.internal.knative.dev
-      labels:
-        serving.knative.dev/release: devel
-        knative.dev/crd-install: "true"
-    spec:
-      group: networking.internal.knative.dev
-      version: v1alpha1
-      names:
-        kind: Certificate
-        plural: certificates
-        singular: certificate
-        categories:
-        - knative-internal
-        - networking
-        shortNames:
-        - kcert
-      scope: Namespaced
-      subresources:
-        status: {}
-      additionalPrinterColumns:
-      - name: Ready
-        type: string
-        JSONPath: ".status.conditions[?(@.type==\"Ready\")].status"
-      - name: Reason
-        type: string
-        JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason"
-    ---
-    apiVersion: apiextensions.k8s.io/v1beta1
-    kind: CustomResourceDefinition
-    metadata:
-      name: configurations.serving.knative.dev
-      labels:
-        serving.knative.dev/release: devel
-        knative.dev/crd-install: "true"
-        duck.knative.dev/podspecable: "true"
-    spec:
-      group: serving.knative.dev
-      versions:
-      - name: v1alpha1
-        served: true
-        storage: true
-      - name: v1beta1
-        served: true
-        storage: false
-      - name: v1
-        served: true
-        storage: false
-      names:
-        kind: Configuration
-        plural: configurations
-        singular: configuration
-        categories:
-        - all
-        - knative
-        - serving
-        shortNames:
-        - config
-        - cfg
-      scope: Namespaced
-      subresources:
-        status: {}
-      additionalPrinterColumns:
-      - name: LatestCreated
-        type: string
-        JSONPath: .status.latestCreatedRevisionName
-      - name: LatestReady
-        type: string
-        JSONPath: .status.latestReadyRevisionName
-      - name: Ready
-        type: string
-        JSONPath: ".status.conditions[?(@.type=='Ready')].status"
-      - name: Reason
-        type: string
-        JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
-    ---
-    apiVersion: apiextensions.k8s.io/v1beta1
-    kind: CustomResourceDefinition
-    metadata:
-      name: images.caching.internal.knative.dev
-      labels:
-        knative.dev/crd-install: "true"
-    spec:
-      group: caching.internal.knative.dev
-      version: v1alpha1
-      names:
-        kind: Image
-        plural: images
-        singular: image
-        categories:
-        - knative-internal
-        - caching
-        shortNames:
-        - img
-      scope: Namespaced
-      subresources:
-        status: {}
-    ---
-    apiVersion: apiextensions.k8s.io/v1beta1
-    kind: CustomResourceDefinition
-    metadata:
-      name: ingresses.networking.internal.knative.dev
-      labels:
-        serving.knative.dev/release: devel
-        knative.dev/crd-install: "true"
-    spec:
-      group: networking.internal.knative.dev
-      versions:
-      - name: v1alpha1
-        served: true
-        storage: true
-      names:
-        kind: Ingress
-        plural: ingresses
-        singular: ingress
-        categories:
-        - knative-internal
-        - networking
-        shortNames:
-        - kingress
-      scope: Namespaced
-      subresources:
-        status: {}
-      additionalPrinterColumns:
-      - name: Ready
-        type: string
-        JSONPath: ".status.conditions[?(@.type=='Ready')].status"
-      - name: Reason
-        type: string
-        JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
-    ---
-    apiVersion: apiextensions.k8s.io/v1beta1
-    kind: CustomResourceDefinition
-    metadata:
-      name: metrics.autoscaling.internal.knative.dev
-      labels:
-        serving.knative.dev/release: devel
-        knative.dev/crd-install: "true"
-    spec:
-      group: autoscaling.internal.knative.dev
-      version: v1alpha1
-      names:
-        kind: Metric
-        plural: metrics
-        singular: metric
-        categories:
-        - knative-internal
-        - autoscaling
-      scope: Namespaced
-      subresources:
-        status: {}
-      additionalPrinterColumns:
-      - name: Ready
-        type: string
-        JSONPath: ".status.conditions[?(@.type=='Ready')].status"
-      - name: Reason
-        type: string
-        JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
-    ---
-    apiVersion: apiextensions.k8s.io/v1beta1
-    kind: CustomResourceDefinition
-    metadata:
-      name: podautoscalers.autoscaling.internal.knative.dev
-      labels:
-        serving.knative.dev/release: devel
-        knative.dev/crd-install: "true"
-    spec:
-      group: autoscaling.internal.knative.dev
-      versions:
-      - name: v1alpha1
-        served: true
-        storage: true
-      names:
-        kind: PodAutoscaler
-        plural: podautoscalers
-        singular: podautoscaler
-        categories:
-        - knative-internal
-        - autoscaling
-        shortNames:
-        - kpa
-        - pa
-      scope: Namespaced
-      subresources:
-        status: {}
-      additionalPrinterColumns:
-      - name: DesiredScale
-        type: integer
-        JSONPath: ".status.desiredScale"
-      - name: ActualScale
-        type: integer
-        JSONPath: ".status.actualScale"
-      - name: Ready
-        type: string
-        JSONPath: ".status.conditions[?(@.type=='Ready')].status"
-      - name: Reason
-        type: string
-        JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
-    ---
-    apiVersion: apiextensions.k8s.io/v1beta1
-    kind: CustomResourceDefinition
-    metadata:
-      name: revisions.serving.knative.dev
-      labels:
-        serving.knative.dev/release: devel
-        knative.dev/crd-install: "true"
-    spec:
-      group: serving.knative.dev
-      versions:
-      - name: v1alpha1
-        served: true
-        storage: true
-      - name: v1beta1
-        served: true
-        storage: false
-      - name: v1
-        served: true
-        storage: false
-      names:
-        kind: Revision
-        plural: revisions
-        singular: revision
-        categories:
-        - all
-        - knative
-        - serving
-        shortNames:
-        - rev
-      scope: Namespaced
-      subresources:
-        status: {}
-      additionalPrinterColumns:
-      - name: Config Name
-        type: string
-        JSONPath: ".metadata.labels['serving\\.knative\\.dev/configuration']"
-      - name: K8s Service Name
-        type: string
-        JSONPath: ".status.serviceName"
-      - name: Generation
-        type: string # int in string form :(
-        JSONPath: ".metadata.labels['serving\\.knative\\.dev/configurationGeneration']"
-      - name: Ready
-        type: string
-        JSONPath: ".status.conditions[?(@.type=='Ready')].status"
-      - name: Reason
-        type: string
-        JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
-    ---
-    apiVersion: apiextensions.k8s.io/v1beta1
-    kind: CustomResourceDefinition
-    metadata:
-      name: routes.serving.knative.dev
-      labels:
-        serving.knative.dev/release: devel
-        knative.dev/crd-install: "true"
-        duck.knative.dev/addressable: "true"
-    spec:
-      group: serving.knative.dev
-      versions:
-      - name: v1alpha1
-        served: true
-        storage: true
-      - name: v1beta1
-        served: true
-        storage: false
-      - name: v1
-        served: true
-        storage: false
-      names:
-        kind: Route
-        plural: routes
-        singular: route
-        categories:
-        - all
-        - knative
-        - serving
-        shortNames:
-        - rt
-      scope: Namespaced
-      subresources:
-        status: {}
-      additionalPrinterColumns:
-      - name: URL
-        type: string
-        JSONPath: .status.url
-      - name: Ready
-        type: string
-        JSONPath: ".status.conditions[?(@.type=='Ready')].status"
-      - name: Reason
-        type: string
-        JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
-    ---
-    apiVersion: apiextensions.k8s.io/v1beta1
-    kind: CustomResourceDefinition
-    metadata:
-      name: services.serving.knative.dev
-      labels:
-        serving.knative.dev/release: devel
-        knative.dev/crd-install: "true"
-        duck.knative.dev/addressable: "true"
-        duck.knative.dev/podspecable: "true"
-    spec:
-      group: serving.knative.dev
-      versions:
-      - name: v1alpha1
-        served: true
-        storage: true
-      - name: v1beta1
-        served: true
-        storage: false
-      - name: v1
-        served: true
-        storage: false
-      names:
-        kind: Service
-        plural: services
-        singular: service
-        categories:
-        - all
-        - knative
-        - serving
-        shortNames:
-        - kservice
-        - ksvc
-      scope: Namespaced
-      subresources:
-        status: {}
-      additionalPrinterColumns:
-      - name: URL
-        type: string
-        JSONPath: .status.url
-      - name: LatestCreated
-        type: string
-        JSONPath: .status.latestCreatedRevisionName
-      - name: LatestReady
-        type: string
-        JSONPath: .status.latestReadyRevisionName
-      - name: Ready
-        type: string
-        JSONPath: ".status.conditions[?(@.type=='Ready')].status"
-      - name: Reason
-        type: string
-        JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
-    ---
-    apiVersion: apiextensions.k8s.io/v1beta1
-    kind: CustomResourceDefinition
-    metadata:
-      name: serverlessservices.networking.internal.knative.dev
-      labels:
-        serving.knative.dev/release: devel
-        knative.dev/crd-install: "true"
-    spec:
-      group: networking.internal.knative.dev
-      versions:
-      - name: v1alpha1
-        served: true
-        storage: true
-      names:
-        kind: ServerlessService
-        plural: serverlessservices
-        singular: serverlessservice
-        categories:
-        - knative-internal
-        - networking
-        shortNames:
-        - sks
-      scope: Namespaced
-      subresources:
-        status: {}
-      additionalPrinterColumns:
-      - name: Mode
-        type: string
-        JSONPath: ".spec.mode"
-      - name: ServiceName
-        type: string
-        JSONPath: ".status.serviceName"
-      - name: PrivateServiceName
-        type: string
-        JSONPath: ".status.privateServiceName"
-      - name: Ready
-        type: string
-        JSONPath: ".status.conditions[?(@.type=='Ready')].status"
-      - name: Reason
-        type: string
-        JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
-    ---
-    apiVersion: admissionregistration.k8s.io/v1beta1
-    kind: ValidatingWebhookConfiguration
-    metadata:
-      name: config.webhook.serving.knative.dev
-      labels:
-        serving.knative.dev/release: devel
-    webhooks:
-    - admissionReviewVersions:
-      - v1beta1
-      clientConfig:
-        service:
-          name: webhook
-          namespace: knative-serving
-      failurePolicy: Fail
-      sideEffects: None
-      name: config.webhook.serving.knative.dev
-      namespaceSelector:
-        matchExpressions:
-        - key: serving.knative.dev/release
-          operator: Exists
-    ---
-    apiVersion: admissionregistration.k8s.io/v1beta1
-    kind: MutatingWebhookConfiguration
-    metadata:
-      name: webhook.serving.knative.dev
-      labels:
-        serving.knative.dev/release: devel
-    webhooks:
-    - admissionReviewVersions:
-      - v1beta1
-      clientConfig:
-        service:
-          name: webhook
-          namespace: knative-serving
-      failurePolicy: Fail
-      sideEffects: None
-      name: webhook.serving.knative.dev
-    ---
-    apiVersion: admissionregistration.k8s.io/v1beta1
-    kind: ValidatingWebhookConfiguration
-    metadata:
-      name: validation.webhook.serving.knative.dev
-      labels:
-        serving.knative.dev/release: devel
-    webhooks:
-    - admissionReviewVersions:
-      - v1beta1
-      clientConfig:
-        service:
-          name: webhook
-          namespace: knative-serving
-      failurePolicy: Fail
-      sideEffects: None
-      name: validation.webhook.serving.knative.dev
-    ---
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: webhook-certs
-      namespace: knative-serving
-      labels:
-        serving.knative.dev/release: devel
+        serving.knative.dev/release: "v0.12.1"
+      name: knative-serving
+
     ---
     apiVersion: caching.internal.knative.dev/v1alpha1
     kind: Image
     metadata:
+      labels:
+        serving.knative.dev/release: "v0.12.1"
       name: queue-proxy
       namespace: knative-serving
-      labels:
-        serving.knative.dev/release: devel
     spec:
-      image: quay.io/openshift-knative/knative-serving-queue:v0.12.1
-    ---
-    apiVersion: autoscaling/v2beta1
-    kind: HorizontalPodAutoscaler
-    metadata:
-      name: activator
-      namespace: knative-serving
-      labels:
-        serving.knative.dev/release: devel
-    spec:
-        minReplicas: 1
-        maxReplicas: 20
-        scaleTargetRef:
-          apiVersion: apps/v1
-          kind: Deployment
-          name: activator
-        metrics:
-        - type: Resource
-          resource:
-            name: cpu
-            targetAverageUtilization: 100
-    ---
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-      name: activator
-      namespace: knative-serving
-      labels:
-        serving.knative.dev/release: devel
-    spec:
-      selector:
-        matchLabels:
-          app: activator
-          role: activator
-      template:
-        metadata:
-          annotations:
-            cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
-          labels:
-            app: activator
-            role: activator
-            serving.knative.dev/release: devel
-        spec:
-          serviceAccountName: controller
-          containers:
-          - name: activator
-            image: quay.io/openshift-knative/knative-serving-activator:v0.12.1
-            resources:
-              requests:
-                cpu: 300m
-                memory: 60Mi
-              limits:
-                cpu: 1000m
-                memory: 600Mi
-            env:
-            - name: GOGC
-              value: "500"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            - name: SYSTEM_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: CONFIG_LOGGING_NAME
-              value: config-logging
-            - name: CONFIG_OBSERVABILITY_NAME
-              value: config-observability
-            - name: METRICS_DOMAIN
-              value: knative.dev/internal/serving
-            securityContext:
-              allowPrivilegeEscalation: false
-            ports:
-            - name: metrics
-              containerPort: 9090
-            - name: profiling
-              containerPort: 8008
-            - name: http1
-              containerPort: 8012
-            - name: h2c
-              containerPort: 8013
-            readinessProbe: &probe
-              httpGet:
-                port: 8012
-                httpHeaders:
-                - name: k-kubelet-probe
-                  value: "activator"
-            livenessProbe: *probe
-          terminationGracePeriodSeconds: 300
+      image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:ee0fd64c6c564f58675045ce289d061d7245186aae274b9a9c5e7ec878dad251
+
     ---
     apiVersion: v1
-    kind: Service
-    metadata:
-      name: activator-service
-      namespace: knative-serving
-      labels:
-        app: activator
-        serving.knative.dev/release: devel
-    spec:
-      selector:
-        app: activator
-      ports:
-      - name: http-metrics
-        port: 9090
-        targetPort: 9090
-      - name: http-profiling
-        port: 8008
-        targetPort: 8008
-      - name: http
-        port: 80
-        targetPort: 8012
-      - name: http2
-        port: 81
-        targetPort: 8013
-      type: ClusterIP
-    ---
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-      name: autoscaler-hpa
-      namespace: knative-serving
-      labels:
-        serving.knative.dev/release: devel
-        autoscaling.knative.dev/autoscaler-provider: hpa
-    spec:
-      selector:
-        matchLabels:
-          app: autoscaler-hpa
-      template:
-        metadata:
-          annotations:
-            cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
-          labels:
-            app: autoscaler-hpa
-            serving.knative.dev/release: devel
-        spec:
-          serviceAccountName: controller
-          containers:
-          - name: autoscaler-hpa
-            image: quay.io/openshift-knative/knative-serving-autoscaler-hpa:v0.12.1
-            resources:
-              requests:
-                cpu: 30m
-                memory: 40Mi
-              limits:
-                cpu: 300m
-                memory: 400Mi
-            env:
-            - name: SYSTEM_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: CONFIG_LOGGING_NAME
-              value: config-logging
-            - name: CONFIG_OBSERVABILITY_NAME
-              value: config-observability
-            - name: METRICS_DOMAIN
-              value: knative.dev/serving
-            securityContext:
-              allowPrivilegeEscalation: false
-            ports:
-            - name: metrics
-              containerPort: 9090
-            - name: profiling
-              containerPort: 8008
-    ---
-    apiVersion: v1
-    kind: Service
-    metadata:
-      labels:
-        app: autoscaler-hpa
-        serving.knative.dev/release: devel
-        autoscaling.knative.dev/autoscaler-provider: hpa
-      name: autoscaler-hpa
-      namespace: knative-serving
-    spec:
-      ports:
-      - name: http-metrics
-        port: 9090
-        targetPort: 9090
-      - name: http-profiling
-        port: 8008
-        targetPort: 8008
-      selector:
-        app: autoscaler-hpa
-    ---
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-      name: autoscaler
-      namespace: knative-serving
-      labels:
-        serving.knative.dev/release: devel
-    spec:
-      replicas: 1
-      selector:
-        matchLabels:
-          app: autoscaler
-      template:
-        metadata:
-          annotations:
-            cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
-          labels:
-            app: autoscaler
-            serving.knative.dev/release: devel
-        spec:
-          serviceAccountName: controller
-          containers:
-          - name: autoscaler
-            image: quay.io/openshift-knative/knative-serving-autoscaler:v0.12.1
-            resources:
-              requests:
-                cpu: 30m
-                memory: 40Mi
-              limits:
-                cpu: 300m
-                memory: 400Mi
-            env:
-            - name: SYSTEM_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: CONFIG_LOGGING_NAME
-              value: config-logging
-            - name: CONFIG_OBSERVABILITY_NAME
-              value: config-observability
-            - name: METRICS_DOMAIN
-              value: knative.dev/serving
-            securityContext:
-              allowPrivilegeEscalation: false
-            ports:
-            - name: metrics
-              containerPort: 9090
-            - name: profiling
-              containerPort: 8008
-            - name: websocket
-              containerPort: 8080
-            - name: custom-metrics
-              containerPort: 8443
-            readinessProbe: &probe
-              httpGet:
-                port: 8080
-                httpHeaders:
-                - name: k-kubelet-probe
-                  value: "autoscaler"
-            livenessProbe: *probe
-            args:
-            - "--secure-port=8443"
-            - "--cert-dir=/tmp"
-    ---
-    apiVersion: v1
-    kind: Service
-    metadata:
-      labels:
-        app: autoscaler
-        serving.knative.dev/release: devel
-      name: autoscaler
-      namespace: knative-serving
-    spec:
-      ports:
-      - name: http-metrics
-        port: 9090
-        targetPort: 9090
-      - name: http-profiling
-        port: 8008
-        targetPort: 8008
-      - name: http
-        port: 8080
-        targetPort: 8080
-      - name: https-custom-metrics
-        port: 443
-        targetPort: 8443
-      selector:
-        app: autoscaler
-    ---
-    apiVersion: v1
+    data:
+      _example: |
+        ################################
+        #                              #
+        #    EXAMPLE CONFIGURATION     #
+        #                              #
+        ################################
+
+        # This block is not actually functional configuration,
+        # but serves to illustrate the available configuration
+        # options and document them in a way that is accessible
+        # to users that `kubectl edit` this config map.
+        #
+        # These sample configuration options may be copied out of
+        # this example block and unindented to be in the data block
+        # to actually change the configuration.
+
+        # The Revision ContainerConcurrency field specifies the maximum number
+        # of requests the Container can handle at once. Container concurrency
+        # target percentage is how much of that maximum to use in a stable
+        # state. E.g. if a Revision specifies ContainerConcurrency of 10, then
+        # the Autoscaler will try to maintain 7 concurrent connections per pod
+        # on average.
+        # Note: this limit will be applied to container concurrency set at every
+        # level (ConfigMap, Revision Spec or Annotation).
+        # For legacy and backwards compatibility reasons, this value also accepts
+        # fractional values in (0, 1] interval (i.e. 0.7 ⇒ 70%).
+        # Thus minimal percentage value must be greater than 1.0, or it will be
+        # treated as a fraction.
+        container-concurrency-target-percentage: "70"
+
+        # The container concurrency target default is what the Autoscaler will
+        # try to maintain when concurrency is used as the scaling metric for a
+        # Revision and the Revision specifies unlimited concurrency.
+        # Even when specifying unlimited concurrency, the autoscaler will
+        # horizontally scale the application based on this target concurrency.
+        # NOTE: Only one metric can be used for autoscaling a Revision.
+        container-concurrency-target-default: "100"
+
+        # The requests per second (RPS) target default is what the Autoscaler will
+        # try to maintain when RPS is used as the scaling metric for a Revision and
+        # the Revision specifies unlimited RPS. Even when specifying unlimited RPS,
+        # the autoscaler will horizontally scale the application based on this
+        # target RPS.
+        # Must be greater than 1.0.
+        # NOTE: Only one metric can be used for autoscaling a Revision.
+        requests-per-second-target-default: "200"
+
+        # The target burst capacity specifies the size of burst in concurrent
+        # requests that the system operator expects the system will receive.
+        # Autoscaler will try to protect the system from queueing by introducing
+        # Activator in the request path if the current spare capacity of the
+        # service is less than this setting.
+        # If this setting is 0, then Activator will be in the request path only
+        # when the revision is scaled to 0.
+        # If this setting is > 0 and container-concurrency-target-percentage is
+        # 100% or 1.0, then activator will always be in the request path.
+        # -1 denotes unlimited target-burst-capacity and activator will always
+        # be in the request path.
+        # Other negative values are invalid.
+        target-burst-capacity: "200"
+
+        # When operating in a stable mode, the autoscaler operates on the
+        # average concurrency over the stable window.
+        # Stable window must be in whole seconds.
+        stable-window: "60s"
+
+        # When observed average concurrency during the panic window reaches
+        # panic-threshold-percentage the target concurrency, the autoscaler
+        # enters panic mode. When operating in panic mode, the autoscaler
+        # scales on the average concurrency over the panic window which is
+        # panic-window-percentage of the stable-window.
+        # When computing the panic window it will be rounded to the closest
+        # whole second.
+        panic-window-percentage: "10.0"
+
+        # The percentage of the container concurrency target at which to
+        # enter panic mode when reached within the panic window.
+        panic-threshold-percentage: "200.0"
+
+        # Max scale up rate limits the rate at which the autoscaler will
+        # increase pod count. It is the maximum ratio of desired pods versus
+        # observed pods.
+        # Cannot less or equal to 1.
+        # I.e with value of 2.0 the number of pods can at most go N to 2N
+        # over single Autoscaler period (see tick-interval), but at least N to
+        # N+1, if Autoscaler needs to scale up.
+        max-scale-up-rate: "1000.0"
+
+        # Max scale down rate limits the rate at which the autoscaler will
+        # decrease pod count. It is the maximum ratio of observed pods versus
+        # desired pods.
+        # Cannot less or equal to 1.
+        # I.e. with value of 2.0 the number of pods can at most go N to N/2
+        # over single Autoscaler evaluation period (see tick-interval), but at
+        # least N to N-1, if Autoscaler needs to scale down.
+        # Not yet used // TODO(vagababov) remove once other parts are ready.
+        max-scale-down-rate: "2.0"
+
+        # Scale to zero feature flag
+        enable-scale-to-zero: "true"
+
+        # Tick interval is the time between autoscaling calculations.
+        tick-interval: "2s"
+
+        # Dynamic parameters (take effect when config map is updated):
+
+        # Scale to zero grace period is the time an inactive revision is left
+        # running before it is scaled to zero (min: 30s).
+        scale-to-zero-grace-period: "30s"
+
+        # Enable graceful scaledown feature flag.
+        # Once enabled, it allows the autoscaler to prioritize pods processing
+        # fewer (or zero) requests for removal when scaling down.
+        enable-graceful-scaledown: "false"
     kind: ConfigMap
     metadata:
+      labels:
+        serving.knative.dev/release: "v0.12.1"
       name: config-autoscaler
       namespace: knative-serving
-      labels:
-        serving.knative.dev/release: devel
-    data:
-      _example: |
-        container-concurrency-target-percentage: "70"
-        container-concurrency-target-default: "100"
-        requests-per-second-target-default: "200"
-        target-burst-capacity: "200"
-        stable-window: "60s"
-        panic-window-percentage: "10.0"
-        panic-threshold-percentage: "200.0"
-        max-scale-up-rate: "1000.0"
-        max-scale-down-rate: "2.0"
-        enable-scale-to-zero: "true"
-        tick-interval: "2s"
-        scale-to-zero-grace-period: "30s"
-        enable-graceful-scaledown: "false"
+
     ---
     apiVersion: v1
+    data:
+      _example: |
+        ################################
+        #                              #
+        #    EXAMPLE CONFIGURATION     #
+        #                              #
+        ################################
+
+        # This block is not actually functional configuration,
+        # but serves to illustrate the available configuration
+        # options and document them in a way that is accessible
+        # to users that `kubectl edit` this config map.
+        #
+        # These sample configuration options may be copied out of
+        # this example block and unindented to be in the data block
+        # to actually change the configuration.
+
+        # revision-timeout-seconds contains the default number of
+        # seconds to use for the revision's per-request timeout, if
+        # none is specified.
+        revision-timeout-seconds: "300"  # 5 minutes
+
+        # max-revision-timeout-seconds contains the maximum number of
+        # seconds that can be used for revision-timeout-seconds.
+        # This value must be greater than or equal to revision-timeout-seconds.
+        # If omitted, the system default is used (600 seconds).
+        max-revision-timeout-seconds: "600"  # 10 minutes
+
+        # revision-cpu-request contains the cpu allocation to assign
+        # to revisions by default.  If omitted, no value is specified
+        # and the system default is used.
+        revision-cpu-request: "400m"  # 0.4 of a CPU (aka 400 milli-CPU)
+
+        # revision-memory-request contains the memory allocation to assign
+        # to revisions by default.  If omitted, no value is specified
+        # and the system default is used.
+        revision-memory-request: "100M"  # 100 megabytes of memory
+
+        # revision-cpu-limit contains the cpu allocation to limit
+        # revisions to by default.  If omitted, no value is specified
+        # and the system default is used.
+        revision-cpu-limit: "1000m"  # 1 CPU (aka 1000 milli-CPU)
+
+        # revision-memory-limit contains the memory allocation to limit
+        # revisions to by default.  If omitted, no value is specified
+        # and the system default is used.
+        revision-memory-limit: "200M"  # 200 megabytes of memory
+
+        # container-name-template contains a template for the default
+        # container name, if none is specified.  This field supports
+        # Go templating and is supplied with the ObjectMeta of the
+        # enclosing Service or Configuration, so values such as
+        # {{.Name}} are also valid.
+        container-name-template: "user-container"
+
+        # container-concurrency specifies the maximum number
+        # of requests the Container can handle at once, and requests
+        # above this threshold are queued.  Setting a value of zero
+        # disables this throttling and lets through as many requests as
+        # the pod receives.
+        container-concurrency: "0"
     kind: ConfigMap
     metadata:
+      labels:
+        serving.knative.dev/release: "v0.12.1"
       name: config-defaults
       namespace: knative-serving
-      labels:
-        serving.knative.dev/release: devel
-    data:
-      _example: |
-        revision-timeout-seconds: "300"  # 5 minutes
-        max-revision-timeout-seconds: "600"  # 10 minutes
-        revision-cpu-request: "400m"  # 0.4 of a CPU (aka 400 milli-CPU)
-        revision-memory-request: "100M"  # 100 megabytes of memory
-        revision-cpu-limit: "1000m"  # 1 CPU (aka 1000 milli-CPU)
-        revision-memory-limit: "200M"  # 200 megabytes of memory
-        container-name-template: "user-container"
-        container-concurrency: "0"
+
     ---
     apiVersion: v1
+    data:
+      _example: |
+        ################################
+        #                              #
+        #    EXAMPLE CONFIGURATION     #
+        #                              #
+        ################################
+
+        # This block is not actually functional configuration,
+        # but serves to illustrate the available configuration
+        # options and document them in a way that is accessible
+        # to users that `kubectl edit` this config map.
+        #
+        # These sample configuration options may be copied out of
+        # this example block and unindented to be in the data block
+        # to actually change the configuration.
+
+        # List of repositories for which tag to digest resolving should be skipped
+        registriesSkippingTagResolving: "ko.local,dev.local"
+      queueSidecarImage: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:ee0fd64c6c564f58675045ce289d061d7245186aae274b9a9c5e7ec878dad251
     kind: ConfigMap
     metadata:
+      labels:
+        serving.knative.dev/release: "v0.12.1"
       name: config-deployment
       namespace: knative-serving
-      labels:
-        serving.knative.dev/release: devel
-    data:
-      queueSidecarImage: quay.io/openshift-knative/knative-serving-queue:v0.12.1
-      _example: |
-        registriesSkippingTagResolving: "ko.local,dev.local"
+
     ---
     apiVersion: v1
-    kind: ConfigMap
-    metadata:
-      name: config-domain
-      namespace: knative-serving
-      labels:
-        serving.knative.dev/release: devel
     data:
       _example: |
+        ################################
+        #                              #
+        #    EXAMPLE CONFIGURATION     #
+        #                              #
+        ################################
+
+        # This block is not actually functional configuration,
+        # but serves to illustrate the available configuration
+        # options and document them in a way that is accessible
+        # to users that `kubectl edit` this config map.
+        #
+        # These sample configuration options may be copied out of
+        # this example block and unindented to be in the data block
+        # to actually change the configuration.
+
+        # Default value for domain.
+        # Although it will match all routes, it is the least-specific rule so it
+        # will only be used if no other domain matches.
         example.com: |
+
+        # These are example settings of domain.
+        # example.org will be used for routes having app=nonprofit.
         example.org: |
           selector:
             app: nonprofit
+
+        # Routes having domain suffix of 'svc.cluster.local' will not be exposed
+        # through Ingress. You can define your own label selector to assign that
+        # domain suffix to your Route here, or you can set the label
+        #    "serving.knative.dev/visibility=cluster-local"
+        # to achieve the same effect.  This shows how to make routes having
+        # the label app=secret only exposed to the local cluster.
         svc.cluster.local: |
           selector:
             app: secret
-    ---
-    apiVersion: v1
     kind: ConfigMap
     metadata:
+      labels:
+        serving.knative.dev/release: "v0.12.1"
+      name: config-domain
+      namespace: knative-serving
+
+    ---
+    apiVersion: v1
+    data:
+      _example: |
+        ################################
+        #                              #
+        #    EXAMPLE CONFIGURATION     #
+        #                              #
+        ################################
+
+        # This block is not actually functional configuration,
+        # but serves to illustrate the available configuration
+        # options and document them in a way that is accessible
+        # to users that `kubectl edit` this config map.
+        #
+        # These sample configuration options may be copied out of
+        # this example block and unindented to be in the data block
+        # to actually change the configuration.
+
+        # Delay after revision creation before considering it for GC
+        stale-revision-create-delay: "48h"
+
+        # Duration since a route has pointed at the revision before it
+        # should be GC'd.
+        # This minus lastpinned-debounce must be longer than the controller
+        # resync period (10 hours).
+        stale-revision-timeout: "15h"
+
+        # Minimum number of generations of revisions to keep before considering
+        # them for GC
+        stale-revision-minimum-generations: "20"
+
+        # To avoid constant updates, we allow an existing annotation to be stale by this
+        # amount before we update the timestamp.
+        stale-revision-lastpinned-debounce: "5h"
+    kind: ConfigMap
+    metadata:
+      labels:
+        serving.knative.dev/release: "v0.12.1"
       name: config-gc
       namespace: knative-serving
-      labels:
-        serving.knative.dev/release: devel
-    data:
-      _example: |
-        stale-revision-create-delay: "48h"
-        stale-revision-timeout: "15h"
-        stale-revision-minimum-generations: "20"
-        stale-revision-lastpinned-debounce: "5h"
+
     ---
     apiVersion: v1
-    kind: ConfigMap
-    metadata:
-      name: config-istio
-      namespace: knative-serving
-      labels:
-        serving.knative.dev/release: devel
-        networking.knative.dev/ingress-provider: istio
     data:
       _example: |
-        gateway.knative-serving.knative-ingress-gateway: "istio-ingressgateway.istio-system.svc.cluster.local"
-        local-gateway.knative-serving.cluster-local-gateway: "cluster-local-gateway.istio-system.svc.cluster.local"
-        local-gateway.mesh: "mesh"
-    ---
-    apiVersion: v1
-    kind: ConfigMap
-    metadata:
-      name: config-logging
-      namespace: knative-serving
-      labels:
-        serving.knative.dev/release: devel
-    data:
-      _example: |
+        ################################
+        #                              #
+        #    EXAMPLE CONFIGURATION     #
+        #                              #
+        ################################
+
+        # This block is not actually functional configuration,
+        # but serves to illustrate the available configuration
+        # options and document them in a way that is accessible
+        # to users that `kubectl edit` this config map.
+        #
+        # These sample configuration options may be copied out of
+        # this example block and unindented to be in the data block
+        # to actually change the configuration.
+
+        # Common configuration for all Knative codebase
         zap-logger-config: |
           {
             "level": "info",
@@ -1135,95 +399,344 @@ data:
               "callerEncoder": ""
             }
           }
+
+        # Log level overrides
+        # For all components except the autoscaler and queue proxy,
+        # changes are be picked up immediately.
+        # For autoscaler and queue proxy, changes require recreation of the pods.
         loglevel.controller: "info"
         loglevel.autoscaler: "info"
         loglevel.queueproxy: "info"
         loglevel.webhook: "info"
         loglevel.activator: "info"
-    ---
-    apiVersion: v1
     kind: ConfigMap
     metadata:
+      labels:
+        serving.knative.dev/release: "v0.12.1"
+      name: config-logging
+      namespace: knative-serving
+
+    ---
+    apiVersion: v1
+    data:
+      _example: |
+        ################################
+        #                              #
+        #    EXAMPLE CONFIGURATION     #
+        #                              #
+        ################################
+
+        # This block is not actually functional configuration,
+        # but serves to illustrate the available configuration
+        # options and document them in a way that is accessible
+        # to users that `kubectl edit` this config map.
+        #
+        # These sample configuration options may be copied out of
+        # this example block and unindented to be in the data block
+        # to actually change the configuration.
+
+        # istio.sidecar.includeOutboundIPRanges specifies the IP ranges that Istio sidecar
+        # will intercept.
+        #
+        # Replace this with the IP ranges of your cluster (see below for some examples).
+        # Separate multiple entries with a comma.
+        # Example: "10.4.0.0/14,10.7.240.0/20"
+        #
+        # If set to "*" Istio will intercept all traffic within
+        # the cluster as well as traffic that is going outside the cluster.
+        # Traffic going outside the cluster will be blocked unless
+        # necessary egress rules are created.
+        #
+        # If omitted or set to "", value of global.proxy.includeIPRanges
+        # provided at Istio deployment time is used. In default Knative serving
+        # deployment, global.proxy.includeIPRanges value is set to "*".
+        #
+        # If an invalid value is passed, "" is used instead.
+        #
+        # If valid set of IP address ranges are put into this value,
+        # Istio will no longer intercept traffic going to IP addresses
+        # outside the provided ranges and there is no need to specify
+        # egress rules.
+        #
+        # To determine the IP ranges of your cluster:
+        #   IBM Cloud Private: cat cluster/config.yaml | grep service_cluster_ip_range
+        #   IBM Cloud Kubernetes Service: "172.30.0.0/16,172.20.0.0/16,10.10.10.0/24"
+        #   Google Container Engine (GKE): gcloud container clusters describe $CLUSTER_NAME --zone=$CLUSTER_ZONE | grep -e clusterIpv4Cidr -e servicesIpv4Cidr
+        #   Azure Kubernetes Service (AKS): "10.0.0.0/16"
+        #   Azure Container Service (ACS; deprecated): "10.244.0.0/16,10.240.0.0/16"
+        #   Azure Container Service Engine (ACS-Engine; OSS): Configurable, but defaults to "10.0.0.0/16"
+        #   Minikube: "10.0.0.1/24"
+        #
+        # For more information, visit
+        # https://istio.io/docs/tasks/traffic-management/egress/
+        #
+        istio.sidecar.includeOutboundIPRanges: "*"
+
+        # ingress.class specifies the default ingress class
+        # to use when not dictated by Route annotation.
+        #
+        # If not specified, will use the Istio ingress.
+        #
+        # Note that changing the Ingress class of an existing Route
+        # will result in undefined behavior.  Therefore it is best to only
+        # update this value during the setup of Knative, to avoid getting
+        # undefined behavior.
+        ingress.class: "istio.ingress.networking.knative.dev"
+
+        # certificate.class specifies the default Certificate class
+        # to use when not dictated by Route annotation.
+        #
+        # If not specified, will use the Cert-Manager Certificate.
+        #
+        # Note that changing the Certificate class of an existing Route
+        # will result in undefined behavior.  Therefore it is best to only
+        # update this value during the setup of Knative, to avoid getting
+        # undefined behavior.
+        certificate.class: "cert-manager.certificate.networking.internal.knative.dev"
+
+        # domainTemplate specifies the golang text template string to use
+        # when constructing the Knative service's DNS name. The default
+        # value is "{{.Name}}.{{.Namespace}}.{{.Domain}}". And those three
+        # values (Name, Namespace, Domain) are the only variables defined.
+        #
+        # Changing this value might be necessary when the extra levels in
+        # the domain name generated is problematic for wildcard certificates
+        # that only support a single level of domain name added to the
+        # certificate's domain. In those cases you might consider using a value
+        # of "{{.Name}}-{{.Namespace}}.{{.Domain}}", or removing the Namespace
+        # entirely from the template. When choosing a new value be thoughtful
+        # of the potential for conflicts - for example, when users choose to use
+        # characters such as `-` in their service, or namespace, names.
+        # {{.Annotations}} can be used for any customization in the go template if needed.
+        # We strongly recommend keeping namespace part of the template to avoid domain name clashes
+        # Example '{{.Name}}-{{.Namespace}}.{{ index .Annotations "sub"}}.{{.Domain}}'
+        # and you have an annotation {"sub":"foo"}, then the generated template would be {Name}-{Namespace}.foo.{Domain}
+        domainTemplate: "{{.Name}}.{{.Namespace}}.{{.Domain}}"
+
+        # tagTemplate specifies the golang text template string to use
+        # when constructing the DNS name for "tags" within the traffic blocks
+        # of Routes and Configuration.  This is used in conjunction with the
+        # domainTemplate above to determine the full URL for the tag.
+        tagTemplate: "{{.Tag}}-{{.Name}}"
+
+        # Controls whether TLS certificates are automatically provisioned and
+        # installed in the Knative ingress to terminate external TLS connection.
+        # 1. Enabled: enabling auto-TLS feature.
+        # 2. Disabled: disabling auto-TLS feature.
+        autoTLS: "Disabled"
+
+        # Controls the behavior of the HTTP endpoint for the Knative ingress.
+        # It requires autoTLS to be enabled.
+        # 1. Enabled: The Knative ingress will be able to serve HTTP connection.
+        # 2. Disabled: The Knative ingress will reject HTTP traffic.
+        # 3. Redirected: The Knative ingress will send a 302 redirect for all
+        # http connections, asking the clients to use HTTPS
+        httpProtocol: "Enabled"
+    kind: ConfigMap
+    metadata:
+      labels:
+        serving.knative.dev/release: "v0.12.1"
       name: config-network
       namespace: knative-serving
-      labels:
-        serving.knative.dev/release: devel
-    data:
-      _example: |
-        istio.sidecar.includeOutboundIPRanges: "*"
-        ingress.class: "istio.ingress.networking.knative.dev"
-        certificate.class: "cert-manager.certificate.networking.internal.knative.dev"
-        domainTemplate: "{{.Name}}.{{.Namespace}}.{{.Domain}}"
-        tagTemplate: "{{.Tag}}-{{.Name}}"
-        autoTLS: "Disabled"
-        httpProtocol: "Enabled"
+
     ---
     apiVersion: v1
-    kind: ConfigMap
-    metadata:
-      name: config-observability
-      namespace: knative-serving
-      labels:
-        serving.knative.dev/release: devel
     data:
       _example: |
+        ################################
+        #                              #
+        #    EXAMPLE CONFIGURATION     #
+        #                              #
+        ################################
+
+        # This block is not actually functional configuration,
+        # but serves to illustrate the available configuration
+        # options and document them in a way that is accessible
+        # to users that `kubectl edit` this config map.
+        #
+        # These sample configuration options may be copied out of
+        # this example block and unindented to be in the data block
+        # to actually change the configuration.
+
+        # logging.enable-var-log-collection defaults to false.
+        # The fluentd daemon set will be set up to collect /var/log if
+        # this flag is true.
         logging.enable-var-log-collection: "false"
+
+        # logging.revision-url-template provides a template to use for producing the
+        # logging URL that is injected into the status of each Revision.
+        # This value is what you might use the the Knative monitoring bundle, and provides
+        # access to Kibana after setting up kubectl proxy.
         logging.revision-url-template: |
           http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana#/discover?_a=(query:(match:(kubernetes.labels.serving-knative-dev%2FrevisionUID:(query:'${REVISION_UID}',type:phrase))))
+
+        # If non-empty, this enables queue proxy writing user request logs to stdout, excluding probe
+        # requests.
+        # The value determines the shape of the request logs and it must be a valid go text/template.
+        # It is important to keep this as a single line. Multiple lines are parsed as separate entities
+        # by most collection agents and will split the request logs into multiple records.
+        #
+        # The following fields and functions are available to the template:
+        #
+        # Request: An http.Request (see https://golang.org/pkg/net/http/#Request)
+        # representing an HTTP request received by the server.
+        #
+        # Response:
+        # struct {
+        #   Code    int       // HTTP status code (see https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml)
+        #   Size    int       // An int representing the size of the response.
+        #   Latency float64   // A float64 representing the latency of the response in seconds.
+        # }
+        #
+        # Revision:
+        # struct {
+        #   Name          string  // Knative revision name
+        #   Namespace     string  // Knative revision namespace
+        #   Service       string  // Knative service name
+        #   Configuration string  // Knative configuration name
+        #   PodName       string  // Name of the pod hosting the revision
+        #   PodIP         string  // IP of the pod hosting the revision
+        # }
+        #
         logging.request-log-template: '{"httpRequest": {"requestMethod": "{{.Request.Method}}", "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}", "status": {{.Response.Code}}, "responseSize": "{{.Response.Size}}", "userAgent": "{{js .Request.UserAgent}}", "remoteIp": "{{js .Request.RemoteAddr}}", "serverIp": "{{.Revision.PodIP}}", "referer": "{{js .Request.Referer}}", "latency": "{{.Response.Latency}}s", "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "X-B3-Traceid"}}"}'
+
+        # If true, this enables queue proxy writing request logs for probe requests to stdout.
+        # It uses the same template for user requests, i.e. logging.request-log-template.
         logging.enable-probe-request-log: "false"
+
+        # metrics.backend-destination field specifies the system metrics destination.
+        # It supports either prometheus (the default) or stackdriver.
+        # Note: Using stackdriver will incur additional charges
         metrics.backend-destination: prometheus
+
+        # metrics.request-metrics-backend-destination specifies the request metrics
+        # destination. It enables queue proxy to send request metrics.
+        # Currently supported values: prometheus (the default), stackdriver.
         metrics.request-metrics-backend-destination: prometheus
+
+        # metrics.stackdriver-project-id field specifies the stackdriver project ID. This
+        # field is optional. When running on GCE, application default credentials will be
+        # used if this field is not provided.
         metrics.stackdriver-project-id: "<your stackdriver project id>"
+
+        # metrics.allow-stackdriver-custom-metrics indicates whether it is allowed to send metrics to
+        # Stackdriver using "global" resource type and custom metric type if the
+        # metrics are not supported by "knative_revision" resource type. Setting this
+        # flag to "true" could cause extra Stackdriver charge.
+        # If metrics.backend-destination is not Stackdriver, this is ignored.
         metrics.allow-stackdriver-custom-metrics: "false"
+
+        # profiling.enable indicates whether it is allowed to retrieve runtime profiling data from
+        # the pods via an HTTP server in the format expected by the pprof visualization tool. When
+        # enabled, the Knative Serving pods expose the profiling data on an alternate HTTP port 8008.
+        # The HTTP context root for profiling is then /debug/pprof/.
         profiling.enable: "false"
-    ---
-    apiVersion: v1
     kind: ConfigMap
     metadata:
-      name: config-tracing
-      namespace: knative-serving
       labels:
-        serving.knative.dev/release: devel
+        serving.knative.dev/release: "v0.12.1"
+      name: config-observability
+      namespace: knative-serving
+
+    ---
+    apiVersion: v1
     data:
       _example: |
+        ################################
+        #                              #
+        #    EXAMPLE CONFIGURATION     #
+        #                              #
+        ################################
+
+        # This block is not actually functional configuration,
+        # but serves to illustrate the available configuration
+        # options and document them in a way that is accessible
+        # to users that `kubectl edit` this config map.
+        #
+        # These sample configuration options may be copied out of
+        # this example block and unindented to be in the data block
+        # to actually change the configuration.
+        #
+        # This may be "zipkin" or "stackdriver", the default is "none"
         backend: "none"
+
+        # URL to zipkin collector where traces are sent.
+        # This must be specified when backend is "zipkin"
         zipkin-endpoint: "http://zipkin.istio-system.svc.cluster.local:9411/api/v2/spans"
+
+        # The GCP project into which stackdriver metrics will be written
+        # when backend is "stackdriver".  If unspecified, the project-id
+        # is read from GCP metadata when running on GCP.
         stackdriver-project-id: "my-project"
+
+        # Enable zipkin debug mode. This allows all spans to be sent to the server
+        # bypassing sampling.
         debug: "false"
+
+        # Percentage (0-1) of requests to trace
         sample-rate: "0.1"
+    kind: ConfigMap
+    metadata:
+      labels:
+        serving.knative.dev/release: "v0.12.1"
+      name: config-tracing
+      namespace: knative-serving
+
+    ---
+    apiVersion: autoscaling/v2beta1
+    kind: HorizontalPodAutoscaler
+    metadata:
+      labels:
+        serving.knative.dev/release: "v0.12.1"
+      name: activator
+      namespace: knative-serving
+    spec:
+      maxReplicas: 20
+      metrics:
+      - resource:
+          name: cpu
+          targetAverageUtilization: 100
+        type: Resource
+      minReplicas: 1
+      scaleTargetRef:
+        apiVersion: apps/v1
+        kind: Deployment
+        name: activator
+
     ---
     apiVersion: apps/v1
     kind: Deployment
     metadata:
-      name: controller
-      namespace: knative-serving
       labels:
-        serving.knative.dev/release: devel
+        serving.knative.dev/release: "v0.12.1"
+      name: activator
+      namespace: knative-serving
     spec:
       selector:
         matchLabels:
-          app: controller
+          app: activator
+          role: activator
       template:
         metadata:
           annotations:
-            cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+            cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
           labels:
-            app: controller
-            serving.knative.dev/release: devel
+            app: activator
+            role: activator
+            serving.knative.dev/release: "v0.12.1"
         spec:
-          serviceAccountName: controller
           containers:
-          - name: controller
-            image: quay.io/openshift-knative/knative-serving-controller:v0.12.1
-            resources:
-              requests:
-                cpu: 100m
-                memory: 100Mi
-              limits:
-                cpu: 1000m
-                memory: 1000Mi
-            env:
+          - env:
+            - name: GOGC
+              value: "500"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             - name: SYSTEM_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -1234,20 +747,218 @@ data:
               value: config-observability
             - name: METRICS_DOMAIN
               value: knative.dev/internal/serving
+            image: gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256:150328fd960b8579a175fbd9dcd16d3196fc5247554df6437f73e08e4b41bbc2
+            livenessProbe:
+              httpGet:
+                httpHeaders:
+                - name: k-kubelet-probe
+                  value: activator
+                port: 8012
+            name: activator
+            ports:
+            - containerPort: 9090
+              name: metrics
+            - containerPort: 8008
+              name: profiling
+            - containerPort: 8012
+              name: http1
+            - containerPort: 8013
+              name: h2c
+            readinessProbe:
+              httpGet:
+                httpHeaders:
+                - name: k-kubelet-probe
+                  value: activator
+                port: 8012
+            resources:
+              limits:
+                cpu: 1000m
+                memory: 600Mi
+              requests:
+                cpu: 300m
+                memory: 60Mi
             securityContext:
               allowPrivilegeEscalation: false
+          serviceAccountName: controller
+          terminationGracePeriodSeconds: 300
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app: activator
+        serving.knative.dev/release: "v0.12.1"
+      name: activator-service
+      namespace: knative-serving
+    spec:
+      ports:
+      - name: http-metrics
+        port: 9090
+        targetPort: 9090
+      - name: http-profiling
+        port: 8008
+        targetPort: 8008
+      - name: http
+        port: 80
+        targetPort: 8012
+      - name: http2
+        port: 81
+        targetPort: 8013
+      selector:
+        app: activator
+      type: ClusterIP
+
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        serving.knative.dev/release: "v0.12.1"
+      name: autoscaler
+      namespace: knative-serving
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: autoscaler
+      template:
+        metadata:
+          annotations:
+            cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+          labels:
+            app: autoscaler
+            serving.knative.dev/release: "v0.12.1"
+        spec:
+          containers:
+          - args:
+            - --secure-port=8443
+            - --cert-dir=/tmp
+            env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_LOGGING_NAME
+              value: config-logging
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: config-observability
+            - name: METRICS_DOMAIN
+              value: knative.dev/serving
+            image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256:3193057da258bbb9a6b8caddcf1924b9b6752877b0fa0940d3393d2492db0b04
+            livenessProbe:
+              httpGet:
+                httpHeaders:
+                - name: k-kubelet-probe
+                  value: autoscaler
+                port: 8080
+            name: autoscaler
             ports:
-            - name: metrics
-              containerPort: 9090
-            - name: profiling
-              containerPort: 8008
+            - containerPort: 9090
+              name: metrics
+            - containerPort: 8008
+              name: profiling
+            - containerPort: 8080
+              name: websocket
+            - containerPort: 8443
+              name: custom-metrics
+            readinessProbe:
+              httpGet:
+                httpHeaders:
+                - name: k-kubelet-probe
+                  value: autoscaler
+                port: 8080
+            resources:
+              limits:
+                cpu: 300m
+                memory: 400Mi
+              requests:
+                cpu: 30m
+                memory: 40Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+          serviceAccountName: controller
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app: autoscaler
+        serving.knative.dev/release: "v0.12.1"
+      name: autoscaler
+      namespace: knative-serving
+    spec:
+      ports:
+      - name: http-metrics
+        port: 9090
+        targetPort: 9090
+      - name: http-profiling
+        port: 8008
+        targetPort: 8008
+      - name: http
+        port: 8080
+        targetPort: 8080
+      - name: https-custom-metrics
+        port: 443
+        targetPort: 8443
+      selector:
+        app: autoscaler
+
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        serving.knative.dev/release: "v0.12.1"
+      name: controller
+      namespace: knative-serving
+    spec:
+      selector:
+        matchLabels:
+          app: controller
+      template:
+        metadata:
+          annotations:
+            cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+          labels:
+            app: controller
+            serving.knative.dev/release: "v0.12.1"
+        spec:
+          containers:
+          - env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_LOGGING_NAME
+              value: config-logging
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: config-observability
+            - name: METRICS_DOMAIN
+              value: knative.dev/internal/serving
+            image: gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256:69a255299717c92757bfa7067889b449d1816c50e9b6cd709d06436418b9aa24
+            name: controller
+            ports:
+            - containerPort: 9090
+              name: metrics
+            - containerPort: 8008
+              name: profiling
+            resources:
+              limits:
+                cpu: 1000m
+                memory: 1000Mi
+              requests:
+                cpu: 100m
+                memory: 100Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+          serviceAccountName: controller
     ---
     apiVersion: v1
     kind: Service
     metadata:
       labels:
         app: controller
-        serving.knative.dev/release: devel
+        serving.knative.dev/release: "v0.12.1"
       name: controller
       namespace: knative-serving
     spec:
@@ -1260,82 +971,15 @@ data:
         targetPort: 8008
       selector:
         app: controller
-    ---
-    apiVersion: apiregistration.k8s.io/v1beta1
-    kind: APIService
-    metadata:
-      name: v1beta1.custom.metrics.k8s.io
-      labels:
-        serving.knative.dev/release: devel
-        autoscaling.knative.dev/metric-provider: custom-metrics
-    spec:
-      service:
-        name: autoscaler
-        namespace: knative-serving
-      group: custom.metrics.k8s.io
-      version: v1beta1
-      insecureSkipTLSVerify: true
-      groupPriorityMinimum: 100
-      versionPriority: 100
+
     ---
     apiVersion: apps/v1
     kind: Deployment
     metadata:
-      name: networking-istio
-      namespace: knative-serving
       labels:
-        serving.knative.dev/release: devel
-        networking.knative.dev/ingress-provider: istio
-    spec:
-      selector:
-        matchLabels:
-          app: networking-istio
-      template:
-        metadata:
-          annotations:
-            cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
-            sidecar.istio.io/inject: "false"
-          labels:
-            app: networking-istio
-            serving.knative.dev/release: devel
-        spec:
-          serviceAccountName: controller
-          containers:
-          - name: networking-istio
-            image: quay.io/openshift-knative/knative-serving-istio:v0.12.1
-            resources:
-              requests:
-                cpu: 30m
-                memory: 40Mi
-              limits:
-                cpu: 300m
-                memory: 400Mi
-            env:
-            - name: SYSTEM_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: CONFIG_LOGGING_NAME
-              value: config-logging
-            - name: CONFIG_OBSERVABILITY_NAME
-              value: config-observability
-            - name: METRICS_DOMAIN
-              value: knative.dev/serving
-            securityContext:
-              allowPrivilegeEscalation: false
-            ports:
-            - name: metrics
-              containerPort: 9090
-            - name: profiling
-              containerPort: 8008
-    ---
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
+        serving.knative.dev/release: "v0.12.1"
       name: webhook
       namespace: knative-serving
-      labels:
-        serving.knative.dev/release: devel
     spec:
       selector:
         matchLabels:
@@ -1348,20 +992,10 @@ data:
           labels:
             app: webhook
             role: webhook
-            serving.knative.dev/release: devel
+            serving.knative.dev/release: "v0.12.1"
         spec:
-          serviceAccountName: controller
           containers:
-          - name: webhook
-            image: quay.io/openshift-knative/knative-serving-webhook:v0.12.1
-            resources:
-              requests:
-                cpu: 20m
-                memory: 20Mi
-              limits:
-                cpu: 200m
-                memory: 2Gi
-            env:
+          - env:
             - name: SYSTEM_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -1372,20 +1006,30 @@ data:
               value: config-observability
             - name: METRICS_DOMAIN
               value: knative.dev/serving
+            image: gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256:137ddd0c8394eccbba4c73121caabdc551e72f2c2661f60c3c1993b90ffda469
+            name: webhook
+            ports:
+            - containerPort: 9090
+              name: metrics
+            - containerPort: 8008
+              name: profiling
+            resources:
+              limits:
+                cpu: 200m
+                memory: 2Gi
+              requests:
+                cpu: 20m
+                memory: 20Mi
             securityContext:
               allowPrivilegeEscalation: false
-            ports:
-            - name: metrics
-              containerPort: 9090
-            - name: profiling
-              containerPort: 8008
+          serviceAccountName: controller
     ---
     apiVersion: v1
     kind: Service
     metadata:
       labels:
         role: webhook
-        serving.knative.dev/release: devel
+        serving.knative.dev/release: "v0.12.1"
       name: webhook
       namespace: knative-serving
     spec:
@@ -1401,3 +1045,802 @@ data:
         targetPort: 8443
       selector:
         role: webhook
+
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        duck.knative.dev/addressable: "true"
+        serving.knative.dev/release: "v0.12.1"
+      name: knative-serving-addressable-resolver
+    rules:
+    - apiGroups:
+      - serving.knative.dev
+      resources:
+      - routes
+      - routes/status
+      - services
+      - services/status
+      verbs:
+      - get
+      - list
+      - watch
+
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        rbac.authorization.k8s.io/aggregate-to-admin: "true"
+        serving.knative.dev/release: "v0.12.1"
+      name: knative-serving-namespaced-admin
+    rules:
+    - apiGroups:
+      - serving.knative.dev
+      - networking.internal.knative.dev
+      - autoscaling.internal.knative.dev
+      - caching.internal.knative.dev
+      resources:
+      - certificates
+      - configurations
+      - images
+      - ingresses
+      - metrics
+      - podautoscalers
+      - revisions
+      - routes
+      - serverlessservices
+      - services
+      verbs:
+      - '*'
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        rbac.authorization.k8s.io/aggregate-to-edit: "true"
+        serving.knative.dev/release: "v0.12.1"
+      name: knative-serving-namespaced-edit
+    rules:
+    - apiGroups:
+      - serving.knative.dev
+      - networking.internal.knative.dev
+      - autoscaling.internal.knative.dev
+      - caching.internal.knative.dev
+      resources:
+      - certificates
+      - configurations
+      - images
+      - ingresses
+      - metrics
+      - podautoscalers
+      - revisions
+      - routes
+      - serverlessservices
+      - services
+      verbs:
+      - create
+      - update
+      - patch
+      - delete
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        rbac.authorization.k8s.io/aggregate-to-view: "true"
+        serving.knative.dev/release: "v0.12.1"
+      name: knative-serving-namespaced-view
+    rules:
+    - apiGroups:
+      - serving.knative.dev
+      - networking.internal.knative.dev
+      - autoscaling.internal.knative.dev
+      - caching.internal.knative.dev
+      resources:
+      - certificates
+      - configurations
+      - images
+      - ingresses
+      - metrics
+      - podautoscalers
+      - revisions
+      - routes
+      - serverlessservices
+      - services
+      verbs:
+      - get
+      - list
+      - watch
+
+    ---
+    aggregationRule:
+      clusterRoleSelectors:
+      - matchLabels:
+          serving.knative.dev/controller: "true"
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        serving.knative.dev/release: "v0.12.1"
+      name: knative-serving-admin
+    rules: []
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        serving.knative.dev/controller: "true"
+        serving.knative.dev/release: "v0.12.1"
+      name: knative-serving-core
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - namespaces
+      - secrets
+      - configmaps
+      - endpoints
+      - services
+      - events
+      - serviceaccounts
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - endpoints/restricted
+      verbs:
+      - create
+    - apiGroups:
+      - apps
+      resources:
+      - deployments
+      - deployments/finalizers
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+    - apiGroups:
+      - admissionregistration.k8s.io
+      resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+    - apiGroups:
+      - apiextensions.k8s.io
+      resources:
+      - customresourcedefinitions
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+    - apiGroups:
+      - autoscaling
+      resources:
+      - horizontalpodautoscalers
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+    - apiGroups:
+      - serving.knative.dev
+      - autoscaling.internal.knative.dev
+      - networking.internal.knative.dev
+      resources:
+      - '*'
+      - '*/status'
+      - '*/finalizers'
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - deletecollection
+      - patch
+      - watch
+    - apiGroups:
+      - caching.internal.knative.dev
+      resources:
+      - images
+      verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        duck.knative.dev/podspecable: "true"
+        serving.knative.dev/release: "v0.12.1"
+      name: knative-serving-podspecable-binding
+    rules:
+    - apiGroups:
+      - serving.knative.dev
+      resources:
+      - configurations
+      - services
+      verbs:
+      - list
+      - watch
+      - patch
+
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        serving.knative.dev/release: "v0.12.1"
+      name: controller
+      namespace: knative-serving
+
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      labels:
+        serving.knative.dev/release: "v0.12.1"
+      name: knative-serving-controller-admin
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: knative-serving-admin
+    subjects:
+    - kind: ServiceAccount
+      name: controller
+      namespace: knative-serving
+
+    ---
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        knative.dev/crd-install: "true"
+        serving.knative.dev/release: "v0.12.1"
+      name: certificates.networking.internal.knative.dev
+    spec:
+      additionalPrinterColumns:
+      - JSONPath: .status.conditions[?(@.type=="Ready")].status
+        name: Ready
+        type: string
+      - JSONPath: .status.conditions[?(@.type=="Ready")].reason
+        name: Reason
+        type: string
+      group: networking.internal.knative.dev
+      names:
+        categories:
+        - knative-internal
+        - networking
+        kind: Certificate
+        plural: certificates
+        shortNames:
+        - kcert
+        singular: certificate
+      scope: Namespaced
+      subresources:
+        status: {}
+      version: v1alpha1
+
+    ---
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        duck.knative.dev/podspecable: "true"
+        knative.dev/crd-install: "true"
+        serving.knative.dev/release: "v0.12.1"
+      name: configurations.serving.knative.dev
+    spec:
+      additionalPrinterColumns:
+      - JSONPath: .status.latestCreatedRevisionName
+        name: LatestCreated
+        type: string
+      - JSONPath: .status.latestReadyRevisionName
+        name: LatestReady
+        type: string
+      - JSONPath: .status.conditions[?(@.type=='Ready')].status
+        name: Ready
+        type: string
+      - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+        name: Reason
+        type: string
+      group: serving.knative.dev
+      names:
+        categories:
+        - all
+        - knative
+        - serving
+        kind: Configuration
+        plural: configurations
+        shortNames:
+        - config
+        - cfg
+        singular: configuration
+      scope: Namespaced
+      subresources:
+        status: {}
+      versions:
+      - name: v1alpha1
+        served: true
+        storage: true
+      - name: v1beta1
+        served: true
+        storage: false
+      - name: v1
+        served: true
+        storage: false
+
+    ---
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        knative.dev/crd-install: "true"
+        serving.knative.dev/release: "v0.12.1"
+      name: ingresses.networking.internal.knative.dev
+    spec:
+      additionalPrinterColumns:
+      - JSONPath: .status.conditions[?(@.type=='Ready')].status
+        name: Ready
+        type: string
+      - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+        name: Reason
+        type: string
+      group: networking.internal.knative.dev
+      names:
+        categories:
+        - knative-internal
+        - networking
+        kind: Ingress
+        plural: ingresses
+        shortNames:
+        - kingress
+        singular: ingress
+      scope: Namespaced
+      subresources:
+        status: {}
+      versions:
+      - name: v1alpha1
+        served: true
+        storage: true
+
+    ---
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        knative.dev/crd-install: "true"
+        serving.knative.dev/release: "v0.12.1"
+      name: metrics.autoscaling.internal.knative.dev
+    spec:
+      additionalPrinterColumns:
+      - JSONPath: .status.conditions[?(@.type=='Ready')].status
+        name: Ready
+        type: string
+      - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+        name: Reason
+        type: string
+      group: autoscaling.internal.knative.dev
+      names:
+        categories:
+        - knative-internal
+        - autoscaling
+        kind: Metric
+        plural: metrics
+        singular: metric
+      scope: Namespaced
+      subresources:
+        status: {}
+      version: v1alpha1
+
+    ---
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        knative.dev/crd-install: "true"
+        serving.knative.dev/release: "v0.12.1"
+      name: podautoscalers.autoscaling.internal.knative.dev
+    spec:
+      additionalPrinterColumns:
+      - JSONPath: .status.desiredScale
+        name: DesiredScale
+        type: integer
+      - JSONPath: .status.actualScale
+        name: ActualScale
+        type: integer
+      - JSONPath: .status.conditions[?(@.type=='Ready')].status
+        name: Ready
+        type: string
+      - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+        name: Reason
+        type: string
+      group: autoscaling.internal.knative.dev
+      names:
+        categories:
+        - knative-internal
+        - autoscaling
+        kind: PodAutoscaler
+        plural: podautoscalers
+        shortNames:
+        - kpa
+        - pa
+        singular: podautoscaler
+      scope: Namespaced
+      subresources:
+        status: {}
+      versions:
+      - name: v1alpha1
+        served: true
+        storage: true
+
+    ---
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        knative.dev/crd-install: "true"
+        serving.knative.dev/release: "v0.12.1"
+      name: revisions.serving.knative.dev
+    spec:
+      additionalPrinterColumns:
+      - JSONPath: .metadata.labels['serving\.knative\.dev/configuration']
+        name: Config Name
+        type: string
+      - JSONPath: .status.serviceName
+        name: K8s Service Name
+        type: string
+      - JSONPath: .metadata.labels['serving\.knative\.dev/configurationGeneration']
+        name: Generation
+        type: string
+      - JSONPath: .status.conditions[?(@.type=='Ready')].status
+        name: Ready
+        type: string
+      - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+        name: Reason
+        type: string
+      group: serving.knative.dev
+      names:
+        categories:
+        - all
+        - knative
+        - serving
+        kind: Revision
+        plural: revisions
+        shortNames:
+        - rev
+        singular: revision
+      scope: Namespaced
+      subresources:
+        status: {}
+      versions:
+      - name: v1alpha1
+        served: true
+        storage: true
+      - name: v1beta1
+        served: true
+        storage: false
+      - name: v1
+        served: true
+        storage: false
+
+    ---
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        duck.knative.dev/addressable: "true"
+        knative.dev/crd-install: "true"
+        serving.knative.dev/release: "v0.12.1"
+      name: routes.serving.knative.dev
+    spec:
+      additionalPrinterColumns:
+      - JSONPath: .status.url
+        name: URL
+        type: string
+      - JSONPath: .status.conditions[?(@.type=='Ready')].status
+        name: Ready
+        type: string
+      - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+        name: Reason
+        type: string
+      group: serving.knative.dev
+      names:
+        categories:
+        - all
+        - knative
+        - serving
+        kind: Route
+        plural: routes
+        shortNames:
+        - rt
+        singular: route
+      scope: Namespaced
+      subresources:
+        status: {}
+      versions:
+      - name: v1alpha1
+        served: true
+        storage: true
+      - name: v1beta1
+        served: true
+        storage: false
+      - name: v1
+        served: true
+        storage: false
+
+    ---
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        knative.dev/crd-install: "true"
+        serving.knative.dev/release: "v0.12.1"
+      name: serverlessservices.networking.internal.knative.dev
+    spec:
+      additionalPrinterColumns:
+      - JSONPath: .spec.mode
+        name: Mode
+        type: string
+      - JSONPath: .status.serviceName
+        name: ServiceName
+        type: string
+      - JSONPath: .status.privateServiceName
+        name: PrivateServiceName
+        type: string
+      - JSONPath: .status.conditions[?(@.type=='Ready')].status
+        name: Ready
+        type: string
+      - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+        name: Reason
+        type: string
+      group: networking.internal.knative.dev
+      names:
+        categories:
+        - knative-internal
+        - networking
+        kind: ServerlessService
+        plural: serverlessservices
+        shortNames:
+        - sks
+        singular: serverlessservice
+      scope: Namespaced
+      subresources:
+        status: {}
+      versions:
+      - name: v1alpha1
+        served: true
+        storage: true
+
+    ---
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        duck.knative.dev/addressable: "true"
+        duck.knative.dev/podspecable: "true"
+        knative.dev/crd-install: "true"
+        serving.knative.dev/release: "v0.12.1"
+      name: services.serving.knative.dev
+    spec:
+      additionalPrinterColumns:
+      - JSONPath: .status.url
+        name: URL
+        type: string
+      - JSONPath: .status.latestCreatedRevisionName
+        name: LatestCreated
+        type: string
+      - JSONPath: .status.latestReadyRevisionName
+        name: LatestReady
+        type: string
+      - JSONPath: .status.conditions[?(@.type=='Ready')].status
+        name: Ready
+        type: string
+      - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+        name: Reason
+        type: string
+      group: serving.knative.dev
+      names:
+        categories:
+        - all
+        - knative
+        - serving
+        kind: Service
+        plural: services
+        shortNames:
+        - kservice
+        - ksvc
+        singular: service
+      scope: Namespaced
+      subresources:
+        status: {}
+      versions:
+      - name: v1alpha1
+        served: true
+        storage: true
+      - name: v1beta1
+        served: true
+        storage: false
+      - name: v1
+        served: true
+        storage: false
+
+    ---
+    apiVersion: admissionregistration.k8s.io/v1beta1
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      labels:
+        serving.knative.dev/release: "v0.12.1"
+      name: config.webhook.serving.knative.dev
+    webhooks:
+    - admissionReviewVersions:
+      - v1beta1
+      clientConfig:
+        service:
+          name: webhook
+          namespace: knative-serving
+      failurePolicy: Fail
+      name: config.webhook.serving.knative.dev
+      namespaceSelector:
+        matchExpressions:
+        - key: serving.knative.dev/release
+          operator: Exists
+      sideEffects: None
+
+    ---
+    apiVersion: admissionregistration.k8s.io/v1beta1
+    kind: MutatingWebhookConfiguration
+    metadata:
+      labels:
+        serving.knative.dev/release: "v0.12.1"
+      name: webhook.serving.knative.dev
+    webhooks:
+    - admissionReviewVersions:
+      - v1beta1
+      clientConfig:
+        service:
+          name: webhook
+          namespace: knative-serving
+      failurePolicy: Fail
+      name: webhook.serving.knative.dev
+      sideEffects: None
+
+    ---
+    apiVersion: admissionregistration.k8s.io/v1beta1
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      labels:
+        serving.knative.dev/release: "v0.12.1"
+      name: validation.webhook.serving.knative.dev
+    webhooks:
+    - admissionReviewVersions:
+      - v1beta1
+      clientConfig:
+        service:
+          name: webhook
+          namespace: knative-serving
+      failurePolicy: Fail
+      name: validation.webhook.serving.knative.dev
+      sideEffects: None
+
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      labels:
+        serving.knative.dev/release: "v0.12.1"
+      name: webhook-certs
+      namespace: knative-serving
+
+    ---
+
+    ---
+
+    ---
+
+    ---
+
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        autoscaling.knative.dev/autoscaler-provider: hpa
+        serving.knative.dev/release: "v0.12.1"
+      name: autoscaler-hpa
+      namespace: knative-serving
+    spec:
+      selector:
+        matchLabels:
+          app: autoscaler-hpa
+      template:
+        metadata:
+          annotations:
+            cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+          labels:
+            app: autoscaler-hpa
+            serving.knative.dev/release: "v0.12.1"
+        spec:
+          containers:
+          - env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_LOGGING_NAME
+              value: config-logging
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: config-observability
+            - name: METRICS_DOMAIN
+              value: knative.dev/serving
+            image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler-hpa@sha256:87242941aa07dfc7d849d83b63b708280e6bd442a871764f2cf301181f6edb5c
+            name: autoscaler-hpa
+            ports:
+            - containerPort: 9090
+              name: metrics
+            - containerPort: 8008
+              name: profiling
+            resources:
+              limits:
+                cpu: 300m
+                memory: 400Mi
+              requests:
+                cpu: 30m
+                memory: 40Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+          serviceAccountName: controller
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app: autoscaler-hpa
+        autoscaling.knative.dev/autoscaler-provider: hpa
+        serving.knative.dev/release: "v0.12.1"
+      name: autoscaler-hpa
+      namespace: knative-serving
+    spec:
+      ports:
+      - name: http-metrics
+        port: 9090
+        targetPort: 9090
+      - name: http-profiling
+        port: 8008
+        targetPort: 8008
+      selector:
+        app: autoscaler-hpa

--- a/ansible/roles/ocp4-workload-ccnrd/files/osm_namespace.yaml
+++ b/ansible/roles/ocp4-workload-ccnrd/files/osm_namespace.yaml
@@ -1,5 +1,0 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: istio-system

--- a/ansible/roles/ocp4-workload-ccnrd/files/osm_subscription.yaml
+++ b/ansible/roles/ocp4-workload-ccnrd/files/osm_subscription.yaml
@@ -10,4 +10,4 @@ spec:
   name: servicemeshoperator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: servicemeshoperator.v1.0.6
+  startingCSV: servicemeshoperator.v1.0.9

--- a/ansible/roles/ocp4-workload-ccnrd/files/pipelines_subscription.yaml
+++ b/ansible/roles/ocp4-workload-ccnrd/files/pipelines_subscription.yaml
@@ -10,4 +10,4 @@ spec:
   name: openshift-pipelines-operator
   source: community-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: openshift-pipelines-operator.v0.8.2
+  startingCSV: openshift-pipelines-operator.v0.10.7

--- a/ansible/roles/ocp4-workload-ccnrd/files/serverless-operator.v1.5.0.csv.yaml
+++ b/ansible/roles/ocp4-workload-ccnrd/files/serverless-operator.v1.5.0.csv.yaml
@@ -266,8 +266,8 @@ spec:
                 volumes:
                   - configMap:
                       items:
-                        - key: knative-serving-v0.12.1.yaml
-                          path: knative-serving-v0.12.1.yaml
+                        - key: 0.12.1.yaml
+                          path: 0.12.1.yaml
                       name: ko-data
                     name: release-manifest
         - name: knative-serving-openshift

--- a/ansible/roles/ocp4-workload-ccnrd/files/serverless_subscription.yaml
+++ b/ansible/roles/ocp4-workload-ccnrd/files/serverless_subscription.yaml
@@ -10,4 +10,4 @@ spec:
   name: serverless-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: serverless-operator.v1.4.1
+  startingCSV: serverless-operator.v1.5.0


### PR DESCRIPTION
##### SUMMARY
Updates to recently released/latest versions of OpenShift Serverless, Knative eventing, Knative Kafka Eventing, OpenShift service mesh operators

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`ocp4-workload-ccnrd`

##### ADDITIONAL INFORMATION
This also includes an update to the workaround that we are carrying until OCP 4.4 is released as originally implemented in https://github.com/redhat-cop/agnosticd/pull/1308

cc @danieloh30 