### PR TITLE
Fix openshift_api_url var in ocp4-workshop config

### DIFF
--- a/ansible/configs/ocp4-workshop/post_software.yml
+++ b/ansible/configs/ocp4-workshop/post_software.yml
@@ -172,7 +172,7 @@
             openshift_user: "{{ t_user }}"
             openshift_password: "{{ user_password }}"
             openshift_webconsole_url: "{{ webconsole }}"
-            openshift_api_url: "{{ ocp4_workshop_openshift_api_url }}"
+            openshift_api_url: "{{ openshift_api_url }}"
             openshift_client_download_url: "{{ ocp4_client_url }}"
 
     - name: Set up OpenTLC LDAP


### PR DESCRIPTION
##### SUMMARY

Fix openshift_api_url var in ocp4-workshop config.

Recent PR introduced an issue with a variable name prefix `ocp4_workshop_` that should not have been there.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ocp4-workshop config