### PR TITLE
Fix ImageStream issue.

### DIFF
--- a/ansible/roles/ocp-workload-fsi-client-onboarding-demo/defaults/main.yml
+++ b/ansible/roles/ocp-workload-fsi-client-onboarding-demo/defaults/main.yml
@@ -23,3 +23,8 @@ build_status_delay: 20
 
 deploy_status_retries: 15
 deploy_status_delay: 20
+
+
+bpms_version_tag: 6.4.x
+bpms_imagestreams_yml: https://raw.githubusercontent.com/jboss-container-images/jboss-processserver-6-openshift-image/{{bpms_version_tag}}/templates/processserver64-image-stream.json"
+bpms_imagestreams_tag: 1.0

--- a/ansible/roles/ocp-workload-fsi-client-onboarding-demo/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-fsi-client-onboarding-demo/tasks/workload.yml
@@ -18,20 +18,38 @@
 #- name: Set project limit LimitRange
 #  shell: "oc create -f /tmp/{{guid}}//limit-range.yaml -n {{ocp_project}}"
 
-- name: Import ImageStreams
-  shell: "oc create -f https://raw.githubusercontent.com/jboss-container-images/jboss-processserver-6-openshift-image/6.4.x/templates/processserver64-image-stream.json -n {{ocp_project}}"
+- name: Check if BPM Suite ImageStreams exists
+  shell: oc get is/jboss-processserver64-openshift -n openshift
+  register: bpms_is_exists_result
+  ignore_errors: true
 
-- name: Patch Image Stream
-  shell: |
-          JSONPATCH='[{"op": "replace", "path": "/spec/tags/'{{item}}'/from/name", "value": "registry.access.redhat.com/jboss-processserver-6/processserver64-openshift:1.'{{item}}'"}]'
-          oc patch is/jboss-processserver64-openshift --type='json' -p "$JSONPATCH"
-  loop:
-    - 0
-    - 1
-    - 2
-    - 3
-    - 4
-    - 5
+- name: Import the BPM Suite ImageStreams into the cluster.
+  shell: "oc create -f {{bpms_imagestreams_yml}} -n openshift"
+  when: bpms_is_exists_result is failed
+  ignore_errors: true
+
+- name: Wait for BPMSuite ImageStream tags to be available
+  shell: "oc get is -n openshift | grep -i processserver | grep -i {{bpms_imagestreams_tag}}"
+  register: result
+  until: result.stdout != ""
+  retries: 5
+  delay: 10
+
+
+#- name: Import ImageStreams
+#  shell: "oc create -f https://raw.githubusercontent.com/jboss-container-images/jboss-processserver-6-openshift-image/6.4.x/templates/processserver64-image-stream.json -n {{ocp_project}}"
+
+#- name: Patch Image Stream
+#  shell: |
+#          JSONPATCH='[{"op": "replace", "path": "/spec/tags/'{{item}}'/from/name", "value": "registry.access.redhat.com/jboss-processserver-6/processserver64-openshift:1.'{{item}}'"}]'
+#          oc patch is/jboss-processserver64-openshift --type='json' -p "$JSONPATCH"
+#  loop:
+#    - 0
+#    - 1
+#    - 2
+#    - 3
+#    - 4
+#    - 5
 
 - name: "Import templates"
   shell: "oc create -f https://raw.githubusercontent.com/jboss-container-images/jboss-processserver-6-openshift-image/6.4.x/templates/processserver64-postgresql-s2i.json -n {{ocp_project}}"
@@ -75,7 +93,6 @@
           -p GIT_URI="https://github.com/entando/fsi-onboarding-bpm" \
           -p GIT_REF="master" \
           -p ENTANDO_BASE_URL="http://{{fsi_customer_route}}/fsi-customer/" \
-          -p IMAGE_STREAM_NAMESPACE="{{ocp_project}}" \
           -n {{ocp_project}} | oc create -f - -n {{ocp_project}}
 
 #- name: "Patch the ImageSteam location"

--- a/ansible/roles/ocp-workload-fsi-client-onboarding-demo/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-fsi-client-onboarding-demo/tasks/workload.yml
@@ -35,22 +35,6 @@
   retries: 5
   delay: 10
 
-
-#- name: Import ImageStreams
-#  shell: "oc create -f https://raw.githubusercontent.com/jboss-container-images/jboss-processserver-6-openshift-image/6.4.x/templates/processserver64-image-stream.json -n {{ocp_project}}"
-
-#- name: Patch Image Stream
-#  shell: |
-#          JSONPATCH='[{"op": "replace", "path": "/spec/tags/'{{item}}'/from/name", "value": "registry.access.redhat.com/jboss-processserver-6/processserver64-openshift:1.'{{item}}'"}]'
-#          oc patch is/jboss-processserver64-openshift --type='json' -p "$JSONPATCH"
-#  loop:
-#    - 0
-#    - 1
-#    - 2
-#    - 3
-#    - 4
-#    - 5
-
 - name: "Import templates"
   shell: "oc create -f https://raw.githubusercontent.com/jboss-container-images/jboss-processserver-6-openshift-image/6.4.x/templates/processserver64-postgresql-s2i.json -n {{ocp_project}}"
 
@@ -95,12 +79,6 @@
           -p ENTANDO_BASE_URL="http://{{fsi_customer_route}}/fsi-customer/" \
           -n {{ocp_project}} | oc create -f - -n {{ocp_project}}
 
-#- name: "Patch the ImageSteam location"
-#  shell: |
-#          oc patch bc/co --type="json" \
-#          -p="[{'op': 'replace', 'path': '/spec/strategy/sourceStrategy/from/namespace', 'value': '{{ocp_project}}'}]"
-
-
 #### Wait for the build to complete before slapping on the quota ....
 - include_tasks: ./wait_for_build.yml
   vars:
@@ -117,9 +95,6 @@
       - co-postgresql
       - fsi-backoffice
       - fsi-customer
-
-#- name: "Start build of BPM Process application"
-#  shell: "oc start-build co"
 
 - name: Annotate the completed project as requested by user
   shell: "oc annotate namespace {{ocp_project}} openshift.io/requester={{ocp_username}} --overwrite"


### PR DESCRIPTION
##### SUMMARY
Fixes an ImagePull problem with the FSI Client Onboarding demo after images have been permanently moved to registry.redhat.io, which requires a login.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp-workload-fsi-client-onboarding-demo

##### ADDITIONAL INFORMATION
The script, like some other scripts that use RHPAM and BPM Suite, now checks for the availability of the IS in the OpenShift namespace, and if the IS is not there yet, adds it. We need to user the "openshift" namespace, as the builder service account in that namespace has pull access to registry.redhat.io.