### PR TITLE
Fix bug in limitrange creation

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_project_request_template/templates/project_request_template.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_project_request_template/templates/project_request_template.j2
@@ -12,7 +12,7 @@ objects:
     namespace: ${PROJECT_NAME}
   spec:
     limits:
-      {{ ocp4_workload_project_request_template_limits | to_yaml }}
+      {{ ocp4_workload_project_request_template_limits }}
 {% endif %}
 {% if ocp4_workload_project_request_template_install_network_policies | bool %}
 - kind: NetworkPolicy


### PR DESCRIPTION
This fixes a bug where the limitrange in the project request template didn't get created properly thus preventing creation of new projects by non cluster-admins.