### PR TITLE
Add role satellite-publish-content-view

### DIFF
--- a/ansible/roles/satellite-publish-content-views/README.adoc
+++ b/ansible/roles/satellite-publish-content-views/README.adoc
@@ -1,0 +1,63 @@
+:role: satellite-publish-content-views 
+:author: Andy Mott <amott@redhat.com>
+:tag1: configure_satellite
+:main_file: tasks/main.yml
+:version_file: tasks/version_6.x.yml
+
+= Role: {role}
+
+This role checks recent sync logs and publishes updated content views to Library.
+
+The playbook is designed to be run daily, after a sync has been completed on the Satellite repositories.
+
+All updated repositories are gathered, then the content views which contain them plus any composite content views they are in are evaluated and checked to make sure they haven't been updated in the last day and that composite views are not configured to auto-publish, then the remainder are published.
+
+
+== Requirements
+
+. Satellite must be installed and configured.
+. foreman-ansible-modules must be installed.
+. `apypie` module must be installed in Perl.
+. Ansible must be using Python version 3. This can be configured in `ansible.cfg` with the line `interpreter_python = /usr/bin/python3`.
+
+== Role Variables
+
+[cols="4a,2a,4a"]
+|===
+|satellite_version: "Digit" | Required | Satellite version
+|org: "String" | Required | Organization name
+|satellite_admin: "String" | Required | Satellite admin username
+|satellite_admin_password: "String" | Required | Satellite admin password
+|publicname: "String" | Required | FQDN of Satellite server
+|===
+
+
+* Example variables
+
+[source,text]
+----
+satellite_version: 6.7
+org="My Organization"
+satellite_admin="admin"
+satellite_admin_password="MySecretPassword"
+publicname="https://satellite.example.com"
+----
+
+== Tags
+
+|===
+|{tag1} | Consistent tag for all satellite config roles
+|===
+
+* Example tags
+
+ ## Tagged jobs
+ ansible-playbook playbook.yml --tags configure_satellite
+
+ ## Skip tagged jobs
+ ansible-playbook playbook.yml --skip-tags configure_satellite
+
+
+== Author Information
+
+{author}

--- a/ansible/roles/satellite-publish-content-views/tasks/main.yml
+++ b/ansible/roles/satellite-publish-content-views/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+
+## Import for version satellite 6.4 ##
+- import_tasks: version_6.x.yml
+  when: satellite_version is version_compare('6.4', '>=')
+  tags:
+    - configure_satellite
+

