### PR TITLE
Locking to specific release to avoid metadata download issues

### DIFF
--- a/ansible/configs/sap-hana/pre_software.yml
+++ b/ansible/configs/sap-hana/pre_software.yml
@@ -7,6 +7,28 @@
   gather_facts: False
   roles:
     - { role: "set-repositories", when: 'repo_method is defined' }
+  tags:
+    - step004
+    - common_tasks
+
+- name: Lock RHEL release
+  hosts:
+    - all:!windows
+  become: true
+  gather_facts: False
+  tasks:
+    - command: subscription-manager release --set=8.1
+
+  tags:
+    - step004
+    - common_tasks
+
+- name: Install Common packages and Set environment key
+  hosts:
+    - all:!windows
+  become: true
+  gather_facts: False
+  roles:
     - { role: "common", when: 'install_common' }
     - { role: "set_env_authorized_key", when: 'set_env_authorized_key' }
   tags:


### PR DESCRIPTION
##### SUMMARY
When moving to e4s repositories some issues downloading from Satellite are causing the package installation to fail. It looks like locking RHEL release solves these issues.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
sap-hana