### PR TITLE
OCP4 Integreatly workload - evals user generation logic

### DIFF
--- a/ansible/roles/ocp4-workload-integreatly/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-integreatly/defaults/main.yml
@@ -22,6 +22,7 @@ silent: False
 #
 # The logic in the workload should only use the dictionary "<role name>".
 ocp4_workload_integreatly_defaults:
+    dedicated_admin_username: "dedicated-admin"
     variable_1: "value 1"
     variable_2: "value 2"
     variable_secret: ""

--- a/ansible/roles/ocp4-workload-integreatly/sample_vars/ocp4_workload_integreatly_vars.yml
+++ b/ansible/roles/ocp4-workload-integreatly/sample_vars/ocp4_workload_integreatly_vars.yml
@@ -3,3 +3,11 @@
 ocp_workloads:
   - ocp4-workload-integreatly-minio
   - ocp4-workload-integreatly
+  - ocp4-workload-authentication
+
+ocp4_workload_authentication_vars:
+  idm_type: htpasswd
+  htpasswd_user_base: evals
+  htpasswd_user_count: 50
+
+  admin_user: dedicated-admin

--- a/ansible/roles/ocp4-workload-integreatly/sample_vars/ocp4_workload_integreatly_vars.yml
+++ b/ansible/roles/ocp4-workload-integreatly/sample_vars/ocp4_workload_integreatly_vars.yml
@@ -2,12 +2,14 @@
 # override ocp workloads to include prerequisite roles
 ocp_workloads:
   - ocp4-workload-integreatly-minio
-  - ocp4-workload-integreatly
   - ocp4-workload-authentication
+  - ocp4-workload-integreatly
 
 ocp4_workload_authentication_vars:
   idm_type: htpasswd
+  
   htpasswd_user_base: evals
   htpasswd_user_count: 50
 
-  admin_user: dedicated-admin
+  # This user is not available in RHMI production/poc clusters. Only RHMI operations teams have cluster-admin access
+  admin_user: admin

--- a/ansible/roles/ocp4-workload-integreatly/tasks/post_workload.yml
+++ b/ansible/roles/ocp4-workload-integreatly/tasks/post_workload.yml
@@ -23,6 +23,52 @@
   with_sequence: count="{{ ocp4_workload_integreatly_defaults.user_count }}"
   when: ocp4_workload_integreatly_defaults.action == "install"
 
+- name: Get current htpasswd secret
+  shell: oc get secret htpasswd-secret -n openshift-config -o json | jq -j '.data.htpasswd' | base64 --decode > /tmp/htpasswd
+
+- name: Backup htpasswd
+  shell: cp /tmp/htpasswd /tmp/htpasswd.backup
+
+- name: Generate dedicated admin password
+  shell: openssl rand -base64 12
+  register: _gen_password
+
+- name: Set dedicated admin password
+  set_fact:
+    _dedicated_admin_password: "{{ _gen_password.stdout }}"
+
+- name: Create dedicated admin user
+  shell: htpasswd -B -b /tmp/htpasswd {{ ocp4_workload_integreatly.dedicated_admin_username }} {{ _dedicated_admin_password }}
+
+- name: Ensure htpasswd Secret is absent
+  k8s:
+    state: absent
+    api_version: v1
+    kind: Secret
+    name: htpasswd-secret
+    namespace: openshift-config
+
+- name: Create new htpasswd secret
+  shell: oc create secret generic htpasswd-secret --from-file=htpasswd=/tmp/htpasswd -n openshift-config
+
+- name: Check for dedicated admins
+  shell: oc get groups dedicated-admins
+  register: group_output
+  ignore_errors: True
+
+- name: Create dedicated admin group
+  shell: oc adm groups new dedicated-admins {{ ocp4_workload_integreatly.dedicated_admin_username }}
+  when: group_output.rc == 1
+
+- name: Add dedicated admin user to dedicated admin group
+  shell: oc adm groups add-users dedicated-admins {{ ocp4_workload_integreatly.dedicated_admin_username }}
+  when: group_output.rc != 1
+
+- name: Print Overview
+  debug:
+    msg: "{{ item }}"
+  with_items:
+    - "user.info: Dedicated Admin User: {{ ocp4_workload_integreatly.dedicated_admin_username }} / {{ _dedicated_admin_password }} (This is the most privileged user account available to consultants and customers in RHMI production/poc environments.)"
 
 
 # Leave these as the last tasks in the playbook


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change generates 50 eval users to be used by integreatly workshop

JIRA: https://issues.redhat.com/browse/INTLY-7046

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
Red Hat Managed Integration (Integreatly)

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Wednesday 29 April 2020  12:02:49 +0100 (0:00:00.023)       0:01:17.094 ******* 
=============================================================================== 
ocp4-workload-integreatly-minio : Create objects for Minio operator ------------------------------------------------------------------------------------------------------------------------------------------------------------------ 17.31s
ocp4-workload-integreatly : Generate dedicated admin password ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 11.23s
ocp4-workload-authentication : Retrieve API server configuration (for API endpoint) --------------------------------------------------------------------------------------------------------------------------------------------------- 5.33s
ocp4-workload-authentication : Print User Information for each User ------------------------------------------------------------------------------------------------------------------------------------------------------------------- 5.26s
ocp4-workload-authentication : Generate htpasswd file --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 3.86s
ocp4-workload-integreatly : Delete current htpasswd secret ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 2.38s
ocp4-workload-authentication : Ensure htpasswd Secret is absent ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- 2.38s
ocp4-workload-authentication : Set up Cluster Admin User ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 2.35s
ocp4-workload-authentication : Remove kubeadmin user secret --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 2.29s
ocp4-workload-integreatly : Add dedicated admin user to dedicated admin group --------------------------------------------------------------------------------------------------------------------------------------------------------- 2.28s
ocp4-workload-authentication : Update OAuth Configuration ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 2.25s
ocp4-workload-integreatly : Get current htpasswd secret ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 2.25s
ocp4-workload-integreatly : Create dedicated admin user ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 2.16s
Check if desired virtualenv is available on the host ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 2.03s
ocp4-workload-integreatly : Create new htpasswd secret -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 2.02s
ocp4-workload-authentication : Create htpasswd secret from htpasswd file -------------------------------------------------------------------------------------------------------------------------------------------------------------- 1.99s
ocp4-workload-integreatly : Backup htpasswd ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 1.90s
ocp4-workload-authentication : Generate htpasswd hash for admin user ------------------------------------------------------------------------------------------------------------------------------------------------------------------ 1.90s
ocp4-workload-authentication : Generate htpasswd hash for user passwords -------------------------------------------------------------------------------------------------------------------------------------------------------------- 1.81s
ocp4-workload-integreatly : Check for dedicated admins -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 1.78s


```
