### PR TITLE
Ovirt Engine role requiring 'null' variable

### DIFF
--- a/ansible/configs/sap-rhvh/default_vars.yml
+++ b/ansible/configs/sap-rhvh/default_vars.yml
@@ -74,7 +74,7 @@ sap_software_size: "{{ sap_software_size }}"
 ovirt_engine_setup_version: '4.3'
 ovirt_engine_setup_answer_file_path: /usr/local/src/rhvm_answers.ini
 ovirt_engine_setup_use_remote_answer_file: true
-ovirt_engine_setup_firewall_manager: ""
+ovirt_engine_setup_firewall_manager: null
 ovirt_password: "{{ ovirt_password }}"
 
 # OSP Security Groups


### PR DESCRIPTION
##### SUMMARY
Ovirt engine setup roles fails with empty variable and requires a 'null' value

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
sap-rhvh
