### PR TITLE
Enable Lifecycle Hooks (and implement start hook for ocp4-cluster)

### DIFF
--- a/ansible/configs/ocp4-cluster/lifecycle_hook_post_start.yml
+++ b/ansible/configs/ocp4-cluster/lifecycle_hook_post_start.yml
@@ -1,0 +1,83 @@
+---
+# Post Start actions for OCP 4 Cluster configs
+
+- import_playbook: ../../setup_runtime.yml
+
+- name: Build inventory
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  become: false
+  tasks:
+  - when: cloud_provider == 'ec2'
+    block:
+    - name: Run infra-ec2-create-inventory Role
+      include_role:
+        name: infra-ec2-create-inventory
+
+    - name: Run Common SSH Config Generator Role
+      include_role:
+        name: infra-common-ssh-config-generate
+      when: "'bastions' in groups"
+
+- name: Set ansible_ssh_extra_args
+  hosts:
+  - all:!windows:!network
+  gather_facts: false
+  any_errors_fatal: true
+  ignore_errors: false
+  tasks:
+  - name: Set facts for remote access
+    set_fact:
+      ansible_ssh_extra_args: >-
+        {{ ansible_ssh_extra_args|d() }}
+        -F {{hostvars.localhost.output_dir}}/{{ env_type }}_{{ guid }}_ssh_conf
+
+- name: Run recover cluster actions
+  hosts: bastions
+  run_once: true
+  become: false
+  gather_facts: false
+  tasks:
+  - name: Set Ansible Python interpreter to k8s virtualenv
+    set_fact:
+      ansible_python_interpreter: /opt/virtualenvs/k8s/bin/python
+
+  - name: Recover cluster if it missed cert rotation
+    when: ACTION == 'start'
+    block:
+    - name: Wait (default 3m) for Nodes to settle and pods to start
+      pause:
+        seconds: "{{ lifecycle_start_pause | default(180) }}"
+
+    - name: Get CSRs that need to be approved
+      k8s_facts:
+        api_version: certificates.k8s.io/v1beta1
+        kind: CertificateSigningRequest
+        # Field selectors don't seem to work
+        # field_selectors:
+        # - status.conditions[0].type="Pending"
+      register: r_csrs
+
+    - name: Approve all Pending CSRs
+      when: r_csrs.resources | length > 0
+      command: "oc adm certificate approve {{ item.metadata.name }}"
+      loop: "{{ r_csrs.resources }}"
+
+    - name: Wait 10s for additional CSRs to appear
+      pause:
+        seconds: 10
+
+    - name: Get additional CSRs that need to be approved
+      k8s_facts:
+        api_version: certificates.k8s.io/v1beta1
+        kind: CertificateSigningRequest
+        # Field selectors don't seem to work
+        # field_selectors:
+        # - status.conditions[0].type = "Pending"
+      register: r_new_csrs
+
+    - name: Approve all additional Pending CSRs
+      when: r_new_csrs.resources | length > 0
+      command: "oc adm certificate approve {{ item.metadata.name }}"
+      loop: "{{ r_new_csrs.resources }}"

--- a/ansible/configs/ocp4-cluster/lifecycle_hook_post_start.yml
+++ b/ansible/configs/ocp4-cluster/lifecycle_hook_post_start.yml
@@ -1,8 +1,6 @@
 ---
 # Post Start actions for OCP 4 Cluster configs
 
-- import_playbook: ../../setup_runtime.yml
-
 - name: Build inventory
   hosts: localhost
   connection: local

--- a/ansible/lifecycle.yml
+++ b/ansible/lifecycle.yml
@@ -3,8 +3,6 @@
 # You should implement those actions in your config if you
 # need a specific process.
 
-- import_playbook: setup_runtime.yml
-
 - name: Run stop/start/status/... actions
   hosts: localhost
   connection: local

--- a/ansible/lifecycle_entry_point.yml
+++ b/ansible/lifecycle_entry_point.yml
@@ -9,4 +9,12 @@
        })
     }}
 
+# Call livecycle_post_hook_ACTION
+- import_playbook: >-
+    {{ lookup('first_found', {
+         'files': [ 'lifecycle_hook_post_' + ACTION + '.yml', 'lifecycle_hook.yml' ],
+         'paths': ['configs/' + env_type, playbook_dir]
+       })
+    }}
+
 - import_playbook: completion_callback.yml

--- a/ansible/lifecycle_entry_point.yml
+++ b/ansible/lifecycle_entry_point.yml
@@ -11,12 +11,12 @@
        })
     }}
 
-# Call livecycle_post_hook_ACTION
 - name: Call Lifecycle Post Hook
   vars:
     _params:
       files:
-        - "{{ configs }}/{{ env_type }}/lifecycle_hook_post_{{ ACTION }}.yml"
+        - configs/{{ env_type }}/lifecycle_hook_post_{{ ACTION }}.yml
+        - configs/{{ env_type }}/lifecycle_hook.yml
         - lifecycle_hook.yml
   import_playbook: >-
     {{ lookup('first_found', _params) }}

--- a/ansible/lifecycle_entry_point.yml
+++ b/ansible/lifecycle_entry_point.yml
@@ -2,6 +2,8 @@
 # This file is the entry point to run stop/start/status actions.
 # It looks in the config directory first, then fallback to lifecycle.yml.
 
+- import_playbook: setup_runtime.yml
+
 - import_playbook: >-
     {{ lookup('first_found', {
          'files': [ ACTION + '.yml', 'lifecycle.yml' ],

--- a/ansible/lifecycle_entry_point.yml
+++ b/ansible/lifecycle_entry_point.yml
@@ -12,11 +12,13 @@
     }}
 
 # Call livecycle_post_hook_ACTION
-- import_playbook: >-
-    {{ lookup('first_found', {
-         'files': [ 'lifecycle_hook_post_' + ACTION + '.yml', 'lifecycle_hook.yml' ],
-         'paths': ['configs/' + env_type, playbook_dir]
-       })
-    }}
+- name: Call Lifecycle Post Hook
+  vars:
+    _params:
+      files:
+        - "{{ configs }}/{{ env_type }}/lifecycle_hook_post_{{ ACTION }}.yml"
+        - lifecycle_hook.yml
+  import_playbook: >-
+    {{ lookup('first_found', _params) }}
 
 - import_playbook: completion_callback.yml

--- a/ansible/lifecycle_hook.yml
+++ b/ansible/lifecycle_hook.yml
@@ -1,0 +1,9 @@
+- name: Lifecycle Hook (fallback)
+  hosts: localhost
+  run_once: true
+  become: false
+  gather_facts: false
+  tasks:
+  - name: Placeholder
+    debug:
+      msg: "No custom lifecycle hook provided. This is the lifecycle hook placeholder"


### PR DESCRIPTION
##### SUMMARY
Enable lifecycle hooks. These should work for all lifecycle actions (start / stop / status).

There is a default hook in the agnosticd directory that's just a no-op.

ocp4-cluster now implements a post start hook to approve any CSRs for clusters newer than 4.4.7 that have been sleeping through the 24h cert rotation window.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Global
ocp4-cluster

##### ADDITIONAL INFORMATION
Needed to implement lifecycle for ocp4-cluster config - and this PR avoids doing a one off for the config.

@fridim Can you double check that this should work for sandboxed environments? I can't test that from my laptop...