### PR TITLE
[ocp4_workload_integreatly] Create dedicated admin 3scale tenant and fuse instance

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_integreatly/files/fuse/create-instance.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_integreatly/files/fuse/create-instance.yml
@@ -1,11 +1,6 @@
 --- 
-- set_fact:
-    _instance_namespace: "{{ ocp4_workload_integreatly_user_base }}{{ item | int }}-fuse"
-    _instance_count: "{{ item }}"
-    _instance_user: "{{ ocp4_workload_integreatly_user_base }}{{ item | int }}"
-    _tenant_admin_secret_name: "{{ ocp4_workload_integreatly_user_base }}{{ item | int }}-admin-credentials"
 
-- debug: msg="creating fuse instance with user '{{ _instance_user }}' "
+- debug: msg="creating fuse instance with user '{{ _instance_user }}'"
 
 # Check 3scale tenant details for this user, need management URL for integration
 - name: Get 3scale tenant details secret

--- a/ansible/roles_ocp_workloads/ocp4_workload_integreatly/files/threescale/create-tenant.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_integreatly/files/threescale/create-tenant.yml
@@ -1,15 +1,5 @@
 ---
 
-# Set internal util variables
-
-- set_fact:
-    _tenant_id: "{{ ocp4_workload_integreatly_user_base }}{{ item | int }}-tenant"
-    _tenant_count: "{{ item }}"
-    _tenant_admin_username: "{{ ocp4_workload_integreatly_user_base }}{{ item | int }}"
-    _tenant_admin_password: "{{ ocp4_workload_integreatly_user_password }}"
-    _tenant_admin_email: "{{ ocp4_workload_integreatly_user_base }}{{ item | int }}@{{ ocp4_workload_integreatly_user_email_host }}"
-    _tenant_admin_secret_name: "{{ ocp4_workload_integreatly_user_base }}{{ item | int }}-admin-credentials"
-
 - debug:
     msg: Creating tenant with id '{{ _tenant_id }}' and admin user {{ _tenant_admin_username }}
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_integreatly/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_integreatly/tasks/post_workload.yml
@@ -2,6 +2,45 @@
 # Implement your Post Workload deployment tasks here
 # --------------------------------------------------
 
+# Create dedicated admin user
+
+- name: Get current htpasswd secret
+  shell: oc get secret htpasswd-secret -n openshift-config -o json | jq -j '.data.htpasswd' | base64 --decode > /tmp/htpasswd
+
+- name: Backup htpasswd
+  shell: cp /tmp/htpasswd /tmp/htpasswd.backup
+
+- name: Create dedicated admin user
+  shell: htpasswd -B -b /tmp/htpasswd {{ ocp4_workload_integreatly_dedicated_admin_username }} {{ ocp4_workload_integreatly_dedicated_admin_user_password }}
+
+- name: Ensure htpasswd Secret is absent
+  k8s:
+    state: absent
+    api_version: v1
+    kind: Secret
+    name: htpasswd-secret
+    namespace: openshift-config
+  register: _delete_htpasswd_secret
+  until: _delete_htpasswd_secret is succeeded
+  retries: 3
+  delay: 5
+
+- name: Create new htpasswd secret
+  shell: oc create secret generic htpasswd-secret --from-file=htpasswd=/tmp/htpasswd -n openshift-config
+
+- name: Check for dedicated admins
+  shell: oc get groups dedicated-admins
+  register: group_output
+  ignore_errors: True
+
+- name: Create dedicated admin group
+  shell: oc adm groups new dedicated-admins {{ ocp4_workload_integreatly_dedicated_admin_username }}
+  when: group_output.rc == 1
+
+- name: Add dedicated admin user to dedicated admin group
+  shell: oc adm groups add-users dedicated-admins {{ ocp4_workload_integreatly_dedicated_admin_username }}
+  when: group_output.rc != 1
+
 # Handle per-user 3scale tenant setup
 
 - name: Get master host url from route
@@ -32,15 +71,48 @@
   delay: 5
   until: _create_3scale_workshop_sso_client is succeeded
 
+# Create evals tenants
 - name: Create 3scale tenants
   include_tasks: ../files/threescale/create-tenant.yml
   with_sequence: count="{{ ocp4_workload_integreatly_user_count }}"
