### PR TITLE
enforcing character limit on keyvault name

### DIFF
--- a/ansible/roles-infra/infra-azure-ssh-key/tasks/main.yml
+++ b/ansible/roles-infra/infra-azure-ssh-key/tasks/main.yml
@@ -39,7 +39,7 @@
         PATH: /usr/bin
       command: >
         az keyvault secret show
-        --vault-name '{{project_tag}}-kv'
+        --vault-name 'rhpds-{{guid[:12]}}-kv'
         --name 'sshPrivateKey'
         --query value -o tsv
       register: r_ssh_key
@@ -67,7 +67,7 @@
         PATH: /usr/bin
       command: >
           az keyvault create
-          --name '{{project_tag}}-kv'
+          --name 'rhpds-{{guid[:12]}}-kv'
           --resource-group '{{ az_resource_group }}'
 
     - name: Store SSH Key in keyvault
@@ -76,7 +76,7 @@
         PATH: /usr/bin
       command: >
           az keyvault secret set
-          --vault-name '{{project_tag}}-kv'
+          --vault-name 'rhpds-{{guid[:12]}}-kv'
           --name 'sshPrivateKey'
           --file '{{ infra_ssh_key }}'
 


### PR DESCRIPTION
##### SUMMARY
Enforcing the keyvault to only use up to its 24 character limit

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
roles-infra/infra-azure-ssh-key

##### ADDITIONAL INFORMATION
forgot about the 24 character limit on the keyvault name which also needs to be globally unqiue
