### PR TITLE
Clean-up related to Azure environment variables

### DIFF
--- a/ansible/cloud_providers/azure_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/azure_infrastructure_deployment.yml
@@ -8,16 +8,17 @@
     - step001
     - deploy_infrastructure
   environment:
+    # These first four are only used by Ansible modules
     AZURE_CLIENT_ID: "{{azure_service_principal}}"
     AZURE_TENANT: "{{azure_tenant}}"
     AZURE_SECRET: "{{azure_password}}"
     AZURE_SUBSCRIPTION_ID: "{{azure_subscription_id}}"
     # AZURE_CONFIG_DIR: create a specific config dir for this stack to allow concurrent access
+    # This variable is also used by the CLI
     AZURE_CONFIG_DIR: "/tmp/.azure-{{project_tag}}"
+    PATH: "/tmp/.azure-{{project_tag}}:/usr/local/bin:/usr/bin"
   tasks:
     - name: Ensure az is installed
-      environment:
-        PATH: /usr/bin
       command: which az
       register: az_result
 
@@ -50,8 +51,6 @@
         -u "{{azure_service_principal}}"
         -p {{azure_password}}
         --tenant {{azure_tenant}}
-      environment:
-        PATH: /usr/bin
       tags:
         - validate_azure_template
         - create_inventory
@@ -119,8 +118,6 @@
         - validate_azure_template
 
     - name: Validate arm template
-      environment:
-        PATH: /usr/bin
       command: >-
         az group deployment validate
         --template-file {{t_dest}}
@@ -132,8 +129,6 @@
         - validate_azure_template
 
     - name: ARM Group deployment create
-      environment:
-        PATH: /usr/bin
       command: >-
         az group deployment create
         --name {{env_type}}.{{guid}}
@@ -208,6 +203,13 @@
     - step001
     - wait_ssh
     - set_hostname
+  environment:
+    AZURE_CLIENT_ID: "{{azure_service_principal}}"
+    AZURE_TENANT: "{{azure_tenant}}"
+    AZURE_SECRET: "{{azure_password}}"
+    AZURE_SUBSCRIPTION_ID: "{{azure_subscription_id}}"
+    AZURE_CONFIG_DIR: "/tmp/.azure-{{project_tag}}"
+    PATH: "/tmp/.azure-{{project_tag}}:/usr/local/bin:/usr/bin"
   tasks:
     - name: wait for linux host to be available
       wait_for_connection:
@@ -217,13 +219,6 @@
 
     - name: restart instance if wait_for_connection failed
       become: false
-      environment:
-        AZURE_CLIENT_ID: "{{azure_service_principal}}"
-        AZURE_TENANT: "{{azure_tenant}}"
-        AZURE_SECRET: "{{azure_password}}"
-        AZURE_SUBSCRIPTION_ID: "{{azure_subscription_id}}"
-        # AZURE_CONFIG_DIR: create a specific config dir for this stack to allow concurrent access
-        AZURE_CONFIG_DIR: "/tmp/.azure-{{project_tag}}"
       command: "az vm restart --resource-group {{az_resource_group}} --name '{{inventory_hostname}}'"
       delegate_to: localhost
       when: rwait is failed
@@ -279,6 +274,13 @@
   gather_facts: false
   hosts:
     - windows
+  environment:
+    AZURE_CLIENT_ID: "{{azure_service_principal}}"
+    AZURE_TENANT: "{{azure_tenant}}"
+    AZURE_SECRET: "{{azure_password}}"
+    AZURE_SUBSCRIPTION_ID: "{{azure_subscription_id}}"
+    AZURE_CONFIG_DIR: "/tmp/.azure-{{project_tag}}"
+    PATH: "/tmp/.azure-{{project_tag}}:/usr/local/bin:/usr/bin"
   tasks:
     - name: set facts for remote access
       set_fact:
@@ -300,13 +302,6 @@
 
     - name: restart instance if wait_for_connection failed
       become: false
-      environment:
-        AZURE_CLIENT_ID: "{{azure_service_principal}}"
-        AZURE_TENANT: "{{azure_tenant}}"
-        AZURE_SECRET: "{{azure_password}}"
-        AZURE_SUBSCRIPTION_ID: "{{azure_subscription_id}}"
-        # AZURE_CONFIG_DIR: create a specific config dir for this stack to allow concurrent access
-        AZURE_CONFIG_DIR: "/tmp/.azure-{{project_tag}}"
       command: "az vm restart --resource-group {{az_resource_group}} --name '{{inventory_hostname}}'"
       delegate_to: localhost
       when: rwait is failed
