### PR TITLE
Enable public ping by default

### DIFF
--- a/ansible/roles-infra/infra-osp-template-generate/defaults/main.yaml
+++ b/ansible/roles-infra/infra-osp-template-generate/defaults/main.yaml
@@ -44,6 +44,12 @@ default_security_groups:
         from_group: BastionSG
         rule_type: Ingress
 
+      - name: Ping from everywhere
+        description: "Allow public ping"
+        protocol: ICMP
+        cidr: "0.0.0.0/0"
+        rule_type: Ingress
+
 # Environment specific security groups
 security_groups: []
 


### PR DESCRIPTION
##### SUMMARY
Enable pings for `DefaultSG` - unsure if it's necessary, but without it the build hangs on non-public hosts because of failed ping.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Role `infra-osp-template-generate`

##### ADDITIONAL INFORMATION
Allow public ICMP (ping)
