### PR TITLE
Add fio test as job pod

### DIFF
--- a/ansible/configs/ocp4-cluster/default_vars.yml
+++ b/ansible/configs/ocp4-cluster/default_vars.yml
@@ -138,6 +138,10 @@ ocp4_base_domain: "example.opentlc.com"
 # Run smoketests after installation
 run_smoke_tests: false
 
+# Run fio performance tests at the end
+test_enable: false
+test_runs: 50
+
 # YAML List of Infrastructure Workloads.
 # REQUIRES Ansible 2.7+ on the deployer host
 # Empty by default - to be set by specific configurations

--- a/ansible/configs/ocp4-cluster/default_vars.yml
+++ b/ansible/configs/ocp4-cluster/default_vars.yml
@@ -139,8 +139,9 @@ ocp4_base_domain: "example.opentlc.com"
 run_smoke_tests: false
 
 # Run fio performance tests at the end
-test_enable: false
-test_runs: 50
+fio_test_enable: false
+fio_test_runs: 50
+fio_test_image: quay.io/nstephan/fio-etcd-osp:v3
 
 # YAML List of Infrastructure Workloads.
 # REQUIRES Ansible 2.7+ on the deployer host

--- a/ansible/configs/ocp4-cluster/files/fio-test-job.yaml.j2
+++ b/ansible/configs/ocp4-cluster/files/fio-test-job.yaml.j2
@@ -8,7 +8,7 @@ spec:
       containers:
       - name: fio-test-osp
         image: quay.io/nstephan/fio-etcd-osp:v3
-        command: []
+        command: ["/tmp/fio-test.sh"]
         env:
         - name: test_runs
           value: "{{ test_runs }}"
@@ -19,19 +19,24 @@ spec:
           mountPath: /host
         - name: etcd
           mountPath: /var/lib/etcd
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
       restartPolicy: Never
-      toleratrions:
+      securityContext:
+        privileged: true
+      tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
       nodeSelector:
         kubernetes.io/hostname: "{{ INFRA_ID }}-master-0"
       volumes:
       - name: host
-        hostpath:
+        hostPath:
           path: /
           type: Directory
       - name: etcd
-        hostpath:
+        hostPath:
           path: /var/lib/etcd
           type: Directory
-  backoffLimit: 4
+  backoffLimit: 2

--- a/ansible/configs/ocp4-cluster/files/fio-test-job.yaml.j2
+++ b/ansible/configs/ocp4-cluster/files/fio-test-job.yaml.j2
@@ -1,0 +1,37 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: fio-test
+spec:
+  template:
+    spec:
+      containers:
+      - name: fio-test-osp
+        image: quay.io/nstephan/fio-etcd-osp:v3
+        command: []
+        env:
+        - name: test_runs
+          value: "{{ test_runs }}"
+        - name: GUID
+          value: "{{ guid }}"
+        volumeMounts:
+        - name: host
+          mountPath: /host
+        - name: etcd
+          mountPath: /var/lib/etcd
+      restartPolicy: Never
+      toleratrions:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      nodeSelector:
+        kubernetes.io/hostname: "{{ INFRA_ID }}-master-0"
+      volumes:
+      - name: host
+        hostpath:
+          path: /
+          type: Directory
+      - name: etcd
+        hostpath:
+          path: /var/lib/etcd
+          type: Directory
+  backoffLimit: 4

--- a/ansible/configs/ocp4-cluster/files/fio-test-job.yaml.j2
+++ b/ansible/configs/ocp4-cluster/files/fio-test-job.yaml.j2
@@ -2,6 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: fio-test
+  namespace: fio-test
 spec:
   template:
     spec:

--- a/ansible/configs/ocp4-cluster/files/fio-test-job.yaml.j2
+++ b/ansible/configs/ocp4-cluster/files/fio-test-job.yaml.j2
@@ -8,11 +8,11 @@ spec:
     spec:
       containers:
       - name: fio-test-osp
