### PR TITLE
Fix destroy with unreachable hosts

### DIFF
--- a/ansible/configs/rhel-custom-security-content/destroy_env.yml
+++ b/ansible/configs/rhel-custom-security-content/destroy_env.yml
@@ -9,14 +9,14 @@
   tasks:
     - when: cloud_provider == 'ec2'
       block:
-      - name: Run infra-ec2-create-inventory Role
-        include_role:
-          name: infra-ec2-create-inventory
+        - name: Run infra-ec2-create-inventory Role
+          include_role:
+            name: infra-ec2-create-inventory
 
-      - name: Run Common SSH Config Generator Role
-        include_role:
-          name: infra-common-ssh-config-generate
-        when: "'bastions' in groups"
+        - name: Run Common SSH Config Generator Role
+          include_role:
+            name: infra-common-ssh-config-generate
+          when: "'bastions' in groups"
 
 - name: Set ssh config
   hosts: all
@@ -34,8 +34,10 @@
   become: true
   gather_facts: false
   ignore_errors: true
+  ignore_unreachable: true
   tasks:
-    - shell: "subscription-manager unsubscribe --all"
+    - name: Attempt subscription-manager unsubscribe
+      command: "subscription-manager unsubscribe --all"
 
 - name: Import default destroy playbook
   import_playbook: ../../cloud_providers/{{cloud_provider}}_destroy_env.yml

--- a/ansible/configs/selinux-policy/destroy_env.yml
+++ b/ansible/configs/selinux-policy/destroy_env.yml
@@ -7,14 +7,14 @@
   tasks:
     - when: cloud_provider == 'ec2'
       block:
-      - name: Run infra-ec2-create-inventory Role
-        include_role:
-          name: infra-ec2-create-inventory
+        - name: Run infra-ec2-create-inventory Role
+          include_role:
+            name: infra-ec2-create-inventory
 
-      - name: Run Common SSH Config Generator Role
-        include_role:
-          name: infra-common-ssh-config-generate
-        when: "'bastions' in groups"
+        - name: Run Common SSH Config Generator Role
+          include_role:
+            name: infra-common-ssh-config-generate
+          when: "'bastions' in groups"
 
 - name: Set ssh config
   hosts: all
@@ -32,8 +32,10 @@
   become: true
   gather_facts: false
   ignore_errors: true
+  ignore_unreachable: true
   tasks:
-    - shell: "subscription-manager unsubscribe --all"
+    - name: Attempt subscription-manager unsubscribe
+      command: "subscription-manager unsubscribe --all"
 
 - name: Import default destroy playbook
   import_playbook: ../../cloud_providers/{{cloud_provider}}_destroy_env.yml


### PR DESCRIPTION
##### SUMMARY

Fix delete of rhel-custom-security-content and selinux-policy configs when hosts are unreachable and so cannot be unregistered from satellite.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

 rhel-custom-security-content and selinux-policy configs

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
