### PR TITLE
Fix OSP Security Group list

### DIFF
--- a/ansible/configs/ocp4-disconnected-osp-lab/default_vars.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/default_vars.yml
@@ -304,6 +304,10 @@ instances:
     security_groups:
       - utility_sg
 
+# Set this if you need security groups in the list created
+# even if they are unused by an instance initially
+create_unused_security_groups: true
+
 # Security groups and associated rules. This will be provided
 #when the Heat template is generated separate groups and rules
 security_groups:

--- a/ansible/roles-infra/infra-osp-template-generate/defaults/main.yaml
+++ b/ansible/roles-infra/infra-osp-template-generate/defaults/main.yaml
@@ -3,7 +3,6 @@ heat_retries: 2
 osp_default_rootfs_size: 30
 
 opentlc_admin_pub_keys:
-  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC3Avw03Dmh1R2QWQ4CV7JgEsXnHQjNhfppD5aZmh0q/64p6lW+2oNKTT7fVQcrsdmlJwrMd5apkUGrOcq0hHXQMEVZEKUmEjko2BqD5A9/zNX7apObW88bFFfgxc91lOT+e+wfCFsrr3b2SJ3+KL6nTBJV7Lf46i6z86vhiDPjqL7U9kTS+bK9ldU20vpn8h+ZAIaiafVWfjihUjhNpcUY46klixV1YcAkBGCbE+YR6RAAc6vWy0zB3YJnTUl9OFt213ofi1qjuWKVMmOxORxPKB4/JQ+hfAsCMysoVFnFYs10dWxaySK63OgY9uLNyaIwkEaVVIfcViRVm0DZfoNH gucore
   - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCvZvn+GL0wTOsAdh1ikIQoqj2Fw/RA6F14O347rgKdpkgOQpGQk1k2gM8wcla2Y1o0bPIzwlNy1oh5o9uNjZDMeDcEXWuXbu0cRBy4pVRhh8a8zAZfssnqoXHHLyPyHWpdTmgIhr0UIGYrzHrnySAnUcDp3gJuE46UEBtrlyv94cVvZf+EZUTaZ+2KjTRLoNryCn7vKoGHQBooYg1DeHLcLSRWEADUo+bP0y64+X/XTMZOAXbf8kTXocqAgfl/usbYdfLOgwU6zWuj8vxzAKuMEXS1AJSp5aeqRKlbbw40IkTmLoQIgJdb2Zt98BH/xHDe9xxhscUCfWeS37XLp75J backdoor_opentlc_key
 
 all_ssh_authorized_keys: "{{ opentlc_admin_pub_keys + [user_pub_key|d()] }}"
@@ -12,7 +11,7 @@ default_security_groups:
   - name: BastionSG
     description: >-
       Bastion security group allows basic ICMP
-      and SSH adn Mosh ingress and egress to *
+      and SSH ingress and egress to *
     rules:
 
       - name: SSHPublic

--- a/ansible/roles-infra/infra-osp-template-generate/defaults/main.yaml
+++ b/ansible/roles-infra/infra-osp-template-generate/defaults/main.yaml
@@ -7,6 +7,8 @@ opentlc_admin_pub_keys:
 
 all_ssh_authorized_keys: "{{ opentlc_admin_pub_keys + [user_pub_key|d()] }}"
 
+create_unused_security_groups: false
+
 default_security_groups:
   - name: BastionSG
     description: >-

--- a/ansible/roles-infra/infra-osp-template-generate/tasks/security_groups.yml
+++ b/ansible/roles-infra/infra-osp-template-generate/tasks/security_groups.yml
@@ -1,5 +1,12 @@
 ---
 - name: Determine the security groups used in 'instances' dictionary
+  when: not create_unused_security_groups
   set_fact:
     used_security_groups: >-
       {{ instances | default([]) | json_query('[].security_groups[]') | list | unique }}
+
+- name: Use full list of defined security groups 
+  when: create_unused_security_groups
+  set_fact:
+    used_security_groups: >-
+      {{ security_groups | json_query('[].name') | list | unique }}

--- a/ansible/roles-infra/infra-osp-template-generate/templates/cloud_template_master.j2
+++ b/ansible/roles-infra/infra-osp-template-generate/templates/cloud_template_master.j2
@@ -78,6 +78,7 @@ resources:
   ###################
 {% for security_group in security_groups | list + default_security_groups | list
    if security_group.name in used_security_groups %}
+
   {{ security_group['name'] }}:
     type: OS::Neutron::SecurityGroup
     properties:
@@ -85,7 +86,6 @@ resources:
 {% if security_group['description'] is defined %}
       description: "{{ security_group['description'] }}"
 {% endif %}
-
 {% for rule in security_group.rules %}
 {% if rule['name'] is defined %}
   {{ guid }}-{{ security_group['name'] }}-rule_{{ rule['name'] }}:


### PR DESCRIPTION
##### SUMMARY
Currently the list of security groups generated are based on what is in use by instances. In some configs, we need to create security groups that are not yet used. With this change, you can now force all of the groups to be created with the `create_unused_security_groups` var. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
oc4-disconnected
osp-infra-template-generate