-        image: quay.io/nstephan/fio-etcd-osp:v3
+        image: "{{ fio_test_image }}"
         command: ["/tmp/fio-test.sh"]
         env:
         - name: test_runs
-          value: "{{ test_runs }}"
+          value: "{{ fio_test_runs }}"
         - name: GUID
           value: "{{ guid }}"
         volumeMounts:

--- a/ansible/configs/ocp4-cluster/files/fio-test.sh
+++ b/ansible/configs/ocp4-cluster/files/fio-test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# This is only needed if we are using the fedora image instead of custom
+# echo "Installing jq and fio"
+# dnf install -y jq fio nmap-nca
+
+echo "running tests"
+
+mkdir -p /var/lib/etcd/fio
+# GUID=$(echo $HOSTNAME |cut -d \- -f 1)
+for i in {1..$test_runs}
+do
+  echo "running test $i"
+  result=$(fio --rw=write --ioengine=sync --fdatasync=1 --directory=/var/lib/etcd/fio --size=22m --bs=2300 --name=mytest --output-format=json+ | jq '.jobs[].sync.lat_ns.percentile."99.000000"')
+  echo $result
+  echo "fio.$GUID.latency $result `date +%s`" | nc overwatch.osp.opentlc.com 2003
+  echo $result >> /host/home/core/$GUID.out
+done

--- a/ansible/configs/ocp4-cluster/files/fio-test.sh
+++ b/ansible/configs/ocp4-cluster/files/fio-test.sh
@@ -8,7 +8,7 @@ echo "running tests"
 
 mkdir -p /var/lib/etcd/fio
 # GUID=$(echo $HOSTNAME |cut -d \- -f 1)
-for i in {1..$test_runs}
+for i in $(seq $test_runs)
 do
   echo "running test $i"
   result=$(fio --rw=write --ioengine=sync --fdatasync=1 --directory=/var/lib/etcd/fio --size=22m --bs=2300 --name=mytest --output-format=json+ | jq '.jobs[].sync.lat_ns.percentile."99.000000"')

--- a/ansible/configs/ocp4-cluster/files/fio.Dockerfile
+++ b/ansible/configs/ocp4-cluster/files/fio.Dockerfile
@@ -1,0 +1,3 @@
+FROM fedora:latest
+RUN dnf install -y jq fio nmap-ncat
+COPY ./fio-test.sh /tmp/fio-test.sh

--- a/ansible/configs/ocp4-cluster/post_software.yml
+++ b/ansible/configs/ocp4-cluster/post_software.yml
@@ -257,7 +257,7 @@
     KUBECONFIG: /home/{{ remote_user }}/{{ cluster_name }}/auth/kubeconfig
   tasks:
   - name: Run fio tests for etcd performance
-    when: test_enable
+    when: fio_test_enable
     block:
     - name: Set Ansible Python interpreter to k8s virtualenv
       set_fact:

--- a/ansible/configs/ocp4-cluster/post_software.yml
+++ b/ansible/configs/ocp4-cluster/post_software.yml
@@ -293,12 +293,13 @@
     - name: Wait for job to finish (1h max)
       k8s_facts:
         api_version: batch/v1
+        kind: Job
         name: fio-test
         namespace: fio-test
       register: r_fio_test_job
       retries: 60
       delay: 60
-      until: r_fio_test_job.resources[].status.conditions | json_query(fio_query) | bool
+      until: r_fio_test_job.resources[0].status.conditions | json_query(fio_query) | bool
       vars:
         fio_query: >-
           [?type=='Complete'].status[] | [0]
@@ -317,7 +318,7 @@
         name: fio-test
         kind: Namespace
         api_version: v1
-        steate: absent
+        state: absent
 
 - name: Step 003.6 Print Student Info
   hosts: localhost

--- a/ansible/configs/ocp4-cluster/post_software.yml
+++ b/ansible/configs/ocp4-cluster/post_software.yml
@@ -249,7 +249,77 @@
     #     state: present
     #     src: /tmp/extension-apiserver-authentication.yaml
 
