### PR TITLE
ocp4_workload_fuse_online: fix apiVersion 

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_fuse_online/templates/coolstore-catalog-mongodb-persistent.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_fuse_online/templates/coolstore-catalog-mongodb-persistent.j2
@@ -274,7 +274,7 @@ items:
       deploymentconfig: {{ ocp4_workload_fuse_online_catalog_service_name }}
     sessionAffinity: None
     type: ClusterIP
-- apiVersion: v1
+- apiVersion: route.openshift.io/v1
   kind: Route
   metadata:
     labels:


### PR DESCRIPTION
Fix for wrong apiVersion in the route definition for the catalog service.