### PR TITLE
Change to prepend local directories to PATH in bash profile

### DIFF
--- a/ansible/roles/bastion-lite/files/bash_profile
+++ b/ansible/roles/bastion-lite/files/bash_profile
@@ -7,5 +7,5 @@ fi
 
 # User specific environment and startup programs
 
-export PATH=$PATH:$HOME/bin:/usr/local/bin:/usr/local/maven/bin
+export PATH=$HOME/bin:$HOME/.local/bin:/usr/local/bin:/usr/local/maven/bin:$PATH
 export GUID=`hostname | awk -F. '{print $2}'`

--- a/ansible/roles/bastion/files/bash_profile
+++ b/ansible/roles/bastion/files/bash_profile
@@ -7,5 +7,5 @@ fi
 
 # User specific environment and startup programs
 
-export PATH=$PATH:$HOME/bin:/usr/local/bin:/usr/local/maven/bin
+export PATH=$HOME/bin:$HOME/.local/bin:/usr/local/bin:/usr/local/maven/bin:$PATH
 export GUID=`hostname | awk -F. '{print $2}'`

--- a/ansible/roles/ocp-client-vm/files/bash_profile
+++ b/ansible/roles/ocp-client-vm/files/bash_profile
@@ -7,5 +7,5 @@ fi
 
 # User specific environment and startup programs
 
-export PATH=$PATH:$HOME/bin:/usr/local/bin:/usr/local/maven/bin
+export PATH=$HOME/bin:$HOME/.local/bin:/usr/local/bin:/usr/local/maven/bin:$PATH
 export GUID=`hostname | awk -F. '{print $2}'`


### PR DESCRIPTION
##### SUMMARY

This PR updates three related bastion roles to change the `.bash_profile` to add `~/.local/bin` as well as reordering the additions to `PATH` so that `/usr/local/bin` and `~/bin` override executables in other locations.

This is particularly relevant for ansible usage, where `ansible` may be installed with `pip3 install --user --upgrade ansible` and so end up in `~/.local/bin`. In this case we want the user copy to override the system copy.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Workload roles `bastion`, `bastion-lite`, and `ocp-client-vm`.