### PR TITLE
Fixing azure tempalte in ocp4-cluster

### DIFF
--- a/ansible/configs/ocp4-cluster/files/cloud_providers/azure_cloud_template.j2
+++ b/ansible/configs/ocp4-cluster/files/cloud_providers/azure_cloud_template.j2
@@ -1,5 +1,16 @@
+{% if guid is not defined %}
+{% set guid = "default" %}
+{% endif %}
+{% if guid|length > 16 %}
+{% set storage_guid = guid[:8]+guid[-8:] %}
+{% else %}
+{% set storage_guid = guid %}
+{% endif %}
 {% if windows_vm_count is not defined %}
-{% set windows_vm_count = 0 %}
+{% set windows_vm_count = 1 %}
+{% endif %}
+{% if windows_vm_count < 1 %}
+{% set windows_vm_count = 1 %}
 {% endif %}
 {% if windows_password is not defined %}
 {% set windows_password = "AwfulP@ssw0rd" %}
@@ -122,7 +133,7 @@
     },
     "variables": {
         "tenantId": "[subscription().tenantId]",
-        "diagnosticStorageAccountName": "[concat('diagstorage',parameters('guid'))]",
+        "diagnosticStorageAccountName": "[concat('diagstor', '{{storage_guid}}')]",
         "networkSecurityGroupName": "default-nsg",
         "subnetName": "default-subnet",
         "subnetRef": "[concat(variables('vnetID'), '/subnets/', variables('subnetName'))]",
@@ -489,4 +500,3 @@
   ],
   "outputs": {}
 }
-


### PR DESCRIPTION
Did not account for longer guids than I tested with.

##### SUMMARY
Storage accounts in Azure have a 24 character limit, just added error correction around that.

Also added a minimum of 1 windows VMs as the default to fix another issues in the template. The more intensive and proper fix excluding all the copyOf sections will come someday.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
config/ocp4-cluster

##### ADDITIONAL INFORMATION
N/A