### PR TITLE
Add Username Distribution tool frontend for CCN Roadshow

### DIFF
--- a/ansible/roles/ocp4-workload-ccnrd/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-ccnrd/defaults/main.yml
@@ -5,6 +5,12 @@ silent: False
 
 num_users: 15
 module_type: m1
+module_titles:
+  - { name: m1, title: "Optimizing Existing Applications", path: /workshop/cloudnative/lab/workshop-environment }
+  - { name: m2, title: "Debugging, Monitoring, and Continous Delivery", path: /workshop/cloudnative/lab/workshop-environment }
+  - { name: m3, title: "Control Cloud Native Apps with Service Mesh", path: /workshop/cloudnative/lab/workshop-environment }
+  - { name: m4, title: "Advanced Cloud-Native with Event-Driven Serverless", path: /workshop/cloudnative/lab/workshop-environment }
+
 gogs_pwd: 'r3dh4t1!'
 
 workshop_openshift_user_name: userXX

--- a/ansible/roles/ocp4-workload-ccnrd/files/redis-template.yaml
+++ b/ansible/roles/ocp4-workload-ccnrd/files/redis-template.yaml
@@ -1,0 +1,177 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+labels:
+  template: redis-persistent-template
+message: |-
+  The following service(s) have been created in your project: ${DATABASE_SERVICE_NAME}.
+
+         Password: ${REDIS_PASSWORD}
+   Connection URL: redis://${DATABASE_SERVICE_NAME}:6379/
+
+  For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/redis-container/blob/master/5.
+metadata:
+  annotations:
+    description: |-
+      Redis in-memory data structure store, with persistent storage. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/redis-container/blob/master/5.
+
+      NOTE: You must have persistent volumes available in your cluster to use this template.
+    iconClass: icon-redis
+    openshift.io/display-name: Redis
+    openshift.io/documentation-url: https://github.com/sclorg/redis-container/tree/master/5
+    openshift.io/long-description: This template provides a standalone Redis server.  The
+      data is stored on persistent storage.
+    openshift.io/provider-display-name: Red Hat, Inc.
+    openshift.io/support-url: https://access.redhat.com
+    samples.operator.openshift.io/version: 4.4.3
+    tags: database,redis
+  creationTimestamp: "2020-05-21T11:54:38Z"
+  labels:
+    samples.operator.openshift.io/managed: "true"
+  name: redis-persistent
+  namespace: openshift
+  resourceVersion: "18076"
+  selfLink: /apis/template.openshift.io/v1/namespaces/openshift/templates/redis-persistent
+  uid: 88513b62-c75a-4aea-861e-62722bfe49d8
+objects:
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    annotations:
+      template.openshift.io/expose-password: '{.data[''database-password'']}'
+    name: ${DATABASE_SERVICE_NAME}
+  stringData:
+    database-password: ${REDIS_PASSWORD}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      template.openshift.io/expose-uri: redis://{.spec.clusterIP}:{.spec.ports[?(.name=="redis")].port}
+    name: ${DATABASE_SERVICE_NAME}
+  spec:
+    ports:
+    - name: redis
+      nodePort: 0
+      port: 6379
+      protocol: TCP
+      targetPort: 6379
+    selector:
+      name: ${DATABASE_SERVICE_NAME}
+    sessionAffinity: None
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: ${DATABASE_SERVICE_NAME}
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: ${VOLUME_CAPACITY}
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    annotations:
+      template.alpha.openshift.io/wait-for-ready: "true"
+    name: ${DATABASE_SERVICE_NAME}
+  spec:
+    replicas: 1
+    selector:
+      name: ${DATABASE_SERVICE_NAME}
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          name: ${DATABASE_SERVICE_NAME}
+      spec:
+        containers:
+        - capabilities: {}
+          env:
+          - name: REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: database-password
+                name: ${DATABASE_SERVICE_NAME}
+          image: ' '
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            initialDelaySeconds: 30
+            tcpSocket:
+              port: 6379
+            timeoutSeconds: 1
+          name: redis
+          ports:
+          - containerPort: 6379
+            protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -i
+              - -c
+              - test "$(redis-cli -h 127.0.0.1 -a $REDIS_PASSWORD ping)" == "PONG"
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              memory: ${MEMORY_LIMIT}
+          securityContext:
+            capabilities: {}
+            privileged: false
+          terminationMessagePath: /dev/termination-log
+          volumeMounts:
+          - mountPath: /var/lib/redis/data
+            name: ${DATABASE_SERVICE_NAME}-data
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        volumes:
+        - name: ${DATABASE_SERVICE_NAME}-data
+          persistentVolumeClaim:
+            claimName: ${DATABASE_SERVICE_NAME}
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - redis
+        from:
+          kind: ImageStreamTag
+          name: redis:${REDIS_VERSION}
+          namespace: ${NAMESPACE}
+        lastTriggeredImage: ""
+      type: ImageChange
+    - type: ConfigChange
+  status: {}
+parameters:
+- description: Maximum amount of memory the container can use.
+  displayName: Memory Limit
+  name: MEMORY_LIMIT
+  required: true
+  value: 512Mi
+- description: The OpenShift Namespace where the ImageStream resides.
+  displayName: Namespace
+  name: NAMESPACE
+  value: openshift
+- description: The name of the OpenShift Service exposed for the database.
+  displayName: Database Service Name
+  name: DATABASE_SERVICE_NAME
+  required: true
+  value: redis
+- description: Password for the Redis connection user.
+  displayName: Redis Connection Password
+  from: '[a-zA-Z0-9]{16}'
+  generate: expression
+  name: REDIS_PASSWORD
+  required: true
+- description: Volume space available for data, e.g. 512Mi, 2Gi.
+  displayName: Volume Capacity
+  name: VOLUME_CAPACITY
+  required: true
+  value: 1Gi
+- description: Version of Redis image to be used (5 or latest).
+  displayName: Version of Redis Image
+  name: REDIS_VERSION
+  required: true
+  value: "5"

