### PR TITLE
Update performance test playbooks

### DIFF
--- a/ansible/configs/ocp4-cluster/default_vars.yml
+++ b/ansible/configs/ocp4-cluster/default_vars.yml
@@ -103,9 +103,10 @@ ocp4_base_domain: "example.opentlc.com"
 run_smoke_tests: false
 
 # Run fio performance tests at the end
-fio_test_enable: false
-fio_test_runs: 50
-fio_test_image: quay.io/nstephan/fio-etcd-osp:v3
+test_deploy_enable: false
+test_deploy_results: false
+test_deploy_runs: 50
+test_deploy_image: quay.io/nstephan/fio-etcd-osp:v3
 
 # YAML List of Infrastructure Workloads.
 # REQUIRES Ansible 2.7+ on the deployer host

--- a/ansible/configs/ocp4-cluster/files/fio-test-job.yaml.j2
+++ b/ansible/configs/ocp4-cluster/files/fio-test-job.yaml.j2
@@ -8,11 +8,11 @@ spec:
     spec:
       containers:
       - name: fio-test-osp
-        image: "{{ fio_test_image }}"
+        image: "{{ test_deploy_image }}"
         command: ["/tmp/fio-test.sh"]
         env:
         - name: test_runs
-          value: "{{ fio_test_runs }}"
+          value: "{{ test_deploy_runs }}"
         - name: GUID
           value: "{{ guid }}"
         volumeMounts:

--- a/ansible/configs/ocp4-cluster/post_software.yml
+++ b/ansible/configs/ocp4-cluster/post_software.yml
@@ -194,7 +194,7 @@
     KUBECONFIG: /home/{{ remote_user }}/{{ cluster_name }}/auth/kubeconfig
   tasks:
   - name: Run fio tests for etcd performance
-    when: fio_test_enable
+    when: test_deploy_results | d(False) | bool
     block:
     - name: Set Ansible Python interpreter to k8s virtualenv
       set_fact:

--- a/ansible/configs/ocp4-disconnected-osp-lab/default_vars.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/default_vars.yml
@@ -212,15 +212,11 @@ provider_network: external
 # Enabling these vars will influence whether or not the FTL solver is run
 # This can be used for function or load testing
 
-test_enable: false
-test_results: false
-test_pull_secret: FROM_SECRET
-test_runs: 50
-test_s3_id: FROM_SECRET
-test_s3_key: FROM_SECRET
-test_s3_bucket: FROM_SECRET
-test_s3_region: FROM_SECRET
-test_overwatch: FROM_SECRET
+test_deploy_enable: false
+test_deploy_results: false
+test_deploy_pull_secret: FROM_SECRET
+test_deploy_runs: 50
+test_deploy_image: quay.io/nstephan/fio-etcd-osp:v3
 
 # If you are deploying OpenShift, this should be set to the network that you
 # want to use and will be used to create security groups.

--- a/ansible/configs/ocp4-disconnected-osp-lab/files/fio-test-job.yaml.j2
+++ b/ansible/configs/ocp4-disconnected-osp-lab/files/fio-test-job.yaml.j2
@@ -1,0 +1,43 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: fio-test
+  namespace: fio-test
+spec:
+  template:
+    spec:
+      containers:
+      - name: fio-test-osp
+        image: "{{ test_deploy_image }}"
+        command: ["/tmp/fio-test.sh"]
+        env:
+        - name: test_runs
+          value: "{{ test_deploy_runs }}"
+        - name: GUID
+          value: "{{ guid }}"
+        volumeMounts:
+        - name: host
+          mountPath: /host
+        - name: etcd
+          mountPath: /var/lib/etcd
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+      restartPolicy: Never
+      securityContext:
+        privileged: true
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      nodeSelector:
+        kubernetes.io/hostname: "{{ INFRA_ID }}-master-0"
+      volumes:
+      - name: host
+        hostPath:
+          path: /
+          type: Directory
+      - name: etcd
+        hostPath:
+          path: /var/lib/etcd
+          type: Directory
+  backoffLimit: 2

--- a/ansible/configs/ocp4-disconnected-osp-lab/files/fio-test.sh
+++ b/ansible/configs/ocp4-disconnected-osp-lab/files/fio-test.sh
@@ -7,12 +7,12 @@
 echo "running tests"
 
 mkdir -p /var/lib/etcd/fio
-guid=$(echo $HOSTNAME |cut -d \- -f 1)
-for i in {1..{{ test_runs }}}
+# GUID=$(echo $HOSTNAME |cut -d \- -f 1)
+for i in $(seq $test_runs)
 do
   echo "running test $i"
   result=$(fio --rw=write --ioengine=sync --fdatasync=1 --directory=/var/lib/etcd/fio --size=22m --bs=2300 --name=mytest --output-format=json+ | jq '.jobs[].sync.lat_ns.percentile."99.000000"')
   echo $result
