### PR TITLE
Adding new OCP4 role for RHMI 2.x (Integreatly)

### DIFF
--- a/ansible/roles/ocp4-workload-integreatly/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-integreatly/defaults/main.yml
@@ -1,0 +1,27 @@
+---
+become_override: False
+ocp_username: opentlc-mgr
+silent: False
+
+# If your workload needs customization options provide variables
+# in a dictionary. The dictionary should be named "<role name>_defaults".
+# So because this example workload is called "ocp-workload-example" the dictionary
+# should be named "ocp_workload_example_defaults". Note that the dictionary can not
+# include "-" characters, so replace all "-" with "_" instead.
+#
+# You can override the defaults as parameters to the Ansible run that runs
+# your workload. The overrides should be in a dictionary called
+# "<role name>_vars".
+#
+# If there are any secrets that need to be passed (data that should not be in a
+# public repo somewhere) you can specify another dictionary "<role name>_secrets".
+#
+# When the workload is executed the dictionary "<role name>" will be constructed from
+# "<role name>_defaults" plus "<role name>_vars" (if defined) and "<role name>_secrets"
+# (if defined).
+#
+# The logic in the workload should only use the dictionary "<role name>".
+ocp4_workload_integreatly_defaults:
+    variable_1: "value 1"
+    variable_2: "value 2"
+    variable_secret: ""

--- a/ansible/roles/ocp4-workload-integreatly/meta/main.yml
+++ b/ansible/roles/ocp4-workload-integreatly/meta/main.yml
@@ -1,0 +1,6 @@
+---
+galaxy_info:
+  role_name: ocp4-workload-integreatly
+  author: Red Hat Cloud Services Engineering
+  description: |
+    Manages installation of Red Hat Managed Integration (Integreatly) on OCP4 RHPDS environments

