### PR TITLE
Adding amq workstation url

### DIFF
--- a/ansible/roles_studentvm/studentvm_user/tasks/main.yml
+++ b/ansible/roles_studentvm/studentvm_user/tasks/main.yml
@@ -156,6 +156,7 @@
     - "user.info: user: {{ studentvm_user_name }}"
     - "user.info: ssh_command: ssh {{ studentvm_user_name }}@studentvm.{{ subdomain_base }}"
     - "user.info: password: {{ studentvm_user_student_password }}"
+    - "user.info: workstation: studentvm.{{ subdomain_base }}"
   - name: Add User Info for Password authentication to user_data.yaml
     agnosticd_user_info:
       user: "{{ studentvm_user_name }}"


### PR DESCRIPTION
##### SUMMARY
Adding amq workstation URL so that student should find AMQ workstation console easily by seeing the details in last mail.
##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
studentvm for amq foundation