@@ -322,6 +317,13 @@
   hosts: all
   become: true
   gather_facts: false
+  environment:
+    AZURE_CLIENT_ID: "{{azure_service_principal}}"
+    AZURE_TENANT: "{{azure_tenant}}"
+    AZURE_SECRET: "{{azure_password}}"
+    AZURE_SUBSCRIPTION_ID: "{{azure_subscription_id}}"
+    AZURE_CONFIG_DIR: "/tmp/.azure-{{project_tag}}"
+    PATH: /tmp/.azure-{{project_tag}}:/usr/local/bin:/usr/bin
   tasks:
     - when: instances is defined
       block:
@@ -357,8 +359,8 @@
     AZURE_TENANT: "{{azure_tenant}}"
     AZURE_SECRET: "{{azure_password}}"
     AZURE_SUBSCRIPTION_ID: "{{azure_subscription_id}}"
-    # AZURE_CONFIG_DIR: create a specific config dir for this stack to allow concurrent access
     AZURE_CONFIG_DIR: "/tmp/.azure-{{project_tag}}"
+    PATH: "/tmp/.azure-{{project_tag}}:/usr/local/bin:/usr/bin"
   tasks:
   - include_role:
       name: infra-azure-create-service-principal

--- a/ansible/configs/aro/destroy_env.yml
+++ b/ansible/configs/aro/destroy_env.yml
@@ -8,15 +8,13 @@
     AZURE_SECRET: "{{azure_password}}"
     AZURE_SUBSCRIPTION_ID: "{{azure_subscription_id}}"
     AZURE_CONFIG_DIR: "/tmp/.azure-{{project_tag}}"
-    PATH: /usr/bin
+    PATH: /tmp/.azure-{{project_tag}}:/usr/local/bin:/usr/bin
   hosts: localhost
   connection: local
   gather_facts: False
   become: no
   tasks:
     - name: Ensure az is installed
-      environment:
-        PATH: /usr/bin
       command: which az
       register: az_result
 

--- a/ansible/configs/aro/post_software.yml
+++ b/ansible/configs/aro/post_software.yml
@@ -21,7 +21,7 @@
     AZURE_SECRET: "{{azure_password}}"
     AZURE_SUBSCRIPTION_ID: "{{azure_subscription_id}}"
     AZURE_CONFIG_DIR: "/tmp/.azure-{{project_tag}}"
-    PATH: /usr/bin
+    PATH: "/tmp/.azure-{{project_tag}}:/usr/local/bin:/usr/bin"
   tasks:
     - name: Grabbing the console URL for ARO3
       command: >
@@ -108,7 +108,7 @@
     AZURE_SECRET: "{{azure_password}}"
     AZURE_SUBSCRIPTION_ID: "{{azure_subscription_id}}"
     AZURE_CONFIG_DIR: "/tmp/.azure-{{project_tag}}"
-    PATH: /usr/bin:/tmp/.azure-{{project_tag}}
+    PATH: "/tmp/.azure-{{project_tag}}:/usr/local/bin:/usr/bin"
   vars:
     az_config_dir: /tmp/.azure-{{project_tag}}
   tasks:

--- a/ansible/configs/aro/pre_software.yml
+++ b/ansible/configs/aro/pre_software.yml
@@ -18,7 +18,7 @@
     AZURE_SECRET: "{{azure_password}}"
     AZURE_SUBSCRIPTION_ID: "{{azure_subscription_id}}"
     AZURE_CONFIG_DIR: "/tmp/.azure-{{project_tag}}"
-    PATH: /usr/bin
+    PATH: "/tmp/.azure-{{project_tag}}:/usr/local/bin:/usr/bin"
   tasks:
     - name: Retrieving which registration to use
       command: >
@@ -50,7 +50,7 @@
     AZURE_SECRET: "{{azure_password}}"
     AZURE_SUBSCRIPTION_ID: "{{azure_subscription_id}}"
     AZURE_CONFIG_DIR: "/tmp/.azure-{{project_tag}}"
-    PATH: /usr/bin
+    PATH: "/tmp/.azure-{{project_tag}}:/usr/local/bin:/usr/bin"
   tasks:
     - name: Create a resource group for the ARO4 cluster
       command: az group create --name {{az_resource_group}} --location {{azure_region}}