--- a/ansible/roles/satellite-publish-content-views/tasks/version_6.x.yml
+++ b/ansible/roles/satellite-publish-content-views/tasks/version_6.x.yml
@@ -1,0 +1,101 @@
+---
+
+- hosts: satellite
+  
+  collections:
+   - theforeman.foreman
+
+  vars:
+    today: "{{ ansible_date_time.date }}"
+    updated_repo_ids: []
+    updated_repo_names: []
+    updated_content_view_ids: []
+    updated_content_view_names: []
+    updated_composite_view_ids: []
+    updated_composite_view_names: []
+    content_views_for_publishing: []
+    published_views: []
+    
+  tasks:
+   - name: get task info for all sync tasks that finished today
+     theforeman.foreman.foreman_search_facts:
+       username: "{{ satellite_admin }}"
+       password: "{{ satellite_admin_password }}"
+       server_url: "https://{{ publicname }}"
+       organization: "{{ org }}"
+       validate_certs: no
+       resource: foreman_tasks
+       search: action ~ Synchronize and result = success and ended_at = today
+     register: synced_tasks_details
+
+   - name: create a list of repository ids for updated repos
+     set_fact:
+       updated_repo_ids: "{{ updated_repo_ids + [ item.input.repository.id ] }}"
+       updated_repo_names: "{{ updated_repo_names + [ item.input.repository.name ] }}"
+     when: item.input.contents_changed == true
+     loop: "{{ synced_tasks_details.resources }}"
+     loop_control:
+       label: "{{ item.action }}"
+
+   - name: get details for all content views
+     theforeman.foreman.foreman_search_facts:
+       username: "{{ satellite_admin }}"
+       password: "{{ satellite_admin_password }}"
+       server_url: "https://{{ publicname }}"
+       organization: "{{ org }}"
+       validate_certs: no
+       resource: content_views
+     register: content_view_details
+
+   - name: find content views which contain updated repos
+     set_fact:
+       updated_content_view_ids: "{{ updated_content_view_ids + [ item.1.id ] }}"
+       updated_content_view_names: "{{ updated_content_view_names + [ item.1.name ] }}"
+     when: item.0 | int in item.1.repository_ids
+     loop: "{{ updated_repo_ids | product(content_view_details.resources) | list }}"
+     loop_control:
+       label: "{{ item.1.id }}"
+
+   - name: remove duplicate entries from content view IDs
+     set_fact:
+      updated_content_view_ids: "{{ updated_content_view_ids | unique }}"
+      updated_content_view_names: "{{ updated_content_view_names | unique }}"
+
+   - name: find matching composite content views
+     set_fact:
+       updated_composite_view_ids: "{{ updated_composite_view_ids + [ item.1.id ] }}"
+       updated_composite_view_names: "{{ updated_composite_view_names + [ item.1.name ] }}"
+     when: item.0 in (lookup('flattened',[ item.1.content_view_components | map(attribute='content_view') | map(attribute='id') | list ])) and item.1.composite == true
+     loop: "{{ updated_content_view_ids | product(content_view_details.resources) | list }}"
+     loop_control:
+       label: "{{ item.1.id }}"
+
+   - name: remove duplicate entries from composite content view IDs
+     set_fact:
+      updated_composite_view_ids: "{{ updated_composite_view_ids | flatten | unique }}"
+      updated_composite_view_names: "{{ updated_composite_view_names | flatten | unique }}"
+
+   - name: Collate list of all content views to update
+     set_fact:
+      content_views_for_publishing: "{{ updated_content_view_names }} + {{ updated_composite_view_names }}"
+
+   - name: final publish list - removing composite views set to auto-publish and any published less than a day ago
+     set_fact:
+       published_views: "{{ published_views + [ item.0 ] }}"
+     when: item.1.name == item.0 and item.1.auto_publish != true and ( ((today | to_datetime('%Y-%m-%d')) - (item.1.last_published | to_datetime('%Y-%m-%d %H:%M:%S %Z'))).days > 1 )
+     loop: "{{ content_views_for_publishing | product(content_view_details.resources) | list }}"
+     loop_control:
+       label: "{{ item.0 }}"
+
+   - name: Publish content views and promote to Library. Not idempotent
+     theforeman.foreman.katello_content_view_version:
+       username: "{{ satellite_admin }}"
+       password: "{{ satellite_admin_password }}"
+       server_url: "https://{{ publicname }}"
+       organization: "{{ org }}"
+       validate_certs: false
+       content_view: "{{ item }}"
+       lifecycle_environments:
+         - Library
+     loop: "{{ published_views }}"
+

--- a/ansible/roles/satellite-publish-content-views/tasks/version_6.x.yml
+++ b/ansible/roles/satellite-publish-content-views/tasks/version_6.x.yml
@@ -82,7 +82,7 @@
    - name: final publish list - removing composite views set to auto-publish and any published less than a day ago
      set_fact:
        published_views: "{{ published_views + [ item.0 ] }}"
-     when: item.1.name == item.0 and item.1.auto_publish != true and ( ((today | to_datetime('%Y-%m-%d')) - (item.1.last_published | to_datetime('%Y-%m-%d %H:%M:%S %Z'))).days > 1 )
+     when: item.1.name == item.0 and item.1.auto_publish != true and ( ((today | to_datetime('%Y-%m-%d')) - (item.1.last_published | to_datetime('%Y-%m-%d %H:%M:%S %Z'))).days >= 0 )
      loop: "{{ content_views_for_publishing | product(content_view_details.resources) | list }}"
      loop_control:
        label: "{{ item.0 }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
A role to check for updated repositories after a sync, then publish new versions of any content views which contain those repositories.
This is designed to run after any sync tasks, and only checks for updates in the last day. It also checks whether a content view has been published in the last day and does not publish a new version if that is the case. It will also not publish a content view that is set to publish automatically.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
satellite-publish-content-views

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
PLAY [satellite] ***************************************************************************************************************************************************************************

