### PR TITLE
ansible_become removed

### DIFF
--- a/ansible/configs/three-tier-app/files/hosts_template.j2
+++ b/ansible/configs/three-tier-app/files/hosts_template.j2
@@ -32,7 +32,6 @@ appdbs
 
 [threetierapp:vars]
 timeout=60
-ansible_become=yes
 ansible_user={{remote_user}}
 ansible_ssh_private_key_file="~/.ssh/{{guid}}key.pem"
 ansible_ssh_common_args="-o StrictHostKeyChecking=no"


### PR DESCRIPTION
##### SUMMARY
ansible_become=yes removed from templeate

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
env_type: three-tier-app