### PR TITLE
Add guid to skel file for studentvm

### DIFF
--- a/ansible/configs/studentvm/pre_software.yml
+++ b/ansible/configs/studentvm/pre_software.yml
@@ -56,7 +56,13 @@
   - { role: "set-repositories",       when: 'repo_method is defined'          }
   - { role: "common",                 when: 'install_common | d(true) | bool' }
   - { role: "set_env_authorized_key", when: 'set_env_authorized_key | bool'   }
-
+  tasks:
+  - name: Add GUID to /etc/skel/.bashrc
+    lineinfile:
+      path: "/etc/skel/.bashrc"
+      regexp: "^export GUID"
+      line: "export GUID={{ guid }}"
+    
 - name: PreSoftware flight-check
   hosts: localhost
   connection: local

--- a/ansible/roles-studentvm/studentvm-user/tasks/main.yml
+++ b/ansible/roles-studentvm/studentvm-user/tasks/main.yml
@@ -25,6 +25,12 @@
   set_fact:
     studentvm_user_student_password: "{{ studentvm_user.password }}"
 
+- name: Add GUID to /etc/skel/.bashrc
+  lineinfile:
+    path: "/etc/skel/.bashrc"
+    regexp: "^export GUID"
+    line: "export GUID={{ guid }}"
+
 # If we don't delete the user the next task fails if the user already exists
 - name: Ensure User does not exist
   become: true


### PR DESCRIPTION
##### SUMMARY
The new `studentvm` workload was missing a task to add the GUID to the user `.bashrc`. This will add that in as part of the config. I also added an identical task in the `studentvm-user` role. Having it in both places doesn't hurt and it makes sure it is there before any user is either created automatically or manually, depending on the workloads selected.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
studentvm
studentvm-user