### PR TITLE
Satellite role to manage authorization - users and user roles

### DIFF
--- a/ansible/configs/satellite-vm/README.adoc
+++ b/ansible/configs/satellite-vm/README.adoc
@@ -184,6 +184,7 @@ Roles
 |satellite-libvirt |link:../../roles/satellite-libvirt[satellite-libvirt] | Install libvirt (kvm) on capsule for provisioning
 |satellite-provisioning |link:../../roles/satellite-provisioning[satellite-provisioning] | Register provisioning resources (compute resource, subnet, domain) to satellite
 |satellite-manage-organization |link:../../roles/satellite-manage-organization[satellite-manage-organization] | Create satellite organization
+|satellite-manage-userroles |link:../../roles/satellite-manage-userroles[satellite-manage-userroles] | Create satellite users and user roles
 |satellite-manage-manifest |link:../../roles/ssatellite-manage-manifest[satellite-manage-manifest] | uploads manifest
 |satellite-manage-repositories |link:../../roles/satellite-manage-repository[satellite-manage-repositories] | Manage subscriptions/repositories and synchronize
 |satellite-manage-lifecycle |link:../../roles/satellite-manage-lifecycle[satellite-manage-lifecycle]  | Create lifecycle environment

--- a/ansible/configs/satellite-vm/default_vars.yml
+++ b/ansible/configs/satellite-vm/default_vars.yml
@@ -57,6 +57,8 @@ common_packages:
 
 cf_template_description: "{{ env_type }}-{{ guid }} Ansible Agnostic Deployer "
 
+satellite_roles: []
+satellite_users: []
 satellite_hostgroups: []
 
 ...

--- a/ansible/configs/satellite-vm/software.yml
+++ b/ansible/configs/satellite-vm/software.yml
@@ -39,6 +39,7 @@
         loop_var: _role
       loop:
         - satellite-manage-organization
+        - satellite-manage-userroles
         - satellite-provisioning
         - satellite-manage-manifest
         - satellite-manage-repositories

--- a/ansible/roles/satellite-manage-userroles/README.adoc
+++ b/ansible/roles/satellite-manage-userroles/README.adoc
@@ -1,0 +1,141 @@
+:role: satellite-manage-userroles
+:author: Satellite Team
+:tag1: configure_satellite
+:tag2: satellite_authorization
+:main_file: tasks/main.yml
+:role_file: tasks/role.yml
+:user_file: tasks/user.yml
+
+Role: {role}
+============
+
+This role add ability to configure authorization in satellite.
+It can add roles and users to the main organization.
+
+Requirements
+------------
+
+. Satellite must be installed and setted up.
+
+
+Role Variables
+--------------
+
+* Following are the variable to customize this role
+
+[cols="3,1,3"]
+|===
+|satellite_admin: "String" |Required |Satellite admin username
+|satellite_admin_password: "String" |Required |Satellite admin password
+|satellite_roles: [list of {Dictionary}] |Required | User roles to add
+|satellite_users: [list of {Dictionary}] |Required | Users to add
+|===
+
+For more reference on variables take a look at foreman-ansible-documentation of modules *foreman_role* and *foreman_user* as this role is using those and basically just copy the arguments over.
+
+* Exammple variables
+
+[source=text]
+----
+satellite_admin: admin
+satellite_admin_password: 'changeme'
+satellite_roles:
+  - name: Report Template Generator
+    description: Role to allow template management
+    filters:
+      - permissions:
+          - lock_report_templates
+          - generate_report_templates
+          - edit_report_templates
+          - destroy_report_templates
+          - create_report_templates
+          - view_report_templates
+
+satellite_users:
+  - name: summit-admin
+    description: 'User with template management permissions'
+    firstname: Summit
+    lastname: Admin
+    mail: 'admin@summit.example.com'
+    admin: yes
+    password: summit2020
+  - name: template_user
+    description: 'User with template management permissions'
+    firstname: Template
+    lastname: User
+    mail: 'template@user.com'
+    password: changeme
+    roles:
+      - Report Template Generator
+
+----
+
+Tags
+---
+
+|===
+|{tag1} |Consistent tag for all satellite config roles
+|{tag2} |This tag is specific to this role only
+|===
+
+
+Example Playbook
+----------------
+
+How to use your role (for instance, with variables passed in playbook).
+
+[source=text]
+----
+[user@desktop ~]$ cat sample_vars.yml
+satellite_version: 6.7
+satellite_admin: admin
+satellite_admin_password: 'changeme'
+
+satellite_roles:
+  - name: Report Template Generator
+    description: Role to allow template management
+    filters:
+      - permissions:
+          - lock_report_templates
+          - generate_report_templates
+          - edit_report_templates
+          - destroy_report_templates
+          - create_report_templates
+          - view_report_templates
+
+satellite_users:
+  - name: summit-admin
+    description: 'User with template management permissions'
+    firstname: Summit
+    lastname: Admin
+    mail: 'admin@summit.example.com'
+    admin: yes
+    password: summit2020
+  - name: template_user
+    description: 'User with template management permissions'
+    firstname: Template
+    lastname: User
+    mail: 'template@user.com'
+    password: changeme
+    roles:
+      - Report Template Generator
+
+[user@desktop ~]$ cat playbook.yml
+- hosts: satellites
+  vars_files:
+    - sample_vars.yml
+  roles:
+    - satellite-provisioning
+
+[user@desktop ~]$ ansible-playbook playbook.yml
+----
+
+Tips to update Role
+------------------
+
+for reference look at link:{main_file}[main.yml] and specific for roles link:{role_file}[role.yml] and for user link:{user_file}[user.yml].
+
+Author Information
+------------------
+
+{author}

