### PR TITLE
update ODH subscription channel

### DIFF
--- a/ansible/roles/ocp4-workload-ml-workflows-infra-summit2020/templates/open-data-hub/subscription.yml.j2
+++ b/ansible/roles/ocp4-workload-ml-workflows-infra-summit2020/templates/open-data-hub/subscription.yml.j2
@@ -4,7 +4,7 @@ metadata:
   name: opendatahub-operator
   namespace: {{ namespace }}
 spec:
-  channel: alpha
+  channel: legacy
   installPlanApproval: Automatic
   name: opendatahub-operator
   source: community-operators


### PR DESCRIPTION
"alpha" went away -- switch to "legacy"

##### SUMMARY

hotfix for IBM Think

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`ocp4-workload-ml-workflows-infra-summit2020`

##### ADDITIONAL INFORMATION

This replaces the subscription channel for the Open Data Hub operator.