### PR TITLE
Update user output information to RHEL Custom Security Content lab.

### DIFF
--- a/ansible/configs/rhel-custom-security-content/post_software.yml
+++ b/ansible/configs/rhel-custom-security-content/post_software.yml
@@ -11,17 +11,17 @@
       agnosticd_user_info:
         msg: "{{ item }}"
       loop:
-        - "How to connect to VNC server using SSH port forwarding:"
+        - "Here are your credentials to access the lab environment:"
         - ""
-        - "First open the SSH connection with port forwarding, as the following:"
+        - "Password: {{ student_password | d(hostvars[groups.bastions.0].student_password)}}"
+        - "IP Address: {{ hostvars[groups.bastions.0].public_ip_address }}"
         - ""
-        - "ssh -L 5901:localhost:5901 -F {{hostvars.localhost.output_dir}}/{{ env_type }}_{{ guid }}_ssh_conf {{ student_name }}@bastion"
+        - "To access your lab environment please follow the guide:"
         - ""
-        - "Then run the VNC client using localhost and selecting the display number one:"
+        - "https://2020-summit-labs.gitlab.io/rhel-custom-security-content"
         - ""
-        - "vncviewer localhost:1"
+        - "Whenever you see instructions on the guide like <PASSWORD> or <IP_ADDRESS> you replace with credentials provided here."
         - ""
-        - "Use the following password: {{ student_password | d(hostvars[groups.bastions.0].student_password) }}"
 
     - name: print out user.data
       agnosticd_user_info:


### PR DESCRIPTION
##### SUMMARY
Update user output information for RHEL Custom Security Content workshop. This way users can access the lab environment by following the email sent as a result of the deployment.

Points users to the rendered version of the bookbag documentation hosted here:
https://2020-summit-labs.gitlab.io/rhel-custom-security-content