TASK [Gathering Facts] *********************************************************************************************************************************************************************
ok: [sat.asmlab.uk]

TASK [get task info for all sync tasks that finished today] ********************************************************************************************************************************
ok: [sat.asmlab.uk]

TASK [create a list of repository ids for updated repos] ***********************************************************************************************************************************
skipping: [sat.asmlab.uk] => (item=Synchronize repository 'Red Hat Ansible Engine 2.8 for RHEL 8 x86_64 RPMs'; product 'Red Hat Ansible Engine'; organization 'ASM Lab') 
skipping: [sat.asmlab.uk] => (item=Synchronize repository 'Red Hat Enterprise Linux 8 for x86_64 - BaseOS RPMs 8.2'; product 'Red Hat Enterprise Linux for x86_64'; organization 'ASM Lab') 
skipping: [sat.asmlab.uk] => (item=Synchronize repository 'Red Hat Enterprise Linux 8 for x86_64 - AppStream RPMs 8.2'; product 'Red Hat Enterprise Linux for x86_64'; organization 'ASM Lab') 
skipping: [sat.asmlab.uk] => (item=Synchronize repository 'Fedora 31 Workstation'; product 'Fedora 31 Workstation'; organization 'ASM Lab') 
skipping: [sat.asmlab.uk] => (item=Synchronize repository 'Red Hat Satellite 6.6 for RHEL 7 Server RPMs x86_64'; product 'Red Hat Satellite'; organization 'ASM Lab') 
skipping: [sat.asmlab.uk] => (item=Synchronize repository 'Red Hat Satellite Maintenance 6 for RHEL 7 Server RPMs x86_64'; product 'Red Hat Enterprise Linux Server'; organization 'ASM Lab') 
skipping: [sat.asmlab.uk] => (item=Synchronize repository 'Red Hat Software Collections RPMs for Red Hat Enterprise Linux 7 Server x86_64 7Server'; product 'Red Hat Software Collections for RHEL Server'; organization 'ASM Lab') 
skipping: [sat.asmlab.uk] => (item=Synchronize repository 'Red Hat Enterprise Linux 7 Server Kickstart x86_64 7.8'; product 'Red Hat Enterprise Linux Server'; organization 'ASM Lab') 
skipping: [sat.asmlab.uk] => (item=Synchronize repository 'Red Hat Satellite Tools 6.6 for RHEL 7 Server RPMs x86_64'; product 'Red Hat Enterprise Linux Server'; organization 'ASM Lab') 
skipping: [sat.asmlab.uk] => (item=Synchronize repository 'Red Hat Ansible Engine 2.8 RPMs for Red Hat Enterprise Linux 7 Server x86_64'; product 'Red Hat Ansible Engine'; organization 'ASM Lab') 
ok: [sat.asmlab.uk] => (item=Synchronize repository 'Red Hat Enterprise Linux 7 Server - Extras RPMs x86_64'; product 'Red Hat Enterprise Linux Server'; organization 'ASM Lab')
skipping: [sat.asmlab.uk] => (item=Synchronize repository 'Red Hat Enterprise Linux 7 Server - Optional RPMs x86_64 7Server'; product 'Red Hat Enterprise Linux Server'; organization 'ASM Lab') 
skipping: [sat.asmlab.uk] => (item=Synchronize repository 'Red Hat Enterprise Linux 7 Server RPMs x86_64 7Server'; product 'Red Hat Enterprise Linux Server'; organization 'ASM Lab') 
skipping: [sat.asmlab.uk] => (item=Synchronize repository 'Red Hat Enterprise Linux 8 for x86_64 - AppStream RPMs 8.1'; product 'Red Hat Enterprise Linux for x86_64'; organization 'ASM Lab') 
skipping: [sat.asmlab.uk] => (item=Synchronize repository 'Red Hat Enterprise Linux 8 for x86_64 - AppStream Kickstart 8.1'; product 'Red Hat Enterprise Linux for x86_64'; organization 'ASM Lab') 
skipping: [sat.asmlab.uk] => (item=Synchronize repository 'Red Hat Enterprise Linux 8 for x86_64 - BaseOS Kickstart 8.1'; product 'Red Hat Enterprise Linux for x86_64'; organization 'ASM Lab') 
skipping: [sat.asmlab.uk] => (item=Synchronize repository 'Red Hat Enterprise Linux 8 for x86_64 - BaseOS RPMs 8.1'; product 'Red Hat Enterprise Linux for x86_64'; organization 'ASM Lab') 
skipping: [sat.asmlab.uk] => (item=Synchronize repository 'Red Hat Satellite Tools 6.6 for RHEL 8 x86_64 RPMs'; product 'Red Hat Enterprise Linux for x86_64'; organization 'ASM Lab') 

