### PR TITLE
enable TLS support for CRW to align with CRW 2.1 requirements

### DIFF
--- a/ansible/roles/ocp4-workload-ccnrd/files/codeready_cr.yaml
+++ b/ansible/roles/ocp4-workload-ccnrd/files/codeready_cr.yaml
@@ -10,7 +10,7 @@ spec:
     cheFlavor: codeready
     devfileRegistryImage: ''
     pluginRegistryImage: ''
-    tlsSupport: false
+    tlsSupport: true
     selfSignedCert: false
     serverMemoryRequest: '2Gi'
     serverMemoryLimit: '6Gi'


### PR DESCRIPTION
##### SUMMARY
CodeReady Workspaces 2.1 introduces a new requirement that one must use TLS-enabled routes. This change updates the custom resource used to deploy CodeReady to enable this feature.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`ocp4-workload-ccnrd`

