### PR TITLE
Update user output information to SELinux policy writing workshop

### DIFF
--- a/ansible/configs/selinux-policy/post_software.yml
+++ b/ansible/configs/selinux-policy/post_software.yml
@@ -7,6 +7,30 @@
     - debug:
         msg: "Step 005 Post Software"
 
+    - name: print out user.info
+      agnosticd_user_info:
+        msg: "{{ item }}"
+      loop:
+        - "Here are your credentials to access the lab environment:"
+        - ""
+        - "Password: {{ student_password | d(hostvars[groups.bastions.0].student_password)}}"
+        - "IP Address: {{ hostvars[groups.bastions.0].public_ip_address }}"
+        - ""
+        - "To access your lab environment please follow the guide:"
+        - ""
+        - "https://2020-summit-labs.gitlab.io/selinux-policy-bookbag/"
+        - ""
+        - "Whenever you see instructions on the guide like &lt;PASSWORD&gt; or &lt;IP_ADDRESS&gt; you replace with credentials provided here."
+        - ""
+
+    - name: print out user.data
+      agnosticd_user_info:
+        data:
+          USERNAME: "{{ student_user }}"
+          PASSWORD: "{{ student_password | d(hostvars[groups.bastions.0].student_password)}}"
+          IP_ADDRESS: "{{ hostvars[groups.bastions.0].public_ip_address }}"
+          PUBLIC_DNS: "{{ hostvars[groups.bastions.0].public_dns_name }}"
+
 - name: PostSoftware flight-check
   hosts: localhost
   connection: local


### PR DESCRIPTION
##### SUMMARY
This way users can access the lab environment by following the email sent as a result of the deployment.

Points users to the rendered version of the bookbag documentation hosted here:
https://2020-summit-labs.gitlab.io/selinux-policy-bookbag/

##### SUMMARY

