### PR TITLE
Add default student_name to env_vars for ocp4-workshop config

### DIFF
--- a/ansible/configs/ocp4-workshop/env_vars.yml
+++ b/ansible/configs/ocp4-workshop/env_vars.yml
@@ -27,6 +27,9 @@ install_ipa_client: false
 install_student_user: false
 install_ftl: false
 
+# Default student_name, referenced in post_software.yml when install_student_user is true
+student_name: lab-user
+
 # install openshift python modules on bastion
 install_k8s_modules: true
 


### PR DESCRIPTION
##### SUMMARY

Set `student_name` in ocp4-workshop config env_vars to prevent error when `install_student_user` is true but `student_name` is not set.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ocp4-workshop config