### PR TITLE
Fix Username in ocp4-workload-quarkus-workshop agnosticd_user_info

### DIFF
--- a/ansible/roles/ocp4-workload-quarkus-workshop/tasks/post_workload.yml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/tasks/post_workload.yml
@@ -8,7 +8,7 @@
     user: "{{ item }}"
     data:
       msg: |
-        Username: user{{ item }}
+        Username: {{ item }}
         Workshop User Guide: http://web-guides.{{ route_subdomain }}
   loop: "{{ users }}"
 


### PR DESCRIPTION
##### SUMMARY

`agnosticd_user_info` for ocp4-workload-quarkus-workshop workload misprinted the username in the output as "useruserX", doubling the "user" prefix.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ocp4-workload-quarkus-workshop workload