### PR TITLE
matching RHPDS to master branch of github.com/ansible/workshops

### DIFF
--- a/ansible/configs/ansible-workshops/vars/networking_arista_tower_workshop_vars.yml
+++ b/ansible/configs/ansible-workshops/vars/networking_arista_tower_workshop_vars.yml
@@ -3,6 +3,6 @@
 
 autolicense:          true
 towerinstall:         true
-workshop_type:        networking
+workshop_type:        network
 network_type:         arista
 ...

--- a/ansible/configs/ansible-workshops/vars/networking_cisco_tower_workshop_vars.yml
+++ b/ansible/configs/ansible-workshops/vars/networking_cisco_tower_workshop_vars.yml
@@ -3,6 +3,6 @@
 
 autolicense:          true
 towerinstall:         true
-workshop_type:        networking
+workshop_type:        network
 network_type:         cisco
 ...

--- a/ansible/configs/ansible-workshops/vars/networking_juniper_tower_workshop_vars.yml
+++ b/ansible/configs/ansible-workshops/vars/networking_juniper_tower_workshop_vars.yml
@@ -3,6 +3,6 @@
 
 autolicense:          true
 towerinstall:         true
-workshop_type:        networking
+workshop_type:        network
 network_type:         juniper
 ...

--- a/ansible/configs/ansible-workshops/vars/networking_multivendor_tower_workshop_vars.yml
+++ b/ansible/configs/ansible-workshops/vars/networking_multivendor_tower_workshop_vars.yml
@@ -3,6 +3,6 @@
 
 autolicense:          true
 towerinstall:         true
-workshop_type:        networking
+workshop_type:        network
 #network_type:         multivendor
 ...

--- a/ansible/configs/ansible-workshops/vars/rhel_90_tower_workshop_vars.yml
+++ b/ansible/configs/ansible-workshops/vars/rhel_90_tower_workshop_vars.yml
@@ -3,5 +3,5 @@
 
 autolicense:          true
 towerinstall:         true                  # Installs latest Tower
-workshop_type:        rhel
+workshop_type:        rhel_90
 ...


### PR DESCRIPTION


##### SUMMARY
- changing networking to network to match workshop scaffolding and reduce complexity
- adding RHEL 90 workshop (shortened version of workshop)

see release PR here: https://github.com/ansible/workshops/pull/819 . this is not merged yet, trying to coordinate RHPDS with master branch changes that affect RHPDS

##### ISSUE TYPE
- New config Pull Request

##### COMPONENT NAME
ansible workshops

##### ADDITIONAL INFORMATION
feel free to text/call me, gchat me, slack me, want to make sure I don't break anything :) 