### PR TITLE
Migration Workloads : agnosticd_user_info variables in the migration workload

### DIFF
--- a/ansible/roles/ocp-workload-migration/tasks/post_workload.yml
+++ b/ansible/roles/ocp-workload-migration/tasks/post_workload.yml
@@ -1,4 +1,10 @@
 ---
+- agnosticd_user_info:
+    data:
+      ocp3_guid: "{{ guid }}"
+      ocp3_domain: "{{ guid }}{{ subdomain_base_suffix }}"
+      ocp3_ssh_user: "{{ student_name }}"
+      ocp3_password: "{{ student_password }}"
 
 # Leave this as the last task in the playbook.
 - name: post_workload tasks complete

--- a/ansible/roles/ocp4-workload-migration/tasks/post_workload.yml
+++ b/ansible/roles/ocp4-workload-migration/tasks/post_workload.yml
@@ -2,6 +2,12 @@
 # Implement your Post Workload deployment tasks here
 
 # Leave these as the last tasks in the playbook
+- agnosticd_user_info:
+    data:
+      ocp4_guid: "{{ guid }}"
+      ocp4_domain: "{{ guid }}{{ subdomain_base_suffix }}"
+      ocp4_ssh_user: "{{ student_name }}"
+      ocp4_password: "{{ student_password }}"
 
 # For deployment onto a dedicated cluster (as part of the
 # cluster deployment) set workload_shared_deployment to False


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

This change allows us to use agnosticd_user_info to inject deployment variables into our bookbag.

We wish to host a permanent bookbag demo page using this. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp-workload-migration
ocp4-workload-migration

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
