### PR TITLE
Allow infra_workloads to be set as list for ocp4-workshop

### DIFF
--- a/ansible/configs/ocp4-workshop/ocp_workloads.yml
+++ b/ansible/configs/ocp4-workshop/ocp_workloads.yml
@@ -52,7 +52,8 @@
         vars:
           ocp_username: "{{ admin_user }}"
           ACTION: "provision"
-        loop: "{{ infra_workloads.split(',')|list }}"
+        loop: >-
+          {{ infra_workloads.split(',') | list if infra_workloads is string else infra_workloads }}
         loop_control:
           loop_var: workload_loop_var
 


### PR DESCRIPTION
##### SUMMARY

Allow infra_workloads to be set as list or string for ocp4-workshop config

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ocp4-workshop config