### PR TITLE
Add agnosticd_user_info for rhel8lab workstation public ip

### DIFF
--- a/ansible/configs/rhel8lab/post_software.yml
+++ b/ansible/configs/rhel8lab/post_software.yml
@@ -24,6 +24,14 @@
         state: restarted
       when: install_ipa_client
 
+- name: Set user info and data
+  hosts: workstation
+  tasks:
+    - name: Set workstation public ip address user data
+      agnosticd_user_info:
+        data:
+          rhel8lab_workstation_public_ip_address: "{{ public_ip_address }}"
+
 - name: PostSoftware flight-check
   hosts: localhost
   connection: local


### PR DESCRIPTION
##### SUMMARY

Add `agnosticd_user_info` call to rhel8lab post software to record workstation public IP.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

rhel8lab config