### PR TITLE
Fix typo in SELinux workshop post_software

### DIFF
--- a/ansible/configs/selinux-policy/post_software.yml
+++ b/ansible/configs/selinux-policy/post_software.yml
@@ -21,7 +21,7 @@
           student_ssh_password: >-
             {{ student_password | default(hostvars[groups.bastions.0].student_password) }}
           student_ssh_command: >-
-            ssh {{ student_name }}@bastion.{{ subdomain_base }}
+            ssh {{ student_user }}@bastion.{{ subdomain_base }}
 
     - debug:
         msg: "Post-Software checks completed successfully"


### PR DESCRIPTION
post_software.yml file contains undefined variable student_name. This
should be replaced by student_user

