### PR TITLE
Satellite - add name to subnet

### DIFF
--- a/ansible/configs/satellite-vm/README.adoc
+++ b/ansible/configs/satellite-vm/README.adoc
@@ -53,6 +53,7 @@ Config Variables
 |satellite_libvirt_provisioning: "Bool" |Optional(*false*) | Whether configure libvirt provisioning
 |satellite_libvirt_network: {Dictionary}
 !===
+!name: "String"
 !domain: "String"
 !network: "String"
 !gateway: "String"
@@ -63,6 +64,7 @@ Config Variables
 |Optional
 |Libvrit default network setting
 !===
+!Name for the subnet in satellite
 !What domain should the subnet belong to
 !Network address
 !Gateway address - this is the hosting system address in this nat network

--- a/ansible/configs/satellite-vm/default_vars_osp.yml
+++ b/ansible/configs/satellite-vm/default_vars_osp.yml
@@ -29,6 +29,7 @@ satellite_instance_count: 1
 satellite_libvirt_provisioning: yes
 
 satellite_libvirt_network:
+  name: Provisioning
   domain: example.org
   network: '192.168.122.0'
   gateway: '192.168.122.1'

--- a/ansible/roles/satellite-provisioning/README.adoc
+++ b/ansible/roles/satellite-provisioning/README.adoc
@@ -32,6 +32,7 @@ Role Variables
 |satellite_libvirt_provisioning: "Bool" |Optional(*false*) | Whether configure libvirt provisioning
 |satellite_libvirt_network: {Dictionary}
 !===
+!name: "String"
 !domain: "String"
 !network: "String"
 !gateway: "String"
@@ -44,6 +45,7 @@ Role Variables
 |Optional
 |Libvrit default network setting
 !===
+!Name of the subnet
 !What domain should the subnet belong to
 !Network address
 !Gateway address - this is the hosting system address in this nat network
@@ -64,6 +66,7 @@ satellite_admin: admin
 satellite_admin_password: 'changeme'
 satellite_libvirt_provisioning: yes
 satellite_libvirt_network:
+  name: LibvirtSubnet
   domain: example.org
   network: '192.168.122.0'
   gateway: '192.168.122.1'
@@ -95,6 +98,7 @@ satellite_admin: admin
 satellite_admin_password: 'changeme'
 satellite_libvirt_provisioning: yes
 satellite_libvirt_network:
+  name: LibvirtSubnet
   domain: example.org
   network: '192.168.122.0'
   gateway: '192.168.122.1'

--- a/ansible/roles/satellite-provisioning/defaults/main.yml
+++ b/ansible/roles/satellite-provisioning/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 satellite_libvirt_provisioning: false
 satellite_libvirt_network:
+  name: LibvirtSubnet
   domain: example.org
   network: '192.168.122.0'
   gateway: '192.168.122.1'

--- a/ansible/roles/satellite-provisioning/tasks/provisioning_resources.yml
+++ b/ansible/roles/satellite-provisioning/tasks/provisioning_resources.yml
@@ -17,8 +17,8 @@
 
 - name: Create libvirt domain
   theforeman.foreman.foreman_domain:
-    name: "summit.example.org"
-    description: "Domain for summit provisioning"
+    name: "{{ satellite_libvirt_network.domain }}"
+    description: "Domain for libvirt provisioning"
     organizations:
       - "{{ org }}"
     locations:
@@ -30,7 +30,7 @@
 
 - name: Create libvirt subnet
   theforeman.foreman.foreman_subnet:
-    name: "SummitLocal"
+    name: "{{ satellite_libvirt_network.name }}"
     description: "Network for summit provisioning"
     network: "{{ satellite_libvirt_network.network }}"
     mask: "{{ satellite_libvirt_network.netmask }}"
@@ -44,7 +44,7 @@
     dns_proxy: "{{ publicname }}"
     mtu: 9000
     domains:
-      - "summit.example.org"
+      - "{{ satellite_libvirt_network.domain }}"
     organizations:
       - "{{ org }}"
     locations:


### PR DESCRIPTION
##### SUMMARY
Ability to customize satellite's subnet name
 
##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Role `satellite-provisioning`

##### ADDITIONAL INFORMATION
Previously I had an static name for the subnet and network - that's not a great idea.