### PR TITLE
Update selinux-policy email to follow selinux-policy docs

### DIFF
--- a/ansible/configs/selinux-policy/post_software.yml
+++ b/ansible/configs/selinux-policy/post_software.yml
@@ -13,8 +13,8 @@
       loop:
         - "Here are your credentials to access the lab environment:"
         - ""
-        - "Password: {{ student_password | d(hostvars[groups.bastions.0].student_password)}}"
-        - 'SSH Connection: ssh -o "ServerAliveInterval 30" {{ student_user }}@{{ hostvars[groups.bastions.0].public_ip_address }}'
+        - "student_ssh_password: {{ student_password | d(hostvars[groups.bastions.0].student_password)}}"
+        - 'student_ssh_command: ssh -o "ServerAliveInterval 30" {{ student_user }}@{{ hostvars[groups.bastions.0].public_ip_address }}'
         - ""
         - "To access the lab instructions, check the following guide:"
         - ""

--- a/ansible/configs/selinux-policy/post_software.yml
+++ b/ansible/configs/selinux-policy/post_software.yml
@@ -14,14 +14,11 @@
         - "Here are your credentials to access the lab environment:"
         - ""
         - "Password: {{ student_password | d(hostvars[groups.bastions.0].student_password)}}"
-        - "IP Address: {{ hostvars[groups.bastions.0].public_ip_address }}"
-        - "SSH command: ssh {{ student_user }}@bastion.{{ subdomain_base }}"
+        - 'SSH Connection: ssh -o "ServerAliveInterval 30" {{ student_user }}@{{ hostvars[groups.bastions.0].public_ip_address }}'
         - ""
-        - "To access your lab environment please follow the guide:"
+        - "To access the lab instructions, check the following guide:"
         - ""
         - "https://2020-summit-labs.gitlab.io/selinux-policy-bookbag/"
-        - ""
-        - "Whenever you see instructions on the guide like &lt;PASSWORD&gt; or &lt;IP_ADDRESS&gt; you replace with credentials provided here."
         - ""
 
     - name: print out user.data


### PR DESCRIPTION
Update selinux-policy workshop user output.

Note that I have added the option `-o "ServerAliveInterval 30"` to the ssh command so users are not disconnected after some period of absence, aka reading workshop's text for more than a few minutes