### PR TITLE
use k8s to deploy imagestream; include admin URL in user.info

### DIFF
--- a/ansible/roles/ocp4-workload-ccnrd/files/sso74-image-stream.yaml
+++ b/ansible/roles/ocp4-workload-ccnrd/files/sso74-image-stream.yaml
@@ -1,39 +1,30 @@
----
-kind: List
+kind: ImageStream
 apiVersion: v1
 metadata:
-  name: sso74-image-stream
+  name: sso74-openshift-rhel8
   annotations:
-    description: ImageStream definition for Red Hat Single Sign-On 7.4 on OpenJDK.
+    description: Red Hat Single Sign-On 7.4 on OpenJDK
+    openshift.io/display-name: Red Hat Single Sign-On 7.4 on OpenJDK
     openshift.io/provider-display-name: Red Hat, Inc.
-items:
-- kind: ImageStream
-  apiVersion: v1
-  metadata:
-    name: sso74-openshift-rhel8
+    version: 7.4.0.GA
+labels:
+  rhsso: 7.4.0.GA
+spec:
+  tags:
+  - name: latest
+    from:
+      kind: ImageStreamTag
+      name: '7.4'
+  - name: '7.4'
     annotations:
-      description: Red Hat Single Sign-On 7.4 on OpenJDK
+      description: Red Hat Single Sign-On 7.4 on OpenJDK image
+      iconClass: icon-sso
+      tags: sso,keycloak,redhat,hidden
+      supports: sso:7.4
+      version: '1.0'
       openshift.io/display-name: Red Hat Single Sign-On 7.4 on OpenJDK
-      openshift.io/provider-display-name: Red Hat, Inc.
-      version: 7.4.0.GA
-  labels:
-    rhsso: 7.4.0.GA
-  spec:
-    tags:
-    - name: latest
-      from:
-        kind: ImageStreamTag
-        name: '7.4'
-    - name: '7.4'
-      annotations:
-        description: Red Hat Single Sign-On 7.4 on OpenJDK image
-        iconClass: icon-sso
-        tags: sso,keycloak,redhat,hidden
-        supports: sso:7.4
-        version: '1.0'
-        openshift.io/display-name: Red Hat Single Sign-On 7.4 on OpenJDK
-      referencePolicy:
-        type: Local
-      from:
-        kind: DockerImage
-        name: registry.redhat.io/rh-sso-7/sso74-openshift-rhel8:7.4
+    referencePolicy:
+      type: Local
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/rh-sso-7/sso74-openshift-rhel8:7.4

--- a/ansible/roles/ocp4-workload-ccnrd/tasks/post_workload.yml
+++ b/ansible/roles/ocp4-workload-ccnrd/tasks/post_workload.yml
@@ -10,7 +10,7 @@
   debug:
     msg:
     - "user.info: "
-    - "user.info: URL for attendees to get a username assigned to them and links to labs:"
+    - "user.info: URL for attendees to get a username assigned to them and get personaliized links to labs:"
     - "user.info: "
     - "user.info: http://get-a-username-labs-infra.{{ route_subdomain }}"
     - "user.info: "

--- a/ansible/roles/ocp4-workload-ccnrd/tasks/post_workload.yml
+++ b/ansible/roles/ocp4-workload-ccnrd/tasks/post_workload.yml
@@ -15,6 +15,12 @@
     - "user.info: http://get-a-username-labs-infra.{{ route_subdomain }}"
     - "user.info: "
     - "user.info: You should share this URL (or a shortlink for it) -- It is all they will need to get started!"
+    - "user.info: "
+    - "user.info: [Instructor Only] To access the admin see which user is assigned to which user ID, use the following:"
+    - "user.info: "
+    - "user.info: [Instructor Only] http://get-a-username-labs-infra.{{ route_subdomain }}/admin"
+    - "user.info: "
+    - "user.info: [Instructor Only] Admin login with 'admin' / '{{ workshop_openshift_user_password }}'"
 
 - name: output workshop username distribution URL
   debug:

--- a/ansible/roles/ocp4-workload-ccnrd/tasks/post_workload.yml
+++ b/ansible/roles/ocp4-workload-ccnrd/tasks/post_workload.yml
@@ -10,7 +10,7 @@
   debug:
     msg:
     - "user.info: "
-    - "user.info: URL for attendees to get a username assigned to them and get personaliized links to labs:"
+    - "user.info: URL for attendees to get a username assigned to them and links to labs:"
     - "user.info: "
     - "user.info: http://get-a-username-labs-infra.{{ route_subdomain }}"
     - "user.info: "

--- a/ansible/roles/ocp4-workload-ccnrd/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-ccnrd/tasks/workload.yml
@@ -45,16 +45,18 @@
     - ./files/coolstore-monolith-binary-build-template.yaml
     - ./files/coolstore-monolith-pipeline-build-template.yaml
     - ./files/jaeger-all-in-one-template.yml
+    - ./files/ccn-sso74-template.yaml
 
 - name: import sso74-image-stream to openshift namespace
-  command: oc create -n openshift -f -
-  args:
-     stdin: "{{ lookup('file', './files/sso74-image-stream.yaml') }}"
-
-- name: create ccn-sso74 templates to openshift namespace
-  command: oc create -n openshift -f -
-  args:
-     stdin: "{{ lookup('file', './files/ccn-sso74-template.yaml') }}"
+  k8s:
+    state: present
+    namespace: openshift
+    merge_type:
+    - strategic-merge
+    - merge
+    definition: "{{ lookup('file', item ) | from_yaml }}"
+  loop:
+  - ./files/sso74-image-stream.yaml
 
 - name: create inventory and catalog user projects
   when: ("m1" in modules or "m2" in modules or "m3" in modules)


### PR DESCRIPTION
##### SUMMARY
Minor fix to make workload idempotent when deploying imagestream. Also added extra URL in `user.info` for username distribution admin console.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`ocp4-workload-ccnrd`

