### PR TITLE
Fixed the host group for satelllite-vm

### DIFF
--- a/ansible/configs/satellite-vm/post_software.yml
+++ b/ansible/configs/satellite-vm/post_software.yml
@@ -38,10 +38,9 @@
         msg: "Post-Software checks completed successfully"
 
 - name: Set user info and data
-  hosts: satellite_hosts
+  hosts: satellites
   tasks:
     - name: Set satellite host name for the user
       agnosticd_user_info:
         data:
           satellite_hostname: "{{ hostvars[groups['satellites'][0]]['publicname'] }}"
-          guid: "{{ guid }}"


### PR DESCRIPTION
While setting the agnosticd_user_info for satellite-vm  the hosts group  was incorrect. This commit changes it to the correct one.