### PR TITLE
replace commas to avoid URL parse errors

### DIFF
--- a/ansible/roles/ocp4-workload-ccnrd/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-ccnrd/defaults/main.yml
@@ -5,9 +5,13 @@ silent: False
 
 num_users: 15
 module_type: m1
+
+#
+# All modules. Do NOT use a comma (,) in the titles or paths!
+#
 module_titles:
   - { name: m1, title: "Optimizing Existing Applications", path: /workshop/cloudnative/lab/workshop-environment }
-  - { name: m2, title: "Debugging, Monitoring, and Continous Delivery", path: /workshop/cloudnative/lab/workshop-environment }
+  - { name: m2, title: "Debugging | Monitoring | Continuous Delivery", path: /workshop/cloudnative/lab/workshop-environment }
   - { name: m3, title: "Control Cloud Native Apps with Service Mesh", path: /workshop/cloudnative/lab/workshop-environment }
   - { name: m4, title: "Advanced Cloud-Native with Event-Driven Serverless", path: /workshop/cloudnative/lab/workshop-environment }
 


### PR DESCRIPTION
##### SUMMARY
Remove commas from lab descriptions to avoid parse errors later on when URLs and descriptions are presented to user.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`ocp4-workload-ccnrd`