--- a/ansible/configs/aro/software.yml
+++ b/ansible/configs/aro/software.yml
@@ -18,7 +18,7 @@
     AZURE_SECRET: "{{azure_password}}"
     AZURE_SUBSCRIPTION_ID: "{{azure_subscription_id}}"
     AZURE_CONFIG_DIR: "/tmp/.azure-{{project_tag}}"
-    PATH: /usr/bin
+    PATH: "/tmp/.azure-{{project_tag}}:/usr/local/bin:/usr/bin"
   tasks:
     - name: Creating the Azure Red Hat OpenShift 3 cluster instance
       command: >

--- a/ansible/roles-infra/infra-azure-create-inventory/tasks/main.yml
+++ b/ansible/roles-infra/infra-azure-create-inventory/tasks/main.yml
@@ -13,7 +13,7 @@
     -p {{azure_password}}
     --tenant {{azure_tenant}}
   environment:
-    PATH: /usr/bin
+    PATH: "/tmp/.azure-{{project_tag}}:/usr/local/bin:/usr/bin"
     AZURE_CONFIG_DIR: "/tmp/.azure-{{project_tag}}"
   tags:
     - validate_azure_template
@@ -26,7 +26,8 @@
   command: az vm list --resource-group "{{az_resource_group}}" --show-details
   # specify path to use azure-cli from system and not from python virtualenv
   environment:
-    PATH: /usr/bin
+    AZURE_CONFIG_DIR: "/tmp/.azure-{{project_tag}}"
+    PATH: "/tmp/.azure-{{project_tag}}:/usr/local/bin:/usr/bin"
   changed_when: false
   register: result_list
   tags:

--- a/ansible/roles-infra/infra-azure-create-service-principal/tasks/main.yml
+++ b/ansible/roles-infra/infra-azure-create-service-principal/tasks/main.yml
@@ -8,21 +8,18 @@
 ##
 
 - environment:
-    AZURE_CLIENT_ID: "{{azure_ru_username}}"
+    AZURE_CLIENT_ID: "{{azure_service_principal}}"
     AZURE_TENANT: "{{azure_tenant}}"
-    AZURE_SECRET: "{{azure_ru_password}}"
+    AZURE_SECRET: "{{azure_password}}"
     AZURE_SUBSCRIPTION_ID: "{{azure_subscription_id}}"
     AZURE_CONFIG_DIR: "/tmp/.azure-{{project_tag}}"
+    PATH: "/tmp/.azure-{{project_tag}}:/usr/local/bin:/usr/bin"
   block:
   - name: Get the scope for the subscripion
-    environment:
-      PATH: /usr/bin
     command: "az group show --name {{ project_tag }} --query id"
     register: azure_rg_scope
   
   - name: Setting service principal password
-    environment:
-      PATH: /usr/bin
     command: uuidgen
     register: ocp_azure_pwd
 
@@ -32,17 +29,11 @@
       -u '{{azure_ru_username}}'
       -p '{{azure_ru_password}}'
       --tenant "{{azure_tenant}}"
-    environment:
-      PATH: /usr/bin
 
   - name: Switch Subscriptions
     command: az account set -s "{{azure_subscription_id}}"
-    environment:
-      PATH: /usr/bin
   
   - name: Create the Service Principal
-    environment:
-      PATH: /usr/bin
     command: >-
       az ad sp create-for-rbac 
       --name "sp-{{ project_tag }}"
@@ -54,15 +45,11 @@
       seconds: 30
   
   - name: Get the ID of the service principal
-    environment:
-      PATH: /usr/bin
     command: az ad sp show --id "http://sp-{{ project_tag }}" --query appId
     register: ocp_azure_sp
 
   - name: Logout of Azure
     command: az logout
-    environment:
-      PATH: /usr/bin
 
   - name: Add Service Principal info to a generic host for later use
     add_host:

--- a/ansible/roles-infra/infra-azure-delete-service-principal/tasks/main.yml
+++ b/ansible/roles-infra/infra-azure-delete-service-principal/tasks/main.yml
@@ -6,12 +6,12 @@
 #
 ##
 - environment:
-    AZURE_CLIENT_ID: "{{azure_ru_username}}"
+    AZURE_CLIENT_ID: "{{azure_service_principal}}"
     AZURE_TENANT: "{{azure_tenant}}"
