### PR TITLE
rollback version of istioctl in studentVM

### DIFF
--- a/ansible/roles_studentvm/studentvm_ocp4/defaults/main.yml
+++ b/ansible/roles_studentvm/studentvm_ocp4/defaults/main.yml
@@ -17,7 +17,7 @@ studentvm_ocp4_tkn_version: '0.8.0'
 # https://github.com/knative/client/releases
 studentvm_ocp4_kn_version: 'v0.12.0'
 # https://github.com/istio/istio/releases
-studentvm_ocp4_istioctl_version: '1.5.2'
+studentvm_ocp4_istioctl_version: '1.4.9'
 # https://github.com/operator-framework/operator-registry/releases
 studentvm_ocp4_opm_version: 'v1.11.1'
 # Source to Image URL (can't use just version because of random hash in the file name)


### PR DESCRIPTION
##### SUMMARY
I was a little aggressive with the version of `istioctl` I originally included and it didn't work with the workloads we needed. This takes us to a well known version in workloads we run, such as the advanced service mesh course.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
studentvm_ocp4