### PR TITLE
rhmi 3scale service discovery

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_integreatly/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_integreatly/defaults/main.yml
@@ -5,15 +5,39 @@ silent: False
 
 ocp4_workload_integreatly_documentation_link: https://docs.google.com/document/d/16mFcIjyykwY9oR0K7xRPZ0nAWm6AnhGvEBYISDlakTQ
 
+# Machine Config
+# We need to override the machine pool config to allow for a larger
+# maximum node quota. This is because on clusters with 50 users, 50
+# Fuse Online instances are created, which contain many pods.
+# On these large clusters, resources are not the bottleneck. The default quotas
+# are, as they stop most resources from ever being used.
+ocp4_workload_integreatly_machineconfigpool_name: worker
+ocp4_workload_integreatly_machineconfigpool_label_value: "true"
+
+ocp4_workload_integreatly_kubeletconfig_name: rhmi-max-pod-override
+ocp4_workload_integreatly_kubeletconfig_template: kubeletconfig-pods.yml.j2
+ocp4_workload_integreatly_kubeletconfig_pods_max: 500
+ocp4_workload_integreatly_kubeletconfig_pods_core: 500
+
 # Operator
 ocp4_workload_integreatly_user_count: 50
 ocp4_workload_integreatly_tmp_dir: /tmp
 ocp4_workload_integreatly_prefix: redhat-rhmi-
 ocp4_workload_integreatly_namespace: "{{ ocp4_workload_integreatly_prefix }}operator"
+# The actual release version. This should be treated as the only version input
+# an end user should need to override in normal circumstances.
+# This should be updated on each new release. It should always be the latest release.
 ocp4_workload_integreatly_release: "2.2.0"
-# RC's are used until full release is available
-# ocp4_workload_integreatly_git_ref: "v{{ ocp4_workload_integreatly_release }}"
-ocp4_workload_integreatly_git_ref: v2.2.0-rc1
+# A map for ocp4_workload_integreatly_release to an actual git ref
+# This allows the version itself and the git ref to differ, which is common
+# as the git ref is often prefixed with a 'v' and during release testing will
+# also contain a '-rc{N}' type suffix.
+# This mapping should be added to for each new release.
+ocp4_workload_integreatly_git_ref_map:
+  "2.2.0-rc2": v2.2.0-rc2
+  "2.2.0-rc3": v2.2.0-rc3
+  "2.2.0": v2.2.0
+ocp4_workload_integreatly_git_ref: "{{ ocp4_workload_integreatly_git_ref_map[ocp4_workload_integreatly_release] }}"
 ocp4_workload_integreatly_manifest_dir_type: 'url'
 ocp4_workload_integreatly_manifest_dir_format: https://raw.githubusercontent.com/integr8ly/integreatly-operator/{branch}/deploy/olm-catalog/integreatly-operator
 ocp4_workload_integreatly_manifest_csv_formats:
@@ -72,6 +96,8 @@ ocp4_workload_integreatly_threescale_sso_client_secret: replaceme
 ocp4_workload_integreatly_threescale_managed_sso_client: 3scale
 
 # Minio instance
+# Minio is used to replace the S3 API that is used by RHMI/Integreatly under
+# normal circumstances.
 ocp4_workload_integreatly_minio_namespace: redhat-rhmi-minio-operator
 ocp4_workload_integreatly_minio_credential_secret: minio-credentials
 ocp4_workload_integreatly_minio_service_name: minio-service

--- a/ansible/roles_ocp_workloads/ocp4_workload_integreatly/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_integreatly/defaults/main.yml
@@ -28,16 +28,11 @@ ocp4_workload_integreatly_namespace: "{{ ocp4_workload_integreatly_prefix }}oper
 # an end user should need to override in normal circumstances.
 # This should be updated on each new release. It should always be the latest release.
 ocp4_workload_integreatly_release: "2.2.0"
