### PR TITLE
Satellite role to manage settings

### DIFF
--- a/ansible/roles/satellite-manage-setting/README.adoc
+++ b/ansible/roles/satellite-manage-setting/README.adoc
@@ -1,0 +1,102 @@
+:role: satellite-manage-setting
+:author: Satellite Team
+:tag1: configure_satellite
+:tag2: satellite_setting
+:main_file: tasks/main.yml
+
+Role: {role}
+============
+
+This role creates a setting in satellite
+
+Requirements
+------------
+
+. Satellite must be installed and setted up.
+
+
+Role Variables
+--------------
+
+* Following are the variable to customize this role
+
+[cols="2a,1a,3a"]
+|===
+|satellite_version: "Digit" |Required |satellite version
+|satellite_admin: "String" |Required |Satellite admin username
+|satellite_admin_password: "String" |Required |Satellite admin password
+|satellite_settings: [list of {Dictionary}]
+!===
+!name: "String"
+!value: "String"
+!===
+|Required
+!===
+!Required
+!Optional
+!===
+|List of setting to create
+!===
+!Name attribute to set
+!Value of the attribute (empty to reset)
+!===
+|===
+
+* Exammple variables
+
+[source=text]
+----
+satellite_version: 6.7
+satellite_admin: admin
+satellite_admin_password: 'changeme'
+
+satellite_settings:
+  - name: "http_proxy"
+    value: "http://localhost:8088"
+----
+
+Tags
+---
+
+|===
+|{tag1} |Consistent tag for all satellite config roles
+|{tag2} |This tag is specific to this role only
+|===
+
+
+Example Playbook
+----------------
+
+How to use your role (for instance, with variables passed in playbook).
+
+[source=text]
+----
+[user@desktop ~]$ cat sample_vars.yml
+satellite_version: 6.7
+satellite_admin: admin
+satellite_admin_password: 'changeme'
+
+satellite_settings:
+  - name: "content_disconnected"
+    value: False
+
+[user@desktop ~]$ cat playbook.yml
+- hosts: satellites
+  vars_files:
+    - sample_vars.yml
+  roles:
+    - satellite-manage-setting
+
+[user@desktop ~]$ ansible-playbook playbook.yml
+----
+
+
+Tips to update Role
+------------------
+
+for reference look at link:{main_file}[main.yml].
+
+Author Information
+------------------
+
+{author}

--- a/ansible/roles/satellite-manage-setting/tasks/main.yml
+++ b/ansible/roles/satellite-manage-setting/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: "Update a foreman setting"
+  theforeman.foreman.foreman_setting:
+    name: "{{ item.name }}"
+    value: "{{ item.value | d(omit) }}"
+    username: "{{ satellite_admin }}"
+    password: "{{ satellite_admin_password }}"
+    server_url: "https://{{ publicname }}"
+    validate_certs: no
+  with_items: "{{ satellite_settings }}"
+  when: satellite_settings is defined
+  tags:
+    - configure_satellite
+    - satellite_setting


### PR DESCRIPTION
##### SUMMARY
Role to manage Satellite settings

##### ISSUE TYPE
- New role Pull Request

##### COMPONENT NAME
Role `satellite-manage-setting`

##### ADDITIONAL INFORMATION
Allows to manage settings of satellite.