### PR TITLE
ensure user count param is treated as int

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_integreatly/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_integreatly/tasks/post_workload.yml
@@ -118,7 +118,7 @@
 - name: Checking Fuse Online installation status
   shell: oc get syndesis --selector=rhmiWorkshop=true --all-namespaces | grep Installed | wc -l
   register: _action_check_fuse_online_installation_status
-  until: _action_check_fuse_online_installation_status.stdout == "{{ ocp4_workload_integreatly_user_count + 1 }}"
+  until: (_action_check_fuse_online_installation_status.stdout | int) == (ocp4_workload_integreatly_user_count | int) + 1"
   delay: 60
   retries: 30
 


### PR DESCRIPTION
parse the user count param with the int filter to ensure it's not
treated as a string

components:
- role, ocp4_workload_integreatly

verification:
- run the role, ensure it does not fail