### PR TITLE
Add ability to specify RHCOS image

### DIFF
--- a/ansible/configs/ocp4-cluster/default_vars_osp.yml
+++ b/ansible/configs/ocp4-cluster/default_vars_osp.yml
@@ -29,6 +29,12 @@ ansible_user: cloud-user
 # See cloud_providers/osp_default_vars.yml
 # See roles-infra/infra-osp-project-create/defaults/main.yml
 
+# openshift-install will try to pull in a copy of RHCOS for every cluster
+# and store it in Glance. These vars will let you override that behaviour
+# and use an existing image.
+rhcos_existing: false
+rhcos_image_name: rhcos-ocp43
+
 # -------------------------------------------------------------------
 # OpenStack Project
 # -------------------------------------------------------------------

--- a/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
+++ b/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
@@ -90,6 +90,9 @@ platform:
     octaviaSupport: "1"
     region: ""
     trunkSupport: "0"
+{% if rhcos_existing %}
+    clusterOSimage: {{ rhcos_image_name }}
+{% endif %}
 {% endif %}
 pullSecret: '{{ ocp4_pull_secret |  replace("'",'"') }}'
 sshKey: |

--- a/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
+++ b/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
@@ -91,7 +91,7 @@ platform:
     region: ""
     trunkSupport: "0"
 {% if rhcos_existing %}
-    clusterOSimage: {{ rhcos_image_name }}
+    clusterOSImage: {{ rhcos_image_name }}
 {% endif %}
 {% endif %}
 pullSecret: '{{ ocp4_pull_secret |  replace("'",'"') }}'


### PR DESCRIPTION
##### SUMMARY
For the OpenStack cloud provider, the openshift installer attempts to pull in a copy of RHCOS and store it in Glance for every deployment. This can be bypassed by specifying an image in the `install-config.yaml`. This is optional and is disabled by default, but the following vars in the `default_vars_osp.yml` file can be set to change this behaviour.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4-cluster
