### PR TITLE
Moved Configure satellites and capsules  play to include_roles

### DIFF
--- a/ansible/configs/satellite-vm/pre_software.yml
+++ b/ansible/configs/satellite-vm/pre_software.yml
@@ -44,9 +44,17 @@
   tags:
     - step004
     - satellite_tasks
-  roles:
-    - role: satellite-public-hostname
-    - role: "set-repositories"
+
+  tasks:
+
+    - name: Include role satellite-public-hostname role
+      include_role:    
+        name: satellite-public-hostname
+
+    - name: Include role set-repositories
+      when: satellite_host_repo_method is defined
+      include_role:    
+        name: set-repositories
       vars:
         rhel_repos: "{{ rhel7_repos + satellite_repos }}"
         repo_method: "{{ satellite_host_repo_method }}"
@@ -54,9 +62,12 @@
         satellite_activationkey: "{{ satellite_host_repo_registration.activationkey }}"
         satellite_url: "{{ satellite_host_repo_registration.url }}"
         use_content_view: false
-      when: 'satellite_host_repo_method is defined'
-    - { role: "set_env_authorized_key", when: 'set_env_authorized_key' }
 
+    - name: Include role set_env_authorized_key
+      when: set_env_authorized_key | default(false) | bool
+      include_role:    
+        name: set_env_authorized_key
+        
 - name: Enable epel and libvirt gem
   hosts:
     - satellites


### PR DESCRIPTION
…lude_roles v roles

##### SUMMARY

roles: showing unpredictable variable inclusion when used with agnosticv --extra-vars. include_role is safer and avoids certain bugs seen in roles: 

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
satellite-vm

##### ADDITIONAL INFORMATION
