### PR TITLE
Fix blank line output to include trailing space

### DIFF
--- a/ansible/action_plugins/agnosticd_user_info.py
+++ b/ansible/action_plugins/agnosticd_user_info.py
@@ -55,10 +55,8 @@ class ActionModule(ActionBase):
         user = self._task.args.get('user')
 
         if not user and msg != None:
-            if msg == '':
-                result['msg'] = 'user.info:'
-            else:
-                result['msg'] = 'user.info: ' + msg
+            # Output msg in result, prepend "user.info: " for cloudforms compatibility
+            result['msg'] = 'user.info: ' + msg
             # Force display of result like debug
             result['_ansible_verbose_always'] = True
 


### PR DESCRIPTION
##### SUMMARY

`agnosticd_user_info` was printing:

```
    "msg": "user.info:"
```

When called with an empty string. This caused odd behavior with our CloudForms integration scripts. A trailing space is required:

```
    "msg": "user.info: "
```

This PR fixes this issue.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`agnosticd_user_info`