### PR TITLE
fix expected fuse online instance count

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_integreatly/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_integreatly/tasks/post_workload.yml
@@ -114,10 +114,11 @@
     _instance_user: "{{ ocp4_workload_integreatly_dedicated_admin_username }}"
     _tenant_admin_secret_name: "{{ ocp4_workload_integreatly_dedicated_admin_username }}-admin-credentials"
 
+# We expect the amount of users provided + 1 as the dedicated admin user will also be created
 - name: Checking Fuse Online installation status
   shell: oc get syndesis --selector=rhmiWorkshop=true --all-namespaces | grep Installed | wc -l
   register: _action_check_fuse_online_installation_status
-  until: _action_check_fuse_online_installation_status.stdout == "{{ ocp4_workload_integreatly_user_count }}"
+  until: _action_check_fuse_online_installation_status.stdout == "{{ ocp4_workload_integreatly_user_count + 1 }}"
   delay: 60
   retries: 30
 


### PR DESCRIPTION
ensure dedicated admin fuse online instance is counted in fuse
online verification check.

components:
- role, ocp4_workload_integreatly