-    AZURE_SECRET: "{{azure_ru_password}}"
+    AZURE_SECRET: "{{azure_password}}"
     AZURE_SUBSCRIPTION_ID: "{{azure_subscription_id}}"
-    # AZURE_CONFIG_DIR: create a specific config dir for this stack to allow concurrent access for 'az' command
     AZURE_CONFIG_DIR: "/tmp/.azure-{{project_tag}}"
+    PATH: "/tmp/.azure-{{project_tag}}:/usr/local/bin:/usr/bin"
   block:
   - name: Login to Azure
     command: >-
@@ -19,31 +19,21 @@
       -u '{{azure_ru_username}}'
       -p '{{azure_ru_password}}'
       --tenant "{{azure_tenant}}"
-    environment:
-      PATH: /usr/bin
 
   - name: Switch Subscriptions
     command: az account set -s "{{azure_subscription_id}}"
-    environment:
-      PATH: /usr/bin
  
   - name: Get the ID of the service principal
-    environment:
-      PATH: /usr/bin
     command: "az ad sp show --id http://sp-{{ project_tag }} --query appId"
     register: ocp_azure_sp_id
     ignore_errors: true
 
   - name: Delete the Service Principal
-    environment:
-      PATH: /usr/bin
     command: "az ad sp delete --id {{ ocp_azure_sp_id.stdout }}"
     ignore_errors: true
 
   - name: Logout of Azure
     command: az logout
-    environment:
-      PATH: /usr/bin
 
   when: 
   - azure_ru_username is defined

--- a/ansible/roles-infra/infra-azure-template-destroy/tasks/main.yml
+++ b/ansible/roles-infra/infra-azure-template-destroy/tasks/main.yml
@@ -4,8 +4,8 @@
     AZURE_TENANT: "{{azure_tenant}}"
     AZURE_SECRET: "{{azure_password}}"
     AZURE_SUBSCRIPTION_ID: "{{azure_subscription_id}}"
-    # AZURE_CONFIG_DIR: create a specific config dir for this stack to allow concurrent access for 'az' command
     AZURE_CONFIG_DIR: "/tmp/.azure-{{project_tag}}"
+    PATH: "/tmp/.azure-{{project_tag}}:/usr/local/bin:/usr/bin"
   block:
     - name: Delete delegation for NS to the main DNSZone
       azure_rm_dnsrecordset:

--- a/ansible/roles/satellite-register-host/tasks/register.yml
+++ b/ansible/roles/satellite-register-host/tasks/register.yml
@@ -19,6 +19,19 @@
   package:
     name: katello-ca-consumer-*.noarch
     state: absent
+  when:
+   - cloud_provider != 'azure'
+   - cloud_provider != 'gcp'
+
+- name: Remove satellite Cert (allow errors on gcp/azure)
+  tags: packer
+  package:
+    name: katello-ca-consumer-*.noarch
+    state: absent
+  ignore_errors: yes
+  when:
+   - cloud_provider == 'azure'
+   - cloud_provider == 'gcp'
 
 - name: Download Cert from Satellite
   get_url:

--- a/ansible/roles/set-repositories/tasks/satellite-repos.yml
+++ b/ansible/roles/set-repositories/tasks/satellite-repos.yml
@@ -29,6 +29,19 @@
   package:
     name: katello-ca-consumer-*.noarch
     state: absent
+  when:
+   - cloud_provider != 'azure'
+   - cloud_provider != 'gcp'
+
+- name: Remove satellite Cert (allow errors on gcp/azure)
+  tags: packer
+  package:
+    name: katello-ca-consumer-*.noarch
+    state: absent
+  ignore_errors: yes
+  when:
+   - cloud_provider == 'azure'
+   - cloud_provider == 'gcp'
 
 - name: Find current repository files
   find:


### PR DESCRIPTION
##### SUMMARY
Cleaned up environment variables for roles and cloud_provider related to provisioning and destroying on Azure

Also found a change to another role caused an error in ocp4-cluster config when used on Azure or GCP since they use the RHEL8 image from their respective marketplace and not a custom gold image.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
config/aro
cloud_provider/azure
roles-infra/*azure*
roles/set-repositories
roles/satellite

##### ADDITIONAL INFORMATION
Tested with aro3, aro4, ocp4-cluster, and ocp-workshop using Azure