--- a/ansible/roles/ocp4-workload-integreatly/readme.adoc
+++ b/ansible/roles/ocp4-workload-integreatly/readme.adoc
@@ -1,0 +1,256 @@
+= ocp4-workload-integreatly - Manages RHMI (Integreatly) installs on OCP4
+
+== Role overview
+
+This role will install the Red Hat Managed Integration (RHMI) offering on a target RHPDS OCP4 environment. It consists of the following playbooks: 
+
+* Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment.
+** Debug task will print out: `pre_workload Tasks completed successfully.`
+
+* Playbook: link:./tasks/workload.yml[workload.yml] - Used to install RHMI (Integreatly)
+** Debug task will print out: `workload Tasks completed successfully.`
+
+* Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
+** Debug task will print out: `post_workload Tasks completed successfully.`
+
+* Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to delete the workload
+** Debug task will print out: `remove_workload Tasks completed successfully.`
+
+== Review the defaults variable file
+
+* This file link:./defaults/main.yml[./defaults/main.yml] contains all the variables you need to control the deployment of your workload.
+* The variable *ocp_username* is mandatory to assign the workload to the correct OpenShift user.
+* A variable *silent=True* can be passed to suppress debug messages.
+* You can modify any of these default values by adding `-e "variable_name=variable_value"` to the command line
+* Add a dictionary for workload parameters
+
+== Understand how parameters to your workload should be specified
+
+=== Overview
+
+A `dictionary` approach should be used in order to neatly encapsulate parameters to roles.
+
+The role itself defines a dictionary `<role name>_defaults` in the file link:./defaults/main.yml[./defaults/main.yml]. Because this example role is `ocp-workload-example` the dictionary is called `ocp_workload_example_defaults`. Note that `_` is used instead of `-` in the dictionary name to create a valid Ansible dictionary name.
+
+When deploying a workload you can specify another dictionary with the specific parameters for this deployment. This dictionary should be called `<role name>_vars`. In our example this dictionary would be called `ocp_workload_example_vars`.
+
+=== Handling secret parameters
+
+In case you need to pass a secret parameter (e.g. the Bind Password for an LDAP server) you may define another dictionary, `<role name>_secrets`, and pass that as well.
+
+[TIP]
+When setting default values for secrets in the *defaults* dictionary be careful what you set. `""` is probably a good choice. Some workloads (ocp4-workload-authentication for example) generate passwords if a password is not being specified. If you set a default password in the defaults dictionary this logic will never be executed.
+
+For deployment via AgnosticD/AgnosticV the contents of this secrets dictionary need to be placed on the provisioning host and referenced in the AgnosticV configuration.
+
+=== Combined dictionary
+
+When running your workload the first task in link:./tasks/workload.yml[./tasks/workload.yml] sets up the combined dictionary with name `<role name>`. The defaults are combined with vars and secrets. In that order. This means that values in *defaults* can be overridden with values in *vars* and *secrets*.
+
+When adapting this example role for your particular workload make sure to update the dictionary names in both link:./tasks/workload.yml[./tasks/workload.yml] and link:./tasks/remove_workload.yml[./tasks/remove_workload.yml] files.
+
+
+=== Deploy a Workload with the `ocp-workload` playbook [Mostly for testing]
+
+. If your workload uses parameters create a `<role name>_vars.yaml` input file.
++
+.ocp4_workload_integreatly_vars.yaml
+[source,yaml]
+----
+# You can set any variable, not just the dictionary
+silent: true
+
+# Set up the `vars` dictionary
+ocp4_workload_integreatly_vars:
+  variable_2: "My variable 2"
+----
+
+. If your workload uses secrets create a `<role name>_secrets.yaml` input file.
++
+.ocp4_workload_integreatly_secrets.yaml
+[source,yaml]
+----
+# Set up the `secrets` dictionary
+ocp4_workload_integreatly_secrets:
+  variable_secret: "top secret data"
+----
+
+. Set up Environment Variables for the bastion you want to run this role on.
++
+[source,yaml]
+----
+TARGET_HOST="bastion.dev.openshift.opentlc.com"
+OCP_USERNAME="pamccart-redhat.com"
+ANSIBLE_USER="ec2-user"
+WORKLOAD="ocp4-workload-integreatly"
+GUID=1001
+----
+
+. Finally run the workload passing the input files as parameters:
++
+[source,sh]
+----
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=${ANSIBLE_USER}" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"guid=${GUID}" \
+    -e"ACTION=create" \
+    -e @./ocp_workload_example_vars.yaml \
+    -e @./ocp_workload_example_secrets.yaml
+----
++
+Note how the dictionary got set up:
+
+* *Variable 1: value 1* This value comes from the *defaults* dictionary. It did not get overwritten anywhere
+* *Variable 2: My variable 2* This value comes from the *vars* dictionary that was passed as a parameter
+* *Variable Secret: top secret data* This value comes from the *secrets* dictionary that was passed as a parameter
++
+.Example output when using the examples above:
+[source,text,options="nowrap"]
+----
+[...]
+
+TASK [ocp-workload-example : Running Pre Workload Tasks] *****************************************************************************************************************************************************************
+Monday 16 March 2020  15:27:10 -0400 (0:00:00.070)       0:00:05.383 **********
+included: /Users/wkulhane/Development/agnosticd/ansible/roles/ocp-workload-example/tasks/./pre_workload.yml for bastion.dev4.openshift.opentlc.com
+
+TASK [ocp-workload-example : Set up ocp4_workload_example combined dictionary] *******************************************************************************************************************************************
+Monday 16 March 2020  15:27:10 -0400 (0:00:00.051)       0:00:05.434 **********
+ok: [bastion.dev4.openshift.opentlc.com]
+
+[...]
+
+TASK [ocp-workload-example : Setting up workload for user] ***************************************************************************************************************************************************************
+Monday 16 March 2020  15:27:10 -0400 (0:00:00.047)       0:00:05.625 **********
+ok: [bastion.dev4.openshift.opentlc.com] => {
+    "msg": "Setting up workload for user ocp_username = wkulhane-redhat.com"
+}
+
+TASK [ocp-workload-example : Print Example Variables] ********************************************************************************************************************************************************************
+Monday 16 March 2020  15:27:10 -0400 (0:00:00.032)       0:00:05.658 **********
+ok: [bastion.dev4.openshift.opentlc.com] => (item=Variable 1: value 1.) => {
+    "msg": "Variable 1: value 1."
+}
+ok: [bastion.dev4.openshift.opentlc.com] => (item=Variable 2: My variable 2.) => {
+    "msg": "Variable 2: My variable 2."
+}
+ok: [bastion.dev4.openshift.opentlc.com] => (item=Variable Secret: top secret data) => {
+    "msg": "Variable Secret: top secret data"
+}
+
+[...]
+----
+
+=== To Delete an environment
+
+----
+TARGET_HOST="bastion.dev.openshift.opentlc.com"
+OCP_USERNAME="pamccart-redhat.com"
+ANSIBLE_USER="ec2-user"
+WORKLOAD="ocp4-workload-integreatly"
+GUID=1002
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=ec2-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"guid=${GUID}" \
+    -e"ACTION=remove" \
+    -e @./ocp_workload_example_vars.yaml \
+    -e @./ocp_workload_example_secrets.yaml
+----
+
+== Deploying a Workload with AgnosticV
+
+When creating a configuration in AgnosticV that includes the deployment of the workload you can specify the dictionary straight in the AgnosticV config. Because AgnosticV configs are usually created by combining a `common.yaml` file with either `dev.yaml`, `test.yaml` or `prod.yaml` you can specify parts of the dictionary in each of these files. For example you could have common values defined in the `common.yaml` file and then specific values for development or production environments in `dev.yaml` or `prod.yaml`.
+
+AgnosticV merges the definition files starting with `common.yaml` and then adding/overwriting what comes from either `dev.yaml` or `prod.yaml`.
+
+Example of a simple AgnosticV config:
+
+.common.yaml
+[source,yaml]
+----
+# --- Quay Shared Workload Deployment for RPDS
+# --- System: RHPDS
+# --- Catalog: OpenShift Demos
+# --- Catalog Item: Quay 3 on OpenShift 4
+
+# --- Platform
+platform: rhpds
+
+# --- Cloud Provider
+cloud_provider: none
+
+# --- Config
+env_type: ocp-workloads
+ocp_workload: ocp4-workload-quay-operator
+# This workload must be run as ec2-user (or cloud-user on OpenStack)
+# because it has tasks requiring sudo.
+ansible_user: ec2-user
+ansible_ssh_private_key_file: /home/opentlc-mgr/.ssh/opentlc_admin_backdoor.pem
+
+# --- Ensure the workload prints the correct statements for CloudForms to realize it finished
+workload_shared_deployment: true
+
+# --- Workload Configuration
+ocp4_workload_quay_operator_vars:
+  project: "quay-{{ guid }}"
+
+# --- AgnosticV Meta variables
+agnosticv_meta:
+  params_to_variables:
+    user: ocp_username
+  secrets:
+  # This secret file holds the token to pull the Quay image
+  - ocp4_workload_quay_secrets
+----
+
+.dev.yaml
+[source,yaml]
+----
+purpose: development
+
+# --- Use specific variable values for Development
+target_host: bastion.dev4.openshift.opentlc.com
+
+# --- Workload Configuration Overrides
+# Deploy Quay v3.2.0
+ocp4_workload_quay_operator_vars:
+  quay_image_tag: "v3.2.0"
+  clair_image_tag: "v3.2.0"
+----
+
+.prod.yaml
+[source,yaml]
+----
+---
+purpose: production
+
+# --- Use specific variable values for Production
+target_host: bastion.rhpds.openshift.opentlc.com
+
+# --- Workload Configuration Overrides
+ocp4_workload_quay_operator_vars:
+  quay_image_tag: "v3.1.3"
+  clair_image_tag: "v3.1.3"
+
+# --- AgnosticV Meta variables
+agnosticv_meta:
+  agnosticd_git_tag_prefix: ocp4-workload-quay-rhpds-prod
+----
+
+
+== Complex Examples
+
+If you want to see more examples of how this works in a real world workload the following workloads already use this approach:
+
+* ocp4-workload-authentication
+* ocp4-workload-machinesets
+* ocp4-workload-logging
+* ocp4-workload-quay-operator

