### PR TITLE
Remove OLM by default from all OCP 3.11 Configs

### DIFF
--- a/ansible/configs/ocp-workshop/files/hosts_template.3.11.104.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.3.11.104.j2
@@ -37,7 +37,11 @@ openshift_crio_enable_docker_gc=True
 logrotate_scripts=[{"name": "syslog", "path": "/var/log/cron\n/var/log/maillog\n/var/log/messages\n/var/log/secure\n/var/log/spooler\n", "options": ["daily", "rotate 7","size 500M", "compress", "sharedscripts", "missingok"], "scripts": {"postrotate": "/bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true"}}]
 
 # Deploy Operator Lifecycle Management Tech Preview
+{% if enable_olm | d(False) | bool %}
 openshift_enable_olm=true
+{% else %}
+openshift_enable_olm=false
+{% endif %}
 
 ##########################################################################
 ### OpenShift Registries Locations
@@ -47,8 +51,10 @@ oreg_url=registry.redhat.io/openshift3/ose-${component}:${version}
 oreg_auth_user={{ redhat_registry_user }}
 oreg_auth_password={{ redhat_registry_password }}
 
+{% if enable_olm | d(False) | bool %}
 # For Operator Framework Images
 openshift_additional_registry_credentials=[{'host':'registry.connect.redhat.com','user':'{{ redhat_registry_user}}','password':'{{ redhat_registry_password }}','test_image':'mongodb/enterprise-operator:0.3.2'}]
+{% endif %}
 
 openshift_examples_modify_imagestreams=true
 

--- a/ansible/configs/ocp-workshop/files/hosts_template.3.11.129.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.3.11.129.j2
@@ -37,7 +37,11 @@ openshift_crio_enable_docker_gc=True
 logrotate_scripts=[{"name": "syslog", "path": "/var/log/cron\n/var/log/maillog\n/var/log/messages\n/var/log/secure\n/var/log/spooler\n", "options": ["daily", "rotate 7","size 500M", "compress", "sharedscripts", "missingok"], "scripts": {"postrotate": "/bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true"}}]
 
 # Deploy Operator Lifecycle Management Tech Preview
+{% if enable_olm | d(False) | bool %}
 openshift_enable_olm=true
+{% else %}
+openshift_enable_olm=false
+{% endif %}
 
 ##########################################################################
 ### OpenShift Registries Locations
@@ -47,8 +51,10 @@ oreg_url=registry.redhat.io/openshift3/ose-${component}:${version}
 oreg_auth_user={{ redhat_registry_user }}
 oreg_auth_password={{ redhat_registry_password }}
 
+{% if enable_olm | d(False) | bool %}
 # For Operator Framework Images
 openshift_additional_registry_credentials=[{'host':'registry.connect.redhat.com','user':'{{ redhat_registry_user}}','password':'{{ redhat_registry_password }}','test_image':'mongodb/enterprise-operator:0.3.2'}]
+{% endif %}
 
 openshift_examples_modify_imagestreams=true
 

--- a/ansible/configs/ocp-workshop/files/hosts_template.3.11.153.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.3.11.153.j2
@@ -37,7 +37,11 @@ openshift_crio_enable_docker_gc=True
 logrotate_scripts=[{"name": "syslog", "path": "/var/log/cron\n/var/log/maillog\n/var/log/messages\n/var/log/secure\n/var/log/spooler\n", "options": ["daily", "rotate 7","size 500M", "compress", "sharedscripts", "missingok"], "scripts": {"postrotate": "/bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true"}}]
 
 # Deploy Operator Lifecycle Management Tech Preview
+{% if enable_olm | d(False) | bool %}
 openshift_enable_olm=true
+{% else %}
+openshift_enable_olm=false
+{% endif %}
 
 ##########################################################################
 ### OpenShift Registries Locations
@@ -47,8 +51,10 @@ oreg_url=registry.redhat.io/openshift3/ose-${component}:${version}
 oreg_auth_user={{ redhat_registry_user }}
 oreg_auth_password={{ redhat_registry_password }}
 
+{% if enable_olm | d(False) | bool %}
 # For Operator Framework Images
 openshift_additional_registry_credentials=[{'host':'registry.connect.redhat.com','user':'{{ redhat_registry_user}}','password':'{{ redhat_registry_password }}','test_image':'mongodb/enterprise-operator:0.3.2'}]
+{% endif %}
 
 openshift_examples_modify_imagestreams=true
 

--- a/ansible/configs/ocp-workshop/files/hosts_template.3.11.154.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.3.11.154.j2
@@ -37,7 +37,11 @@ openshift_crio_enable_docker_gc=True
 logrotate_scripts=[{"name": "syslog", "path": "/var/log/cron\n/var/log/maillog\n/var/log/messages\n/var/log/secure\n/var/log/spooler\n", "options": ["daily", "rotate 7","size 500M", "compress", "sharedscripts", "missingok"], "scripts": {"postrotate": "/bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true"}}]
 
 # Deploy Operator Lifecycle Management Tech Preview
