### PR TITLE
Update test tasks for OCP on OSP

### DIFF
--- a/ansible/configs/ocp4-disconnected-osp-lab/files/fio-test.sh.j2
+++ b/ansible/configs/ocp4-disconnected-osp-lab/files/fio-test.sh.j2
@@ -1,11 +1,21 @@
 #!/bin/sh
 
-echo "Installing jq and fio"
-dnf install -y jq fio
+# echo "Installing jq and fio"
+# dnf install -y jq fio nmap-ncat
 
-echo "creating fio directory"
-mkdir /var/lib/etcd/fio
+# echo "creating fio directory"
+# mkdir /var/lib/etcd/fio
 
 echo "running tests"
+
 #for i in {1..{{ test_runs }}};do echo "running test $i";fio --rw=write --ioengine=sync --fdatasync=1 --directory=/var/lib/etcd/fio --size=22m --bs=2300 --name=mytest --output-format=json+ | jq '.jobs[].sync.lat_ns.percentile."99.000000"' >> {{ guid }}-$i.json;/host/home/core/upload-to-s3.sh '{{ test_s3_id }}' '{{ test_s3_key }}' {{ test_s3_bucket }}@{{ test_s3_region }} ./{{ guid }}-$i.json {{ guid }}-$i.json;done
-for i in {1..{{ test_runs }}};do echo "running test $i";fio --rw=write --ioengine=sync --fdatasync=1 --directory=/var/lib/etcd/fio --size=22m --bs=2300 --name=mytest --output-format=json+ > {{ guid }}-$i.json;/host/home/core/upload-to-s3.sh '{{ test_s3_id }}' '{{ test_s3_key }}' {{ test_s3_bucket }}@{{ test_s3_region }} ./{{ guid }}-$i.json {{ guid }}-$i.json;done
+# for i in {1..{{ test_runs }}};do echo "running test $i";fio --rw=write --ioengine=sync --fdatasync=1 --directory=/var/lib/etcd/fio --size=22m --bs=2300 --name=mytest --output-format=json+ > {{ guid }}-$i.json;/host/home/core/upload-to-s3.sh '{{ test_s3_id }}' '{{ test_s3_key }}' {{ test_s3_bucket }}@{{ test_s3_region }} ./{{ guid }}-$i.json {{ guid }}-$i.json;done
+
+mkdir -p /var/lib/etcd/fio
+for i in {1..{{ test_runs }}}
+do
+  echo "running test $i"
+  result=$(fio --rw=write --ioengine=sync --fdatasync=1 --directory=/var/lib/etcd/fio --size=22m --bs=2300 --name=mytest --output-format=json+ | jq '.jobs[].sync.lat_ns.percentile."99.000000"')
+  echo "fio.$guid.latency $result `date +%s`" | nc overwatch.osp.opentlc.com 2003
+  echo $result >> /host/home/core/{{ guid }}.out
+done

--- a/ansible/configs/ocp4-disconnected-osp-lab/files/fio.Dockerfile
+++ b/ansible/configs/ocp4-disconnected-osp-lab/files/fio.Dockerfile
@@ -1,0 +1,2 @@
+FROM fedora:latest
+RUN dnf install -y jq fio nmap-ncat

--- a/ansible/configs/ocp4-disconnected-osp-lab/software.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/software.yml
@@ -299,11 +299,11 @@
           register: r_infra_id
           when: r_metadata.stat.exists
 
-        - name: copy upload script to bastion
-          copy:
-            src: "./files/upload-to-s3.sh"
-            dest: "/home/{{ student_name }}/resources/upload-to-s3.sh"
-            mode: preserve
+        # - name: copy upload script to bastion
+        #   copy:
+        #     src: "./files/upload-to-s3.sh"
+        #     dest: "/home/{{ student_name }}/resources/upload-to-s3.sh"
+        #     mode: preserve
 
         - name: Copy test script to bastion
           template:
@@ -319,18 +319,18 @@
             core@{{ INFRA_ID }}-master-0.example.com:{{ item }}
           loop:
             - "fio-test.sh"
-            - "upload-to-s3.sh"
+            # - "upload-to-s3.sh"
           vars:
             INFRA_ID: "{{ r_infra_id.stdout }}"
             
-        - name: Send notice to overwatch for start
-          uri:
-            url: http://overwatch.osp.opentlc.com:3000/api/annotations
-            method: POST
-            body_format: json
-            headers:
-              Authorization: "Bearer {{ test_overwatch }}"
-            body: {"text":"BEGIN fio test","tags":["ocp4","perftest"]}
+        # - name: Send notice to overwatch for start
+        #   uri:
+        #     url: http://overwatch.osp.opentlc.com:3000/api/annotations
+        #     method: POST
+        #     body_format: json
+        #     headers:
+        #       Authorization: "Bearer {{ test_overwatch }}"
+        #     body: {"text":"BEGIN fio test","tags":["ocp4","perftest"]}
 
         - name: Run test container on master-0
           shell: >
@@ -338,18 +338,18 @@
             -F /home/{{ student_name }}/.ssh/config
             core@{{ INFRA_ID }}-master-0.example.com
             sudo podman run --privileged --ipc=host --net=host --pid=host
-            -v /var/lib/etcd:/var/lib/etcd -v /:/host docker.io/fedora:latest /host/home/core/fio-test.sh
+            -v /var/lib/etcd:/var/lib/etcd -v /:/host quay.io/nstephan/fio-etcd-osp:v2 /host/home/core/fio-test.sh
           vars:
             INFRA_ID: "{{ r_infra_id.stdout }}"
 
-        - name: Send notice to overwatch for finish
-          uri:
-            url: http://overwatch.osp.opentlc.com:3000/api/annotations
-            method: POST
-            body_format: json
-            headers:
-              Authorization: "Bearer {{ test_overwatch }}"
-            body: {"text":"END fio test","tags":["ocp4","perftest"]}
+        # - name: Send notice to overwatch for finish
+        #   uri:
+        #     url: http://overwatch.osp.opentlc.com:3000/api/annotations
+        #     method: POST
+        #     body_format: json
+        #     headers:
+        #       Authorization: "Bearer {{ test_overwatch }}"
+        #     body: {"text":"END fio test","tags":["ocp4","perftest"]}
 
         - name: Remove test scripts
           file:
@@ -357,4 +357,4 @@
             path: /home/{{ student_name }}/resources/{{ item }}
           loop:
             - "fio-test.sh"
-            - "upload-to-s3.sh"
+            # - "upload-to-s3.sh"


### PR DESCRIPTION
##### SUMMARY
These changes clean up some of the testing tasks to help evaluate performance of OCP on OSP config. The updated script should send results directly to overwatch. It can still be enabled or disabled by var.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4-disconnected-osp-lab
