### PR TITLE
[osp-migration] Create objects with user instead opentlc-mgr

### DIFF
--- a/ansible/configs/osp-migration/infra.yml
+++ b/ansible/configs/osp-migration/infra.yml
@@ -79,8 +79,8 @@
       register: stack_user_output
       environment:
         OS_AUTH_URL: "{{ osp_auth_url }}"
-        OS_USERNAME: "{{ osp_auth_username }}"
-        OS_PASSWORD: "{{ osp_auth_password }}"
+        OS_USERNAME: "{{ guid }}"
+        OS_PASSWORD: "{{ api_pass }}"
         OS_PROJECT_NAME: "{{ osp_project_name }}"
         OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
         OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"

--- a/ansible/configs/osp-migration/infra.yml
+++ b/ansible/configs/osp-migration/infra.yml
@@ -10,7 +10,7 @@
       purpose: "{{ purpose | default('unkownpurpose') }}"
   tasks:
     - set_fact:
-        api_pass: "{{ lookup('password', '/dev/null length=20 chars=ascii_letters') }}"
+        osp_migration_api_pass: "{{ lookup('password', '/dev/null length=20 chars=ascii_letters') }}"
 
     - import_tasks: pull_repo.yml
 
@@ -47,7 +47,7 @@
           project_guid: "{{ guid }}"
           project_description: "created:{{ ansible_date_time.epoch }}"
           project_api_user: "{{ guid }}"
-          project_api_pass: "{{ api_pass }}"
+          project_api_pass: "{{ osp_migration_api_pass }}"
           blueprint: "{{ project }}"
 
     # when deleting we need to be able to authenticate using that project
@@ -80,7 +80,7 @@
       environment:
         OS_AUTH_URL: "{{ osp_auth_url }}"
         OS_USERNAME: "{{ guid }}"
-        OS_PASSWORD: "{{ api_pass }}"
+        OS_PASSWORD: "{{ osp_migration_api_pass }}"
         OS_PROJECT_NAME: "{{ osp_project_name }}"
         OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
         OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"
@@ -92,7 +92,7 @@
           public_net_id: "{{ external_network }}"
           api_url: "{{ osp_auth_url }}"
           api_user: "{{ guid }}"
-          api_pass: "{{ api_pass }}"
+          api_pass: "{{ osp_migration_api_pass }}"
           project_guid: "{{ guid }}"
           dns_domain: "{{ osp_cluster_dns_zone }}"
 
@@ -169,7 +169,7 @@
       environment:
         OS_AUTH_URL: "{{ osp_auth_url }}"
         OS_USERNAME: "{{ guid }}"
-        OS_PASSWORD: "{{ api_pass }}"
+        OS_PASSWORD: "{{ osp_migration_api_pass }}"
         OS_PROJECT_NAME: "{{ osp_project_name }}"
         OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
         OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"
@@ -203,7 +203,7 @@
       environment:
         OS_AUTH_URL: "{{ osp_auth_url }}"
         OS_USERNAME: "{{ guid }}"
-        OS_PASSWORD: "{{ api_pass }}"
+        OS_PASSWORD: "{{ osp_migration_api_pass }}"
         OS_PROJECT_NAME: "{{ osp_project_name }}"
         OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
         OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"

--- a/ansible/configs/osp-migration/post_software.yml
+++ b/ansible/configs/osp-migration/post_software.yml
@@ -11,7 +11,7 @@
         data:
           bookbag_os_auth_url: "{{ osp_auth_url }}"
           bookbag_os_username: "{{ guid }}"
-          bookbag_os_password: "{{ api_pass }}"
+          bookbag_os_password: "{{ osp_migration_api_pass }}"
           bookbag_os_project_name: "{{ osp_project_name }}"
           student_ssh_password: >-
             {{ student_password | default(hostvars[groups.bastions.0].student_password) }}


### PR DESCRIPTION
Creating keypair with a opentlc-mgr reachs a quota limit

This reverts: https://github.com/redhat-cop/agnosticd/commit/a26d7d7ca06a82342eb16aab0e4f5efb90a584cf