### PR TITLE
Fix osp public dns metadata for all cloud_templates

### DIFF
--- a/ansible/configs/ansible-tower-implementation/files/cloud_providers/osp_cloud_template_master.j2
+++ b/ansible/configs/ansible-tower-implementation/files/cloud_providers/osp_cloud_template_master.j2
@@ -172,16 +172,18 @@ resources:
       user_data_format: RAW
       networks:
         - port: {get_resource: port_{{ iname }}}
-    {% if instance['metadata'] is defined %}
-      metadata: {{ instance.metadata | combine(default_metadata) | to_json }}
-    {% endif %}
-
-    {% if instance.tags is defined %}
-      # Convert EC2 tags
       metadata:
+        'public_dns': {{ instance.public_dns | default(false) }}
       {% for key, value in default_metadata.items() %}
         '{{ key }}': {{ value | to_json }}
       {% endfor %}
+    {% if instance['metadata'] is defined %}
+      {% for key, value in instance.metadata %}
+        '{{ key }}': {{ value | to_json }}
+      {% endfor %}
+    {% endif %}
+    {# Convert EC2 tags #}
+    {% if instance.tags is defined %}
       {% for tag in instance.tags %}
         '{{ tag.key }}': {{ tag.value | to_json }}
       {% endfor %}

--- a/ansible/configs/multi-cloud-capsule/files/cloud_providers/osp_cloud_template_master.j2
+++ b/ansible/configs/multi-cloud-capsule/files/cloud_providers/osp_cloud_template_master.j2
@@ -172,16 +172,18 @@ resources:
       user_data_format: RAW
       networks:
         - port: {get_resource: port_{{ iname }}}
-    {% if instance['metadata'] is defined %}
-      metadata: {{ instance.metadata | combine(default_metadata) | to_json }}
-    {% endif %}
-
-    {% if instance.tags is defined %}
-      # Convert EC2 tags
       metadata:
+        'public_dns': {{ instance.public_dns | default(false) }}
       {% for key, value in default_metadata.items() %}
         '{{ key }}': {{ value | to_json }}
       {% endfor %}
+    {% if instance['metadata'] is defined %}
+      {% for key, value in instance.metadata %}
+        '{{ key }}': {{ value | to_json }}
+      {% endfor %}
+    {% endif %}
+    {# Convert EC2 tags #}
+    {% if instance.tags is defined %}
       {% for tag in instance.tags %}
         '{{ tag.key }}': {{ tag.value | to_json }}
       {% endfor %}

--- a/ansible/configs/sap-hana/files/cloud_providers/osp_cloud_template_master.j2
+++ b/ansible/configs/sap-hana/files/cloud_providers/osp_cloud_template_master.j2
@@ -178,16 +178,18 @@ resources:
       user_data_format: RAW
       networks:
         - port: {get_resource: port_{{ iname }}}
-    {% if instance['metadata'] is defined %}
-      metadata: {{ instance.metadata | combine(default_metadata) | to_json }}
-    {% endif %}
-
-    {% if instance.tags is defined %}
-      # Convert EC2 tags
       metadata:
+        'public_dns': {{ instance.public_dns | default(false) }}
       {% for key, value in default_metadata.items() %}
         '{{ key }}': {{ value | to_json }}
       {% endfor %}
+    {% if instance['metadata'] is defined %}
+      {% for key, value in instance.metadata %}
+        '{{ key }}': {{ value | to_json }}
+      {% endfor %}
+    {% endif %}
+    {# Convert EC2 tags #}
+    {% if instance.tags is defined %}
       {% for tag in instance.tags %}
         '{{ tag.key }}': {{ tag.value | to_json }}
       {% endfor %}

--- a/ansible/roles-infra/infra-osp-create-inventory/tasks/main.yml
+++ b/ansible/roles-infra/infra-osp-create-inventory/tasks/main.yml
@@ -82,7 +82,7 @@
   loop_control:
     loop_var: host
   when:
-    - hostvars[host].has_public_dns|default(False)
+    - host in groups['bastions'] or (hostvars[host].has_public_dns | default(False))
     - hostvars[host].public_ip_address != ''
 
 - debug:

--- a/ansible/roles-infra/infra-osp-template-generate/templates/nested_version/cloud_template_master.j2
+++ b/ansible/roles-infra/infra-osp-template-generate/templates/nested_version/cloud_template_master.j2
@@ -163,16 +163,18 @@ resources:
 {% else %}
           instance_fip: false
 {% endif %}
-{% if instance['metadata'] is defined %}
-          instance_metadata: {{ instance.metadata | combine(default_metadata) | to_json }}
-{% endif %}
-
-          # Convert EC2 tags
-{% if instance.tags is defined %}
           instance_metadata:
+            'public_dns': {{ instance.public_dns | default(false) }}
 {% for key, value in default_metadata.items() %}
             '{{ key }}': {{ value | to_json }}
 {% endfor %}
+{% if instance['metadata'] is defined %}
+{% for key, value in instance.metadata.items() %}
+            '{{ key }}': {{ value | to_json }}
+{% endfor %}
+{% endif %}
+{# Convert EC2 tags #}
+{% if instance.tags is defined %}
 {% for tag in instance.tags %}
             '{{ tag.key }}': {{ tag.value | to_json }}
 {% endfor %}


### PR DESCRIPTION
##### SUMMARY
Fixing metadata setting for custom `stack_templates`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Custom `osp_cloud_template_master` templates

##### ADDITIONAL INFORMATION
I've introduced a metadata earlier, but forgot to set them in all templates 