-# A map for ocp4_workload_integreatly_release to an actual git ref
-# This allows the version itself and the git ref to differ, which is common
-# as the git ref is often prefixed with a 'v' and during release testing will
-# also contain a '-rc{N}' type suffix.
-# This mapping should be added to for each new release.
-ocp4_workload_integreatly_git_ref_map:
-  "2.2.0-rc2": v2.2.0-rc2
-  "2.2.0-rc3": v2.2.0-rc3
-  "2.2.0": v2.2.0
-ocp4_workload_integreatly_git_ref: "{{ ocp4_workload_integreatly_git_ref_map[ocp4_workload_integreatly_release] }}"
+# Assume that the git ref is the release number prefixed with a 'v'.
+# This won't be the case for RC releases or when requiring to reference master,
+# however in production we don't require that use case and in development the
+# git ref can be overridden by setting '-e ocp4_workload_integreatly_git_ref="master"'.
+ocp4_workload_integreatly_git_ref: "v{{ ocp4_workload_integreatly_release }}"
 ocp4_workload_integreatly_manifest_dir_type: 'url'
 ocp4_workload_integreatly_manifest_dir_format: https://raw.githubusercontent.com/integr8ly/integreatly-operator/{branch}/deploy/olm-catalog/integreatly-operator
 ocp4_workload_integreatly_manifest_csv_formats:

--- a/ansible/roles_ocp_workloads/ocp4_workload_integreatly/files/fuse/create-instance.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_integreatly/files/fuse/create-instance.yml
@@ -3,8 +3,20 @@
     _instance_namespace: "{{ ocp4_workload_integreatly_user_base }}{{ item | int }}-fuse"
     _instance_count: "{{ item }}"
     _instance_user: "{{ ocp4_workload_integreatly_user_base }}{{ item | int }}"
+    _tenant_admin_secret_name: "{{ ocp4_workload_integreatly_user_base }}{{ item | int }}-admin-credentials"
 
 - debug: msg="creating fuse instance with user '{{ _instance_user }}' "
+
+# Check 3scale tenant details for this user, need management URL for integration
+- name: Get 3scale tenant details secret
+  k8s_facts:
+    kind: Secret
+    name: "{{ _tenant_admin_secret_name }}"
+    namespace: "{{ ocp4_workload_integreatly_threescale_namespace }}"
+  register: _tenant_details
+
+- set_fact:
+    _threescale_management_url: "{{ _tenant_details.resources[0].data.admin_domain | b64decode }}"
 
 # create namespace and label it
 - name : Create and switch to user fuse project and label fuse namespace 

--- a/ansible/roles_ocp_workloads/ocp4_workload_integreatly/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_integreatly/tasks/workload.yml
@@ -37,8 +37,6 @@
   delay: 60
   until: _get_machinepoolconfig_worker.resources[0].status.readyMachineCount in [3, _get_machinepoolconfig_worker.resources[0].status.machineCount]
 
-- debug: msg="Git Ref {{ ocp4_workload_integreatly_git_ref }}"
-
 - name: Create operator namespace {{ ocp4_workload_integreatly_namespace }}
   k8s:
     api_version: v1

--- a/ansible/roles_ocp_workloads/ocp4_workload_integreatly/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_integreatly/tasks/workload.yml
@@ -3,6 +3,42 @@
   debug:
     msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
 
