### PR TITLE
Tower version to 3.6.2 for ansible-tower-advanced and simplified password

### DIFF
--- a/ansible/configs/ansible-tower-advanced/env_vars.yml
+++ b/ansible/configs/ansible-tower-advanced/env_vars.yml
@@ -17,8 +17,8 @@
 ### Common Host settings
 
 repo_method: file # Other Options are: file, satellite and rhn
-tower_admin_password: 'c13aa1f099ee8970cd3fe0e1348f95fe'
-tower_version: "3.6.0-1"
+tower_admin_password: 'changeme'
+tower_version: "3.6.2-1"
 # Do you want to run a full yum update
 update_packages: false
 #If using repo_method: satellite, you must set these values as well.


### PR DESCRIPTION
##### SUMMARY
Bumped Tower version to 3.6.2 for ansible-tower-advanced and simplified admin password (it was a mess to test things)

##### ISSUE TYPE

- Bugfix Pull Request
- Feature Pull Request
(somewhere in-between)

##### COMPONENT NAME

config ansible-tower-advanced

##### ADDITIONAL INFORMATION

Required for the Summit