### PR TITLE
Satellite - fix webconsole button

### DIFF
--- a/ansible/roles/satellite-installation/tasks/version_6.7.yml
+++ b/ansible/roles/satellite-installation/tasks/version_6.7.yml
@@ -8,6 +8,21 @@
   tags:
     - install_satellite
 
+- name: Find remote_execution web console button file
+  shell: rpm -ql tfm-rubygem-foreman_remote_execution | grep 'foreman_remote_execution/hosts_helper_extensions.rb'
+  register: rex_hosts_helper_lookup_file
+  tags:
+  - install_satellite
+
+- name: Fix remote_execution web console button
+  lineinfile:
+    path: "{{ rex_hosts_helper_lookup_file.stdout }}"
+    line: "\\1url ? link_to(_('Web Console'), url, :class => 'btn btn-default', :id => :'web-console-button', :target => '_new') : nil"
+    regex: '^(\s+)url \? link_to\(_\(''Web Console'
+    backrefs: yes
+  tags:
+  - install_satellite
+
 - name: configure satellite
   command: >-
     satellite-installer --scenario satellite


### PR DESCRIPTION
##### SUMMARY
The `web console` button in satellite open the webconsole in the same tab. It feels bit weird to first users and those are the target group in the labs.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`satellite-installation`
