### PR TITLE
Escape HTML special characters on user output information.

### DIFF
--- a/ansible/configs/rhel-custom-security-content/post_software.yml
+++ b/ansible/configs/rhel-custom-security-content/post_software.yml
@@ -20,7 +20,7 @@
         - ""
         - "https://2020-summit-labs.gitlab.io/rhel-custom-security-content"
         - ""
-        - "Whenever you see instructions on the guide like <PASSWORD> or <IP_ADDRESS> you replace with credentials provided here."
+        - "Whenever you see instructions on the guide like &lt;PASSWORD&gt; or &lt;IP_ADDRESS&gt; you replace with credentials provided here."
         - ""
 
     - name: print out user.data


### PR DESCRIPTION
##### SUMMARY
A follow-up to #1829 . We need to escape characters `<` and `>` since the content is used in a HTML page.
