### PR TITLE
use clientvm., not bastion. hostnames

### DIFF
--- a/ansible/configs/ocp-clientvm/post_software.yml
+++ b/ansible/configs/ocp-clientvm/post_software.yml
@@ -16,13 +16,13 @@
       loop:
         - "You can access your bastion via SSH:"
         - ""
-        - "SSH Access: ssh {{ student_name }}@bastion.{{ guid }}{{ subdomain_base_suffix }}"
+        - "SSH Access: ssh {{ student_name }}@clientvm.{{ guid }}{{ subdomain_base_suffix }}"
         - "SSH password: {{ hostvars[groups.bastions.0].student_password | d('The password is a myth.') }}"
 
     - name: Save user data
       agnosticd_user_info:
         data:
-          ssh_command: "ssh {{ student_name }}@bastion.{{ guid }}{{ subdomain_base_suffix }}"
+          ssh_command: "ssh {{ student_name }}@clientvm.{{ guid }}{{ subdomain_base_suffix }}"
           ssh_user: "{{ student_name }}"
           ssh_password: "{{ hostvars[groups.bastions.0].student_password | d('The password is a myth.') }}"
 


### PR DESCRIPTION
##### SUMMARY
bastion name for ocp-clientvm is clientvm, not bastion.



##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
config/ocp-clientvm

##### ADDITIONAL INFORMATION
