### PR TITLE
updated to reflect correct destination for 'git clone'

### DIFF
--- a/ansible/configs/rhel8lab/software.yml
+++ b/ansible/configs/rhel8lab/software.yml
@@ -130,13 +130,19 @@
       state: restarted
 
 
-  - name: Copy RHEL8-Workshop playbooks out to workstation and run
-    copy:
-      src: RHEL8-Workshop.tgz
-      dest: /tmp/RHEL8-Workshop.tgz
+#  - name: Copy RHEL8-Workshop playbooks out to workstation and run
+#    copy:
+#      src: RHEL8-Workshop.tgz
+#      dest: /tmp/RHEL8-Workshop.tgz
+
+  - name: git clone the RHEL8-Workshop on the "workstation" node and run
+    git:
+      repo: 'https://github.com/xtophd/RHEL8-Workshop/'
+      dest: /root/RHEL8-Workshop
+      version: Summit2020
 
   - name: Change the working directory to RHEL8-Workshop, then run the prep/install script
-    shell: "cd /tmp; tar -xzf RHEL8-Workshop.tgz; cd RHEL8-Workshop; cp sample-configs/rhel8-workshop config/rhel8-workshop; /bin/bash prepare-rhel8-workshop.sh > prepare-rhel8-workshop.log 2>&1 ; let status=$?; echo \"status=$status\" >> prepare-rhel8-workshop.log;if [[ $status -ne 0 ]]; then /bin/bash prepare-rhel8-workshop.sh >> prepare-rhel8-workshop.log 2>&1 ; fi; echo 'done'"
+    shell: "cd /root/RHEL8-Workshop; cp sample-configs/rhel8-workshop config/rhel8-workshop; /bin/bash prepare-rhel8-workshop.sh > prepare-rhel8-workshop.log 2>&1 ; let status=$?; echo \"status=$status\" >> prepare-rhel8-workshop.log;if [[ $status -ne 0 ]]; then /bin/bash prepare-rhel8-workshop.sh >> prepare-rhel8-workshop.log 2>&1 ; fi; echo 'done'"
 
 
 #if [[ $status -ne 0 ]]; then  echo "non-zero"; else echo "success"; fi


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
commented out copy of tar.gz file to "workstation".  added 'git clone' to retrieve 
Summit2020 branch of RHEL8-Workshop instead, per a conference call with
Summit team.

Also fixed incorrect git clone dest.   Changed from '/root' to '/root/RHEL8-Workshop'
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
software.yml

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
