### PR TITLE
change swiftoperator role default to false

### DIFF
--- a/ansible/roles-infra/infra-osp-template-generate/templates/cloud_template_master.j2
+++ b/ansible/roles-infra/infra-osp-template-generate/templates/cloud_template_master.j2
@@ -29,7 +29,7 @@ resources:
       user: {get_resource: {{ guid }}-project_user}
       roles:
         - {project: {{ osp_project_name }}, role: _member_}
-{% if osp_use_swift | d(true) | bool %}        
+{% if osp_use_swift | d(false) | bool %}        
         - {project: {{ osp_project_name }}, role: swiftoperator}
 {% endif %}
     depends_on:


### PR DESCRIPTION
##### SUMMARY
In the cloud provider template, the default was to enable the use of the `swiftoperator` role. Since the Novello clusters will not run Swift, this should be defaulted to false. Some of the new clusters don't even have this role defined and deployments fail. If you need to use it, you can still set the `osp_use_swift` var in a config.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
infra-osp-template-generate
