### PR TITLE
Remove RHCOS default

### DIFF
--- a/ansible/configs/ocp4-cluster/default_vars_osp.yml
+++ b/ansible/configs/ocp4-cluster/default_vars_osp.yml
@@ -32,7 +32,7 @@ ansible_user: cloud-user
 # openshift-install will try to pull in a copy of RHCOS for every cluster
 # and store it in Glance. These vars will let you override that behaviour
 # and use an existing image.
-rhcos_image_name: rhcos-ocp43
+# rhcos_image_name: rhcos-ocp43
 
 # -------------------------------------------------------------------
 # OpenStack Project


### PR DESCRIPTION
##### SUMMARY
This variable being defined in the default vars for the OSP cloud provider made it impossible to test OCP 4.4 with native functionality where it pulls in its own copy of RHCOS. This variable can still be set to force the installer to use a version of RHCOS that is present in Glance on the clusters.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-cluster