### PR TITLE
Update cluster name for OCP4 installs

### DIFF
--- a/ansible/configs/ocp4-disconnected-osp-lab/post_software.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/post_software.yml
@@ -21,10 +21,10 @@
         - "For reference, the floating IPs you will use for OpenShift are:"
         - ""
         - "API IP: {{ ocp_api_fip }}"
-        - "API FQDN: api.{{ guid }}.{{ osp_cluster_dns_zone }}"
+        - "API FQDN: api.cluster-{{ guid }}.{{ osp_cluster_dns_zone }}"
         - ""
         - "Ingress IP: {{ ocp_ingress_fip }}"
-        - "Ingress FQDN: *.apps.{{ guid }}.{{ osp_cluster_dns_zone }}"
+        - "Ingress FQDN: *.apps.cluster-{{ guid }}.{{ osp_cluster_dns_zone }}"
 
     - name: Save user data
       agnosticd_user_info:
@@ -34,9 +34,9 @@
           ssh_password: "{{ hostvars.bastion.student_password }}"
           base_domain: "{{ osp_cluster_dns_zone }}"
           api_ip: "{{ ocp_api_fip }}"
-          api_fqdn: "api.{{ guid }}.{{ osp_cluster_dns_zone }}"
+          api_fqdn: "api.cluster-{{ guid }}.{{ osp_cluster_dns_zone }}"
           ingress_ip: "{{ ocp_ingress_fip }}"
-          ingress_fqdn: "*.apps.{{ guid }}.{{ osp_cluster_dns_zone }}"
+          ingress_fqdn: "*.apps.cluster-{{ guid }}.{{ osp_cluster_dns_zone }}"
 
     - debug:
         msg: "Post-Software checks completed successfully"

--- a/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
+++ b/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 metadata:
-  name: {{ guid }}
+  name: cluster-{{ guid }}
 baseDomain: {{ ocp4_base_domain }}
 controlPlane:
   name: master

--- a/ansible/roles/ocp-infra-osp-fip/tasks/main.yml
+++ b/ansible/roles/ocp-infra-osp-fip/tasks/main.yml
@@ -26,7 +26,7 @@
   nsupdate:
     server: "{{ osp_cluster_dns_server }}"
     zone: "{{ osp_cluster_dns_zone }}"
-    record: "{{ item.dns }}.{{ guid }}"
+    record: "{{ item.dns }}.cluster-{{ guid }}"
     type: A
     ttl: 5
     value: "{{ item.name }}"


### PR DESCRIPTION
##### SUMMARY
When we get an `e` in our GUID, it is sometimes interpreted as an exponent instead of a string. This will change the names of clusters from `$GUID` to `cluster-$GUID`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-disconnected-osp-lab
ocp-infra-osp-fip
ocp4-cluster