--- a/ansible/roles/ocp4-workload-ccnrd/tasks/install-username-distribution.yaml
+++ b/ansible/roles/ocp4-workload-ccnrd/tasks/install-username-distribution.yaml
@@ -1,0 +1,66 @@
+---
+- name: search for username distribution tool
+  k8s_facts:
+    kind: DeploymentConfig
+    name: get-a-username
+    namespace: labs-infra
+  register: r_gau_dc
+
+- name: deploy redis
+  when: r_gau_dc.resources | list | length == 0
+  shell: >
+    oc process -f -
+    -p DATABASE_SERVICE_NAME=redis
+    -p REDIS_PASSWORD=redis
+    -p VOLUME_CAPACITY=1Gi
+    -p MEMORY_LIMIT=1Gi
+    -p REDIS_VERSION=5
+    | oc create -n labs-infra  -f -
+  args:
+    stdin: "{{ lookup('file', './files/redis-template.yaml') }}"
+
+- name: wait for redis to be ready
+  when: r_gau_dc.resources | list | length == 0
+  k8s_facts:
+    api_version: v1
+    kind: Pod
+    namespace: labs-infra
+    label_selectors:
+      - name = redis
+      - deploymentconfig = redis
+    field_selectors:
+      - status.phase=Running
+  register: r_redis_pod
+  retries: 120
+  delay: 10
+  until: r_redis_pod.resources | list | length == 1
+
+- name: url var
+  set_fact:
+    guides_urls: []
+
+- name: construct url argument for username distribution
+  set_fact:
+    guides_urls: "{{ guides_urls + ['http://guides-' + item.name + '-labs-infra.' + route_subdomain + item.path + '?userid=%USERNAME%;' + item.title ] if (item.name in modules) else guides_urls }}"
+  loop: "{{ module_titles }}"
+
+
+- name: deploy username distribution tool
+  when: r_gau_dc.resources | list | length == 0
+  shell: >
+    oc -n labs-infra new-app quay.io/openshiftlabs/username-distribution --name=get-a-username
+    -e LAB_REDIS_HOST=redis
+    -e LAB_REDIS_PASS=redis
+    -e LAB_TITLE={{ 'Containers & Cloud Native Roadshow' | quote }}
+    -e LAB_DURATION_HOURS=8h
+    -e LAB_USER_COUNT={{ num_users }}
+    -e LAB_USER_ACCESS_TOKEN={{ workshop_openshift_user_password }}
+    -e LAB_USER_PASS={{ workshop_openshift_user_password }}
+    -e LAB_USER_PREFIX=user
+    -e LAB_USER_PAD_ZERO=false
+    -e LAB_ADMIN_PASS={{ workshop_openshift_user_password }}
+    -e LAB_MODULE_URLS={{ guides_urls | join(',') | quote }}
+
+- name: expose username distribution tool
+  when: r_gau_dc.resources | list | length == 0
+  command: oc expose -n labs-infra svc/get-a-username

