### PR TITLE
test-empty-config: add test for multiline secrets

### DIFF
--- a/ansible/configs/test-empty-config/post_software.yml
+++ b/ansible/configs/test-empty-config/post_software.yml
@@ -55,6 +55,11 @@
           loop_control:
             loop_var: n
 
+    - when: test_empty_config_multiline_secret is defined
+      assert:
+        that: test_empty_config_multiline_secret.rstrip().split('\n') | length > 1
+        msg: Multiline secret is not multiline
+
     - name: Print string expected by Cloudforms
       debug:
         msg: "Post-Software checks completed successfully"


### PR DESCRIPTION
Add a test to ensure multiline secrets are passed correctly through all the
Babylon components, and are not reduced to single-line variables.

##### SUMMARY

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
configs/test-empty-config

##### ADDITIONAL INFORMATION
