### PR TITLE
Revert "Clean up intly vars (#1222)"

### DIFF
--- a/ansible/roles/ocp-workload-integreatly/defaults/main.yml
+++ b/ansible/roles/ocp-workload-integreatly/defaults/main.yml
@@ -8,6 +8,7 @@ inventory_hosts_file: inventories/pds.template
 release_tag: "release-{{ ig_version }}"
 webapp_namespace: webapp
 self_signed_certs_enabled: True
+amq_streams: True
 openshift_master_config_path: /etc/origin/master/master-config.yaml
 cluster_admin_username: admin@example.com
 cluster_admin_password: ""

--- a/ansible/roles/ocp-workload-integreatly/tasks/remove_workload.yml
+++ b/ansible/roles/ocp-workload-integreatly/tasks/remove_workload.yml
@@ -1,7 +1,9 @@
 ---
 
 - name: Uninstall Integreatly
-  shell: ansible-playbook -i "{{ inventory_hosts_file }}" playbooks/uninstall.yml
+  shell: |
+          ansible-playbook -i "{{ inventory_hosts_file }}" \
+          playbooks/uninstall.yml -e amq_streams="{{ amq_streams }}"
   args:
     chdir: "{{ install_dir }}"
 

--- a/ansible/roles/ocp-workload-integreatly/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-integreatly/tasks/workload.yml
@@ -7,7 +7,7 @@
   when: lets_encrypt_production|bool
 
 - name: Generate passwords
-  set_fact:
+  set_fact: 
     cluster_admin_password: "{{ lookup('password', '/tmp/cluster_{{ ansible_date_time.iso8601_micro | to_uuid }} length=15 chars=ascii_letters,digits') }}"
     evals_password: "{{ lookup('password', '/tmp/evals_{{ ansible_date_time.iso8601_micro | to_uuid }} length=15 chars=ascii_letters,digits') }}"
     customer_admin_password: "{{ lookup('password', '/tmp/customer_{{ ansible_date_time.iso8601_micro | to_uuid }} length=15 chars=ascii_letters,digits') }}"
@@ -19,9 +19,11 @@
           playbooks/install.yml \
           -e eval_self_signed_certs="{{ self_signed_certs_enabled }} \
           -e rhsso_identity_provider_ca_cert_path={{ rhsso_identity_provider_ca_cert_path }} \
+          -e amq_streams={{ amq_streams }} \
           -e rhsso_seed_users_password={{ evals_password }} \
           -e rhsso_evals_admin_password={{ customer_admin_password }} \
           -e rhsso_cluster_admin_password={{ cluster_admin_password }}" \
+          -e gitea=false \
           | tee -a "{{ integreatly_logs }}"
   args:
     chdir: "{{ install_dir }}"


### PR DESCRIPTION
This reverts commit 52ef77ff449478f99f1b4c5d8ac1030211ceee00.

This change causes integreatly workshops for both 1.5.2 and 1.6.0 to break due to gitea being installed.   See https://issues.redhat.com/browse/INTLY-6721 for more details.