### PR TITLE
Add the ability to build python3 venv to tower-create-venv

### DIFF
--- a/ansible/roles/tower-custom-venv/tasks/loop.yml
+++ b/ansible/roles/tower-custom-venv/tasks/loop.yml
@@ -20,6 +20,7 @@
     state: latest
     name: "{{ _venv.requirements }}"
     virtualenv: "{{ _venv.dest }}/{{ _venv.name }}"
+    virtualenv_python: "{{ _venv.virtualenv_python | default(omit) }}"
 
   delegate_to: "{{ item }}"
   loop: "{{ query('inventory_hostnames', 'towers:workers') }}"

--- a/ansible/roles/tower-settings-update/tasks/main.yml
+++ b/ansible/roles/tower-settings-update/tasks/main.yml
@@ -3,12 +3,14 @@
 
 - name: Set the value of AWX_PROOT_BASE_PATH
   tower_settings:
-    name:               "{{ item.key }}"
-    value:              "{{ item.value }}"
+    name:               "{{ tower_setting.key }}"
+    value:              "{{ tower_setting.value }}"
     tower_host:         "{{ tower_hostname }}"
-    tower_username:     admin
+    tower_username:     "{{ tower_admin_username | default('admin') }}"
     tower_password:     "{{ tower_admin_password }}"
-    tower_verify_ssl:   no
+    tower_verify_ssl:   "{{ tower_verify_ssl | default(false) }}"
   when: tower_setting_params is defined
   loop: "{{ lookup('dict', tower_setting_params) }}"
+  loop_control:
+    loop_var: tower_setting
 ...

--- a/ansible/roles/tower-user-create/tasks/main.yml
+++ b/ansible/roles/tower-user-create/tasks/main.yml
@@ -8,18 +8,20 @@
 
 - name: Add tower user
   tower_user:
-     username: "{{ item.user }}"
-     password: "{{ item.password | default('change_me') }}"
-     email: "{{ item.email | default('rhpds-admins@redhat.com') }}"
-     first_name: "{{ item.firstname | default(item.user) }}"
-     last_name: "{{ item.lastname | default(item.user) }}"
-     superuser: "{{ item.superuser | default('no')}}"
+     username: "{{ user.user }}"
+     password: "{{ user.password | default('change_me') }}"
+     email: "{{ user.email | default('rhpds-admins@redhat.com') }}"
+     first_name: "{{ user.firstname | default(user.user) }}"
+     last_name: "{{ user.lastname | default(user.user) }}"
+     superuser: "{{ user.superuser | default('no')}}"
      state: present
-     tower_host: "{{ tower_hostname }}"  
-     tower_username: admin
-     tower_password: "{{tower_admin_password}}"
-     tower_verify_ssl: false
+     tower_host: "{{ tower_hostname }}"
+     tower_username: "{{ tower_admin_username | default('admin') }}"
+     tower_password: "{{ tower_admin_password }}"
+     tower_verify_ssl: "{{ tower_verify_ssl | default(false) }}"
   loop: "{{ tower_user_accounts }}"
+  loop_control:
+    loop_var: user
   when: tower_user_accounts is defined
   tags:
     - tower-user-create


### PR DESCRIPTION
##### SUMMARY
The tower-create-venv role supported only the system python, typically python2.

Extended it to allow an **optional** `virtualenv_python` so, for example, python3 based virtualenvs can be created

In addition extended supporting roles to be more flexible and configurable for tower creds i.e. not hardcoded to `admin` user etc
##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
All tower-based configs

##### ADDITIONAL INFORMATION

```
