### PR TITLE
Create security groups only if they are used in 'instances'

### DIFF
--- a/ansible/roles-infra/infra-ec2-template-generate/tasks/main.yml
+++ b/ansible/roles-infra/infra-ec2-template-generate/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 - import_tasks: locate_template.yml
+- import_tasks: security_groups.yml
 
 - set_fact:
     cloudformation_template: "{{output_dir}}/{{ env_type }}.{{ guid }}.{{cloud_provider}}_cloud_template"

--- a/ansible/roles-infra/infra-ec2-template-generate/tasks/security_groups.yml
+++ b/ansible/roles-infra/infra-ec2-template-generate/tasks/security_groups.yml
@@ -1,0 +1,5 @@
+---
+- name: Determine the security groups used in 'instances' dictionary
+  set_fact:
+    used_security_groups: >-
+      {{ instances | default([]) | json_query('[].security_groups[]') | list | unique }}

--- a/ansible/roles-infra/infra-ec2-template-generate/templates/cloud_template.j2
+++ b/ansible/roles-infra/infra-ec2-template-generate/templates/cloud_template.j2
@@ -85,7 +85,8 @@ Resources:
           Value: "{{security_group['name']}}"
 {% endfor %}
 
-{% for security_group in default_security_groups|list + security_groups|list %}
+{% for security_group in default_security_groups|list + security_groups|list
+  if security_group.name in used_security_groups %}
 {% for rule in security_group.rules %}
   {{security_group['name']}}{{rule['name']}}:
     Type: "AWS::EC2::SecurityGroup{{rule['rule_type']}}"

--- a/ansible/roles-infra/infra-osp-template-generate/tasks/main.yml
+++ b/ansible/roles-infra/infra-osp-template-generate/tasks/main.yml
@@ -1,4 +1,4 @@
 ---
 - import_tasks: locate_template.yml
-
+- import_tasks: security_groups.yml
 - import_tasks: generate_osp_template.yml

--- a/ansible/roles-infra/infra-osp-template-generate/tasks/security_groups.yml
+++ b/ansible/roles-infra/infra-osp-template-generate/tasks/security_groups.yml
@@ -1,0 +1,5 @@
+---
+- name: Determine the security groups used in 'instances' dictionary
+  set_fact:
+    used_security_groups: >-
+      {{ instances | default([]) | json_query('[].security_groups[]') | list | unique }}

--- a/ansible/roles-infra/infra-osp-template-generate/templates/cloud_template_master.j2
+++ b/ansible/roles-infra/infra-osp-template-generate/templates/cloud_template_master.j2
@@ -29,7 +29,7 @@ resources:
       user: {get_resource: {{ guid }}-project_user}
       roles:
         - {project: {{ osp_project_name }}, role: _member_}
-{% if osp_use_swift | d(false) | bool %}        
+{% if osp_use_swift | d(false) | bool %}
         - {project: {{ osp_project_name }}, role: swiftoperator}
 {% endif %}
     depends_on:
@@ -76,7 +76,8 @@ resources:
   ###################
   # Security groups #
   ###################
-{% for security_group in security_groups | list + default_security_groups | list %}
+{% for security_group in security_groups | list + default_security_groups | list
+   if security_group.name in used_security_groups %}
   {{ security_group['name'] }}:
     type: OS::Neutron::SecurityGroup
     properties:


### PR DESCRIPTION
##### SUMMARY
If a config has security groups and use those, the default security groups are still create, for nothing.

The commits in this PR addresses that and make sure only used security groups are created in the templates.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Feature Pull Request