### PR TITLE
RHS_2020_T77D26: Fix for `user_count` and minor fixes for pipeline build

### DIFF
--- a/ansible/roles/ocp4-workload-ml-workflows-infra-summit2020/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-ml-workflows-infra-summit2020/defaults/main.yml
@@ -50,7 +50,7 @@ install_pipelines: true
 # The first user number to start with when creating projects
 user_count_start: 1
 # The last user number to start with when creating projects
-user_count_end: "{{user_count_start|int + num_users|int}}"
+user_count: 10
 
 # Amount of memory for the JupyterHub server
 jupyterhub_memory: "1Gi"

--- a/ansible/roles/ocp4-workload-ml-workflows-infra-summit2020/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-ml-workflows-infra-summit2020/defaults/main.yml
@@ -49,7 +49,7 @@ install_pipelines: true
 
 # The first user number to start with when creating projects
 user_count_start: 1
-# The last user number to start with when creating projects
+# The total number of users when creating projects
 user_count: 10
 
 # Amount of memory for the JupyterHub server

--- a/ansible/roles/ocp4-workload-ml-workflows-infra-summit2020/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-ml-workflows-infra-summit2020/tasks/workload.yml
@@ -6,7 +6,7 @@
   when: install_storage
 
 - include_tasks: per_user_workload.yml
-  loop: "{{ range(user_count_start|int, user_count_end|int)|list }}"
+  loop: "{{ range(user_count_start | int, (user_count_start | int) + (user_count | int)) | list }}"
   loop_control:
     loop_var: user_num
 

--- a/ansible/roles/ocp4-workload-ml-workflows-workshop/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-ml-workflows-workshop/defaults/main.yml
@@ -6,7 +6,6 @@ silent: false
 user_count: 10
 user_count_start: 1
 
-# The last user number to start with when creating projects
 instructor_mode: false
 
 use_openshift_build: false

--- a/ansible/roles/ocp4-workload-ml-workflows-workshop/tasks/per_user_remove_workload.yml
+++ b/ansible/roles/ocp4-workload-ml-workflows-workshop/tasks/per_user_remove_workload.yml
@@ -16,6 +16,21 @@
     - pipeline-buildconfig.yaml.j2
     - pipeline-deploymentconfig.yaml.j2
     - pipeline-service.yaml.j2
+  when: use_openshift_build
+
+- name: Remove project resources from {{ t_project_name }}
+  k8s:
+    state: absent
+    namespace: "{{ t_project_name }}"
+    definition: "{{ lookup('template', item) }}"
+  loop:
+    - pipeline-s2i-imagestream.yaml.j2
+    - pipeline-resource-source.yaml.j2
+    - pipeline-resource-image.yaml.j2
+    - pipeline-task-definition.yaml.j2
+    - pipeline-definition.yaml.j2
+  when: use_openshift_pipelines
+
 
 # Leave this as the last task in the playbook.
 - name: workload tasks complete

--- a/ansible/roles/ocp4-workload-ml-workflows-workshop/tasks/per_user_workload.yml
+++ b/ansible/roles/ocp4-workload-ml-workflows-workshop/tasks/per_user_workload.yml
@@ -31,6 +31,7 @@
     namespace: "{{ t_project_name }}"
     definition: "{{ lookup('template', item) }}"
   loop:
+    - pipeline-s2i-imagestream.yaml.j2
     - pipeline-resource-source.yaml.j2
     - pipeline-resource-image.yaml.j2
     - pipeline-task-definition.yaml.j2


### PR DESCRIPTION
* Replace `user_count_end` in infra workload with `user_count` so that the two lab roles are now consistent
* Clean up some inconsistencies in the way the build pipeline is set up (as opposed to the build config) in the workshop role