### PR TITLE
Satellite role to manage hostgroups in satellite

### DIFF
--- a/ansible/configs/satellite-vm/README.adoc
+++ b/ansible/configs/satellite-vm/README.adoc
@@ -188,7 +188,8 @@ Roles
 |satellite-manage-repositories |link:../../roles/satellite-manage-repository[satellite-manage-repositories] | Manage subscriptions/repositories and synchronize
 |satellite-manage-lifecycle |link:../../roles/satellite-manage-lifecycle[satellite-manage-lifecycle]  | Create lifecycle environment
 |satellite-manage-content-view |link:../../roles/satellite-manage-content-view[satellite-manage-content-view]  | Create content-view
-|satellite-manage-activationkey |link:../../roles/satellite-manage-activationkey[satellite-manage-content-view]  | Create activation key
+|satellite-manage-activationkey |link:../../roles/satellite-manage-activationkey[satellite-manage-activationkey]  | Create activation key
+|satellite-manage-hostgroup |link:../../roles/satellite-manage-hostgroup[satellite-manage-hostgroup]  | Create hostgroups
 |satellite-manage-capsule-certificate | link:../../roles/satellite-manage-capsule-certificate[satellite-manage-capsule-certificate]  | Create certificates for capsule installation on satellite
 |satellite-capsule-installation |link:../../roles/satellite-capsule-installation[satellite-capsule-installation]  | Install capsule packages
 |satellite-capsule-configuration | link:../../roles/satellite-capsule-configuration[satellite-capsule-configuration] | Setup capsule server

--- a/ansible/configs/satellite-vm/default_vars.yml
+++ b/ansible/configs/satellite-vm/default_vars.yml
@@ -1,20 +1,20 @@
 ---
 
-env_type: satellite-vm 
+env_type: satellite-vm
 output_dir: /tmp/workdir                # Writable working scratch directory
 email: "{{env_type}}@example.com"
 guid: defaultguid
 
 # for file based repo
-repo_method: file 
+repo_method: file
 use_own_repos: true
 repo_version: "6.4"
-## For RHN login 
+## For RHN login
 # repo_method: rhn
 # rhsm_pool_ids:
 #   - 8a85f99b6b498682016b521dfe463949
 # rhel_subscription_user:
-# rhel_subscription_pass: 
+# rhel_subscription_pass:
 ######
 
 deploy_local_ssh_config_location: "{{output_dir}}/"
@@ -36,10 +36,10 @@ configure_satellite: false
 project_tag: "{{ env_type }}-{{ guid }}"
 
 rhel_repos:
-  - rhel-7-server-rpms 
-  - rhel-server-rhscl-7-rpms 
-  - rhel-7-server-satellite-6.4-rpms 
-  - rhel-7-server-satellite-maintenance-6-rpms 
+  - rhel-7-server-rpms
+  - rhel-server-rhscl-7-rpms
+  - rhel-7-server-satellite-6.4-rpms
+  - rhel-7-server-satellite-maintenance-6-rpms
   - rhel-7-server-ansible-2.6-rpms
   - rhel-7-server-extras-rpms
 
@@ -57,5 +57,6 @@ common_packages:
 
 cf_template_description: "{{ env_type }}-{{ guid }} Ansible Agnostic Deployer "
 
+satellite_hostgroups: []
 
 ...

--- a/ansible/configs/satellite-vm/software.yml
+++ b/ansible/configs/satellite-vm/software.yml
@@ -45,6 +45,7 @@
         # - satellite-manage-lifecycle
         # - satellite-manage-content-view
         # - satellite-manage-activationkey
+        # - satellite-manage-hostgroup
         # - satellite-manage-capsule-certificate
 
 - name: Software flight-check

