### PR TITLE
Migration Workloads : align migration workloads with latest z-stream

### DIFF
--- a/ansible/roles/ocp-workload-migration/templates/operator.yml.j2
+++ b/ansible/roles/ocp-workload-migration/templates/operator.yml.j2
@@ -245,17 +245,17 @@ spec:
         - name: VELERO_RESTIC_RESTORE_HELPER_TAG
           value: 44f0362c8570d707582bd428aaf18f390ce915ef72cdeb60cf2699171dbda3c8
         - name: VELERO_PLUGIN_TAG
-          value: 94d5f45f5e8236614e124d2753da7165b913b0e2d8199f164d8f2d208339e85e
+          value: 4009d8488a9aa382d7799e8d25617048f57b273c298a9c89a4f233d7a12af628
         - name: VELERO_AWS_PLUGIN_TAG
-          value: 460dfc455de7ee6a2e49d17d5227c5d653340197b7ad9ed430576c35f4651f4d
+          value: 2623e239a43208390680fb1da81f547248773d48da546b9cc6c516b2e60daee4
         - name: VELERO_GCP_PLUGIN_TAG
           value: 44f40ff5a3c8ad9b76105e2b8fc5bd04692464cc4aa683da2cf83b3336200863
         - name: VELERO_AZURE_PLUGIN_TAG
           value: 9e69f2af712452218cde0c3325c60f9e1eb4624bcaff67770822b60f2e19ac60
         - name: MIG_UI_TAG
-          value: ed16db50ffd6614d8f654449bf29003b82d4d5da420419add00fd5ec5b1fd79b
+          value: 11c8c729bd4871c33b52f0405a0c5ec0438aefd2ed0ffc712034ba89160ed133
         - name: MIG_CONTROLLER_TAG
-          value: cbdd2cdc2c050bb62c713004497e57bfb9c4f7575dd1ec38e69f41689575d365
+          value: 52e3bb16a6fb0852aec7676bba5e5a5af01580f4997bac7747f158239b839ece
       volumes:
         - name: runner
           emptyDir: {}

--- a/ansible/roles/ocp4-workload-migration/templates/mig-operator-subscription-downstream.yml.j2
+++ b/ansible/roles/ocp4-workload-migration/templates/mig-operator-subscription-downstream.yml.j2
@@ -9,5 +9,3 @@ spec:
   name: cam-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: cam-operator.{{ mig_operator_release }}
-


### PR DESCRIPTION
##### SUMMARY
- removes `startingCSV` from OCP 4 workload to accept latest z-stream

- updates SHAs on OCP 3 side to align with latest z-stream 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp-workload-migration
ocp4-workload-migration

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
