### PR TITLE
Satellite insights role - enable multiple labs

### DIFF
--- a/ansible/roles/satellite-insights/README.adoc
+++ b/ansible/roles/satellite-insights/README.adoc
@@ -1,0 +1,85 @@
+:role: satellite-insights
+:author: Satellite Team
+:tag1: configure_satellite
+:tag2: satellite_insights
+:main_file: tasks/main.yml
+:version_file: tasks/main.yml
+
+Role: {role}
+============
+
+This role set Satellite insights plugin to work under one Red Hat account for more Satellites. It allows us to reuse one manifest for multiple labs at the same time.
+
+Requirements
+------------
+
+. Satellite must be installed and setted up.
+. Manifest must be uploaded by `satellite-manage-manifest` role (or it's location set up in variable `manifest_basename` by other means).
+
+
+Role Variables
+--------------
+
+* Following are the variable to customize this role
+
+
+[cols="2a,1a,3a"]
+|===
+|satellite_version: "Digit" |Required |satellite version
+|satellite_admin: "String" |Required |Satellite admin username
+|satellite_admin_password: "String" |Required |Satellite admin password
+|===
+
+* Exammple variables
+
+[source=text]
+----
+satellite_version: 6.7
+satellite_admin: admin
+satellite_admin_password: 'changeme'
+
+----
+
+Tags
+---
+
+|===
+|{tag1} |Consistent tag for all satellite config roles
+|{tag2} |This tag is specific to this role only
+|===
+
+
+Example Playbook
+----------------
+
+How to use your role (for instance, with variables passed in playbook).
+
+[source=text]
+----
+[user@desktop ~]$ cat sample_vars.yml
+satellite_version: 6.7
+satellite_admin: admin
+satellite_admin_password: 'changeme'
+
+[user@desktop ~]$ cat playbook.yml
+- hosts: satellites
+  vars_files:
+    - sample_vars.yml
+  roles:
+    - satellite-insights
+
+[user@desktop ~]$ ansible-playbook playbook.yml
+----
+
+
+Tips to update Role
+------------------
+
+For each version of satellite, it will be necesary to change the path to the gem `redhat_access` as it includes version, that changes often.
+
+for reference look at link:{main_file}[main.yml] and version file at link:{version_file}[version_6.7.yml].
+
+Author Information
+------------------
+
+{author}

--- a/ansible/roles/satellite-insights/handlers/main.yml
+++ b/ansible/roles/satellite-insights/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: restart satellite
+  command: satellite-maintain service restart

--- a/ansible/roles/satellite-insights/tasks/main.yml
+++ b/ansible/roles/satellite-insights/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- import_tasks: version_6.7.yml
+  when: satellite_version is version_compare('6.7', '==')
+  tags:
+    - configure_satellite
+    - satellite_insights

--- a/ansible/roles/satellite-insights/tasks/version_6.7.yml
+++ b/ansible/roles/satellite-insights/tasks/version_6.7.yml
@@ -1,0 +1,19 @@
+---
+- name: Set the branch_id to include the satellite uuid
+  lineinfile:
+    path: "/opt/theforeman/tfm/root/usr/share/gems/gems/redhat_access-2.2.8/app/services/redhat_access/telemetry/look_ups.rb"
+    regexp: '^(\s+)branch_id ='
+    line: '\1branch_id = "#{owner[''uuid'']}-#{Digest::SHA1.hexdigest(Setting[:instance_id])}"'
+    backrefs: yes
+  notify: restart satellite
+
+- name: "Refresh the manifest to reset cdn url to default"
+  theforeman.foreman.katello_manifest:
+    username: "{{ satellite_admin }}"
+    password: "{{ satellite_admin_password }}"
+    server_url: "https://{{ publicname }}"
+    validate_certs: no
+    organization: "{{ org }}"
+    repository_url: "https://cdn.redhat.com"
+    manifest_path: "/tmp/{{ manifest_basename }}"
+    state: present


### PR DESCRIPTION
##### SUMMARY
Role that enables satellite insights reuse the same account for multiple labs.

##### ISSUE TYPE
- New role Pull Request

##### COMPONENT NAME
Role `satellite-insights`

##### ADDITIONAL INFORMATION
We need to tweak the gem for accessing Red Hat cloud to have specific `branch_id` for every satellite to distinguish between labs.