### PR TITLE
Using instance shelve on OpenStack 

### DIFF
--- a/ansible/lifecycle_osp.yml
+++ b/ansible/lifecycle_osp.yml
@@ -26,7 +26,7 @@
                   | json_query('[*].id') }}
 
             - name: Stop all servers
-              command: openstack server stop {{ all_instances | join(' ') }}
+              command: openstack server shelve {{ all_instances | join(' ') }}
 
     - when: ACTION == 'start'
       block:
@@ -36,18 +36,21 @@
               metadata:
                 guid: "{{ guid }}"
                 env_type: "{{ env_type }}"
-              vm_state: stopped
           register: r_osp_facts
 
         - when: r_osp_facts.ansible_facts.openstack_servers | length > 0
           block:
             - set_fact:
-                all_instances: >-
-                  {{ r_osp_facts.ansible_facts.openstack_servers
-                  | json_query('[*].id') }}
+                all_instances: "{{ r_osp_facts.ansible_facts.openstack_servers
+                  | json_query('[*].{id:id, vm_state:vm_state}')   }}"
 
-            - name: Start all servers
-              command: openstack server start {{ all_instances | join(' ') }}
+            - name: Start servers
+              command: echo openstack server start {{ all_instances
+               |  json_query("[?vm_state == 'stopped'].id") | join(" ") }}
+
+            - name: Unshelve servers
+              command: echo openstack server unshelve {{ all_instances
+               | json_query("[?vm_state == 'shelved_offloaded'].id") | join(" ") }}
 
     - when: ACTION == 'status'
       block:

--- a/ansible/lifecycle_osp.yml
+++ b/ansible/lifecycle_osp.yml
@@ -45,12 +45,18 @@
                   | json_query('[*].{id:id, vm_state:vm_state}')   }}"
 
             - name: Start servers
-              command: openstack server start {{ all_instances
-               |  json_query("[?vm_state == 'stopped'].id") | join(" ") }}
+              command: openstack server start {{ _stopped_instances | join(" ") }}
+              vars:
+                _stopped_instances: >-
+                  {{ all_instances |  json_query("[?vm_state == 'stopped'].id") }}
+              when: _stopped_instances | length > 0
 
             - name: Unshelve servers
-              command: openstack server unshelve {{ all_instances
-               | json_query("[?vm_state == 'shelved_offloaded'].id") | join(" ") }}
+              command: openstack server unshelve {{ _shelved_instances | join(" ") }}
+              vars:
+                _shelved_instances: >-
+                  {{ all_instances |  json_query("[?vm_state == 'shelved_offloaded'].id") }}
+              when: _shelved_instances | length > 0
 
     - when: ACTION == 'status'
       block:

--- a/ansible/lifecycle_osp.yml
+++ b/ansible/lifecycle_osp.yml
@@ -45,11 +45,11 @@
                   | json_query('[*].{id:id, vm_state:vm_state}')   }}"
 
             - name: Start servers
-              command: echo openstack server start {{ all_instances
+              command: openstack server start {{ all_instances
                |  json_query("[?vm_state == 'stopped'].id") | join(" ") }}
 
             - name: Unshelve servers
-              command: echo openstack server unshelve {{ all_instances
+              command: openstack server unshelve {{ all_instances
                | json_query("[?vm_state == 'shelved_offloaded'].id") | join(" ") }}
 
     - when: ACTION == 'status'


### PR DESCRIPTION
##### SUMMARY
* Instance shelving allows to retain the state of an instance without having it consume resources.
A shelved instance will be retained as a bootable instance this is useful as part of an instance to conserve resources.
* This patch maintains compatibility with vm_state stopped 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
OpenStack Provider
