### PR TITLE
Add guacamole information (username / password) to user.info

### DIFF
--- a/ansible/configs/osp-migration/post_infra.yml
+++ b/ansible/configs/osp-migration/post_infra.yml
@@ -30,7 +30,7 @@
       register: open_init
 
     - name: Execute open-init script on bastion
-      command: "/usr/local/bin/open-init.sh {{ student_name }}"
+      command: "/usr/local/bin/open-init.sh {{ student_name }} {{ student_password | d(hostvars[groups.bastions.0].student_password) }}"
       when:
         - open_init.stat.exists
         - open_init.stat.executable
@@ -47,3 +47,16 @@
       debug:
         msg: "user.info: SSH password: {{ student_password | d(hostvars[groups.bastions.0].student_password) }}"
       when: print_student_password | default(true) | bool
+
+    - name: Print guacamole information as user.info
+      debug:
+        msg: "{{ item }}"
+      with_items:
+        - "user.info: "
+        - "user.info: To access to guacamole use the following credentials:"
+        - "user.info: Username: {{ student_name }}"
+        - "user.info: Password: {{ student_password | d(hostvars[groups.bastions.0].student_password) }}"
+      when:
+        - open_init.stat.exists
+        - open_init.stat.executable      
+      


### PR DESCRIPTION
Previously guacamole was using IPA authentication, new version is using local user (htpasswd)

This code is printing just printing guacamole information and including the password to the open-init.sh script