### PR TITLE
Add check for jupyterhub dc to ocp4-workload-ml-workflows-workshop workload

### DIFF
--- a/ansible/roles/ocp4-workload-ml-workflows-workshop/tasks/per_user_remove_workload.yml
+++ b/ansible/roles/ocp4-workload-ml-workflows-workshop/tasks/per_user_remove_workload.yml
@@ -2,39 +2,23 @@
 # Implement your Workload deployment tasks here
 
 - debug:
-    msg: "Removing ML Workflows workshop materials from preexisting project {{ project_name }}"
+    msg: "Removing ML Workflows workshop materials from preexisting project {{ t_project_name }}"
 
-- name: Create the custom notebook image
+- name: Remove project resources from {{ t_project_name }}
   k8s:
     state: absent
-    namespace: "{{ project_name }}"
-    definition: "{{ item }}"
-  with_items:
-    - "{{ lookup('template', 'custom-notebook-imagestream.yaml.j2') }}"
-
-- name: Create the pipeline builder image
-  k8s:
-    state: absent
-    namespace: "{{ project_name }}"
-    definition: "{{ item }}"
-  with_items:
-    - "{{ lookup('template', 'pipeline-s2i-imagestream.yaml.j2') }}"
-
-- name: Create the pipeline build and app
-  k8s:
-    state: absent
-    namespace: "{{ project_name }}"
-    definition: "{{ item }}"
-  with_items:
-    - "{{ lookup('template', 'pipeline-imagestream.yaml.j2') }}"
-    - "{{ lookup('template', 'pipeline-buildconfig.yaml.j2') }}"
-    - "{{ lookup('template', 'pipeline-deploymentconfig.yaml.j2') }}"
-    - "{{ lookup('template', 'pipeline-service.yaml.j2') }}"
-  when: instructor_mode
+    namespace: "{{ t_project_name }}"
+    definition: "{{ lookup('template', item) }}"
+  loop:
+    - custom-notebook-imagestream.yaml.j2
+    - pipeline-s2i-imagestream.yaml.j2
+    - pipeline-imagestream.yaml.j2
+    - pipeline-buildconfig.yaml.j2
+    - pipeline-deploymentconfig.yaml.j2
+    - pipeline-service.yaml.j2
 
 # Leave this as the last task in the playbook.
 - name: workload tasks complete
   debug:
     msg: "Workload Tasks completed successfully."
   when: not silent|bool
-

--- a/ansible/roles/ocp4-workload-ml-workflows-workshop/tasks/per_user_workload.yml
+++ b/ansible/roles/ocp4-workload-ml-workflows-workshop/tasks/per_user_workload.yml
@@ -1,65 +1,64 @@
 ---
 # Implement your Workload deployment tasks here
 
-- set_fact:
-    user_name: "user{{ user_num }}"
-
-- set_fact:
-    project_name: "opendatahub-{{ user_name }}"
-
 - debug:
-    msg: "Deploying ML Workflows workshop materials to preexisting project {{ project_name }}"
+    msg: "Deploying ML Workflows workshop materials to preexisting project {{ t_project_name }}"
 
-- name: Verify user can create projects
-  command: "oc auth can-i create project"
-  register: canicreateprojects
-  failed_when: canicreateprojects.stdout != 'yes'
-
-- name: "Make sure project {{ project_name }} is there"
+- name: "Make sure project {{ t_project_name }} is there"
   k8s:
     state: present
-    name: "{{ project_name }}"
+    name: "{{ t_project_name }}"
     kind: Project
     api_version: project.openshift.io/v1
 
-- name: Create the custom notebook image
+- name: Create the project resources in {{ t_project_name }}
   k8s:
     state: present
-    namespace: "{{ project_name }}"
-    definition: "{{ item }}"
-  with_items:
-    - "{{ lookup('template', 'custom-notebook-imagestream.yaml.j2') }}"
+    namespace: "{{ t_project_name }}"
+    definition: "{{ lookup('template', item) }}"
+  loop:
+    - custom-notebook-imagestream.yaml.j2
+    - pipeline-s2i-imagestream.yaml.j2
+    - pipeline-imagestream.yaml.j2
+    - pipeline-buildconfig.yaml.j2
+    - pipeline-deploymentconfig.yaml.j2
+    - pipeline-service.yaml.j2
 
