### PR TITLE
Simplified and added support for OSP destruction in satellite-vm config

### DIFF
--- a/ansible/configs/satellite-vm/destroy_env.yml
+++ b/ansible/configs/satellite-vm/destroy_env.yml
@@ -1,26 +1,9 @@
 ---
+
 - import_playbook: ../../include_vars.yml
+  
+# Placeholder for Satellite unregister unless dealt with implicitly in the future
 
-- name: Delete Infrastructure
-  hosts: localhost
-  connection: local
-  gather_facts: False
-  become: no
-  tasks:
-    - name: Run infra-ec2-template-destroy
-      include_role:
-        name: "infra-{{cloud_provider}}-template-destroy"
-      when: cloud_provider == 'ec2'
-
-    - name: Run infra-azure-template-destroy
-      include_role:
-        name: "infra-{{cloud_provider}}-template-destroy"
-      when: cloud_provider == 'azure'
-
-- name: Unsubscribe systems
-  hosts: all
-  become: true
-  gather_facts: false
-  ignore_errors: true
-  tasks:
-    - shell: "subscription-manager unsubscribe --all"
+- name: Import default destroy playbook
+  import_playbook: ../../cloud_providers/{{ cloud_provider }}_destroy_env.yml
+...


### PR DESCRIPTION
##### SUMMARY
satellite-vm config destroy.yml had redundant code that **failed** to call OSP destroy playbook. Simpler and cleaner syntax adds support for OSP and future clouds

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
Satellite-vm config
##### ADDITIONAL INFORMATION
