### PR TITLE
[WIP] Asciidoc workflow fix

### DIFF
--- a/.github/workflows/asciidoc.yml
+++ b/.github/workflows/asciidoc.yml
@@ -20,7 +20,7 @@ jobs:
           program: "asciidoctor -D public/ --backend=html5 -o index.html docs/README.adoc"
 
     - name: Copy Image folder to public/ dir
-      run: cp -r docs/images/ public/images
+      run: sudo cp -r docs/images/ public/images
 
     - name: Print execution time
       run: echo "Time ${{ steps.adocbuild.outputs.time }}"


### PR DESCRIPTION
##### SUMMARY

Github workflow was failing because of file permissions on image copy. Add sudo.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

GitHub workflow for asciidoc