--- a/ansible/roles/ocp4-workload-integreatly/tasks/main.yml
+++ b/ansible/roles/ocp4-workload-integreatly/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+# Do not modify this file
+
+- name: Running Pre Workload Tasks
+  include_tasks:
+    file: ./pre_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload Tasks
+  include_tasks:
+    file: ./workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  include_tasks:
+    file: ./post_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload removal Tasks
+  include_tasks:
+    file: ./remove_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles/ocp4-workload-integreatly/tasks/post_workload.yml
+++ b/ansible/roles/ocp4-workload-integreatly/tasks/post_workload.yml
@@ -1,0 +1,29 @@
+---
+# Implement your Post Workload deployment tasks here
+# --------------------------------------------------
+
+
+
+
+# Leave these as the last tasks in the playbook
+# ---------------------------------------------
+
+# For deployment onto a dedicated cluster (as part of the
+# cluster deployment) set workload_shared_deployment to False
+# This is the default so it does not have to be set explicitely
+- name: post_workload tasks complete
+  debug:
+    msg: "Post-Workload tasks completed successfully."
+  when:
+  - not silent|bool
+  - not workload_shared_deployment|d(False)
+
+# For RHPDS deployment (onto a shared cluster) set
+# workload_shared_deployment to True
+# (in the deploy script or AgnosticV configuration)
+- name: post_workload tasks complete
+  debug:
+    msg: "Post-Software checks completed successfully"
+  when:
+  - not silent|bool
+  - workload_shared_deployment|d(False)

