### PR TITLE
Fix project_name in templates for ocp4-workload-ml-workflows-workshop

### DIFF
--- a/ansible/roles/ocp4-workload-ml-workflows-workshop/templates/pipeline-buildconfig.yaml.j2
+++ b/ansible/roles/ocp4-workload-ml-workflows-workshop/templates/pipeline-buildconfig.yaml.j2
@@ -35,7 +35,5 @@ spec:
       from:
         kind: ImageStreamTag
         name: simple-model-s2i:latest
-        namespace: {{ project_name }}
+        namespace: {{ t_project_name }}
     type: Source
-status:
-  lastVersion: 0

--- a/ansible/roles/ocp4-workload-ml-workflows-workshop/templates/pipeline-deploymentconfig.yaml.j2
+++ b/ansible/roles/ocp4-workload-ml-workflows-workshop/templates/pipeline-deploymentconfig.yaml.j2
@@ -24,7 +24,7 @@ spec:
         deploymentconfig: pipeline
     spec:
       containers:
-      - image: image-registry.openshift-image-registry.svc:5000/{{ project_name }}/pipeline:latest
+      - image: image-registry.openshift-image-registry.svc:5000/{{ t_project_name }}/pipeline:latest
         name: pipeline
         ports:
         - containerPort: 8080
@@ -40,13 +40,5 @@ spec:
       from:
         kind: ImageStreamTag
         name: pipeline:latest
-        namespace: {{ project_name }}
+        namespace: {{ t_project_name }}
     type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
-

--- a/ansible/roles/ocp4-workload-ml-workflows-workshop/templates/workshop-notebook-buildconfig.yaml.j2
+++ b/ansible/roles/ocp4-workload-ml-workflows-workshop/templates/workshop-notebook-buildconfig.yaml.j2
@@ -29,7 +29,7 @@ spec:
       from:
         kind: ImageStreamTag
         name: s2i-minimal-notebook:3.6
-        namespace: {{ project_name }}
+        namespace: {{ t_project_name }}
     type: Source
   triggers:
   - github:
@@ -41,6 +41,3 @@ spec:
   - type: ConfigChange
   - imageChange: {}
     type: ImageChange
-status:
-  lastVersion: 0
-


### PR DESCRIPTION
##### SUMMARY

Fix use of `project_name` variable in templates in workload ocp4-workload-ml-workflows-workshop

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ocp4-workload-ml-workflows-workshop workload