-  echo "fio.{{ guid }}.latency $result `date +%s`" | nc overwatch.osp.opentlc.com 2003
-  echo $result >> /host/home/core/{{ guid }}.out
+  echo "fio.$GUID.latency $result `date +%s`" | nc overwatch.osp.opentlc.com 2003
+  echo $result >> /host/home/core/$GUID.out
 done

--- a/ansible/configs/ocp4-disconnected-osp-lab/files/fio.Dockerfile
+++ b/ansible/configs/ocp4-disconnected-osp-lab/files/fio.Dockerfile
@@ -1,2 +1,3 @@
 FROM fedora:latest
 RUN dnf install -y jq fio nmap-ncat
+COPY ./fio-test.sh /tmp/fio-test.sh

--- a/ansible/configs/ocp4-disconnected-osp-lab/software.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/software.yml
@@ -236,125 +236,114 @@
     - name: Update CA trust
       command: update-ca-trust
   
-- name: Step 005 Prep for FTL solver
+- name: Step 005 Run solver and performance test (optional)
   hosts: bastions
   gather_facts: false
   become: true
   tasks:
-    - when: test_enable
+  - name: Set python3
+    set_fact:
+      ansible_python_interpreter: /usr/bin/python3
+  
+  - name: Run the solver to install OpenShift
+    when: test_deploy_enable | d(False) | bool
+    block:
+    - name: Create pull secret file
+      file:
+        state: touch
+        path: "/home/{{ student_name }}/ocp_pullsecret.json"
+        mode: 0644
+        owner: "{{ student_name }}"
+
+    - name: Add pull secret to bastion
+      copy:
+        dest: "/home/{{ student_name }}/ocp_pullsecret.json"
+        content: "{{ test_deploy_pull_secret }}"
+
+    - name: Create neutral clouds.yaml directory
+      file:
+        path: /etc/openstack
+        state: directory
+        mode: 0644
+
+    - name: copy clouds.yaml to neutral location
+      copy:
+        remote_src: true
+        src: "/home/{{ student_name }}/.config/openstack/clouds.yaml"
+        dest: "/etc/openstack/clouds.yaml"
+        mode: 0644
+
+    - name: Run solver for lab 03
+      shell: /usr/local/bin/solve_lab ocp4_advanced_deployment 03_1
+      register: r_solve_lab_03
+      become_user: "{{ student_name }}"
+      environment:
+        OS_CLOUD: "{{ guid }}-project"
+        GUID: "{{ guid }}"
+        OPENSHIFT_DNS_ZONE: "{{ osp_cluster_dns_zone }}"
+        API_FIP: "{{ hostvars['localhost']['ocp_api_fip'] }}"
+        INGRESS_FIP: "{{ hostvars['localhost']['ocp_ingress_fip'] }}"
+      vars:
+        GUID: "{{ guid }}"
+
+    - name: Run the fio tests and report results
+      when: 
+        - test_deploy_enable | d(False) | bool
+        - test_deploy_results | d(False) | bool
       block:
-        - name: Set python3
-          set_fact:
-            ansible_python_interpreter: /usr/bin/python3
+      - name: Get metadata.json
+        stat:
+          path: /home/{{ student_name }}/openstack-upi/metadata.json
+        register: r_metadata
 
-        - name: Create pull secret file
-          file:
-            state: touch
-            path: "/home/{{ student_name }}/ocp_pullsecret.json"
-            mode: 0644
-            owner: "{{ student_name }}"
+      - name: Get the infra ID
+        shell: jq -r .infraID /home/{{ student_name }}/openstack-upi/metadata.json
+        register: r_infra_id
+        when: r_metadata.stat.exists
 
-        - name: Add pull secret to bastion
-          copy:
-            dest: "/home/{{ student_name }}/ocp_pullsecret.json"
-            content: "{{ test_pull_secret }}"
+      - name: create fio testing project
+        k8s:
+          name: fio-test
+          api_version: v1
+          kind: Namespace
+          state: present
 
-        - name: Create neutral clouds.yaml directory
-          file:
-            path: /etc/openstack
-            state: directory
-            mode: 0644
+      - name: give default sa privileged scc
+        shell: oc adm policy add-scc-to-user privileged system:serviceaccount:fio-test:default
 
-        - name: copy clouds.yaml to neutral location
-          copy:
-            remote_src: true
-            src: "/home/{{ student_name }}/.config/openstack/clouds.yaml"
-            dest: "/etc/openstack/clouds.yaml"
-            mode: 0644
+      - name: run job pod with fio-etcd-osp container
+        k8s:
+          state: present
+          definition: "{{ lookup('template', './files/fio-test-job.yaml.j2') }}"
+        vars:
+          INFRA_ID: "{{ r_infra_id.stdout }}"
 
