### PR TITLE
Update project_resources.yml

### DIFF
--- a/ansible/roles-infra/infra-osp-resources-destroy/tasks/project_resources.yml
+++ b/ansible/roles-infra/infra-osp-resources-destroy/tasks/project_resources.yml
@@ -47,7 +47,18 @@
         - debug:
             var: _all_volumes
             verbosity: 2
-
+            
+        - name: Reset all volumes state to error
+          command: >-
+            openstack volume set --state error {{ item }}
+          loop: "{{ _all_volumes }}"
+          
+        - name: Detach all volumes
+          command: >-
+            openstack volume set --detached {{ item }}
+          loop: "{{ _all_volumes }}"
+          ignore_errors: yes
+          
         - name: Delete all volumes
           command: >-
             openstack volume delete {{ item }}


### PR DESCRIPTION
##### SUMMARY
Set openstack volumes state to error and detached before deleting the volume.  There is an issue where Heat templates created via agnosticD do not maintain dependency with all volumes.  This breaks deletion.  To fix it, the volume status must be set to error or available then detached from any instance.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
https://github.com/redhat-cop/agnosticd/blob/development/ansible/roles-infra/infra-osp-resources-destroy/tasks/project_resources.yml

##### ADDITIONAL INFORMATION
```
openstack volume set --state error <vol id>
openstack volume set --detached <vol id>
```
