### PR TITLE
Added roles_path ansible.cfg in all ansible_workshop based configs

### DIFF
--- a/ansible/configs/ansible-workshops/ansible.cfg
+++ b/ansible/configs/ansible-workshops/ansible.cfg
@@ -1,5 +1,8 @@
 [defaults]
 
+roles_path              = dynamic-roles:ansible/dynamic-roles:roles-infra:ansible/roles-infra:roles:ansible/roles
+
+# some basic default values...
 inventory               = hosts
 forks                   = 50
 host_key_checking       = False

--- a/ansible/configs/linklight-foundations/ansible.cfg
+++ b/ansible/configs/linklight-foundations/ansible.cfg
@@ -1,5 +1,7 @@
 [defaults]
 
+roles_path              = dynamic-roles:ansible/dynamic-roles:roles-infra:ansible/roles-infra:roles:ansible/roles
+
 # some basic default values...
 
 inventory               = hosts


### PR DESCRIPTION
##### SUMMARY
Ansible Workshop (aka linklight) based configs have their own ansible.cfg (historically the routers were sensitive to ssh timeouts etc). Builds on PR #1385 and extends same change to 2 other related configs.

This adds roles_path to pick up new roles structure changes in agnosticd

Ansible Workshop based configs are a special case in that they are a deployed wrapped in a deployed plus the network equipment they sometimes deploy are sensitive to ssh config.

##### ISSUE TYPE

- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
config/ansible-workshops
config/linklight-foundations

##### ADDITIONAL INFORMATION

