### PR TITLE
add unique var back to clientvm

### DIFF
--- a/ansible/configs/ocp-clientvm/default_vars.yml
+++ b/ansible/configs/ocp-clientvm/default_vars.yml
@@ -51,6 +51,7 @@ docker_size: '200'
 
 # The next flag is 1 by default. If it is set to more than 1 then instead of creating
 # clientvm.guid.baseurl it will create clientvm{1..num_users}.guid.baseurl
+# Leaving the var here, but it is no longer used in the default instance dict
 num_users: 1
 
 install_bastion: true

--- a/ansible/configs/ocp-clientvm/default_vars_ec2.yml
+++ b/ansible/configs/ocp-clientvm/default_vars_ec2.yml
@@ -77,7 +77,8 @@ rootfs_size_clientvm: 200
 
 instances:
 - name: "clientvm"
-  count: "{{ num_users }}"
+  count: 1
+  unique: true
   public_dns: true
   floating_ip: true
   image: "{{ clientvm_instance_image }}"


### PR DESCRIPTION
##### SUMMARY
Without `unique: true` the clientvm was being named incorrectly in ec2 config.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp-clientvm