### PR TITLE
Satellite - keep default provisioning url

### DIFF
--- a/ansible/roles/satellite-provisioning/tasks/provisioning_resources.yml
+++ b/ansible/roles/satellite-provisioning/tasks/provisioning_resources.yml
@@ -53,11 +53,3 @@
     username: "{{ satellite_admin }}"
     password: "{{ satellite_admin_password }}"
     state: present
-
-- name: "Set a Setting"
-  foreman_setting:
-    server_url: "https://{{ publicname }}"
-    username: "{{ satellite_admin }}"
-    password: "{{ satellite_admin_password }}"
-    name: "unattended_url"
-    value: "http://{{ satellite_libvirt_network.gateway }}"


### PR DESCRIPTION
##### SUMMARY
Keeps the default provisioning url.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Role `satellite-provisioning`

##### ADDITIONAL INFORMATION
As we've solved the dns resolution issue in satellite, we don't need to change the provisioning url anymore.