### PR TITLE
Update fio test script to report to overwatch

### DIFF
--- a/ansible/configs/ocp4-disconnected-osp-lab/files/fio-test.sh.j2
+++ b/ansible/configs/ocp4-disconnected-osp-lab/files/fio-test.sh.j2
@@ -7,13 +7,11 @@
 echo "running tests"
 
 mkdir -p /var/lib/etcd/fio
-guid=$(echo $HOSTNAME |cut -d \- -f 1)
 for i in {1..{{ test_runs }}}
 do
   echo "running test $i"
   result=$(fio --rw=write --ioengine=sync --fdatasync=1 --directory=/var/lib/etcd/fio --size=22m --bs=2300 --name=mytest --output-format=json+ | jq '.jobs[].sync.lat_ns.percentile."99.000000"')
   echo $result
-  echo $guid
-  echo "fio.$guid.latency $result `date +%s`" | nc overwatch.osp.opentlc.com 2003
-  echo $result >> /host/home/core/sten6.out
+  echo "fio.{{ guid }}.latency $result `date +%s`" | nc overwatch.osp.opentlc.com 2003
+  echo $result >> /host/home/core/{{ guid }}.out
 done

--- a/ansible/configs/ocp4-disconnected-osp-lab/files/fio-test.sh.j2
+++ b/ansible/configs/ocp4-disconnected-osp-lab/files/fio-test.sh.j2
@@ -1,21 +1,19 @@
 #!/bin/sh
 
+# This is only needed if we are using the fedora image instead of custom
 # echo "Installing jq and fio"
-# dnf install -y jq fio nmap-ncat
-
-# echo "creating fio directory"
-# mkdir /var/lib/etcd/fio
+# dnf install -y jq fio nmap-nca
 
 echo "running tests"
 
-#for i in {1..{{ test_runs }}};do echo "running test $i";fio --rw=write --ioengine=sync --fdatasync=1 --directory=/var/lib/etcd/fio --size=22m --bs=2300 --name=mytest --output-format=json+ | jq '.jobs[].sync.lat_ns.percentile."99.000000"' >> {{ guid }}-$i.json;/host/home/core/upload-to-s3.sh '{{ test_s3_id }}' '{{ test_s3_key }}' {{ test_s3_bucket }}@{{ test_s3_region }} ./{{ guid }}-$i.json {{ guid }}-$i.json;done
-# for i in {1..{{ test_runs }}};do echo "running test $i";fio --rw=write --ioengine=sync --fdatasync=1 --directory=/var/lib/etcd/fio --size=22m --bs=2300 --name=mytest --output-format=json+ > {{ guid }}-$i.json;/host/home/core/upload-to-s3.sh '{{ test_s3_id }}' '{{ test_s3_key }}' {{ test_s3_bucket }}@{{ test_s3_region }} ./{{ guid }}-$i.json {{ guid }}-$i.json;done
-
 mkdir -p /var/lib/etcd/fio
+guid=$(echo $HOSTNAME |cut -d \- -f 1)
 for i in {1..{{ test_runs }}}
 do
   echo "running test $i"
   result=$(fio --rw=write --ioengine=sync --fdatasync=1 --directory=/var/lib/etcd/fio --size=22m --bs=2300 --name=mytest --output-format=json+ | jq '.jobs[].sync.lat_ns.percentile."99.000000"')
+  echo $result
+  echo $guid
   echo "fio.$guid.latency $result `date +%s`" | nc overwatch.osp.opentlc.com 2003
-  echo $result >> /host/home/core/{{ guid }}.out
+  echo $result >> /host/home/core/sten6.out
 done


### PR DESCRIPTION
##### SUMMARY
When tests are enabled, the results were not being reported to overwatch because of a missing var in the payload. GUID is not an env var on the masters, so this will set it when the template is written out by Ansible.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-disconnected-osp-lab