--- a/ansible/roles/satellite-manage-userroles/tasks/main.yml
+++ b/ansible/roles/satellite-manage-userroles/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- include_tasks: role.yml
+  with_items: "{{ satellite_roles }}"
+  loop_control:
+    loop_var: role
+  tags:
+    - configure_satellite
+    - satellite_authorization
+
+- include_tasks: user.yml
+  with_items: "{{ satellite_users }}"
+  loop_control:
+    loop_var: user
+  tags:
+    - configure_satellite
+    - satellite_authorization

--- a/ansible/roles/satellite-manage-userroles/tasks/role.yml
+++ b/ansible/roles/satellite-manage-userroles/tasks/role.yml
@@ -1,0 +1,14 @@
+---
+- name: Create a role
+  theforeman.foreman.foreman_role:
+    name: "{{ item.name }}"
+    description: "{{ item.description |d(omit) }}"
+    organizations:
+      - "{{ org }}"
+    filters: "{{ item.filters }}"
+    username: "{{ satellite_admin }}"
+    password: "{{ satellite_admin_password }}"
+    server_url: "https://{{ publicname }}"
+    validate_certs: no
+    state: present
+  with_items: "{{ satellite_roles }}"

--- a/ansible/roles/satellite-manage-userroles/tasks/user.yml
+++ b/ansible/roles/satellite-manage-userroles/tasks/user.yml
@@ -1,0 +1,25 @@
+- name: Create a user
+  theforeman.foreman.foreman_user:
+    name: "{{ user.name }}"
+    firstname: "{{ user.firstname | d('John') }}"
+    lastname: "{{ user.lastname | d('Doe') }}"
+    mail: "{{ user.mail | d('john.doe@example.com') }}"
+    description: "{{ user.description | d(omit) }}"
+    admin: "{{ user.admin | d(false) }}"
+    user_password: "{{ user.password }}"
+    default_location: Default Location
+    default_organization: "{{ org }}"
+    auth_source: Internal
+    timezone: "{{ user.timezone | d(omit) }}"
+    locale: en
+    roles: "{{ user.roles | d(omit) }}"
+    locations:
+      - Default Location
+    organizations:
+      - "{{ org }}"
+    username: "{{ satellite_admin }}"
+    password: "{{ satellite_admin_password }}"
+    server_url: "https://{{ publicname }}"
+    validate_certs: no
+    state: present
+  with_items: "{{ satellite_users }}"


### PR DESCRIPTION
##### SUMMARY
Add role satellite-manage-userroles to add ability to manage authorization through users and roles.

##### ISSUE TYPE
- New role Pull Request

##### COMPONENT NAME
Role `satellite-manage-userroles`

##### ADDITIONAL INFORMATION
Takes array for roles as `satellite_roles` and array for users as `satellite_users` and create them in the satellite.