### PR TITLE
[WIP] [DONTMERGE] [osp-migration] Use uuid as project name and user created

### DIFF
--- a/ansible/configs/osp-migration/destroy_env.yml
+++ b/ansible/configs/osp-migration/destroy_env.yml
@@ -14,11 +14,18 @@
     OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
     OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"
   tasks:
-    - set_fact:
+    - name: Set project name based on guid if uuid doesn't exist
+      when: uuid is undefined
+      set_fact:
         osp_project_name: >-
           {{ project
           | replace('-bp','')
           }}-{{ guid }}
+
+    - name: Set project name based on uuid
+      when: uuid is defined
+      set_fact:
+        osp_project_name: "{{ uuid }}"
 
     - name: Check if project exists
       environment:

--- a/ansible/configs/osp-migration/env_vars.yml
+++ b/ansible/configs/osp-migration/env_vars.yml
@@ -41,10 +41,7 @@ guid: mydefault
 # Used to add metadata (tags) to OpenStack objects created
 project_tag: "{{ env_type }}-{{ guid }}"
 
-osp_project_name: >-
-  {{ project
-  | replace('-bp','')
-  }}-{{ guid }}
+osp_project_name: "{{ uuid }}"
 
 
 # Why is this config being deployed?

--- a/ansible/configs/osp-migration/infra.yml
+++ b/ansible/configs/osp-migration/infra.yml
@@ -44,7 +44,7 @@
         template: "{{ output_dir }}/imported-templates/heat-templates/{{ project }}/stack_admin.yaml"
         parameters:
           project_name: "{{ osp_project_name }}"
-          project_guid: "{{ guid }}"
+          project_guid: "{{ uuid }}"
           project_description: "created:{{ ansible_date_time.epoch }}"
           project_api_user: "{{ uuid }}"
           project_api_pass: "{{ osp_migration_api_pass }}"
@@ -93,7 +93,7 @@
           api_url: "{{ osp_auth_url }}"
           api_user: "{{ uuid }}"
           api_pass: "{{ osp_migration_api_pass }}"
-          project_guid: "{{ guid }}"
+          project_guid: "{{ uuid }}"
           dns_domain: "{{ osp_cluster_dns_zone }}"
 
     - name: Save services content
@@ -177,7 +177,7 @@
         server: "*"
         filters:
           metadata:
-            guid: "{{ guid }}"
+            guid: "{{ uuid|default(guid) }}"
       register: r_osp_facts
 
 

--- a/ansible/configs/osp-migration/infra.yml
+++ b/ansible/configs/osp-migration/infra.yml
@@ -2,9 +2,9 @@
 - hosts: localhost
   gather_facts: false
   vars:
-    api_user: "{{ guid }}"
+    api_user: "{{ uuid }}"
     default_metadata:
-      project: "{{ project |d('unknownproject')}}"
+      project: "{{ uuid |d('unknownproject')}}"
       env_type: "{{ env_type |d('unknownenvtype') }}"
       course_name: "{{ course_name | default('unkowncourse') }}"
       purpose: "{{ purpose | default('unkownpurpose') }}"
@@ -46,7 +46,7 @@
           project_name: "{{ osp_project_name }}"
           project_guid: "{{ guid }}"
           project_description: "created:{{ ansible_date_time.epoch }}"
-          project_api_user: "{{ guid }}"
+          project_api_user: "{{ uuid }}"
           project_api_pass: "{{ osp_migration_api_pass }}"
           blueprint: "{{ project }}"
 
@@ -79,7 +79,7 @@
       register: stack_user_output
       environment:
         OS_AUTH_URL: "{{ osp_auth_url }}"
-        OS_USERNAME: "{{ guid }}"
+        OS_USERNAME: "{{ uuid }}"
         OS_PASSWORD: "{{ osp_migration_api_pass }}"
         OS_PROJECT_NAME: "{{ osp_project_name }}"
         OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
@@ -91,7 +91,7 @@
           project_name: "{{ osp_project_name }}"
           public_net_id: "{{ external_network }}"
           api_url: "{{ osp_auth_url }}"
-          api_user: "{{ guid }}"
+          api_user: "{{ uuid }}"
           api_pass: "{{ osp_migration_api_pass }}"
           project_guid: "{{ guid }}"
           dns_domain: "{{ osp_cluster_dns_zone }}"
@@ -168,7 +168,7 @@
     - name: Gather instance facts
       environment:
         OS_AUTH_URL: "{{ osp_auth_url }}"
-        OS_USERNAME: "{{ guid }}"
+        OS_USERNAME: "{{ uuid }}"
         OS_PASSWORD: "{{ osp_migration_api_pass }}"
         OS_PROJECT_NAME: "{{ osp_project_name }}"
         OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
@@ -202,7 +202,7 @@
 
       environment:
         OS_AUTH_URL: "{{ osp_auth_url }}"
-        OS_USERNAME: "{{ guid }}"
+        OS_USERNAME: "{{ uuid }}"
         OS_PASSWORD: "{{ osp_migration_api_pass }}"
         OS_PROJECT_NAME: "{{ osp_project_name }}"
         OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"

--- a/ansible/configs/osp-migration/infra.yml
+++ b/ansible/configs/osp-migration/infra.yml
@@ -177,7 +177,7 @@
         server: "*"
         filters:
           metadata:
-            guid: "{{ uuid|default(guid) }}"
+            guid: "{{ uuid }}"
       register: r_osp_facts
 
 


### PR DESCRIPTION
Instead to use the guid for the project name and username, it uses the uuid generated by CF as project name and username created 