### PR TITLE
Satellite remote execution capsule config

### DIFF
--- a/ansible/roles/satellite-capsule-rex/README.adoc
+++ b/ansible/roles/satellite-capsule-rex/README.adoc
@@ -1,0 +1,84 @@
+:role: satellite-capsule-rex
+:author: Satellite Team
+:tag1: configure_capsule
+:tag2: satellite_remote_execution
+:main_file: tasks/main.yml
+
+
+Role: {role}
+============
+
+This role adds remote execution config for the OSP based satellite hosts.
+
+Requirements
+------------
+
+. Capsule must be install and setup.
+
+Role Variables
+--------------
+
+|===
+|satellite_remote_execution_user: "String" |Optional(*root*) | User to ssh under to the hosts. Defaults to root
+|capsule_rex_ssh_config_path: "String" |Required |Defaults to /usr/share/foreman-proxy/.ssh/config
+|===
+
+* Example variables
+
+[source=text]
+----
+satellite_version: 6.7
+satellite_remote_execution_user: cloud-user
+capsule_rex_ssh_config_path: /home/foreman-proxy/.ssh/config
+----
+
+Tags
+---
+
+|===
+|{tag1} |Consistent tag for all satellite config roles
+|{tag2} | This tag is specific to this role only
+|===
+
+* Example tags
+
+[source=text]
+----
+## Tagged jobs
+ansible-playbook playbook.yml --tags configure_capsule,satellite_remote_execution
+
+## Skip tagged jobs
+ansible-playbook playbook.yml --skip-tags configure_capsule,satellite_remote_execution
+
+----
+
+
+Example Playbook
+----------------
+
+How to use your role (for instance, with variables passed in playbook).
+
+[source=text]
+----
+[user@desktop ~]$ cat playbook.yml
+- hosts: satellite.example.com
+  vars:
+    satellite_version: 6.7
+    satellite_remote_execution_user: cloud-user
+    capsule_rex_ssh_config_path: /home/foreman-proxy/.ssh/config
+  roles:
+    - satellite-capsule-rex
+
+[user@desktop ~]$ ansible-playbook playbook.yml
+----
+
+Tips to update Role
+------------------
+
+for reference look at link:{main_file[main.yml].
+
+
+Author Information
+------------------
+
+{author}

--- a/ansible/roles/satellite-capsule-rex/defaults/main.yml
+++ b/ansible/roles/satellite-capsule-rex/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+capsule_rex_ssh_config_path: /usr/share/foreman-proxy/.ssh/config

--- a/ansible/roles/satellite-capsule-rex/tasks/main.yml
+++ b/ansible/roles/satellite-capsule-rex/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+- name: Ensure ssh config exists
+  file:
+    dest: "{{ capsule_rex_ssh_config_path }}"
+    state: touch
+    owner: foreman-proxy
+    group: foreman-proxy
+    mode: '0644'
+  tags:
+    - configure_capsule
+    - satellite_remote_execution
+
+- name: Add all hosts to workdir ssh config file
+  blockinfile:
+    dest: "{{ rex_ssh_config_path }}"
+    marker: "##### {mark} ADDED Config  {{ item }} {{ env_type }}-{{ guid }} ######"
+    block: |
+        Host {{ item }} {{  hostvars[item].public_ip_address | default('') }} {{ hostvars[item].shortname |d('')}}
+        {% if hostvars[item].isolated %}
+          Hostname {{ hostvars[item].public_ip_address }}
+        {% else %}
+          Hostname {{ hostvars[item].private_ip_address }}
+        {% endif %}
+          User {{ satellite_remote_execution_user | d('root') }}
+          StrictHostKeyChecking no
+  with_items: "{{ groups['satellite_hosts'] }}"
+  tags:
+    - configure_capsule
+    - satellite_remote_execution


### PR DESCRIPTION
##### SUMMARY
Satellite ssh config to enable remote execution run against hosts created by agnosticd

##### ISSUE TYPE
- New role Pull Request

##### COMPONENT NAME
Role `satellite-capsule-rex`

##### ADDITIONAL INFORMATION
Role adds ssh config to be able to ssh to the agnosticd provisioned hosts without DNS record.