### PR TITLE
Fix to test-empty-config user info data

### DIFF
--- a/ansible/configs/test-empty-config/post_software.yml
+++ b/ansible/configs/test-empty-config/post_software.yml
@@ -49,15 +49,11 @@
         - name: Test add agnosticd_user_info for users
           agnosticd_user_info:
             user: student{{ n }}
-            msg: student{{ n }} password is {{ random_string }}
             data:
               dns_domain: student{{ n }}.example.com
           loop: "{{ range(1, 10) | list }}"
           loop_control:
             loop_var: n
-          vars:
-            random_string: >-
-              {{ lookup('password', '/dev/null length=15 chars=ascii_letters') }}
 
     - name: Print string expected by Cloudforms
       debug:


### PR DESCRIPTION
##### SUMMARY

Simple fix to test-empty-config user info data to clean up example for documentation purposes.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

test-empty-config

##### ADDITIONAL INFORMATION

The code included a variable that did not make sense in context.