### PR TITLE
Supoort user_count_start and user_count_end for ocp4-workshop config

### DIFF
--- a/ansible/configs/ocp4-workshop/post_software.yml
+++ b/ansible/configs/ocp4-workshop/post_software.yml
@@ -140,19 +140,27 @@
 
       - name: Generate htpasswd file
         template:
-          src: "./files/htpasswd.j2"
+          src: htpasswd.j2
           dest: "/home/{{ ansible_user }}/users.htpasswd"
           owner: "{{ ansible_user }}"
-          mode: 0664
+          mode: u=rw,go=
+        vars:
+          # Force htpasswd user passwords to exist from user 0 .. 200 at minimum
+          # Password template also includes users andrew and karla with fixed passwords
+          t_user_count_start: 0
+          t_user_count_end: "{{ [ user_count_end | default(user_count + 1) | int, 200 ] | max }}"
+
       - name: Upload OAuth Configuration File
         copy:
-          src: "./files/oauth-htpasswd.yaml"
+          src: oauth-htpasswd.yaml
           dest: "/home/{{ ansible_user }}/oauth-htpasswd.yaml"
           owner: "{{ ansible_user }}"
-          mode: 0664
+          mode: u=rw,go=
+
       - name: Create htpasswd Secret
         command: oc create secret generic htpasswd-secret -n openshift-config --from-file=htpasswd=$HOME/users.htpasswd
         ignore_errors: true
+
       - name: Update OAuth Configuration
         shell: "oc apply -f /home/{{ ansible_user }}/oauth-htpasswd.yaml"
 
@@ -160,7 +168,11 @@
         when:
           - install_ocp4 | bool
           - user_password is defined
-        loop: "{{ range(0, 1 + user_count | default(200) | int) | list }}"
+        loop: >-
+          {{ range(
+              user_count_start | default(1) | int,
+              user_count_end | default(1 + user_count | default(200) | int) | int
+          ) | list }}
         loop_control:
           loop_var: n
           label: "{{ t_user }}"

--- a/ansible/configs/ocp4-workshop/templates/htpasswd.j2
+++ b/ansible/configs/ocp4-workshop/templates/htpasswd.j2
@@ -1,6 +1,6 @@
 andrew:$apr1$dZPb2ECf$ercevOFO5znrynUfUj4tb/
 karla:$apr1$FQx2mX4c$eJc21GuVZWNg1ULF8I2G31
 {{admin_user|d('opentlc-mgr')}}:{{admin_password_hash|d('$apr1$glFN48wz$dR9w94PGiQL8qZXcXGd0L0')}}
-{% for i in range(0, [ (user_count|int), 200 ] | max + 1) %}
+{% for i in range(t_user_count_start | int, t_user_count_end | int + 1) %}
 {{ user_base_name | default('user') }}{{i}}:{{user_password_hash|d('$apr1$FmrTsuSa$yducoDpvYq0KEV0ErmwpA1')}}
 {% endfor %}


### PR DESCRIPTION
##### SUMMARY

Some workloads use `user_count` while others use `user_count_start` and `user_count_end`. This pull request adds support for ocp4-workshop to output user info to honor these variables when set.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ocp4-workshop config