+- name: Label worker MachineConfigPool
+  k8s:
+    api_version: machineconfiguration.openshift.io/v1
+    kind: MachineConfigPool
+    name: "{{ ocp4_workload_integreatly_machineconfigpool_name }}"
+    merge_type:
+    - strategic-merge
+    - merge
+    definition:
+      metadata:
+        labels:
+          "rhmi.io/worker-config": "{{ ocp4_workload_integreatly_machineconfigpool_label_value }}"
+
+- name: Create pod override KubeletConfig
+  k8s:
+    api_version: machineconfiguration.openshift.io/v1
+    kind: KubeletConfig
+    name: "{{ ocp4_workload_integreatly_kubeletconfig_name }}"
+    definition: "{{ lookup('template', ocp4_workload_integreatly_kubeletconfig_template) | from_yaml }}"
+
+# _get_machinepoolconfig_worker.resources[0].status.readyMachineCount should
+# either be the full amount of worker nodes, or 3, whichever is the least. this
+# should speed up the start of rhmi installations on clusters with more than 3
+# worker nodes.
+- name: Check worker MachineConfigPool has enough available nodes
+  k8s_facts:
+    api_version: machineconfiguration.openshift.io/v1
+    kind: MachineConfigPool
+    name: "{{ ocp4_workload_integreatly_machineconfigpool_name }}"
+  register: _get_machinepoolconfig_worker
+  retries: 20
+  delay: 60
+  until: _get_machinepoolconfig_worker.resources[0].status.readyMachineCount in [3, _get_machinepoolconfig_worker.resources[0].status.machineCount]
+
+- debug: msg="Git Ref {{ ocp4_workload_integreatly_git_ref }}"
+
 - name: Create operator namespace {{ ocp4_workload_integreatly_namespace }}
   k8s:
     api_version: v1

--- a/ansible/roles_ocp_workloads/ocp4_workload_integreatly/templates/fuse-syndesis.yml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_integreatly/templates/fuse-syndesis.yml.j2
@@ -29,7 +29,9 @@ spec:
     prometheus:
       resources: {}
     server:
-      features: {}
+      features: {
+        managementUrlFor3scale: {{ _threescale_management_url }}
+      }
       resources: {}
     upgrade:
       resources: {}

--- a/ansible/roles_ocp_workloads/ocp4_workload_integreatly/templates/kubeletconfig-pods.yml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_integreatly/templates/kubeletconfig-pods.yml.j2
@@ -1,0 +1,11 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  name: {{ ocp4_workload_integreatly_kubeletconfig_name }}
+spec:
+  machineConfigPoolSelector:
+    matchLabels:
+      rhmi.io/worker-config: "{{ ocp4_workload_integreatly_machineconfigpool_label_value }}"
+  kubeletConfig:
+    podsPerCore: {{ ocp4_workload_integreatly_kubeletconfig_pods_max }}
+    maxPods: {{ ocp4_workload_integreatly_kubeletconfig_pods_core }}


### PR DESCRIPTION
##### SUMMARY

update integreatly workload to include per-user fuse online service discovery in 3scale. even though [1] will still cause an issue in 3scale 2.8. also ensure that pod quotas are not hit on large user count installations.

[1] https://issues.redhat.com/browse/THREESCALE-4851

@ciaranRoche @dimitraz @pmccarthy mind taking a look? i'll give you all write permissions to this branch

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

role: `roles_ocp_workloads/ocp4_workload_integreatly`

##### ADDITIONAL INFORMATION

commit a05891e1d15494b971283d7d3236a800d21b5b31

increase default node pod quota to 500

ensure the default node pod quota is updated for the openshift
cluster, to avoid hitting pod quota limits upon rhmi installation.

verification:
- run the installation
- wait for the installation to get to rhmi cr checks
- once the rhmi cr checks begin, run [1] and ensure each node has
  .status.capacity.pods equal to '500'

[1] 'oc get node --selector=node-role.kubernetes.io/worker='' -o yaml'

commit fdc7531b3c2077b98715e6f94d9c21df9ac8dacc

ensure 3scale service discovery is enabled in per-user fuse

set management url in per-user syndesis custom resources to ensure
that service discovery is enabled for fuse online by default.

verification:
- run the install
- ensure the per-user syndesis crs, format 'evals{N}' have the
  3scale management url feature set and that the url points to the
  per-user 3scale tenant admin url
- create an api provider integration in the per-user fuse online
  instance, [1] can be used as an example openapi spec
- ensure that after the app is published, 3scale integration is set
  to enabled by default in the ui. there should be a disable
  discovery button on the view integration page in the ui
- ensure that after the integration is published, a service exists
  in the per-user fuse online namespace, named after the
  integration, with labels referencing 3scale

[1] https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v3.0/petstore.yaml
