### PR TITLE
Fix ODH CR for CephObjectStore

### DIFF
--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/templates/cephobjectstore.yaml.j2
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/templates/cephobjectstore.yaml.j2
@@ -18,7 +18,7 @@ spec:
       algorithm: ""
       codingChunks: 0
       dataChunks: 0
-    failureDomain: rack
+    failureDomain: zone
     replicated:
       size: 3
   gateway:


### PR DESCRIPTION
##### SUMMARY
Fixes an error in role `ocp4-workload-rhte-analytics_data_ocp_workshop` when creating a CephObjectStore

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
ocp4-workload-rhte-analytics_data_ocp_workshop
