### PR TITLE
Fix StudentVM user.info output

### DIFF
--- a/ansible/configs/studentvm/default_vars_osp.yml
+++ b/ansible/configs/studentvm/default_vars_osp.yml
@@ -67,7 +67,7 @@ provider_network: external
 subdomain_base_short: "{{ guid }}"
 # osp_cluster_dns_zone needs to come from secrets
 subdomain_base_suffix: "{{ osp_cluster_dns_zone }}"
-subdomain_base: "{{subdomain_base_short}}{{subdomain_base_suffix}}"
+subdomain_base: "{{ subdomain_base_short }}.{{ subdomain_base_suffix }}"
 
 # A list of the private networks and subnets to create in the project
 # You can create as many as you want, but at least one is required.


### PR DESCRIPTION
##### SUMMARY
The format of the output was wrong for the OSP provider with studentvm. 

subdomain base was being created without a . between the other vars. We define osp_cluster_dns_zone without a . prefix everywhere, so the var was created as something like `guidsubdomainbasesuffix` with no . between.


##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
studentvm
