### PR TITLE
Set ansible_python_interpreter for selinux-policy config

### DIFF
--- a/ansible/configs/selinux-policy/env_vars.yml
+++ b/ansible/configs/selinux-policy/env_vars.yml
@@ -3,13 +3,13 @@ bastion_instance_type:
   ec2: "t2.medium"
   azure: Standard_A2_V2
 
-bastion_instance_image: RHEL75
+bastion_instance_image: RHEL81
 
 node_instance_type:
   ec2: "t2.medium"
   azure: Standard_A2_V2
 
-node_instance_image: RHEL75
+node_instance_image: RHEL81
 
 # How many do you want for each instance type
 node_instance_count: 0
@@ -32,6 +32,8 @@ instances:
         value: "linux"
       - key: "instance_filter"
         value: "{{ env_type }}-{{ email }}"
+      - key: ansible_python_interpreter
+        value: /usr/libexec/platform-python
     volumes:
       - name: '/dev/sda1'
         size: 20
@@ -53,7 +55,8 @@ instances:
         value: "linux"
       - key: "instance_filter"
         value: "{{ env_type }}-{{ email }}"
-
+      - key: ansible_python_interpreter
+        value: /usr/libexec/platform-python
 
 # DNS settings for environmnet
 subdomain_base_short: "{{ guid }}"


### PR DESCRIPTION
##### SUMMARY

Set ansible_python_interpreter for selinux-policy config and set image to RHEL81.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

selinux-policy config