### PR TITLE
Update ocp4-workload-logging to match version

### DIFF
--- a/ansible/roles/ocp4-workload-logging/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-logging/tasks/workload.yml
@@ -22,6 +22,13 @@
 - name: Install Elasticsearch Operator if not installed
   when: r_eo_deployment_exists.resources | length | int == 0
   block:
+  - name: Get cluster version
+    k8s_facts:
+      api_version: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+    register: r_cluster_version
+
   - name: Get current stable channel for Elasticsearch
     k8s_facts:
       api_version: packages.operators.coreos.com/v1
@@ -29,9 +36,17 @@
       name: elasticsearch-operator
       namespace: openshift-marketplace
     register: r_eo_channel
+
   - name: Set Elasticsearch channel
     set_fact:
-      logging_elasticsearch_channel: "{{ r_eo_channel.resources[0].status.defaultChannel }}"  
+      logging_elasticsearch_channel: >-
+        {{ t_version_match_channel | default(r_eo_channel.resources[0].status.defaultChannel, true) }}
+    vars:
+      t_cluster_version: >-
+        {{ r_cluster_version.resources[0].spec.channel | regex_replace('.*-(\d+\.\d+)', '\1') }}
+      t_version_match_query: "[?name=='{{ t_cluster_version }}']|[0].name"
+      t_version_match_channel: >-
+        {{ r_eo_channel.resources[0].status.channels | json_query(t_version_match_query) }}
 
   - name: Print Elasticsearch channel to be installed
     debug:


### PR DESCRIPTION
##### SUMMARY

With the release of the elasticsearch operator 4.4, this version is now the default, even though it is not compatible with OCP 4.3. This PR causes us to prefer to install the subscription channel that matches the cluster version.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ocp4-workload-logging role