### PR TITLE
Fix agnosticd_user_info

### DIFF
--- a/ansible/action_plugins/agnosticd_user_info.py
+++ b/ansible/action_plugins/agnosticd_user_info.py
@@ -51,20 +51,23 @@ class ActionModule(ActionBase):
         del tmp # tmp no longer has any effect
 
         msg = self._task.args.get('msg')
-        data = self._task.args.get('data')
+        data = self._task.args.get('data', {})
         user = self._task.args.get('user')
 
-        if msg:
-            result['msg'] = 'user.info: ' + msg
+        if not user and msg != None:
+            if msg == '':
+                result['msg'] = 'user.info:'
+            else:
+                result['msg'] = 'user.info: ' + msg
+            # Force display of result like debug
+            result['_ansible_verbose_always'] = True
+
         if data:
             result['data'] = data
             if not isinstance(data, dict):
                 result['failed'] = True
                 result['error'] = 'data must be a dictionary of name/value pairs'
                 return result
-
-        # Force display of result like debug
-        result['_ansible_verbose_always'] = True
 
         try:
             output_dir = self._templar.template(
@@ -74,11 +77,11 @@ class ActionModule(ActionBase):
                     )
                 )
             )
-            if msg:
+            if not user and msg != None:
                 fh = open(os.path.join(output_dir, 'user-info.yaml'), 'a')
                 fh.write('- ' + json.dumps(msg) + "\n")
                 fh.close()
-            if data:
+            if data or user:
                 user_data = None
                 try:
                     fh = open(os.path.join(output_dir, 'user-data.yaml'), 'r')
@@ -94,9 +97,16 @@ class ActionModule(ActionBase):
                     if 'users' not in user_data:
                         user_data['users'] = {}
                     if user in user_data['users']:
-                        user_data['users'][user].update(data)
+                        user_data_item = user_data['users'][user]
+                        user_data_item.update(data)
                     else:
-                        user_data['users'][user] = data
+                        user_data_item = data
+                        user_data['users'][user] = user_data_item
+                    if msg:
+                        if 'msg' in user_data_item:
+                            user_data_item['msg'] += "\n" + msg
+                        else:
+                            user_data_item['msg'] = msg
                 else:
                     user_data.update(data)
 

--- a/ansible/library/agnosticd_user_info.py
+++ b/ansible/library/agnosticd_user_info.py
@@ -31,7 +31,9 @@ short_description: Display user information for agnosticd deployment and save in
 version_added: "2.9"
 
 description:
-- This module provides the capability of displaying user information in agnosticd processing while saving the output as a YAML list in the output directory.
+- This module provides the capability of displaying user information in agnosticd processing while saving the output as a YAML in the output directory.
+- Files "user-info.yaml" stores a list of messages to deliver to the environment owner and "user-data.yaml" store structured data.
+- Messages and data can be stored for specific users to support multi-user environments.
 - The string "user.info: " is prepended to the displayed output for compatibility with the prior practice of using the debug module with this special prefix string.
 
 options:
@@ -46,7 +48,7 @@ options:
       - Subsequent calls to agnosticd_user_info will add new keys and update existing keys.
   user:
     description:
-      - User name if data should be set for a particular user.
+      - User name if data or message should be set for a particular user.
 
 author:
 - Johnathan Kupferer

--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -19,6 +19,8 @@ include::Preparing_your_workstation.adoc[]
 include::Creating_an_OpenShift_Workload.adoc[]
 include::First_OSP_Env_walkthrough.adoc[leveloffset=1]
 
+include::User_Info.adoc[]
+
 include::Contributing.adoc[]
 
 include::FAQ.adoc[FAQ]

