### PR TITLE
Ansible tower add node exporter

### DIFF
--- a/ansible/configs/ansible-tower/env_vars.yml
+++ b/ansible/configs/ansible-tower/env_vars.yml
@@ -100,6 +100,7 @@ security_groups:
         protocol: tcp
         cidr: "0.0.0.0/0"
         rule_type: Ingress
+
       - name: HTTPTower
         description: "HTTP public"
         from_port: 80
@@ -107,6 +108,7 @@ security_groups:
         protocol: tcp
         cidr: "0.0.0.0/0"
         rule_type: Ingress
+
       - name: HTTPSTower
         description: "HTTP public"
         from_port: 443
@@ -114,6 +116,7 @@ security_groups:
         protocol: tcp
         cidr: "0.0.0.0/0"
         rule_type: Ingress
+
       - name: RabbitMq
         description: "RabbitMq"
         from_port: 5672
@@ -121,6 +124,7 @@ security_groups:
         protocol: tcp
         cidr: "0.0.0.0/0"
         rule_type: Ingress
+
       - name: EPMD
         description: "EPMD"
         from_port: 4369
@@ -128,6 +132,7 @@ security_groups:
         protocol: tcp
         cidr: "0.0.0.0/0"
         rule_type: Ingress
+
       - name: RabbitMqCLi
         description: "RabbitMq Cli"
         from_port: 25672
@@ -135,6 +140,7 @@ security_groups:
         protocol: tcp
         cidr: "0.0.0.0/0"
         rule_type: Ingress
+
       - name: RabbitMqAPi
         description: "RabbitMq Api"
         from_port: 15672
@@ -142,6 +148,7 @@ security_groups:
         protocol: tcp
         cidr: "0.0.0.0/0"
         rule_type: Ingress
+
       - name: RabbitMqCliTools
         description: "RabbitMq CLi tools"
         from_port: 35672
@@ -149,6 +156,15 @@ security_groups:
         protocol: tcp
         cidr: "0.0.0.0/0"
         rule_type: Ingress
+
+      - name: TowerNodeExporter
+        description: "node-exporter for prometheus metrics"
+        from_port: 9100
+        to_port: 9100
+        protocol: tcp
+        cidr: "0.0.0.0/0"
+        rule_type: Ingress
+
       - name: BasTowerTcp
         description: "ALL from bastion tcp"
         from_port: 0
@@ -156,6 +172,7 @@ security_groups:
         protocol: tcp
         group: BastionSG
         rule_type: Ingress
+
       - name: BasTowerUdp
         description: "ALL from bastion udp"
         from_port: 0
@@ -163,6 +180,7 @@ security_groups:
         protocol: udp
         group: BastionSG
         rule_type: Ingress
+
       - name: AllInternaltcp
         description: "All other nodes tcp"
         from_port: 0
@@ -170,6 +188,7 @@ security_groups:
         protocol: tcp
         group: HostSG
         rule_type: Ingress
+
       - name: AllInternaludp
         description: "All other nodes udp"
         from_port: 0
@@ -177,6 +196,7 @@ security_groups:
         protocol: udp
         group: HostSG
         rule_type: Ingress
+
       - name: AllTowerNodestcp
         description: "All tower nodes tcp"
         from_port: 0
@@ -184,6 +204,7 @@ security_groups:
         protocol: tcp
         group: TowerSG
         rule_type: Ingress
+
       - name: AllTowerNodesudp
         description: "All tower nodes udp"
         from_port: 0
@@ -191,8 +212,17 @@ security_groups:
         protocol: udp
         group: TowerSG
         rule_type: Ingress
+
   - name: HostSG
     rules:
+      - name: HostNodeExporter
+        description: "node-exporter for prometheus metrics"
+        from_port: 9100
+        to_port: 9100
+        protocol: tcp
+        cidr: "0.0.0.0/0"
+        rule_type: Ingress
+
       - name: HostUDPPorts
         description: "Only from Itself udp"
         from_port: 0
@@ -200,6 +230,7 @@ security_groups:
         protocol: udp
         group: HostSG
         rule_type: Ingress
+
       - name: Postgresql1
         description: "PostgreSql"
         from_port: 5432
@@ -207,6 +238,7 @@ security_groups:
         protocol: tcp
         rule_type: Ingress
         group: HostSG
+
       - name: Postgresql2
         description: "PostgreSql"
         from_port: 5432
@@ -214,6 +246,7 @@ security_groups:
         protocol: tcp
         rule_type: Ingress
         group: TowerSG
+
       - name: HostTCPPorts
         description: "Only from Itself tcp"
         from_port: 0
@@ -221,6 +254,7 @@ security_groups:
         protocol: tcp
         group: HostSG
         rule_type: Ingress
+
       - name: TowerUDPPorts
         description: "Only from tower"
         from_port: 0
@@ -228,6 +262,7 @@ security_groups:
         protocol: udp
         group: TowerSG
         rule_type: Ingress
+
       - name: TowerTCPPorts
         description: "Only from tower"
         from_port: 0
@@ -235,6 +270,7 @@ security_groups:
         protocol: tcp
         group: TowerSG
         rule_type: Ingress
+
       - name: BastionUDPPorts
         description: "Only from bastion"
         from_port: 0
@@ -242,6 +278,7 @@ security_groups:
         protocol: udp
         group: BastionSG
         rule_type: Ingress
+
       - name: BastionTCPPorts
         description: "Only from bastion"
         from_port: 0

--- a/ansible/configs/ansible-tower/post_software.yml
+++ b/ansible/configs/ansible-tower/post_software.yml
@@ -19,7 +19,17 @@
   import_playbook: tower_workloads.yml
 
 
-
+- name: Setup node-exporter
+  hosts:
+    - support
+    - towers
+    - workers
+  gather_facts: true
+  tags:
+    - node-exporter
+  tasks:
+    - include_role:
+        name: node-exporter
 
 - name: PostSoftware flight-check
   hosts: localhost

--- a/ansible/configs/ansible-tower/requirements.yml
+++ b/ansible/configs/ansible-tower/requirements.yml
@@ -4,3 +4,7 @@
 - src: https://github.com/redhat-gpte-devopsautomation/ftl-injector
   name: ftl-injector
   version: v0.16.0
+
+- src: cloudalchemy.node-exporter
+  name: node-exporter
+  version: '0.19.0'

--- a/ansible/configs/ansible-tower/requirements.yml
+++ b/ansible/configs/ansible-tower/requirements.yml
@@ -1,6 +1,6 @@
 ---
 # External role to setup grader host virtualenv and FTL grading infra
-
+roles:
 - src: https://github.com/redhat-gpte-devopsautomation/ftl-injector
   name: ftl-injector
   version: v0.16.0


### PR DESCRIPTION
##### SUMMARY
The commits in the PR, if applied, will update the ansible-tower config in order to have [node-exporter](https://github.com/prometheus/node_exporter) installed on all nodes via the role [node-exporter](https://galaxy.ansible.com/cloudalchemy/node-exporter)
##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
ansible-tower config

