### PR TITLE
Add variable test_empty_config_multi_user

### DIFF
--- a/ansible/configs/test-empty-config/post_software.yml
+++ b/ansible/configs/test-empty-config/post_software.yml
@@ -31,31 +31,33 @@
         random_string: >-
           {{ lookup('password', '/dev/null length=15 chars=ascii_letters') }}
 
-    - name: Test set agnosticd_user_info for users
-      agnosticd_user_info:
-        msg: student{{ n }} password is {{ random_string }}
-        data:
-          password: "{{ random_string }}"
-        user: student{{ n }}
-      loop: "{{ range(1, 10) | list }}"
-      loop_control:
-        loop_var: n
-      vars:
-        random_string: >-
-          {{ lookup('password', '/dev/null length=15 chars=ascii_letters') }}
+    - when: test_empty_config_multi_user | default(false) | bool
+      block:
+        - name: Test set agnosticd_user_info for users
+          agnosticd_user_info:
+            user: student{{ n }}
+            msg: student{{ n }} password is {{ random_string }}
+            data:
+              password: "{{ random_string }}"
+          loop: "{{ range(1, 10) | list }}"
+          loop_control:
+            loop_var: n
+          vars:
+            random_string: >-
+              {{ lookup('password', '/dev/null length=15 chars=ascii_letters') }}
 
-    - name: Test add agnosticd_user_info for users
-      agnosticd_user_info:
-        msg: student{{ n }} password is {{ random_string }}
-        data:
-          dns_domain: student{{ n }}.example.com
-        user: student{{ n }}
-      loop: "{{ range(1, 10) | list }}"
-      loop_control:
-        loop_var: n
-      vars:
-        random_string: >-
-          {{ lookup('password', '/dev/null length=15 chars=ascii_letters') }}
+        - name: Test add agnosticd_user_info for users
+          agnosticd_user_info:
+            user: student{{ n }}
+            msg: student{{ n }} password is {{ random_string }}
+            data:
+              dns_domain: student{{ n }}.example.com
+          loop: "{{ range(1, 10) | list }}"
+          loop_control:
+            loop_var: n
+          vars:
+            random_string: >-
+              {{ lookup('password', '/dev/null length=15 chars=ascii_letters') }}
 
     - name: Print string expected by Cloudforms
       debug:


### PR DESCRIPTION
##### SUMMARY

Add `test_empty_config_multi_user` variable to optionally call `agnosticd_user_info` with multiple users.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

config test-empty-config