-- name: Step 003.5 Print Student Info
+- name: Step 003.5 Run performance test (optional)
+  hosts: bastions
+  gather_facts: false
+  become: false
+  environment:
+    KUBECONFIG: /home/{{ remote_user }}/{{ cluster_name }}/auth/kubeconfig
+  tasks:
+  - name: Run fio tests for etcd performance
+    when: test_enable
+    block:
+    - name: Set Ansible Python interpreter to k8s virtualenv
+      set_fact:
+        ansible_python_interpreter: /opt/virtualenvs/k8s/bin/python
+
+    - name: Get metadata.json
+      stat:
+        path: /home/{{ ansible_user }}/{{ cluster_name }}/metadata.json
+      register: r_metadata
+
+    - name: Get the infra ID
+      shell: jq -r .infraID /home/{{ ansible_user }}/{{ cluster_name }}/metadata.json
+      register: r_infra_id
+      when: r_metadata.stat.exists
+
+    - name: create fio testing project
+      k8s:
+        name: fio-test
+        api_version: v1
+        kind: Namespace
+        state: present
+
+    - name: give default sa privileged scc
+      shell: oc adm policy add-scc-to-user privileged system:serviceaccount:fio-test:default
+
+    - name: run job pod with fio-etcd-osp container
+      k8s:
+        state: present
+        definition: "{{ lookup('template', './files/fio-test-job.yaml.j2') }}"
+      vars:
+        INFRA_ID: "{{ r_infra_id.stdout }}"
+
+    - name: Wait for job to finish (1h max)
+      k8s_facts:
+        api_version: batch/v1
+        name: fio-test
+        namespace: fio-test
+      register: r_fio_test_job
+      retries: 30
+      delay: 120
+      until: r_fio_test_job.resources[].status.conditions | json_query(fio_query) | bool
+      vars:
+        fio_query: >-
+          [?type=='Complete'].status[] | [0]
+        INFRA_ID: "{{ r_infra_id.stdout }}"
+
+    - name: Remove job
+      k8s:
+        name: fio-test
+        kind: Job
+        api_version: batch/v1
+        namespace: fio-test
+        state: absent
+
+    - name: Remove fio testing project
+      k8s:
+        name: fio-test
+        kind: Namespace
+        api_version: v1
+        steate: absent
+
+- name: Step 003.6 Print Student Info
   hosts: localhost
   gather_facts: false
   become: false
@@ -266,7 +336,7 @@
     - "user.info: "
     - "user.info: Make sure you use the username '{{ student_name }}' and the password '{{ hostvars[bastion_hostname]['student_password'] }}' when prompted."
 
-- name: Step 003.6 Tell CloudForms we are done
+- name: Step 003.7 Tell CloudForms we are done
   hosts: localhost
   run_once: yes
   gather_facts: false

--- a/ansible/configs/ocp4-cluster/post_software.yml
+++ b/ansible/configs/ocp4-cluster/post_software.yml
@@ -296,8 +296,8 @@
         name: fio-test
         namespace: fio-test
       register: r_fio_test_job
-      retries: 30
-      delay: 120
+      retries: 60
+      delay: 60
       until: r_fio_test_job.resources[].status.conditions | json_query(fio_query) | bool
       vars:
         fio_query: >-

--- a/ansible/configs/ocp4-disconnected-osp-lab/files/fio-test.sh.j2
+++ b/ansible/configs/ocp4-disconnected-osp-lab/files/fio-test.sh.j2
@@ -7,6 +7,7 @@
 echo "running tests"
 
 mkdir -p /var/lib/etcd/fio
+guid=$(echo $HOSTNAME |cut -d \- -f 1)
 for i in {1..{{ test_runs }}}
 do
   echo "running test $i"


### PR DESCRIPTION
##### SUMMARY
Performance (etcd) testing was already an option in the OCP4 disconnected config. These changes add the capability to the ocp4-cluster config as well. In addition, the workload will launch as a job pod instead of using Ansible to have podman run the container on the master directly.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4-cluster
