### PR TITLE
Fix ansible-windows to 2012 R2 AMIs

### DIFF
--- a/ansible/configs/ansible-windows/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/ansible-windows/files/cloud_providers/ec2_cloud_template.j2
@@ -4,7 +4,7 @@ Mappings:
     us-east-1:
       RHELAMI: ami-c998b6b2
       # WIN2012R2AMI: ami-01a2180a66e81fae2  # Windows_Server-2012-R2_RTM-English-64Bit-Base-
-      WIN2012R2AMI: ami-0a0db2c70c7c161a4  # Windows_Server-2012-R2_RTM-English-64Bit-Base-
+      WIN2012R2AMI: ami-02fc0cb4aa47ce2e9  # Windows_Server-2012-R2_RTM-English-64Bit-Base-
     eu-central-1:
       RHELAMI: ami-d74be5b8
       WIN2012R2AMI: ami-09b3a18f72a3082d2 # Windows_Server-2012-R2_RTM-English-64Bit-Base-


### PR DESCRIPTION
##### SUMMARY
Config ansible-windows needs 2012 R2 AMIs - currently set to pre R2

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
Config ansible-windows

##### ADDITIONAL INFORMATION
