### PR TITLE
Revert "Get OCP4 installation logs in a block"

### DIFF
--- a/ansible/configs/ocp4-cluster/post_software.yml
+++ b/ansible/configs/ocp4-cluster/post_software.yml
@@ -8,18 +8,6 @@
   tasks:
   - debug:
       msg: "Post-Software Steps starting"
-  
-  - name: Gzip Install log
-    archive:
-      path: /home/{{ ansible_user }}/{{ cluster_name }}/.openshift_install.log
-      dest: /home/{{ ansible_user }}/{{ cluster_name }}/.openshift_install.log.gz
-      format: gz
-
-  - name: Get Install log
-    fetch:
-      src: /home/{{ ansible_user }}/{{ cluster_name }}/.openshift_install.log.gz
-      dest: "{{ output_dir }}/{{ env_type }}_{{ guid }}_log/"
-      flat: yes
 
 - name: Step 005.1 - Post Software flight-check
   hosts: bastions

--- a/ansible/configs/ocp4-workshop/software.yml
+++ b/ansible/configs/ocp4-workshop/software.yml
@@ -120,31 +120,17 @@
             src: /home/{{ ansible_user }}/{{ cluster_name }}/install-config.yaml
             dest: /home/{{ ansible_user }}/{{ cluster_name }}/install-config.yaml.bak
 
-          block:
-            - name: Run the installer
-              command: openshift-install create cluster --dir=/home/{{ ansible_user }}/{{ cluster_name }}
-              async: "{{ 2 * 60 * 60 }}"
-              tags:
-                - run_installer
-              register: r_openshift_install
-              until: >-
-                r_openshift_install.rc == 0 or
-                'validate AWS credentials: mint credentials check: error simulating policy: Throttling: Rate exceeded' not in r_openshift_install.stderr
-              delay: 300
-              retries: 10
-
-          always:
-            - name: Gzip Install log
-              archive:
-                path: /home/{{ ansible_user }}/{{ cluster_name }}/.openshift_install.log
-                dest: /home/{{ ansible_user }}/{{ cluster_name }}/.openshift_install.log.gz
-                format: gz
-
-            - name: Get Install log
-              fetch:
-                src: /home/{{ ansible_user }}/{{ cluster_name }}/.openshift_install.log.gz
-                dest: "{{ output_dir }}/{{ env_type }}_{{ guid }}_log/"
-                flat: true
+        - name: Run the installer
+          tags:
+          - run_installer
+          command: openshift-install create cluster --dir=/home/{{ ansible_user }}/{{ cluster_name }}
+          async: "{{ 2 * 60 * 60 }}"
+          register: r_openshift_install
+          until: >-
+            r_openshift_install.rc == 0 or
+            'validate AWS credentials: mint credentials check: error simulating policy: Throttling: Rate exceeded' not in r_openshift_install.stderr
+          delay: 300
+          retries: 10
 
         - name: Fetch kube config
           fetch:


### PR DESCRIPTION
Reverts redhat-cop/agnosticd#1937

I'm not sure how this was tested. It is breaking things because the syntax for the block doesn't appear to be correct. I also don't understand why we have the same tasks in both software and post-software phase?

I don't have the bandwidth to test the fix, but it should be as simple as a `-` and some spaces.

```
The error appears to have been in '/tmp/ocp4-workshop-046f/ansible_agnostic_deployer/ansible/configs/ocp4-workshop/software.yml': line 117, column 11, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

        - name: Make a copy of the cluster install config
          ^ here
```