### PR TITLE
Make eth0 inmutable to avoid cloud-init existing issues

### DIFF
--- a/ansible/configs/sap-rhvh/post_software.yml
+++ b/ansible/configs/sap-rhvh/post_software.yml
@@ -278,6 +278,8 @@
     - name: Ensure cloud-init is configured in all the VMs
       ovirt_vm:
         name: "{{ item.hname }}"
+        cloud_init_persist: yes
+        state: running
         cloud_init:
           user_name: root
           root_password: "{{ vms_root_password }}"
@@ -285,11 +287,13 @@
           host_name: "{{ item.hname }}.saplab.local"
           custom_script: |
             runcmd:
+              - systemctl mask cloud-init
               - nmcli c m 'System eth0' ipv4.addresses {{ item.addr }}/24
               - nmcli c m 'System eth0' ipv4.gateway 192.168.47.1
               - nmcli c m 'System eth0' ipv4.method manual
               - nmcli c m 'System eth0' ipv6.method ignore
               - nmcli c m 'System eth0' ipv4.dns 192.168.47.10
+              - chattr +i /etc/sysconfig/network-scripts/ifcfg-eth0
         auth:
           hostname: 'rhvm-{{ guid }}.{{ guid }}.{{ osp_cluster_dns_zone }}'
           insecure: yes


### PR DESCRIPTION
##### SUMMARY
Cloud-init is wrongly trying to get metadata info from OSP causing eth0 info to reset to DHCP once VM is rebooted. Making eth0 configuration immutable once configured properly in the first run.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
sap-rhvh

