### PR TITLE
Send documentation link and fix issue with port order

### DIFF
--- a/ansible/configs/osp-migration/infra.yml
+++ b/ansible/configs/osp-migration/infra.yml
@@ -109,8 +109,8 @@
         msg: >-
           user.info: - {{ item.1
           | replace(80,"http")
-          | replace(443,"https")
-          | replace(8443,"https") }}://{{ item.0.key
+          | replace(8443,"https")
+          | replace(443,"https") }}://{{ item.0.key
           | regex_replace('REPL', guid) 
           | regex_replace('DOMAIN$', osp_cluster_dns_zone) 
           }}:{{ item.1 }}

--- a/ansible/configs/osp-migration/infra.yml
+++ b/ansible/configs/osp-migration/infra.yml
@@ -102,7 +102,7 @@
       when: openstack_project_services == ""
 
     - debug:
-        msg: "Access to the documentation: {{ document_link }}
+        msg: "Access to the documentation: {{ document_link }}"
       when: document_link | default('') != ''
       
     - debug:

--- a/ansible/configs/osp-migration/infra.yml
+++ b/ansible/configs/osp-migration/infra.yml
@@ -102,6 +102,10 @@
       when: openstack_project_services == ""
 
     - debug:
+        msg: "Access to the documentation: {{ document_link }}
+      when: document_link | default('') != ''
+      
+    - debug:
          msg: "user.info: you can connect to this environment from the following hostnames and services:"
       when: openstack_project_services != {}
 

--- a/ansible/configs/osp-migration/infra.yml
+++ b/ansible/configs/osp-migration/infra.yml
@@ -101,17 +101,17 @@
         openstack_project_services: {}
       when: openstack_project_services == ""
 
-    - debug:
+    - agnosticd_user_info:
         msg: "Access to the documentation: {{ document_link }}"
       when: document_link | default('') != ''
       
-    - debug:
-         msg: "user.info: you can connect to this environment from the following hostnames and services:"
+    - agnosticd_user_info:
+         msg: "you can connect to this environment from the following hostnames and services:"
       when: openstack_project_services != {}
 
-    - debug:
+    - agnosticd_user_info:
         msg: >-
-          user.info: - {{ item.1
+          - {{ item.1
           | replace(80,"http")
           | replace(8443,"https")
           | replace(443,"https") }}://{{ item.0.key
@@ -121,9 +121,9 @@
       when: "item.1 in ['80', '443', '8443']"
       loop: "{{ openstack_project_services | dict2items | subelements('value') }}"
 
-    - debug:
+    - agnosticd_user_info:
         msg: >-
-          user.info: - {{ item.0.key 
+          - {{ item.0.key 
           | regex_replace('REPL', guid)
           | regex_replace('DOMAIN$', osp_cluster_dns_zone) }} port 
           {{ item.1 }}


### PR DESCRIPTION
1) Send a mail if documentation_link variable in agnosticV exists

2) The previous commit was not working properly because is was replacing first 443 