### PR TITLE
modified Role:set-repositories

### DIFF
--- a/ansible/roles/set-repositories/tasks/satellite-repos.yml
+++ b/ansible/roles/set-repositories/tasks/satellite-repos.yml
@@ -55,14 +55,14 @@
 - name: Randomize hostname for Satellite
   copy:
     dest: /etc/rhsm/facts/katello.facts
-    content: {"network.fqdn": "{{ inventory_hostname }}-{{ ansible_date_time.iso8601_basic | lower }}"}
-  when: cloud_provider == 'ec2'
-
-- name: Randomize hostname for Satellite
-  copy:
-    dest: /etc/rhsm/facts/katello.facts
-    content: {"network.fqdn": "{{ inventory_hostname }}.{{guid}}.internal-{{ ansible_date_time.iso8601_basic | lower }}"}
-  when: cloud_provider == 'osp'  
+    content: >-
+        {
+          "network.fqdn": {% if guid in inventory_hostname %}
+          "{{ inventory_hostname }}-{{ ansible_date_time.iso8601_basic | lower }}"
+          {% else %}
+          "{{ inventory_hostname }}.{{guid}}.internal-{{ ansible_date_time.iso8601_basic | lower }}" 
+          {% endif %}
+        } 
 
 - name: Register with activation-key
   when: satellite_activationkey is defined

--- a/ansible/roles/set-repositories/tasks/satellite-repos.yml
+++ b/ansible/roles/set-repositories/tasks/satellite-repos.yml
@@ -4,7 +4,7 @@
   package:
     name: rh-amazon-rhui-client
     state: absent
-  when: cloud_provider == 'aws'
+  when: cloud_provider == 'ec2'
 
 - name: Remove satellite Cert
   tags: packer
@@ -56,6 +56,13 @@
   copy:
     dest: /etc/rhsm/facts/katello.facts
     content: {"network.fqdn": "{{ inventory_hostname }}-{{ ansible_date_time.iso8601_basic | lower }}"}
+  when: cloud_provider == 'ec2'
+
+- name: Randomize hostname for Satellite
+  copy:
+    dest: /etc/rhsm/facts/katello.facts
+    content: {"network.fqdn": "{{ inventory_hostname }}.{{guid}}.internal-{{ ansible_date_time.iso8601_basic | lower }}"}
+  when: cloud_provider == 'osp'  
 
 - name: Register with activation-key
   when: satellite_activationkey is defined


### PR DESCRIPTION
##### SUMMARY
Modification and addition in the role: set-repositories

##### ISSUE TYPE

- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
Role : set-repositories

##### ADDITIONAL INFORMATION

Conditional value changed from aws to ec2

```
- name: Remove rh-amazon-rhui-client package
  tags: packer
  package:
    name: rh-amazon-rhui-client
    state: absent
  when: cloud_provider == 'ec2'

```

Following code gives ease to filter nodes in satellite sepcially especially when deployed on osp ( novello ) cloud.  

```
- name: Randomize hostname for Satellite
  copy:
    dest: /etc/rhsm/facts/katello.facts
    content: {"network.fqdn": "{{ inventory_hostname }}.{{guid}}.internal-{{ ansible_date_time.iso8601_basic | lower }}"}
  when: cloud_provider == 'osp'  


```
