### PR TITLE
Satellite manifest add basic auth for manifest fetch

### DIFF
--- a/ansible/roles/satellite-manage-manifest/README.adoc
+++ b/ansible/roles/satellite-manage-manifest/README.adoc
@@ -29,19 +29,24 @@ Role Variables
 |org: "String" |Required |Organization name
 |org_label: "String" |Optional | Organization label in string without space
 |org_description: "String" |Optional | Organization description
+|cdn_repository_url: "String"|Optional | If to sync content from another cdn than https://cdn.redhat.com/
 |satellite_manifest: {Dictionary}
 [cols="1"]
 !===
 !type: "String"
 !path: "String"
 !url: "String"
+!username: "String"
+!password: "String"
 !===
 |Required
 [cols="1"]
 !===
 !Required
-!Required for type
+!Required for 'file'
 !Required for 'url'
+!Optional for 'url'
+!Optional for 'url'
 !===
 |Holds info to access the manifest file
 [cols="1"]
@@ -49,8 +54,9 @@ Role Variables
 ! Type of the storage (One of 'file', 'url')
 ! Path to the local file
 ! Url for the remote file
+! Basic auth username for the remote file
+! Basic auth password for the remote file
 !===
-|cdn_repository_url: "String"|Optional | If to sync content from another cdn than https://cdn.redhat.com/
 |===
 
 
@@ -63,9 +69,16 @@ org: "gpte"
 org_label: "gpte"
 org_description: "Global Partner Training and Enablement"
 cdn_repository_url: "http://my.local.com/cdn"
+
 satellite_manifest:
   type: file
   path: /home/user/manifest.zip
+# or
+satellite_manifest:
+  type: url
+  path: http://my-private.server.com/manifest.zip
+  username: basicAuthUser
+  password: verySecretPass
 ----
 
 Tags
@@ -100,9 +113,10 @@ org_label: "gpte"
 org_description: "Global Partner Training and Enablement"
 cdn_repository_url: "http://my.local.com/cdn"
 satellite_manifest:
-  type: file
-  path: /home/user/manifest.zip
-
+  type: url
+  path: http://my-private.server.com/manifest.zip
+  username: basicAuthUser
+  password: verySecretPass
 
 [user@desktop ~]$ cat playbook.yml
 - hosts: satellite.example.com

--- a/ansible/roles/satellite-manage-manifest/tasks/version_6.x.yml
+++ b/ansible/roles/satellite-manage-manifest/tasks/version_6.x.yml
@@ -25,6 +25,8 @@
   get_url:
     url: "{{ satellite_manifest.url }}"
     dest: /tmp
+    username: "{{ satellite_manifest.username | d(omit)}}"
+    password: "{{ satellite_manifest.password | d(omit)}}"
   when:
     - satellite_manifest.type == 'url'
     - not manifest_file_existance_result.stat.exists


### PR DESCRIPTION
##### SUMMARY
Adds ability to access manifest secured by basic auth.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Role `satellite-manage-manifest`

##### ADDITIONAL INFORMATION
We need to download secured manifest files.