### PR TITLE
Add new required variable for upstream SAP Ansible Role

### DIFF
--- a/ansible/configs/sap-hana/default_vars.yml
+++ b/ansible/configs/sap-hana/default_vars.yml
@@ -303,7 +303,7 @@ ansible_tower:
     license_file: "/tmp/license.json"
   inventories:
     - name: "sap-hosts"
-      variables: '---\nsap_preconfigure_modify_etc_hosts: true\nsap_domain: \"labs.local\"\nsap_hostagent_installation_type: \"rpm\"\nsap_hostagent_rpm_remote_path: \"/software/SAPHOSTAGENT\"\nsap_hostagent_rpm_file_name: \"saphostagentrpm_44-20009394.rpm\"'
+      variables: '---\nsap_preconfigure_modify_etc_hosts: true\nsap_preconfigure_fail_if_reboot_required: \"no\"\nsap_domain: \"labs.local\"\nsap_hostagent_installation_type: \"rpm\"\nsap_hostagent_rpm_remote_path: \"/software/SAPHOSTAGENT\"\nsap_hostagent_rpm_file_name: \"saphostagentrpm_44-20009394.rpm\"'
       description: "SAP HANA and S/4HANA"
       organization: "Default"
       hosts:


### PR DESCRIPTION
##### SUMMARY
The upstream `https://github.com/linux-system-roles/sap-preconfigure` role requires now a new variable to skip errors in case the host needs a reboot. Adding this to the config so the e2e process doesn't fail because of this.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
sap-hana
