### PR TITLE
Copy images to gh-pages branch so they show up in documentation

### DIFF
--- a/.github/workflows/asciidoc.yml
+++ b/.github/workflows/asciidoc.yml
@@ -19,12 +19,15 @@ jobs:
       with:
           program: "asciidoctor -D public/ --backend=html5 -o index.html docs/README.adoc"
 
+    - name: Copy Image folder to public/ dir
+      run: cp -r docs/images/ public/images
+
     - name: Print execution time
       run: echo "Time ${{ steps.adocbuild.outputs.time }}"
 
     - name: Deploy docs to ghpages
       uses: peaceiris/actions-gh-pages@v3
-      with: 
+      with:
         deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
         publish_branch: gh-pages
         publish_dir: ./public/


### PR DESCRIPTION
##### SUMMARY

The image links are broken on the docs site because they aren't getting copied over to the gh-pages branch in the CI workflow,. This should fix that.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME
Documentation CI