TASK [get details for all content views] ***************************************************************************************************************************************************
ok: [sat.asmlab.uk]

TASK [find content views which contain updated repos] **************************************************************************************************************************************
skipping: [sat.asmlab.uk] => (item=1) 
skipping: [sat.asmlab.uk] => (item=12) 
skipping: [sat.asmlab.uk] => (item=6) 
skipping: [sat.asmlab.uk] => (item=7) 
ok: [sat.asmlab.uk] => (item=16)
skipping: [sat.asmlab.uk] => (item=5) 
skipping: [sat.asmlab.uk] => (item=18) 
skipping: [sat.asmlab.uk] => (item=11) 
skipping: [sat.asmlab.uk] => (item=3) 
skipping: [sat.asmlab.uk] => (item=9) 
skipping: [sat.asmlab.uk] => (item=14) 
skipping: [sat.asmlab.uk] => (item=2) 

TASK [remove duplicate entries from content view IDs] **************************************************************************************************************************************
ok: [sat.asmlab.uk]

TASK [find matching composite content views] ***********************************************************************************************************************************************
skipping: [sat.asmlab.uk] => (item=1) 
skipping: [sat.asmlab.uk] => (item=12) 
skipping: [sat.asmlab.uk] => (item=6) 
skipping: [sat.asmlab.uk] => (item=7) 
skipping: [sat.asmlab.uk] => (item=16) 
skipping: [sat.asmlab.uk] => (item=5) 
skipping: [sat.asmlab.uk] => (item=18) 
skipping: [sat.asmlab.uk] => (item=11) 
skipping: [sat.asmlab.uk] => (item=3) 
skipping: [sat.asmlab.uk] => (item=9) 
skipping: [sat.asmlab.uk] => (item=14) 
skipping: [sat.asmlab.uk] => (item=2) 

TASK [remove duplicate entries from composite content view IDs] ****************************************************************************************************************************
ok: [sat.asmlab.uk]

TASK [Collate list of all content views to update] *****************************************************************************************************************************************
ok: [sat.asmlab.uk]

TASK [final publish list - removing composite views set to auto-publish and any published less than a day ago] *****************************************************************************
skipping: [sat.asmlab.uk] => (item=RHEL 7 Full) 
skipping: [sat.asmlab.uk] => (item=RHEL 7 Full) 
skipping: [sat.asmlab.uk] => (item=RHEL 7 Full) 
skipping: [sat.asmlab.uk] => (item=RHEL 7 Full) 
skipping: [sat.asmlab.uk] => (item=RHEL 7 Full) 
skipping: [sat.asmlab.uk] => (item=RHEL 7 Full) 
skipping: [sat.asmlab.uk] => (item=RHEL 7 Full) 
skipping: [sat.asmlab.uk] => (item=RHEL 7 Full) 
skipping: [sat.asmlab.uk] => (item=RHEL 7 Full) 
skipping: [sat.asmlab.uk] => (item=RHEL 7 Full) 
skipping: [sat.asmlab.uk] => (item=RHEL 7 Full) 
skipping: [sat.asmlab.uk] => (item=RHEL 7 Full) 

TASK [Publish content views and promote to Library. Not idempotent] ************************************************************************************************************************

PLAY RECAP *********************************************************************************************************************************************************************************
sat.asmlab.uk              : ok=9    changed=0    unreachable=0    failed=0    skipped=3    rescued=0    ignored=0 
```