--- a/ansible/roles/ocp4-workload-integreatly/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-integreatly/tasks/pre_workload.yml
@@ -1,0 +1,30 @@
+---
+# Implement your Pre Workload deployment tasks here
+# -------------------------------------------------
+
+
+
+
+# Leave these as the last tasks in the playbook
+# ---------------------------------------------
+
+# For deployment onto a dedicated cluster (as part of the
+# cluster deployment) set workload_shared_deployment to False
+# This is the default so it does not have to be set explicitely
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Workload tasks completed successfully."
+  when:
+  - not silent|bool
+  - not workload_shared_deployment|d(False)
+
+# For RHPDS deployment (onto a shared cluster) set
+# workload_shared_deployment to True
+# (in the deploy script or AgnosticV configuration)
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Software checks completed successfully"
+  when:
+  - not silent|bool
+  - workload_shared_deployment|d(False)
+  

--- a/ansible/roles/ocp4-workload-integreatly/tasks/remove_workload.yml
+++ b/ansible/roles/ocp4-workload-integreatly/tasks/remove_workload.yml
@@ -1,0 +1,23 @@
+---
+# Set up the combined dictionary for the workload
+# 
+# To Do: Adjust the names of your dictionaries here
+- name: Set up ocp4_workload_integreatly combined dictionary
+  set_fact:
+    ocp_workload_example: >-
+      {{ ocp4_workload_integreatly_defaults
+       | combine(ocp4_workload_integreatly_vars    | default( {} ),
+                 ocp4_workload_integreatly_secrets | default( {} ), recursive=true )
+      }}
+
+# Implement your Workload removal tasks here
+# ------------------------------------------
+
+
+
+# Leave this as the last task in the playbook.
+# --------------------------------------------
+- name: remove_workload tasks complete
+  debug:
+    msg: "Remove Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp4-workload-integreatly/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-integreatly/tasks/workload.yml
@@ -1,0 +1,42 @@
+---
+- name: Setting up workload for user
+  debug:
+    msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
+
+# Set up the combined dictionary for the workload
+# 
+# To Do: Adjust the names of your dictionaries here
+- name: Set up ocp4_workload_integreatly combined dictionary
+  set_fact:
+    ocp4_workload_integreatly: >-
+      {{ ocp4_workload_integreatly_defaults
+        | combine(ocp4_workload_integreatly_vars    | default( {} ),
+                  ocp4_workload_integreatly_secrets | default( {} ), recursive=true )
+      }}
+
+# Because now secrets are part of the combined dictionary use
+# verbosity 2 to prevent printing the dictionary during every run.
+- name: Print combined role variables
+  debug:
+    var: ocp4_workload_integreatly
+    verbosity: 2
+
+# To Do: Implement your Workload deployment tasks here
+# If you have parameters for your workload use the "<role name> dictionary"
+# -------------------------------------------------------------------------
+
+- name: Example Workload, print dictionary values
+  debug:
+    msg: "{{ item }}"
+  loop:
+  - "Variable 1:      {{ ocp4_workload_integreatly.variable_1 }}"
+  - "Variable 2:      {{ ocp4_workload_integreatly.variable_2 }}"
+  - "Variable Secret: {{ ocp4_workload_integreatly.variable_secret }}"
+
+# Leave this as the last task in the playbook.
+# --------------------------------------------
+- name: workload tasks complete
+  debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent|bool
+  


### PR DESCRIPTION
##### SUMMARY
Adding new base template OCP4 role for managing Red Hat Managed Integration (Integreatly) installations. This role does not do anything yet but will act as the foundation for future development which will be progressed over the coming days/weeks

Equivalent OCP3 role can be found [here](https://github.com/redhat-cop/agnosticd/tree/development/ansible/roles/ocp-workload-integreatly)

##### ISSUE TYPE
- New role Pull Request

##### COMPONENT NAME
Red Hat Managed Integration (Integreatly)
