### PR TITLE
Making OCP4 on Azure IaaS have a functional destroy

### DIFF
--- a/ansible/roles-infra/infra-azure-create-inventory/tasks/main.yml
+++ b/ansible/roles-infra/infra-azure-create-inventory/tasks/main.yml
@@ -27,6 +27,7 @@
   # specify path to use azure-cli from system and not from python virtualenv
   environment:
     PATH: /usr/bin
+    AZURE_CONFIG_DIR: "/tmp/.azure-{{project_tag}}"
   changed_when: false
   register: result_list
   tags:


### PR DESCRIPTION
##### SUMMARY
Immediate goal is to make OCP4 on Azure IaaS functional, so this is the only PATH that fails. A wider cleanup of environment settings will come after for the Azure cloud provider and roles.
 
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
roles-infra/infra-azure-create-inventory

##### ADDITIONAL INFORMATION
N/A