--- a/docs/User_Info.adoc
+++ b/docs/User_Info.adoc
@@ -1,0 +1,106 @@
+== AgnosticD User Info
+
+Configs and Workloads in AgnosticD often need to save or return information during provisioning.
+Some examples include dynamically generated hostnames, IP addresses, and passwords.
+This information may be text messages to be delivered by email or structured data to be consumed by automation.
+
+The `agnosticd_user_info` action plugin can be used to provide to save messages and data within your config playbook, workload, or anywhere you have an Ansible task.
+This replaces the previous conventions of using `debug` with `user.info:` messages.
+
+=== Environment Messages
+
+To return a message to show to the lab provisioner, set `msg`. For example:
+
+---------------------------------------------------------------
+  - name: Report URL for web console
+    agnosticd_user_info:
+      msg: "OpenShift Web Console: {{ _openshift_console_url }}
+---------------------------------------------------------------
+
+To set messages on several lines then call `agnosticd_user_info` with `loop`.
+Multiline messages cannot be passed as a text block with embedded linebreaks due to how these messages are processed by current automation.
+
+---------------------------------------------------------------
+  - name: Provide OpenShift Access Information
+    agnosticd_user_info:
+      msg: "{{ item }}"
+    loop:
+      - "OpenShift Web Console: {{ _openshift_console_url }}"
+      - "OpenShift API for command line 'oc' client: {{ _openshift_api_url }}"
+---------------------------------------------------------------
+
+Blank lines may be included in your message output by sending an empty message string.
+
+---------------------------------------------------------------
+  - name: Provide OpenShift Access Information
+    agnosticd_user_info:
+      msg: "{{ item }}"
+    loop:
+      - "OpenShift Web Console: {{ _openshift_console_url }}"
+      - "OpenShift API for command line 'oc' client: {{ _openshift_api_url }}"
+      - ""
+      - "You may download the 'oc' client from {{ ocp4_client_url }}"
+---------------------------------------------------------------
+
+Messages sent this way will be saved to `user-info.yaml` in the output directory, set by `output_dir`.
+
+=== Environment Data
+
+To set data to be consumed by other automation, such as the Babylon Events UI/Bookbag, set `data` when calling `agnosticd_user_info`.
+
+---------------------------------------------------------------
+  - name: OpenShift Access Data
+    agnosticd_user_info:
+      data:
+        openshift_console_url: "{{ _openshift_console_url }}"
+        openshift_api_url: "{{ _openshift_api_url }}"
+---------------------------------------------------------------
+
+Data values are saved as a dictionary to `user-data.yaml` in the output directory.
+
+To use this data through bookbag Asciidoc deployed by the Babylon Events UI we recommend setting AsciiDoc macros:
+
+---------------------------------------------------------------
+:openshift_console_url: %openshift_console_url%
+:openshift_api_url: %openshift_api_url%
+
+OpenShift Web Console: {openshift_console_url}
+OpenShift API: {openshift_api_url}
+---------------------------------------------------------------
+
+=== Multi-User Lab Environments
+
+When provisioning a multi-user environment with AgnosticD you will want to deliver separate messages to each user.
+For example, a secure unique password for each user, a separate OpenShift namespace per user, etc.
+
+User messages and data are set similarly to environment messages and data, but adding a `user` argument to `agnosticd_user_info`:
+
+---------------------------------------------------------------
+  - name: OpenShift Access Data
+    agnosticd_user_info:
+      user: "user-{{ n }}"
+      msg: |-
+       OpenShift Web Console: {{ _openshift_console_url }}
+       OpenShift API: {{ openshift_api_url }}
+
+       Login with user "user-{{ n }}" and password "{{ _openshift_user_password[n] }}"
+      data:
+        openshift_console_url: "{{ _openshift_console_url }}"
+        openshift_api_url: "{{ _openshift_api_url }}"
+        openshift_user_name: "user-{{ n }}"
+        openshift_user_password: "{{ _openshift_user_password[n] }}"
+        openshift_user_namespace: "user-{{ n }}"
+    loop: "{{ range(user_count | int) | list }}"
+    loop_control:
+      loop_var: n
+---------------------------------------------------------------
+
+Messages set with `msg` may be multi-line when combined with `user`.
+This makes it easier to loop over a range of users.
+If `msg` is called repeatedly for the same `user` then messages will be joined with a newline character.
+
+User `data` dictionary values are combined with any values previously set for the same user.
+If the same key is set twice for a user then the previous value is replaced.
+Environment data, set by calls to `agnosticd_user_info` without `user` will not be exposed to users.
+
+All user data and messages is collected in `user-data.yaml` with user data stored as a dictionary under the key "users".


### PR DESCRIPTION

##### SUMMARY

Fixes and add documentation for `agnosticd_user_info`:

- Fix missing blank lines in output.
- Do not show "user.info:" style messages when user is set.
- Append user messages rather than replace.
- Add documentation.

##### ISSUE TYPE

- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME

`agnosticd_user_info`