### PR TITLE
Fix operator versions; add retries to avoid slow operators failing

### DIFF
--- a/ansible/roles/ocp4-workload-quarkus-workshop/files/amqstreams_subscription.yaml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/files/amqstreams_subscription.yaml
@@ -10,4 +10,3 @@ spec:
   name: amq-streams
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: amqstreams.v1.3.0

--- a/ansible/roles/ocp4-workload-quarkus-workshop/files/codeready_subscription.yaml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/files/codeready_subscription.yaml
@@ -10,4 +10,3 @@ spec:
   name: codeready-workspaces
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: crwoperator.v2.0.0

--- a/ansible/roles/ocp4-workload-quarkus-workshop/files/jaeger_subscription.yaml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/files/jaeger_subscription.yaml
@@ -10,4 +10,3 @@ spec:
   name: jaeger-product
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: jaeger-operator.v1.13.1

--- a/ansible/roles/ocp4-workload-quarkus-workshop/tasks/verify-workload.yaml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/tasks/verify-workload.yaml
@@ -20,7 +20,9 @@
     field_selectors:
       - status.phase=Running
   register: r_guides_pod
-  failed_when: r_guides_pod.resources | list | length != 1
+  retries: 200
+  delay: 10
+  until: r_guides_pod.resources | list | length == 1
 
 - name: verify guides are accessible
   uri:
@@ -39,7 +41,9 @@
     field_selectors:
       - status.phase=Running
   register: r_codeready_pod
-  failed_when: r_codeready_pod.resources | list | length != 1
+  retries: 200
+  delay: 10
+  until: r_codeready_pod.resources | list | length == 1
 
 - name: verify codeready is accessible
   uri:
@@ -58,7 +62,9 @@
     field_selectors:
       - status.phase=Running
   register: r_keycloak_pod
-  failed_when: r_keycloak_pod.resources | list | length != 1
+  retries: 200
+  delay: 10
+  until: r_keycloak_pod.resources | list | length == 1
 
 - name: verify keycloak is accessible
   uri:
@@ -94,7 +100,9 @@
     kind: CustomResourceDefinition
     name: kafkas.kafka.strimzi.io
   register: r_kafka_crd
-  failed_when: r_kafka_crd.resources | list | length != 1
+  retries: 200
+  delay: 10
+  until: r_kafka_crd.resources | list | length == 1
 
 - name: verify Kafka operator pod is running
   k8s_facts:
@@ -106,7 +114,9 @@
     field_selectors:
       - status.phase=Running
   register: r_amq_operator_pod
-  failed_when: r_amq_operator_pod.resources | list | length != 1
+  retries: 200
+  delay: 10
+  until: r_amq_operator_pod.resources | list | length == 1
 
 - name: Verify Jaeger CRD
   k8s_facts:
@@ -114,7 +124,9 @@
     kind: CustomResourceDefinition
     name: jaegers.jaegertracing.io
   register: r_jaeger_crd
-  failed_when: r_jaeger_crd.resources | list | length != 1
+  retries: 200
+  delay: 10
+  until: r_jaeger_crd.resources | list | length == 1
 
 - name: verify Jaeger operator pod is running
   k8s_facts:
@@ -124,7 +136,9 @@
     label_selectors:
       - name = jaeger-operator
   register: r_jaeger_operator_pod
-  failed_when: r_jaeger_operator_pod.resources | list | length != 1
+  retries: 200
+  delay: 10
+  until: r_jaeger_operator_pod.resources | list | length == 1
 
 - name: verify user workspaces are started
   include_tasks: confirm_che_workspace.yaml


### PR DESCRIPTION
##### SUMMARY
This fix removes the `startingCSV` values so that the operator subscriptions always get the version appropriate for the OCP release it's being installed on, rather than starting with a specific version and then auto-upgrading (which takes more time and could fail the deployment).

It also adds `retries` to the verification step in case an operator takes a bit longer than expected to asynchronously provision.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`ocp4-workload-quarkus-workshop`

