### PR TITLE
OSP - public hostname

### DIFF
--- a/ansible/roles-infra/infra-osp-create-inventory/tasks/main.yml
+++ b/ansible/roles-infra/infra-osp-create-inventory/tasks/main.yml
@@ -37,7 +37,7 @@
       groups:
       #TODO: remove thos tag_*
       # - "tag_Project_{{stack_tag}}"
-      # - "tag_{{ stack_tag}} | default('unknowns') }}"
+      # - "tag_{{ stack_tag | default('unknowns') }}"
       - "{{ server.metadata.ostype | default('unknowns') }}"
       ansible_user: "{{ ansible_user }}"
       remote_user: "{{ remote_user }}"
@@ -53,6 +53,7 @@
       ansible_ssh_extra_args: "-o StrictHostKeyChecking=no"
       ansible_python_interpreter: "{{ server.metadata.ansible_python_interpreter | default(omit) }}"
       bastion: "{{ local_bastion | default('') }}"
+      has_public_dns: "{{ server.metadata.public_dns }}"
     loop: "{{ r_osp_facts.ansible_facts.openstack_servers }}"
     loop_control:
       label: "{{ server | json_query(_name_selector) | default(server.name) }}"
@@ -73,14 +74,16 @@
     - create_inventory
     - must
 
-- name: Make sure bastion has public DNS name defined
+- name: Make sure hosts have public DNS name defined if required
   add_host:
     name: "{{ host }}"
     public_dns_name: "{{ host }}.{{ guid }}.{{osp_cluster_dns_zone}}"
-  loop: "{{ groups['bastions'] }}"
+  loop: "{{ groups['all'] }}"
   loop_control:
     loop_var: host
-  when: hostvars[host].public_ip_address != ''
+  when:
+    - hostvars[host].has_public_dns
+    - hostvars[host].public_ip_address != ''
 
 - debug:
     var: hostvars[local_bastion].public_ip_address

--- a/ansible/roles-infra/infra-osp-template-generate/templates/cloud_template_master.j2
+++ b/ansible/roles-infra/infra-osp-template-generate/templates/cloud_template_master.j2
@@ -172,16 +172,18 @@ resources:
       user_data_format: RAW
       networks:
         - port: {get_resource: port_{{ iname }}}
-    {% if instance['metadata'] is defined %}
-      metadata: {{ instance.metadata | combine(default_metadata) | to_json }}
-    {% endif %}
-
-    {% if instance.tags is defined %}
-      # Convert EC2 tags
       metadata:
+        'public_dns': {{ instance.public_dns | default(false) }}
       {% for key, value in default_metadata.items() %}
         '{{ key }}': {{ value | to_json }}
       {% endfor %}
+    {% if instance['metadata'] is defined %}
+      {% for key, value in instance.metadata %}
+        '{{ key }}': {{ value | to_json }}
+      {% endfor %}
+    {% endif %}
+    {# Convert EC2 tags #}
+    {% if instance.tags is defined %}
       {% for tag in instance.tags %}
         '{{ tag.key }}': {{ tag.value | to_json }}
       {% endfor %}


### PR DESCRIPTION
##### SUMMARY
Set the `public_dns_name` for all the hosts that have the `public_dns: true` flag

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
`infra-osp-create-inventory`

##### ADDITIONAL INFORMATION
Adding a flag to `metadata` to state what instances have the dns enabled, setting the fact `has_public_dns` and afterwards using that flag to set `public_dns_name` for all linux hosts.

Fixing a typo in groups and `metadata` definition.