### PR TITLE
Use HTML enconding to output double quotes into selinux-policy post_software

### DIFF
--- a/ansible/configs/selinux-policy/post_software.yml
+++ b/ansible/configs/selinux-policy/post_software.yml
@@ -14,7 +14,7 @@
         - "Here are your credentials to access the lab environment:"
         - ""
         - "student_ssh_password: {{ student_password | d(hostvars[groups.bastions.0].student_password)}}"
-        - 'student_ssh_command: ssh -o "ServerAliveInterval 30" {{ student_user }}@{{ hostvars[groups.bastions.0].public_ip_address }}'
+        - "student_ssh_command: ssh -o &quot;ServerAliveInterval 30&quot; {{ student_user }}@{{ hostvars[groups.bastions.0].public_ip_address }}"
         - ""
         - "To access the lab instructions, check the following guide:"
         - ""


### PR DESCRIPTION
Use HTML enconding to output double quotes into selinux-policy post_software