### PR TITLE
Add nmcli commands to cloud-init

### DIFF
--- a/ansible/configs/sap-rhvh/post_software.yml
+++ b/ansible/configs/sap-rhvh/post_software.yml
@@ -285,7 +285,6 @@
           host_name: "{{ item.hname }}.saplab.local"
           custom_script: |
             runcmd:
-              - systemctl mask cloud-init
               - nmcli c m 'System eth0' ipv4.addresses {{ item.addr }}/24
               - nmcli c m 'System eth0' ipv4.gateway 192.168.47.1
               - nmcli c m 'System eth0' ipv4.method manual

--- a/ansible/configs/sap-rhvh/post_software.yml
+++ b/ansible/configs/sap-rhvh/post_software.yml
@@ -291,15 +291,6 @@
               - nmcli c m 'System eth0' ipv4.method manual
               - nmcli c m 'System eth0' ipv6.method ignore
               - nmcli c m 'System eth0' ipv4.dns 192.168.47.10
-        cloud_init_nics:
-          - nic_name: eth0
-            nic_boot_protocol: static
-            nic_boot_protocol_v6: none
-            nic_gateway: 192.168.47.1
-            nic_ip_address: "{{ item.addr }}"
-            nic_netmask: 255.255.255.0
-            nic_on_boot: yes
-        cloud_init_persist: yes
         auth:
           hostname: 'rhvm-{{ guid }}.{{ guid }}.{{ osp_cluster_dns_zone }}'
           insecure: yes

--- a/ansible/configs/sap-rhvh/post_software.yml
+++ b/ansible/configs/sap-rhvh/post_software.yml
@@ -286,6 +286,11 @@
           custom_script: |
             runcmd:
               - systemctl mask cloud-init
+              - nmcli c m 'System eth0' ipv4.addresses {{ item.addr }}/24
+              - nmcli c m 'System eth0' ipv4.gateway 192.168.47.1
+              - nmcli c m 'System eth0' ipv4.method manual
+              - nmcli c m 'System eth0' ipv6.method ignore
+              - nmcli c m 'System eth0' ipv4.dns 192.168.47.10
         cloud_init_nics:
           - nic_name: eth0
             nic_boot_protocol: static


### PR DESCRIPTION
##### SUMMARY
Add `nmcli` commands to cloud-init to generate persistent eth0 configuration

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
sap-rhvh

