### PR TITLE
necessary change to references to deployed items

### DIFF
--- a/ansible/roles/ocp4-workload-istio-workshop-homeroom/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-istio-workshop-homeroom/tasks/workload.yml
@@ -20,7 +20,7 @@
   k8s_facts:
     api_version: apps.openshift.io/v1
     kind: DeploymentConfig
-    name: lab-ossm
+    name: lab-ossm-spawner
     namespace: lab-ossm
   register: lab_ossm_deployment
     
@@ -38,7 +38,7 @@
   k8s_facts:
     api_version: route.openshift.io/v1
     kind: Route
-    name: lab-ossm
+    name: lab-ossm-spawner
     namespace: lab-ossm
   register: lab_ossm_route
 


### PR DESCRIPTION
a recent update to the way we deploy something broke something else. This fixes that.