+  loop_control:
+    loop_var: _tenant_count
+  vars:
+    _tenant_id: "{{ ocp4_workload_integreatly_user_base }}{{ _tenant_count | int }}-tenant"
+    _tenant_admin_username: "{{ ocp4_workload_integreatly_user_base }}{{ _tenant_count | int }}"
+    _tenant_admin_password: "{{ ocp4_workload_integreatly_user_password }}"
+    _tenant_admin_email: "{{ ocp4_workload_integreatly_user_base }}{{ _tenant_count | int }}@{{ ocp4_workload_integreatly_user_email_host }}"
+    _tenant_admin_secret_name: "{{ ocp4_workload_integreatly_user_base }}{{ _tenant_count | int }}-admin-credentials"
+
+# Create dedicated admin tenant
+- name: Create 3scale dedicated admin tenant
+  include_tasks: ../files/threescale/create-tenant.yml
+  vars:
+    _tenant_id: "{{ ocp4_workload_integreatly_dedicated_admin_username }}-tenant"
+    _tenant_admin_username: "{{ ocp4_workload_integreatly_dedicated_admin_username }}"
+    _tenant_admin_password: "{{ ocp4_workload_integreatly_dedicated_admin_user_password }}"
+    _tenant_admin_email: "{{ ocp4_workload_integreatly_dedicated_admin_username }}@{{ ocp4_workload_integreatly_user_email_host }}"
+    _tenant_admin_secret_name: "{{ ocp4_workload_integreatly_dedicated_admin_username }}-admin-credentials"
 
 # Handle Fuse Online
 
 - name: create fuse instances
   include_tasks: ../files/fuse/create-instance.yml
   with_sequence: count="{{ ocp4_workload_integreatly_user_count }}"
+  loop_control:
+    loop_var: _instance_count
+  vars:
+    _instance_namespace: "{{ ocp4_workload_integreatly_user_base }}{{ _instance_count | int }}-fuse"
+    _instance_user: "{{ ocp4_workload_integreatly_user_base }}{{ _instance_count | int }}"
+    _tenant_admin_secret_name: "{{ ocp4_workload_integreatly_user_base }}{{ _instance_count | int }}-admin-credentials"
+
+# Create dedicated admin fuse instance
+- name: create dedicated admin fuse instance
+  include_tasks: ../files/fuse/create-instance.yml
+  vars:
+    _instance_namespace: "{{ ocp4_workload_integreatly_dedicated_admin_username }}-fuse"
+    _instance_user: "{{ ocp4_workload_integreatly_dedicated_admin_username }}"
+    _tenant_admin_secret_name: "{{ ocp4_workload_integreatly_dedicated_admin_username }}-admin-credentials"
 
 - name: Checking Fuse Online installation status
   shell: oc get syndesis --selector=rhmiWorkshop=true --all-namespaces | grep Installed | wc -l
@@ -49,45 +121,7 @@
   delay: 60
   retries: 30
 
-# Create dedicated admin user
-
-- name: Get current htpasswd secret
-  shell: oc get secret htpasswd-secret -n openshift-config -o json | jq -j '.data.htpasswd' | base64 --decode > /tmp/htpasswd
-
-- name: Backup htpasswd
-  shell: cp /tmp/htpasswd /tmp/htpasswd.backup
-
-
-- name: Create dedicated admin user
-  shell: htpasswd -B -b /tmp/htpasswd {{ ocp4_workload_integreatly_dedicated_admin_username }} {{ ocp4_workload_integreatly_dedicated_admin_user_password }}
-
-- name: Ensure htpasswd Secret is absent
-  k8s:
-    state: absent
-    api_version: v1
-    kind: Secret
-    name: htpasswd-secret
-    namespace: openshift-config
-  register: _ensure_absent_secret
-  retries: 3
-  delay: 5
-  until: _ensure_absent_secret is succeeded
-
-- name: Create new htpasswd secret
-  shell: oc create secret generic htpasswd-secret --from-file=htpasswd=/tmp/htpasswd -n openshift-config
-
-- name: Check for dedicated admins
-  shell: oc get groups dedicated-admins
-  register: group_output
-  ignore_errors: True
-
-- name: Create dedicated admin group
-  shell: oc adm groups new dedicated-admins {{ ocp4_workload_integreatly_dedicated_admin_username }}
-  when: group_output.rc == 1
-
-- name: Add dedicated admin user to dedicated admin group
-  shell: oc adm groups add-users dedicated-admins {{ ocp4_workload_integreatly_dedicated_admin_username }}
-  when: group_output.rc != 1
+# Wait for installation to complete
 
 - name: Get RHMI custom resource
   k8s_facts:


### PR DESCRIPTION
##### SUMMARY
Create a 3scale tenant and fuse instance for the `dedicated-admin` user for the `ocp4_workload_integreatly` role.

Fixes: https://issues.redhat.com/browse/INTLY-8153

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
Role: `ocp4_workload_integreatly`

##### ADDITIONAL INFORMATION
Verification steps
- Provision an ocp 4.4 workshop (note: increase the number of ocp users to increase the number of nodes. 60-100 should be enough for `50` evals users)
- Run an integreatly installation from this branch 
- Log in as the `dedicated-admin` user, ensure this user can:
   - Access the fuse console from solution explorer
   - Access the 3scale console from solution explorer
   - Run through the walkthroughs and can access the links to the 3scale and fuse consoles 
- Login is as an `evals` user, ensure this user can: 
   - Access the fuse console from solution explorer
   - Access the 3scale console from solution explorer
   - Run through the walkthroughs and can access the links to the 3scale and fuse consoles 