### PR TITLE
ocp4_workload_integreatly: fix unicode string handling in list append

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_integreatly/files/threescale/create-tenant.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_integreatly/files/threescale/create-tenant.yml
@@ -116,7 +116,7 @@
     until: _create_tenantdetails_secret is succeeded
 
   - set_fact:
-      _sso_redirect_uris: "{{ _action_get_client.resources[0].spec.client.redirectUris + [_tenant_host + '/*'] }}"
+      _sso_redirect_uris: "{{ (_action_get_client.resources[0].spec.client.redirectUris | default([])) + [(_tenant_host + '/*' | string)] }}"
 
   - name: Get managed 3scale SSO client
     k8s_facts:

--- a/ansible/roles_ocp_workloads/ocp4_workload_integreatly/templates/keycloakclient-3scale-workshop.yml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_integreatly/templates/keycloakclient-3scale-workshop.yml.j2
@@ -7,7 +7,7 @@ spec:
     enabled: true
     clientAuthenticatorType: client-secret
     fullScopeAllowed: true
-    redirectUris: {{ ocp4_workload_integreatly_threescale_sso_client_redirect_uris }}
+    redirectUris: {{ ocp4_workload_integreatly_threescale_sso_client_redirect_uris | to_json }}
     access:
       configure: true
       manage: true


### PR DESCRIPTION
fix unicode string handling discussed in [1] in the 3scale workshop
sso client updates.

this ensures the sso client custom resource does not contain any 'u'
characters.

components:

- role: roles_ocp_workloads/ocp4_workload_integreatly

[1] https://stackoverflow.com/questions/41521138/ansible-template-adds-u-to-array-in-template