### PR TITLE
Add nsupdate algorithm to deletion task for infra-osp-dns role

### DIFF
--- a/ansible/roles-infra/infra-osp-dns/tasks/nested_loop.yml
+++ b/ansible/roles-infra/infra-osp-dns/tasks/nested_loop.yml
@@ -34,5 +34,6 @@
         ttl: "{{ _infra_osp_dns_default_ttl }}"
         port: "{{ osp_cluster_dns_port | d('53') }}"
         key_name: "{{ ddns_key_name }}"
+        key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
         key_secret: "{{ ddns_key_secret }}"
         state: absent


### PR DESCRIPTION
##### SUMMARY
In the `infra-osp-dns` role, the `nsupdate` is used to update DNS for the deployed instances. When creating a new instance, the module uses the `key_algorithm` attribute to specify the algorithm of the TSIG key, and it defaults to `hmac-md5`. However, this attribute is not present for instance deletion, which leads to failure when the key algorithm is not `hmac-md5`.

This pull request adds the attribute, with `hmac-md5` default value.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
infra-osp-dns

##### ADDITIONAL INFORMATION