+{% if enable_olm | d(False) | bool %}
 openshift_enable_olm=true
+{% else %}
+openshift_enable_olm=false
+{% endif %}
 
 ##########################################################################
 ### OpenShift Registries Locations
@@ -47,8 +51,10 @@ oreg_url=registry.redhat.io/openshift3/ose-${component}:${version}
 oreg_auth_user={{ redhat_registry_user }}
 oreg_auth_password={{ redhat_registry_password }}
 
+{% if enable_olm | d(False) | bool %}
 # For Operator Framework Images
 openshift_additional_registry_credentials=[{'host':'registry.connect.redhat.com','user':'{{ redhat_registry_user}}','password':'{{ redhat_registry_password }}','test_image':'mongodb/enterprise-operator:0.3.2'}]
+{% endif %}
 
 openshift_examples_modify_imagestreams=true
 

--- a/ansible/configs/ocp-workshop/files/hosts_template.3.11.16.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.3.11.16.j2
@@ -37,7 +37,11 @@ openshift_node_groups=[{'name': 'node-config-master', 'labels': ['node-role.kube
 logrotate_scripts=[{"name": "syslog", "path": "/var/log/cron\n/var/log/maillog\n/var/log/messages\n/var/log/secure\n/var/log/spooler\n", "options": ["daily", "rotate 7","size 500M", "compress", "sharedscripts", "missingok"], "scripts": {"postrotate": "/bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true"}}]
 
 # Deploy Operator Lifecycle Management Tech Preview
+{% if enable_olm | d(False) | bool %}
 openshift_enable_olm=true
+{% else %}
+openshift_enable_olm=false
+{% endif %}
 
 ##########################################################################
 ### OpenShift Registries Locations
@@ -47,8 +51,10 @@ oreg_url=registry.redhat.io/openshift3/ose-${component}:${version}
 oreg_auth_user={{ redhat_registry_user }}
 oreg_auth_password={{ redhat_registry_password }}
 
+{% if enable_olm | d(False) | bool %}
 # For Operator Framework Images
 openshift_additional_registry_credentials=[{'host':'registry.connect.redhat.com','user':'{{ redhat_registry_user}}','password':'{{ redhat_registry_password }}','test_image':'mongodb/enterprise-operator:0.3.2'}]
+{% endif %}
 
 openshift_examples_modify_imagestreams=true
 

--- a/ansible/configs/ocp-workshop/files/hosts_template.3.11.161.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.3.11.161.j2
@@ -37,7 +37,11 @@ openshift_crio_enable_docker_gc=True
 logrotate_scripts=[{"name": "syslog", "path": "/var/log/cron\n/var/log/maillog\n/var/log/messages\n/var/log/secure\n/var/log/spooler\n", "options": ["daily", "rotate 7","size 500M", "compress", "sharedscripts", "missingok"], "scripts": {"postrotate": "/bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true"}}]
 
 # Deploy Operator Lifecycle Management Tech Preview
+{% if enable_olm | d(False) | bool %}
 openshift_enable_olm=true
+{% else %}
+openshift_enable_olm=false
+{% endif %}
 
 ##########################################################################
 ### OpenShift Registries Locations
@@ -47,8 +51,10 @@ oreg_url=registry.redhat.io/openshift3/ose-${component}:${version}
 oreg_auth_user={{ redhat_registry_user }}
 oreg_auth_password={{ redhat_registry_password }}
 
+{% if enable_olm | d(False) | bool %}
 # For Operator Framework Images
 openshift_additional_registry_credentials=[{'host':'registry.connect.redhat.com','user':'{{ redhat_registry_user}}','password':'{{ redhat_registry_password }}','test_image':'mongodb/enterprise-operator:0.3.2'}]
+{% endif %}
 
 openshift_examples_modify_imagestreams=true
 

--- a/ansible/configs/ocp-workshop/files/hosts_template.3.11.43.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.3.11.43.j2
@@ -37,7 +37,11 @@ openshift_node_groups=[{'name': 'node-config-master', 'labels': ['node-role.kube
 logrotate_scripts=[{"name": "syslog", "path": "/var/log/cron\n/var/log/maillog\n/var/log/messages\n/var/log/secure\n/var/log/spooler\n", "options": ["daily", "rotate 7","size 500M", "compress", "sharedscripts", "missingok"], "scripts": {"postrotate": "/bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true"}}]
 
 # Deploy Operator Lifecycle Management Tech Preview
+{% if enable_olm | d(False) | bool %}
 openshift_enable_olm=true
+{% else %}
+openshift_enable_olm=false
+{% endif %}
 
 ##########################################################################
 ### OpenShift Registries Locations
@@ -47,8 +51,10 @@ oreg_url=registry.redhat.io/openshift3/ose-${component}:${version}
 oreg_auth_user={{ redhat_registry_user }}
 oreg_auth_password={{ redhat_registry_password }}
 
+{% if enable_olm | d(False) | bool %}
 # For Operator Framework Images
 openshift_additional_registry_credentials=[{'host':'registry.connect.redhat.com','user':'{{ redhat_registry_user}}','password':'{{ redhat_registry_password }}','test_image':'mongodb/enterprise-operator:0.3.2'}]
+{% endif %}
 
 openshift_examples_modify_imagestreams=true
 

--- a/ansible/configs/ocp-workshop/files/hosts_template.3.11.51.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.3.11.51.j2
@@ -37,7 +37,11 @@ openshift_crio_enable_docker_gc=True
 logrotate_scripts=[{"name": "syslog", "path": "/var/log/cron\n/var/log/maillog\n/var/log/messages\n/var/log/secure\n/var/log/spooler\n", "options": ["daily", "rotate 7","size 500M", "compress", "sharedscripts", "missingok"], "scripts": {"postrotate": "/bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true"}}]
 
 # Deploy Operator Lifecycle Management Tech Preview
+{% if enable_olm | d(False) | bool %}
 openshift_enable_olm=true
+{% else %}
+openshift_enable_olm=false
+{% endif %}
 
 ##########################################################################
 ### OpenShift Registries Locations
@@ -47,8 +51,10 @@ oreg_url=registry.redhat.io/openshift3/ose-${component}:${version}
 oreg_auth_user={{ redhat_registry_user }}
 oreg_auth_password={{ redhat_registry_password }}
 
+{% if enable_olm | d(False) | bool %}
 # For Operator Framework Images
 openshift_additional_registry_credentials=[{'host':'registry.connect.redhat.com','user':'{{ redhat_registry_user}}','password':'{{ redhat_registry_password }}','test_image':'mongodb/enterprise-operator:0.3.2'}]
+{% endif %}
 
 openshift_examples_modify_imagestreams=true
 

--- a/ansible/configs/ocp-workshop/files/hosts_template.3.11.59.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.3.11.59.j2
@@ -37,7 +37,11 @@ openshift_crio_enable_docker_gc=True
 logrotate_scripts=[{"name": "syslog", "path": "/var/log/cron\n/var/log/maillog\n/var/log/messages\n/var/log/secure\n/var/log/spooler\n", "options": ["daily", "rotate 7","size 500M", "compress", "sharedscripts", "missingok"], "scripts": {"postrotate": "/bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true"}}]
 
 # Deploy Operator Lifecycle Management Tech Preview
+{% if enable_olm | d(False) | bool %}
 openshift_enable_olm=true
+{% else %}
+openshift_enable_olm=false
+{% endif %}
 
 ##########################################################################
 ### OpenShift Registries Locations
@@ -47,8 +51,10 @@ oreg_url=registry.redhat.io/openshift3/ose-${component}:${version}
 oreg_auth_user={{ redhat_registry_user }}
 oreg_auth_password={{ redhat_registry_password }}
 
+{% if enable_olm | d(False) | bool %}
 # For Operator Framework Images
 openshift_additional_registry_credentials=[{'host':'registry.connect.redhat.com','user':'{{ redhat_registry_user}}','password':'{{ redhat_registry_password }}','test_image':'mongodb/enterprise-operator:0.3.2'}]
+{% endif %}
 
 openshift_examples_modify_imagestreams=true
 

--- a/ansible/configs/ocp-workshop/files/hosts_template.3.11.69.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.3.11.69.j2
@@ -37,7 +37,11 @@ openshift_crio_enable_docker_gc=True
 logrotate_scripts=[{"name": "syslog", "path": "/var/log/cron\n/var/log/maillog\n/var/log/messages\n/var/log/secure\n/var/log/spooler\n", "options": ["daily", "rotate 7","size 500M", "compress", "sharedscripts", "missingok"], "scripts": {"postrotate": "/bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true"}}]
 
 # Deploy Operator Lifecycle Management Tech Preview
+{% if enable_olm | d(False) | bool %}
 openshift_enable_olm=true
+{% else %}
+openshift_enable_olm=false
+{% endif %}
 
 ##########################################################################
 ### OpenShift Registries Locations
@@ -47,8 +51,10 @@ oreg_url=registry.redhat.io/openshift3/ose-${component}:${version}
 oreg_auth_user={{ redhat_registry_user }}
 oreg_auth_password={{ redhat_registry_password }}
 
+{% if enable_olm | d(False) | bool %}
 # For Operator Framework Images
 openshift_additional_registry_credentials=[{'host':'registry.connect.redhat.com','user':'{{ redhat_registry_user}}','password':'{{ redhat_registry_password }}','test_image':'mongodb/enterprise-operator:0.3.2'}]
+{% endif %}
 
 openshift_examples_modify_imagestreams=true
 

--- a/ansible/configs/ocp-workshop/files/hosts_template.3.11.82.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.3.11.82.j2
@@ -37,7 +37,11 @@ openshift_crio_enable_docker_gc=True
 logrotate_scripts=[{"name": "syslog", "path": "/var/log/cron\n/var/log/maillog\n/var/log/messages\n/var/log/secure\n/var/log/spooler\n", "options": ["daily", "rotate 7","size 500M", "compress", "sharedscripts", "missingok"], "scripts": {"postrotate": "/bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true"}}]
 
 # Deploy Operator Lifecycle Management Tech Preview
+{% if enable_olm | d(False) | bool %}
 openshift_enable_olm=true
+{% else %}
+openshift_enable_olm=false
+{% endif %}
 
 ##########################################################################
 ### OpenShift Registries Locations
@@ -47,8 +51,10 @@ oreg_url=registry.redhat.io/openshift3/ose-${component}:${version}
 oreg_auth_user={{ redhat_registry_user }}
 oreg_auth_password={{ redhat_registry_password }}
 
+{% if enable_olm | d(False) | bool %}
 # For Operator Framework Images
 openshift_additional_registry_credentials=[{'host':'registry.connect.redhat.com','user':'{{ redhat_registry_user}}','password':'{{ redhat_registry_password }}','test_image':'mongodb/enterprise-operator:0.3.2'}]
+{% endif %}
 
 openshift_examples_modify_imagestreams=true
 

--- a/ansible/configs/ocp-workshop/files/hosts_template.3.11.88.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.3.11.88.j2
@@ -37,7 +37,11 @@ openshift_crio_enable_docker_gc=True
 logrotate_scripts=[{"name": "syslog", "path": "/var/log/cron\n/var/log/maillog\n/var/log/messages\n/var/log/secure\n/var/log/spooler\n", "options": ["daily", "rotate 7","size 500M", "compress", "sharedscripts", "missingok"], "scripts": {"postrotate": "/bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true"}}]
 
 # Deploy Operator Lifecycle Management Tech Preview
+{% if enable_olm | d(False) | bool %}
 openshift_enable_olm=true
+{% else %}
+openshift_enable_olm=false
+{% endif %}
 
 ##########################################################################
 ### OpenShift Registries Locations
@@ -47,8 +51,10 @@ oreg_url=registry.redhat.io/openshift3/ose-${component}:${version}
 oreg_auth_user={{ redhat_registry_user }}
 oreg_auth_password={{ redhat_registry_password }}
 
+{% if enable_olm | d(False) | bool %}
 # For Operator Framework Images
 openshift_additional_registry_credentials=[{'host':'registry.connect.redhat.com','user':'{{ redhat_registry_user}}','password':'{{ redhat_registry_password }}','test_image':'mongodb/enterprise-operator:0.3.2'}]
+{% endif %}
 
 openshift_examples_modify_imagestreams=true
 

--- a/ansible/configs/ocp-workshop/files/hosts_template.3.11.98.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.3.11.98.j2
@@ -37,7 +37,11 @@ openshift_crio_enable_docker_gc=True
 logrotate_scripts=[{"name": "syslog", "path": "/var/log/cron\n/var/log/maillog\n/var/log/messages\n/var/log/secure\n/var/log/spooler\n", "options": ["daily", "rotate 7","size 500M", "compress", "sharedscripts", "missingok"], "scripts": {"postrotate": "/bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true"}}]
 
 # Deploy Operator Lifecycle Management Tech Preview
+{% if enable_olm | d(False) | bool %}
 openshift_enable_olm=true
+{% else %}
+openshift_enable_olm=false
+{% endif %}
 
 ##########################################################################
 ### OpenShift Registries Locations
@@ -47,8 +51,10 @@ oreg_url=registry.redhat.io/openshift3/ose-${component}:${version}
 oreg_auth_user={{ redhat_registry_user }}
 oreg_auth_password={{ redhat_registry_password }}
 
+{% if enable_olm | d(False) | bool %}
 # For Operator Framework Images
 openshift_additional_registry_credentials=[{'host':'registry.connect.redhat.com','user':'{{ redhat_registry_user}}','password':'{{ redhat_registry_password }}','test_image':'mongodb/enterprise-operator:0.3.2'}]
+{% endif %}
 
 openshift_examples_modify_imagestreams=true
 


### PR DESCRIPTION
OLM install seems to be breaking as of late. Since this is an unsupported component in 3.11 removing... also it changed dramatically in 4.x so there isn't even value in it being there.