### PR TITLE
Add a public key to ansible_user on the bastion if specified

### DIFF
--- a/ansible/roles/bastion/tasks/main.yml
+++ b/ansible/roles/bastion/tasks/main.yml
@@ -193,3 +193,10 @@
     group: "{{ ansible_user }}"
   tags:
   - install_bash_customization
+
+# Especially for Erik Jakobs. :-)
+- name: Add public key to bastion
+  when: bastion_public_key | d("") | length > 0
+  authorized_key:
+    user: "{{ ansible_user }}"
+    key: "{{ bastion_public_key }}"


### PR DESCRIPTION
@thoraxe needs way to add a random public key to the bastion VM (ansible-user).