### PR TITLE
add software_to_deploy

### DIFF
--- a/ansible/configs/ocp4-cluster/default_vars.yml
+++ b/ansible/configs/ocp4-cluster/default_vars.yml
@@ -50,6 +50,9 @@ all_use_python3: true
 # This might be enabled when we have solvers to run or graders for ILT
 install_ftl: false
 
+# This will use the software_playbook phase to install OpenShift 4 in the new environment
+software_to_deploy: openshift4
+
 # TODO: Decide on whether to use sat or give access to repos directly with key
 # This will tell Agnosticd to use either:
 # satellite, rhn, or file for repos


### PR DESCRIPTION
##### SUMMARY
@wkulhanek I think this belongs in the `default_vars` for this config. I don't see us ever deploying the `ocp4-cluster` config without...OCP4. It is in the samples already, but there is no reason not have it as a default for everything.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-cluster