### PR TITLE
Fix aws credential in ocp4-workshop destroy playbook

### DIFF
--- a/ansible/configs/ocp4-ha-lab/destroy_env.yml
+++ b/ansible/configs/ocp4-ha-lab/destroy_env.yml
@@ -175,7 +175,7 @@
           register: r_check_openshift_install_running
           failed_when: r_check_openshift_install_running.rc == 0
           changed_when: false
-          until: r_check_openshift_install_running.failed
+          until: r_check_openshift_install_running is succeeded
           retries: 360
           delay: 10
 

--- a/ansible/configs/ocp4-workshop/destroy_cluster.yml
+++ b/ansible/configs/ocp4-workshop/destroy_cluster.yml
@@ -6,6 +6,9 @@
     - name: destroy terraform resources (openshift-install destroy cluster)
       environment:
         PATH: /usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin:/usr/local/bin:/usr/local/bin:/root/bin
+        AWS_ACCESS_KEY_ID: "{{ aws_access_key_id }}"
+        AWS_SECRET_ACCESS_KEY: "{{ aws_secret_access_key }}"
+        AWS_REGION: "{{ aws_region_final | default(aws_region) }}"
       shell: openshift-install destroy cluster --dir={{ cluster_dir }}
       become: true
       become_user: "{{ username }}"

--- a/ansible/configs/ocp4-workshop/destroy_env.yml
+++ b/ansible/configs/ocp4-workshop/destroy_env.yml
@@ -219,6 +219,10 @@
         - when: statclusterdir.stat.exists
           block:
             - name: destroy terraform resources (openshift-install destroy cluster)
+              environment:
+                AWS_ACCESS_KEY_ID: "{{ aws_access_key_id }}"
+                AWS_SECRET_ACCESS_KEY: "{{ aws_secret_access_key }}"
+                AWS_REGION: "{{ aws_region_final | default(aws_region) }}"
               command: openshift-install destroy cluster --dir=/home/{{ ansible_user }}/{{ cluster_name }}/
               register: destroyr
               async: 2400

--- a/ansible/configs/ocp4-workshop/destroy_env.yml
+++ b/ansible/configs/ocp4-workshop/destroy_env.yml
@@ -212,7 +212,7 @@
           register: r_check_openshift_install_running
           failed_when: r_check_openshift_install_running.rc == 0
           changed_when: false
-          until: r_check_openshift_install_running.failed
+          until: r_check_openshift_install_running is succeeded
           retries: 360
           delay: 10
 


### PR DESCRIPTION
##### SUMMARY
It happens that the `openshift-install destroy` comamnd loops forever with this kind of error messages:

```
time="2020-05-26T14:17:29Z" level=debug msg="search for and delete matching instances by tag matching aws.Filter{\"openshiftClusterID\":\"66564c10-bc6f-4c81-a373-719a03722447\"}"
time="2020-05-26T14:17:29Z" level=info msg="describe instances: UnauthorizedOperation: You are not authorized to perform this operation.\n\tstatus code: 403, request id: 0eb0b0e6-913d-4d2f-8abd-7f2e60b5f548"
```

This happens when the AWS credential file `.aws/credentials` is modified on the
clientVM between provision and destroy.

This commit will fix that by ensuring the credentials are passed as environment
variables. The ocp4-workshop being aws-only, it's OK to specify the environment variables there.

Also fix the logic of the condition of the task waiting for the PID of `openshift-install`.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- ocp4-workshop config

##### ADDITIONAL INFORMATION
I tested this change with the following:

1. Deploy an ocp4-workshop
2. Intentionally corrupt the `.aws/credentials` file on the clientvm
3. Run the destroy playbook and see that it fails
4. Apply this change
5. Run again and see that it succeeds