-        - name: Run solver for lab 03
-          shell: /usr/local/bin/solve_lab ocp4_advanced_deployment 03_1
-          register: r_solve_lab_03
-          become_user: "{{ student_name }}"
-          environment:
-            OS_CLOUD: "{{ guid }}-project"
-            GUID: "{{ guid }}"
-            OPENSHIFT_DNS_ZONE: "{{ osp_cluster_dns_zone }}"
-            API_FIP: "{{ hostvars['localhost']['ocp_api_fip'] }}"
-            INGRESS_FIP: "{{ hostvars['localhost']['ocp_ingress_fip'] }}"
-          vars:
-            GUID: "{{ guid }}"
+      - name: Wait for job to finish (1h max)
+        k8s_facts:
+          api_version: batch/v1
+          kind: Job
+          name: fio-test
+          namespace: fio-test
+        register: r_fio_test_job
+        retries: 60
+        delay: 60
+        until: r_fio_test_job.resources[0].status.conditions | json_query(fio_query) | bool
+        vars:
+          fio_query: >-
+            [?type=='Complete'].status[] | [0]
+          INFRA_ID: "{{ r_infra_id.stdout }}"
 
-    - when: 
-        - test_enable
-        - test_results
-      block:
-        - name: Check if metadata.json exists
-          stat:
-            path: /home/{{ student_name }}/openstack-upi/metadata.json
-          register: r_metadata
+      - name: Remove job
+        k8s:
+          name: fio-test
+          kind: Job
+          api_version: batch/v1
+          namespace: fio-test
+          state: absent
 
-        - name: Get the infra ID
-          shell: jq -r .infraID /home/{{ student_name }}/openstack-upi/metadata.json
-          register: r_infra_id
-          when: r_metadata.stat.exists
-
-        # - name: copy upload script to bastion
-        #   copy:
-        #     src: "./files/upload-to-s3.sh"
-        #     dest: "/home/{{ student_name }}/resources/upload-to-s3.sh"
-        #     mode: preserve
-
-        - name: Copy test script to bastion
-          template:
-            src: "./files/fio-test.sh.j2"
-            dest: "/home/{{ student_name }}/resources/fio-test.sh"
-            mode: preserve
-
-        - name: copy files to master-0
-          shell: >
-            scp -i /home/{{ student_name }}/.ssh/{{ guid }}key.pem
-            -F /home/{{ student_name }}/.ssh/config
-            /home/{{ student_name }}/resources/{{ item }}
-            core@{{ INFRA_ID }}-master-0.example.com:{{ item }}
-          loop:
-            - "fio-test.sh"
-            # - "upload-to-s3.sh"
-          vars:
-            INFRA_ID: "{{ r_infra_id.stdout }}"
-            
-        # - name: Send notice to overwatch for start
-        #   uri:
-        #     url: http://overwatch.osp.opentlc.com:3000/api/annotations
-        #     method: POST
-        #     body_format: json
-        #     headers:
-        #       Authorization: "Bearer {{ test_overwatch }}"
-        #     body: {"text":"BEGIN fio test","tags":["ocp4","perftest"]}
-
-        - name: Run test container on master-0
-          shell: >
-            ssh -i /home/{{ student_name }}/.ssh/{{ guid }}key.pem
-            -F /home/{{ student_name }}/.ssh/config
-            core@{{ INFRA_ID }}-master-0.example.com
-            sudo podman run --privileged --ipc=host --net=host --pid=host
-            -v /var/lib/etcd:/var/lib/etcd -v /:/host quay.io/nstephan/fio-etcd-osp:v2 /host/home/core/fio-test.sh
-          vars:
-            INFRA_ID: "{{ r_infra_id.stdout }}"
-
-        # - name: Send notice to overwatch for finish
-        #   uri:
-        #     url: http://overwatch.osp.opentlc.com:3000/api/annotations
-        #     method: POST
-        #     body_format: json
-        #     headers:
-        #       Authorization: "Bearer {{ test_overwatch }}"
-        #     body: {"text":"END fio test","tags":["ocp4","perftest"]}
-
-        - name: Remove test scripts
-          file:
-            state: absent
-            path: /home/{{ student_name }}/resources/{{ item }}
-          loop:
-            - "fio-test.sh"
-            # - "upload-to-s3.sh"
+      - name: Remove fio testing project
+        k8s:
+          name: fio-test
+          kind: Namespace
+          api_version: v1
+          state: absent


### PR DESCRIPTION
##### SUMMARY
The previous implementation to run etcd fio tests was hacky to run a container on one of the masters via ssh. This brings in the previous updates to run this as a job pod since OpenShift is already installed. It will also report back directly to Overwatch instead of uploading to s3 bucket for later processing.

Also updates vars across both configs for consistency.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4-cluster
ocp4-disconnected-osp-lab
