### PR TITLE
infra-ec2-template-generate: upgrades the strong, downgrades the weak

### DIFF
--- a/ansible/roles-infra/infra-ec2-template-generate/tasks/main.yml
+++ b/ansible/roles-infra/infra-ec2-template-generate/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - import_tasks: locate_template.yml
 
+- import_tasks: validate_instances_amis.yaml
+
 - set_fact:
     cloudformation_template: "{{output_dir}}/{{ env_type }}.{{ guid }}.{{cloud_provider}}_cloud_template"
 

--- a/ansible/roles-infra/infra-ec2-template-generate/tasks/validate_instances_amis.yaml
+++ b/ansible/roles-infra/infra-ec2-template-generate/tasks/validate_instances_amis.yaml
@@ -1,5 +1,7 @@
-  - name: test 1
-    debug: msg="{{ instances }}"
+  - name: what instances am I dealing with?
+    debug:
+      verbosity: 2
+      var: instances
 
   - name: prep facts
     set_fact:
@@ -31,8 +33,8 @@
     when: 
       - item.value['image'] is defined
       - item.value['image'] is regex("^RHEL.*$")
-      - item.value['image'] is not regex("^.*GOLD$")      
-      - aws_ami_region_mapping[aws_region][item.value['image']|regex_replace("^(.*)$", "\\1GOLD")] is defined
+      - item.value['image'] is not regex("^.*GOLD$")
+      - item.value['image'] |regex_replace("^(.*)$", "\\1GOLD")] in aws_ami_region_mapping[aws_region]
     ec2_ami_facts:
       # profile: "{{ profile }}"
       region: "{{ aws_region }}"
@@ -44,7 +46,8 @@
 
   - name: debug ami_presence
     debug:
-      msg: "{{ ami_presence.results }}"
+      verbosity: 2
+      var: ami_presence.results
 
   - name: rename successful bumps from RHEL<VERSION> to RHEL<VERSION>GOLD in instances_DoD
     # items that returned images array not empty
@@ -113,4 +116,5 @@
 
   - name: debug instances
     debug:
-      msg: "{{ instances }}"
+      verbosity: 2
+      var: instances

--- a/ansible/roles-infra/infra-ec2-template-generate/tasks/validate_instances_amis.yaml
+++ b/ansible/roles-infra/infra-ec2-template-generate/tasks/validate_instances_amis.yaml
@@ -1,0 +1,116 @@
+  - name: test 1
+    debug: msg="{{ instances }}"
+
+  - name: prep facts
+    set_fact:
+      instances_DoD: "{{ [] }}"  # DoD
+  
+  - name: fail if I can't map an image to aws_ami_region_mapping
+    loop: "{{ instances }}"
+    when:
+    - item.image is defined
+    - aws_ami_region_mapping[aws_region][item.image] is not defined
+    fail:
+      msg: >- 
+        instance.image "{{ item.image }}" is not defined in aws_ami_region_mapping.
+
+  - name: create instances_DoD from instances LoD
+    loop: "{{ instances }}"
+    loop_control:
+      extended: yes
+    set_fact: 
+      instances_DoD: >-
+        {{ 
+          instances_DoD| combine(
+            { ansible_loop.index0: instances[ansible_loop.index0]  }
+          )
+        }}
+
+  - name: test if bump RHEL<VERSION> images to GOLD, if available in aws_ami_region_mapping
+    loop: "{{ instances_DoD|dict2items }}"
+    when: 
+      - item.value['image'] is defined
+      - item.value['image'] is regex("^RHEL.*$")
+      - item.value['image'] is not regex("^.*GOLD$")      
+      - aws_ami_region_mapping[aws_region][item.value['image']|regex_replace("^(.*)$", "\\1GOLD")] is defined
+    ec2_ami_facts:
+      # profile: "{{ profile }}"
+      region: "{{ aws_region }}"
+      image_ids: >-
+        {{ aws_ami_region_mapping[aws_region][
+            item.value['image']|regex_replace("^(.*)$", "\1GOLD")
+          ] }}
+    register: ami_presence
+
+  - name: debug ami_presence
+    debug:
+      msg: "{{ ami_presence.results }}"
+
+  - name: rename successful bumps from RHEL<VERSION> to RHEL<VERSION>GOLD in instances_DoD
+    # items that returned images array not empty
+    loop: "{{ ami_presence.results|json_query(' [? not_null(invocation) && not_null(images)].item.key' ) }}"
+    set_fact:
+      instances_DoD: >-
+        {{ instances_DoD| combine(
+          { item:
+            { "image": instances_DoD[item]['image']|regex_replace("^(.*)$", "\1GOLD")}
+            }, 
+          recursive=True
+        )}}
+
+  - name: test all images.  Some have <ANYTHYING>, RHEL<VERSION>, RHEL<VERSION>GOLD
+    ignore_errors: True
+    loop: "{{ instances_DoD|dict2items }}"
+    when: 
+      - item.value['image'] is defined
+      - aws_ami_region_mapping[aws_region][item.value['image']] is defined
+    ec2_ami_facts:
+      # profile: "{{ profile }}"
+      region: "{{ aws_region }}"
+      image_ids: "{{ aws_ami_region_mapping[aws_region][item.value['image']] }}"
+    register: ami_presence
+
+  - name: if there was a failure of a GOLD and there's no RHEL<VERSION>, bail out
+    loop: "{{ ami_presence.results|json_query(' [? not_null(invocation) && ! not_null(images)].item.key ') }}"
+    vars:
+      my_image_wihtout_gold: "{{ instances_DoD[item].image|replace('GOLD','') }}"
+    assert:
+      that:
+        - instances_DoD[item].image is regex("^RHEL.*GOLD$")
+        # the gold has non-gold
+        - aws_ami_region_mapping[aws_region][my_image_wihtout_gold] is defined 
+      fail_msg: >-
+        Image {{ my_image_wihtout_gold }} not available.
+
+  - name: if there was a failure of a GOLD, try without GOLD
+    # get indexes of instances that could be queried for, but could not be found.
+    # "! not_null(images)" seems to be the only way to identify an empty list in jinja2
+    loop: "{{ ami_presence.results|json_query(' [? not_null(invocation) && ! not_null(images)].item.key ') }}"
+    when:
+    - instances_DoD[item].image is regex("^.*GOLD$")
+    ec2_ami_facts:
+      # profile: "{{ profile }}"
+      region: "{{ aws_region }}"
+      image_ids: "{{ aws_ami_region_mapping[aws_region][instances[item].image|replace('GOLD', '')] }}"
+    register: ami_presence_no_GOLD
+
+  # fail if one of the no-longer-gold instances cannot be accessed (syntax error in name?)
+
+  - name: for those that failed RHEL<VERSION>GOLD and RHEL<VERSION> are found, remove GOLD from image
+    loop: "{{ ami_presence_no_GOLD.results|json_query(' [? not_null(invocation) && not_null(images)].item ') }}"
+    set_fact:
+      instances_DoD: >-
+        {{ instances_DoD| combine(
+          { item:
+            { "image": instances_DoD[item]['image']|replace("GOLD", "")}
+            }, 
+          recursive=True
+        )}}
+
+  - name: rebuild instances LoD
+    set_fact:
+      instances: "{{ instances_DoD.values() | list }}"
+
+  - name: debug instances
+    debug:
+      msg: "{{ instances }}"