-- name: Create the pipeline builder image
+- name: Wait for jupyterhub DeploymentConfig
+  k8s_info:
+    api_version: apps.openshift.io/v1
+    kind: DeploymentConfig
+    namespace: "{{ t_project_name }}"
+    name: jupyterhub
+  register: r_jupyterhub_k8s_info
+  retries: 10
+  delay: 5
+  until: r_jupyterhub_k8s_info.resources | length > 0
+
+- name: Stop Jupyterhub
   k8s:
-    state: present
-    namespace: "{{ project_name }}"
-    definition: "{{ item }}"
-  with_items:
-    - "{{ lookup('template', 'pipeline-s2i-imagestream.yaml.j2') }}"
+    api_version: apps.openshift.io/v1
+    kind: DeploymentConfig
+    namespace: "{{ t_project_name }}"
+    name: jupyterhub
+    merge_type: merge
+    definition:
+      spec:
+        replicas: 0
 
-- name: Create the pipeline build and app
+- name: Restart Jupyterhub
   k8s:
-    state: present
-    namespace: "{{ project_name }}"
-    definition: "{{ item }}"
-  with_items:
-    - "{{ lookup('template', 'pipeline-imagestream.yaml.j2') }}"
-    - "{{ lookup('template', 'pipeline-buildconfig.yaml.j2') }}"
-    - "{{ lookup('template', 'pipeline-deploymentconfig.yaml.j2') }}"
-    - "{{ lookup('template', 'pipeline-service.yaml.j2') }}"
-
-- name: Kick Jupyterhub
-  shell: |
-      oc scale dc/jupyterhub --replicas=0 -n {{ project_name }}
-
-- name: Nudge Jupyterhub
-  shell: |
-      oc scale dc/jupyterhub --replicas=1 -n {{ project_name }}
+    api_version: apps.openshift.io/v1
+    kind: DeploymentConfig
+    namespace: "{{ t_project_name }}"
+    name: jupyterhub
+    merge_type: merge
+    definition:
+      spec:
+        replicas: 1
 
 # Leave this as the last task in the playbook.
 - name: workload tasks complete
   debug:
     msg: "Workload Tasks completed successfully."
   when: not silent|bool
-

--- a/ansible/roles/ocp4-workload-ml-workflows-workshop/tasks/remove_workload.yml
+++ b/ansible/roles/ocp4-workload-ml-workflows-workshop/tasks/remove_workload.yml
@@ -1,6 +1,13 @@
 ---
 # Implement your Workload removal tasks here
 
+- include_tasks: per_user_remove_workload.yml
+  loop: "{{ range(user_count_start|int, user_count_end|int)|list }}"
+  loop_control:
+    loop_var: t_user_num
+  vars:
+    t_user_name: user{{ t_user_num }}
+    t_project_name: "opendatahub-{{ t_user_name }}"
 
 # Leave this as the last task in the playbook.
 - name: remove_workload tasks complete

--- a/ansible/roles/ocp4-workload-ml-workflows-workshop/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-ml-workflows-workshop/tasks/workload.yml
@@ -11,7 +11,10 @@
 - include_tasks: per_user_workload.yml
   loop: "{{ range(user_count_start|int, user_count_end|int)|list }}"
   loop_control:
-    loop_var: user_num
+    loop_var: t_user_num
+  vars:
+    t_user_name: user{{ t_user_num }}
+    t_project_name: "opendatahub-{{ t_user_name }}"
 
 # Leave this as the last task in the playbook.
 - name: workload tasks complete


### PR DESCRIPTION
##### SUMMARY

In ocp4-workload-ml-workflows-workshop workload role, add check to wait for jupyterhub deployment config in user namespace. Without this the command to scale the deployment config may run before the deployment config is created.

PR also includes various style changes to make the codebase more robust.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ocp4-workload-ml-workflows-workshop workload role