--- a/ansible/roles/satellite-manage-hostgroup/README.adoc
+++ b/ansible/roles/satellite-manage-hostgroup/README.adoc
@@ -1,0 +1,145 @@
+:role: satellite-manage-hostgroup
+:author: Satellite Team
+:tag1: configure_satellite
+:tag2: satellite_hostgroup
+:main_file: tasks/main.yml
+
+Role: {role}
+============
+
+This role creates hostgroup in satellite
+
+Requirements
+------------
+
+. Satellite must be installed and setted up.
+. All the resources, that the hostgroup is using needs to be ready, so all the content roles should run beforehand.
+
+
+Role Variables
+--------------
+
+* Following are the variable to customize this role
+
+[cols="2a,1a,3a"]
+|===
+|satellite_version: "Digit" |Required |satellite version
+|satellite_admin: "String" |Required |Satellite admin username
+|satellite_admin_password: "String" |Required |Satellite admin password
+|satellite_hostgroups: [list of {Dictionary}]
+!===
+!name: "String"
+!architecture: "String"
+!operatingsystem: "String"
+!compute_resource: "String"
+!lifecycle_environment: "String"
+!content_view: "String"
+!kickstart_repository: "String"
+!medium: "String"
+!pxe_loader: "String"
+!ptable: "String"
+!root_pass: "String"
+!===
+|Required
+!===
+!Required
+!Optional(*x86_64*)
+!Required
+!Optional(*''*)
+!Required
+!Required
+!Required if no *medium*
+!Required if no *kickstart*
+!Required
+!Required
+!Required(*changeme*)
+!===
+|List of hostgroups to create
+!===
+!Name of the hostgroup
+!Architecture of the OS
+!Name of the OS
+!What compute resource to deploy on
+!Environment to promote hosts to
+!What content view should the hosts use
+!Repository to provision from
+!Medium to provision from
+!Pxe loader type
+!Partition table to use
+!Root password for hosts
+!===
+|===
+
+* Exammple variables
+
+[source=text]
+----
+satellite_version: 6.7
+satellite_admin: admin
+satellite_admin_password: 'changeme'
+
+satellite_hostgroups:
+  - name: "RHEL-8"
+    root_pass: rhpds123
+    operatingsystem: 'RadHat 8.1'
+    lifecycle_environment: Staging
+    content_view: 'RHEL 8 Content'
+    kickstart_repository: 'Red_Hat_Enterprise_Linux_8_for_x86_64_-_BaseOS_Kickstart_8_1'
+    ptable: 'Kickstart default'
+    pxe_loader: 'PXELinux BIOS'
+    compute_resource: 'LibvirtLocal'
+
+----
+
+Tags
+---
+
+|===
+|{tag1} |Consistent tag for all satellite config roles
+|{tag2} |This tag is specific to this role only
+|===
+
+
+Example Playbook
+----------------
+
+How to use your role (for instance, with variables passed in playbook).
+
+[source=text]
+----
+[user@desktop ~]$ cat sample_vars.yml
+satellite_version: 6.7
+satellite_admin: admin
+satellite_admin_password: 'changeme'
+
+satellite_hostgroups:
+  - name: "RHEL-8"
+    root_pass: rhpds123
+    operatingsystem: 'RadHat 8.1'
+    lifecycle_environment: Staging
+    content_view: 'RHEL 8 Content'
+    kickstart_repository: 'Red_Hat_Enterprise_Linux_8_for_x86_64_-_BaseOS_Kickstart_8_1'
+    ptable: 'Kickstart default'
+    pxe_loader: 'PXELinux BIOS'
+    compute_resource: 'LibvirtLocal'
+
+[user@desktop ~]$ cat playbook.yml
+- hosts: satellites
+  vars_files:
+    - sample_vars.yml
+  roles:
+    - satellite-provisioning
+
+[user@desktop ~]$ ansible-playbook playbook.yml
+----
+
+
+Tips to update Role
+------------------
+
+for reference look at link:{main_file}[main.yml].
+
+Author Information
+------------------
+
+{author}

--- a/ansible/roles/satellite-manage-hostgroup/tasks/main.yml
+++ b/ansible/roles/satellite-manage-hostgroup/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+- name: "Create a Hostgroup"
+  theforeman.foreman.foreman_hostgroup:
+    name: "{{ item.name }}"
+    architecture: "{{ item.architecture | d('x86_64') }}"
+    operatingsystem: "{{ item.operatingsystem }}"
+    organization: "{{ org }}"
+    locations:
+      - Default Location
+    compute_resource: "{{ item.compute_resource }}"
+    lifecycle_environment: "{{ item.lifecycle_environment }}"
+    content_view: "{{ item.content_view }}"
+    kickstart_repository: "{{ item.kickstart_repository | d(omit) }}"
+    medium: "{{ item.medium | d(omit) }}"
+    ptable: "{{ item.ptable }}"
+    root_pass: "{{ item.root_pass | d('changeme') }}"
+    content_source: "{{ publicname }}"
+    pxe_loader: "{{ item.pxe_loader | d('PXELinux BIOS') }}"
+    username: "{{ satellite_admin }}"
+    password: "{{ satellite_admin_password }}"
+    server_url: "https://{{ publicname }}"
+    validate_certs: no
+    state: present
+  with_items: "{{ satellite_hostgroups }}"
+  tags:
+    - configure_satellite
+    - satellite_hostgroup


### PR DESCRIPTION
##### SUMMARY
Add role `satellite-manage-hostgroup` to add ability to manage hostgroups.

##### ISSUE TYPE
- New role Pull Request

##### COMPONENT NAME
Role `satellite-manage-hostgroup`

##### ADDITIONAL INFORMATION
Takes array of hostgroups as `satellite_hostgroups` and create them in the satellite.