--- a/ansible/roles/ocp4-workload-ccnrd/tasks/post_workload.yml
+++ b/ansible/roles/ocp4-workload-ccnrd/tasks/post_workload.yml
@@ -5,13 +5,52 @@
     msg:
     - "user.info: "
     - "user.info: CCN Roadshow Dev Track provisioned for {{ num_users }} user(s)"
+
+- name: output workshop info guides
+  debug:
+    msg:
     - "user.info: "
-    - "user.info: Roadshow User Guides: "
-    - "user.info: Module 1 (if selected) http://guides-m1-labs-infra.{{ route_subdomain }}"
-    - "user.info: Module 2 (if selected) http://guides-m2-labs-infra.{{ route_subdomain }}"
-    - "user.info: Module 3 (if selected) http://guides-m3-labs-infra.{{ route_subdomain }}"
-    - "user.info: Module 4 (if selected) http://guides-m4-labs-infra.{{ route_subdomain }}"
+    - "user.info: URL for attendees to get a username assigned to them and links to labs:"
+    - "user.info: "
+    - "user.info: http://get-a-username-labs-infra.{{ route_subdomain }}"
+    - "user.info: "
     - "user.info: You should share this URL (or a shortlink for it) -- It is all they will need to get started!"
+
+- name: output workshop username distribution URL
+  debug:
+    msg:
+    - "user.info: "
+    - "user.info: Individual module guide URLs (in case you need them for direct linking):"
+    - "user.info: "
+
+
+- name: output workshop info guides
+  when: ("m1" in modules)
+  debug:
+    msg:
+    - "user.info: Module 1 http://guides-m1-labs-infra.{{ route_subdomain }}"
+
+- name: output workshop info guides
+  when: ("m2" in modules)
+  debug:
+    msg:
+    - "user.info: Module 2 http://guides-m2-labs-infra.{{ route_subdomain }}"
+
+- name: output workshop info guides
+  when: ("m3" in modules)
+  debug:
+    msg:
+    - "user.info: Module 3 http://guides-m3-labs-infra.{{ route_subdomain }}"
+
+- name: output workshop info guides
+  when: ("m4" in modules)
+  debug:
+    msg:
+    - "user.info: Module 4 http://guides-m4-labs-infra.{{ route_subdomain }}"
+
+- name: output workshop info guides
+  debug:
+    msg:
     - "user.info: "
     - "user.info: OpenShift credentials for attendees: {{ workshop_openshift_user_name }} / {{ workshop_openshift_user_password }}"
     - "user.info: CodeReady Workspaces credentials for attendees: {{ workshop_che_user_name }} / {{ workshop_che_user_password }}"

--- a/ansible/roles/ocp4-workload-ccnrd/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-ccnrd/tasks/workload.yml
@@ -176,6 +176,9 @@
     guide: "{{ item }}"
   loop: "{{ modules }}"
 
+- name: install username distribution
+  include_tasks: install-username-distribution.yaml
+
 # Install CodeReady Workspaces
 - name: see if codeready is installed
   k8s_facts:


### PR DESCRIPTION
##### SUMMARY
Adds a lightweight, frontend tool to provide a password-protected aggregated list of links to the individual workshop guides and a way to distribute user IDs and assign/unassign users.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`ocp4-workload-ccnrd`

##### ADDITIONAL INFORMATION
The tool itself was originally developed by the Red Hat EMEA partner team and has been very well received. This PR only introduces the integration code to use the tool. The actual container image for the tool is [external on quay.io](https://quay.io/repository/openshiftlabs/username-distribution).