### PR DESCRIPTION
##### SUMMARY

* save $
* reduce deployment failures 
* reduce support calls
* reduce complexity in agnosticV settings
* tested against ocp-clientvm

- test aws account access to images, upgrade and downgrade as necessary.

###### Process

- for all instances and the aws account
- validate images that begin with RHEL against aws_ami_reigon_mapping
- validate against AWS bumping configs that use RHEL<VERSION> images to RHEL<VERSION>GOLD
- change successful bumps
- degrade RHEL<VERIONS>GOLD failures to RHEL<VERSION>
- validate all images
- continue CF template generation

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
infra-ec2-template-generate

##### ADDITIONAL INFORMATION

###### To test

Emit a CF tempalte only - no need to deploy env


1. create launch script:
```
cd ~/agnosticv/
GUID=test_clientvm
./merge.sh gpte OCP_CLIENTVM dev > $HOME/ocp_clientvm.yaml                                                                                                                                                                            
cd ~/agnosticd/
mkdir ~/output/
ansible-playbook -vvvv ./ansible/main.yml  -e @${HOME}/ocp_clientvm.yaml -e @${HOME}/secrets/secret.yaml -e guid=$GUID -e output_dir=${HOME}/output/$GUID/ -e debug_template=true
```
1. get the GPTE aws config/credentails files with accounts `default` and `infra`
1. run config as `default` aws account (full access to GOLD images). `export AWS_PROFILE=default`
1. change agnosticv `gpte` `OCP_CLIENTVM` dev.yaml: `clientvm_instance_image: RHEL77GOLD`
1. run script
1. observe CF template is OK with RHEL77GOLD
1. change agnosticv `gpte` `OCP_CLIENTVM` dev.yaml: `clientvm_instance_image: RHEL77`
1. run script
1. observe CF template is bumped up to RHEL77GOLD
1. observe ansible logs showing AWS tests
1. change to "infra" user who does not have GOLD access  `export AWS_PROFILE=infra`
1. run script
1. observe CF template remains RHEL77
1. observe ansible logs checking access
1. change agnosticv `gpte` `OCP_CLIENTVM` dev.yaml: `clientvm_instance_image: RHEL77GOLD`
1. run script
1. observe CF template is degraded to RHEL77
1. observe ansible logs checking access

