### PR TITLE
Satellite - add networking setting for hostgroup

### DIFF
--- a/ansible/roles/satellite-manage-hostgroup/README.adoc
+++ b/ansible/roles/satellite-manage-hostgroup/README.adoc
@@ -32,6 +32,10 @@ Role Variables
 !architecture: "String"
 !operatingsystem: "String"
 !compute_resource: "String"
+!compute_profile: "String"
+!domain: "String"
+!subnet: "String"
+!subnet6: "String"
 !lifecycle_environment: "String"
 !content_view: "String"
 !kickstart_repository: "String"
@@ -46,6 +50,10 @@ Role Variables
 !Optional(*x86_64*)
 !Required
 !Optional(*''*)
+!Optional
+!Optional
+!Optional
+!Optional
 !Required
 !Required
 !Required if no *medium*
@@ -60,6 +68,10 @@ Role Variables
 !Architecture of the OS
 !Name of the OS
 !What compute resource to deploy on
+!What compute profile to deploy
+!Which domain to register the host to
+!Which IPv4 subnet should the host use
+!Which IPv6 subnet should the host use
 !Environment to promote hosts to
 !What content view should the hosts use
 !Repository to provision from
@@ -88,6 +100,10 @@ satellite_hostgroups:
     ptable: 'Kickstart default'
     pxe_loader: 'PXELinux BIOS'
     compute_resource: 'LibvirtLocal'
+    compute_profile: 'Medium'
+    domain: 'example.org'
+    subnet: 'LibvirtNetwork'
+    subnet6: 'LibvirtNetwork_v6'
 
 ----
 
@@ -122,6 +138,10 @@ satellite_hostgroups:
     ptable: 'Kickstart default'
     pxe_loader: 'PXELinux BIOS'
     compute_resource: 'LibvirtLocal'
+    compute_profile: 'Medium'
+    domain: 'example.org'
+    subnet: 'LibvirtNetwork'
+    subnet6: 'LibvirtNetwork_v6'
 
 [user@desktop ~]$ cat playbook.yml
 - hosts: satellites

--- a/ansible/roles/satellite-manage-hostgroup/tasks/main.yml
+++ b/ansible/roles/satellite-manage-hostgroup/tasks/main.yml
@@ -8,6 +8,10 @@
     locations:
       - Default Location
     compute_resource: "{{ item.compute_resource }}"
+    compute_profile: "{{ item.compute_profile | d(omit) }}"
+    domain: "{{ item.domain | d(omit) }}"
+    subnet: "{{ item.subnet | d(omit) }}"
+    subnet6: "{{ item.subnet6 | d(omit) }}"
     lifecycle_environment: "{{ item.lifecycle_environment }}"
     content_view: "{{ item.content_view }}"
     kickstart_repository: "{{ item.kickstart_repository | d(omit) }}"


### PR DESCRIPTION
##### SUMMARY
Add domain, subnet, subnet6 and compute_profile to the hostgroup

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Role `satellite-manage-hostgroup`

##### ADDITIONAL INFORMATION
Now we should be able to set up all the parameters for seamless provisioning