### PR TITLE
Removing credentials so lab users can't access them

### DIFF
--- a/ansible/configs/ocp4-cluster/post_software.yml
+++ b/ansible/configs/ocp4-cluster/post_software.yml
@@ -265,6 +265,31 @@
       path: "/home/{{ ansible_user }}/.aws"
       state: absent
 
+  - name: Remove Azure Credentials directory from bastion
+    when: cloud_provider == 'azure'
+    file:
+      path: "/home/{{ ansible_user }}/.azure"
+      state: absent
+
+  - name: Remove Azure Credentials directory from bastion
+    when: cloud_provider == 'gcp'
+    file:
+      path: "/home/{{ ansible_user }}/.gcp"
+      state: absent
+
+  - name: Remove Azure Credentials directory from bastion
+    when: cloud_provider == 'gcp'
+    file:
+      path: "/home/{{ ansible_user }}/.config/gcloud"
+      state: absent
+
+  - name: set fact for kubeadmin password for Azure and GCP
+    slurp:
+      src: '/home/{{ ansible_user }}/{{ cluster_name }}/auth/kubeadmin-password'
+    register: kubeadmin_password
+    when: cloud_provider == "azure" or cloud_provider == "gcp"
+
+
 - name: Step 005.6 Print Student Info
   hosts: localhost
   gather_facts: false
@@ -284,6 +309,10 @@
       - "user.info: ssh {{ student_name }}@bastion.{{ guid }}{{ subdomain_base_suffix if cloud_provider == 'ec2' else '.'+ocp4_base_domain }}"
       - "user.info: "
       - "user.info: Make sure you use the username '{{ student_name }}' and the password '{{ hostvars[bastion_hostname]['student_password'] }}' when prompted."
+    - name: print out user.info
+      debug:
+        msg: "user.info: kubeadmin password {{ hostvars[bastion_hostname]['kubeadmin_password']['content']}}"
+      when: cloud_provider == "azure" or cloud_provider == "gcp"
 
 - name: Step 005.7 Tell CloudForms we are done
   hosts: localhost

--- a/ansible/configs/ocp4-cluster/post_software.yml
+++ b/ansible/configs/ocp4-cluster/post_software.yml
@@ -271,13 +271,13 @@
       path: "/home/{{ ansible_user }}/.azure"
       state: absent
 
-  - name: Remove Azure Credentials directory from bastion
+  - name: Remove the openshift-installer GCP Credentials directory from bastion
     when: cloud_provider == 'gcp'
     file:
       path: "/home/{{ ansible_user }}/.gcp"
       state: absent
 
-  - name: Remove Azure Credentials directory from bastion
+  - name: Remove gcloud CLI Credentials directory from bastion
     when: cloud_provider == 'gcp'
     file:
       path: "/home/{{ ansible_user }}/.config/gcloud"

--- a/ansible/roles/host-ocp4-destroy/tasks/azure_prereqs.yml
+++ b/ansible/roles/host-ocp4-destroy/tasks/azure_prereqs.yml
@@ -1,0 +1,16 @@
+---
+- name: make the base directory
+  file:
+    path: "/home/{{ ansible_user }}/.azure"
+    mode: 0700
+    owner: "{{ ansible_user }}"
+    state: directory
+
+- name: Add osServicePrincipal.json file for OpenShift Installer
+  template:
+    src: "osServicePrincipal.json.j2"
+    dest: "/home/{{ ansible_user }}/.azure/osServicePrincipal.json"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: 0600
+

--- a/ansible/roles/host-ocp4-destroy/tasks/gcp_prereqs.yml
+++ b/ansible/roles/host-ocp4-destroy/tasks/gcp_prereqs.yml
@@ -1,0 +1,16 @@
+---
+- name: make the base directory
+  file:
+    path: "/home/{{ ansible_user }}/.gcp"
+    mode: 0700
+    owner: "{{ ansible_user }}"
+    state: directory
+
+- name: Create key file for Google Cloud SDK
+  copy:
+    src: "{{ gcp_credentials_file }}"
+    dest: "/home/{{ ansible_user }}/.gcp/osServiceAccount.json"
+    mode: 0600
+    owner: "{{ ansible_user }}"
+  become: no
+

--- a/ansible/roles/host-ocp4-destroy/tasks/main.yml
+++ b/ansible/roles/host-ocp4-destroy/tasks/main.yml
@@ -1,3 +1,9 @@
+- name: Set up cloud provider specific prerequisites
+  when:
+  - cloud_provider == "azure" or
+    cloud_provider == "gcp"
+  import_tasks: "{{cloud_provider}}_prereqs.yml"
+
 - name: Wait for openshift-install to complete
   command: pidof openshift-install
   register: r_check_openshift_install_running

--- a/ansible/roles/host-ocp4-destroy/templates/osServicePrincipal.json.j2
+++ b/ansible/roles/host-ocp4-destroy/templates/osServicePrincipal.json.j2
@@ -1,0 +1,1 @@
+{"subscriptionId":"{{azure_subscription_id}}","clientId":"{{azure_service_principal}}","clientSecret":"{{azure_password}}","tenantId":"{{azure_tenant}}"}


### PR DESCRIPTION
##### SUMMARY
Giving kubeadmin password on GCP and Azure so the web console can be used and removing the actual cloud credentials post-install (and readding them during the destroy) so lab users can't deploy their own Azure and GCP assets. 

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
configs/ocp4-cluster
role/host-ocp4-destroy

##### ADDITIONAL INFORMATION
This brings up almost completely inline with how AWS is treated by AgnosticD for ocp4-cluster.

