### PR TITLE
Role set repositaries var changes 2020 04 02

### DIFF
--- a/ansible/configs/satellite-vm/pre_software.yml
+++ b/ansible/configs/satellite-vm/pre_software.yml
@@ -58,9 +58,9 @@
       vars:
         rhel_repos: "{{ rhel7_repos + satellite_repos }}"
         repo_method: "{{ satellite_host_repo_method }}"
-        satellite_org: "{{ satellite_host_repo_registration.org }}"
-        satellite_activationkey: "{{ satellite_host_repo_registration.activationkey }}"
-        satellite_url: "{{ satellite_host_repo_registration.url }}"
+        set_repositories_satellite_org: "{{ satellite_host_repo_registration.org }}"
+        set_repositories_satellite_activationkey: "{{ satellite_host_repo_registration.activationkey }}"
+        set_repositories_satellite_url: "{{ satellite_host_repo_registration.url }}"
         use_content_view: false
 
     - name: Include role set_env_authorized_key

--- a/ansible/roles/set-repositories/tasks/satellite-repos.yml
+++ b/ansible/roles/set-repositories/tasks/satellite-repos.yml
@@ -65,7 +65,7 @@
         } 
 
 - name: Register with activation-key
-  when: satellite_activationkey is defined
+  when: satellite_activationkey is defined or set_repositories_satellite_activationkey is defined
   redhat_subscription:
     state: present
     server_hostname: "{{ set_repositories_satellite_url | default(satellite_url) }}"

--- a/ansible/roles/set-repositories/tasks/satellite-repos.yml
+++ b/ansible/roles/set-repositories/tasks/satellite-repos.yml
@@ -14,7 +14,7 @@
 
 - name: Download Cert from Satellite
   get_url:
-    url: "https://{{satellite_url}}/pub/katello-ca-consumer-latest.noarch.rpm"
+    url: "https://{{ set_repositories_satellite_url | default(satellite_url) }}/pub/katello-ca-consumer-latest.noarch.rpm"
     dest: /root/katello-ca-consumer-latest.noarch.rpm
     mode: 0664
     validate_certs: no
@@ -68,9 +68,9 @@
   when: satellite_activationkey is defined
   redhat_subscription:
     state: present
-    server_hostname: "{{ satellite_url }}"
-    activationkey: "{{ satellite_activationkey }}"
-    org_id: "{{ satellite_org }}"
+    server_hostname: "{{ set_repositories_satellite_url | default(satellite_url) }}"
+    activationkey: "{{ set_repositories_satellite_activationkey | default(satellite_activationkey) }}"
+    org_id: "{{ set_repositories_satellite_org | default(satellite_org) }}"
 
 - name: Enable repos
   rhsm_repository:
@@ -78,7 +78,7 @@
     state: enabled
   when:
   - use_content_view
-  - satellite_activationkey is defined
+  - satellite_activationkey is defined or set_repositories_satellite_activationkey is defined
 
 - name: Enable repos for RHEL
   rhsm_repository:


### PR DESCRIPTION
##### SUMMARY
Satellite specific roles running into var naming collisions. Internal vars have no prefix so GPTEs use of Satellite over-rides any end-users hoping to configure their own satellites e.g. `satellite_url` rtc.

Fix should be backward compatible and is not a substitute for a better thought out internal naming convention for user exposed role vars however it does adopt the pattern of prefixing the vars with the role name (dashes `-` notwithstanding).

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
Config satellite-vm
Role set-repositaries

##### ADDITIONAL INFORMATION
Blocker on on-boarding Summit lab
