### PR TITLE
Add SSH-based Git repo on bastion host of ansible-tower-advanced config

### DIFF
--- a/ansible/configs/ansible-tower-advanced/post_software.yml
+++ b/ansible/configs/ansible-tower-advanced/post_software.yml
@@ -20,7 +20,7 @@
   - name: fetch locally the newly created SSH key for later usage in git-server-ssh
     fetch:
       src: /home/{{ ansible_user }}/.ssh/id_rsa.pub
-      dest: /tmp/{{ guid }}_{{ ansible_user }}_id_rsa.pub
+      dest: "{{ output_dir }}/{{ guid }}_{{ ansible_user }}_id_rsa.pub"
       flat: true
   - name: install some additional convenience software on the bastion
     package:
@@ -32,7 +32,7 @@
     vars:
       git_user: git
       git_project: structured-content
-      git_authorized_keys: /tmp/{{ guid }}_{{ ansible_user }}_id_rsa.pub
+      git_authorized_keys: "{{ output_dir }}/{{ guid }}_{{ ansible_user }}_id_rsa.pub"
   post_tasks:
   - name: add user {{ ansible_user }} to {{ git_user }} group
     user:

--- a/ansible/configs/ansible-tower-advanced/post_software.yml
+++ b/ansible/configs/ansible-tower-advanced/post_software.yml
@@ -12,8 +12,33 @@
   become: yes
   tags:
     - opentlc_bastion_tasks
-  tasks:
-
+  pre_tasks:
+  - name: create SSH key for user {{ ansible_user }}
+    user:
+      name: "{{ ansible_user }}"
+      generate_ssh_key: true
+  - name: fetch locally the newly created SSH key for later usage in git-server-ssh
+    fetch:
+      src: /home/{{ ansible_user }}/.ssh/id_rsa.pub
+      dest: /tmp/{{ guid }}_{{ ansible_user }}_id_rsa.pub
+      flat: true
+  - name: install some additional convenience software on the bastion
+    package:
+      name:
+      - tree
+      state: present
+  roles:
+  - role: git-server-ssh
+    vars:
+      git_user: git
+      git_project: structured-content
+      git_authorized_keys: /tmp/{{ guid }}_{{ ansible_user }}_id_rsa.pub
+  post_tasks:
+  - name: add user {{ ansible_user }} to {{ git_user }} group
+    user:
+      name: "{{ ansible_user }}"
+      groups: "{{ git_user }}"  # it has been created by the git-server-ssh role
+      append: true
 
 - name: Setup Workloads on Tower
   import_playbook: tower_workloads.yml


### PR DESCRIPTION
##### SUMMARY

Add SSH-based Git repo on bastion host of ansible-tower-advanced config (for the Summit 2020)

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ansible-tower-advanced config

##### ADDITIONAL INFORMATION

Include the git-server-ssh role and some glue around it to make sure the ec2-user _and_ Tower can access the Git repo created.
