### PR TITLE
enable sudo and set default packages

### DIFF
--- a/ansible/roles-studentvm/studentvm-user/defaults/main.yml
+++ b/ansible/roles-studentvm/studentvm-user/defaults/main.yml
@@ -5,7 +5,7 @@ studentvm_user_defaults:
   user_name: lab-user
 
   # Enable sudo for the student user
-  enable_sudo: false
+  enable_sudo: true
 
   # Use a password for the student account
   # When false use / generate ssh key

--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -29,4 +29,6 @@ common_packages_el8:
 - httpd-tools
 - openldap-clients
 - podman
+- skopeo
+- buildah
 - tree


### PR DESCRIPTION
##### SUMMARY
This PR changes the default for the student VM user workload to enable sudo. You can still override this and set to false if you need, but that should not be as common.

It also adds the buildah and skopeo packages to the common list for EL8.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
common
studentvm-user