### PR TITLE
Add GUID addition back to skel

### DIFF
--- a/ansible/configs/ocp4-disconnected-osp-lab/pre_software.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/pre_software.yml
@@ -38,12 +38,6 @@
   - { role: "set-repositories",       when: 'repo_method is defined' }
   - { role: "common",                 when: 'install_common | bool' }
   - { role: "set_env_authorized_key", when: 'set_env_authorized_key | bool' }
-  tasks:
-    - name: Add GUID to /etc/skel/.bashrc
-      lineinfile:
-        path: "/etc/skel/.bashrc"
-        regexp: "^export GUID"
-        line: "export GUID={{ guid }}"
 
 - name: Configuring Bastion Hosts
   hosts: bastions

--- a/ansible/roles/bastion-lite/tasks/main.yml
+++ b/ansible/roles/bastion-lite/tasks/main.yml
@@ -31,15 +31,6 @@
   tags:
     - copy_sshconfig_file
 
-# - name: Install python-requests
-#   ignore_errors: yes
-#   become: true
-#   yum:
-#     name:
-#     - python-requests
-#   when: not hostvars.localhost.skip_packer_tasks | d(false)
-#   tags: packer
-
 - name: Stat /etc/sysconfig/iptables
   stat:
     path: /etc/sysconfig/iptables
@@ -80,3 +71,9 @@
     mode: 0775
     owner: root
     group: root
+
+- name: Add GUID to /etc/skel/.bashrc
+  lineinfile:
+    path: "/etc/skel/.bashrc"
+    regexp: "^export GUID"
+    line: "export GUID={{ guid }}"


### PR DESCRIPTION
##### SUMMARY
At some point we lost the addition of the GUID to the skel/.bashrc file in the bastion-lite role. This adds it back in and removes a redundant task to create it in the ocp4-disconnected config.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
bastion-lite