### PR TITLE
FIX workload ocp4-workload-homeroomlab-starter-guides

### DIFF
--- a/ansible/roles/ocp4-workload-homeroomlab-starter-guides/tasks/per_user.yml
+++ b/ansible/roles/ocp4-workload-homeroomlab-starter-guides/tasks/per_user.yml
@@ -26,10 +26,6 @@
       command: "{{ openshift_cli }} adm policy add-role-to-user admin {{ my_user }} -n {{ my_user }}"
       tags: always
 
-    - name: Add cluster-role cluster-monitoring-view for user "{{ my_user }}"
-      command: "{{ openshift_cli }} adm policy add-cluster-role-to-user cluster-monitoring-view {{ my_user }}"
-      tags: always
-
     - name: per_user {{my_user}} Tasks Complete
       debug:
         msg: "per_user {{my_user}} Tasks - Completed"


### PR DESCRIPTION

##### SUMMARY
Removes the code to add the cluster-monitoring-view to users.

This is not necessary for the OpenShift starter lab and causes confusion as it gives users view access into other projects and complicates the Kibana (cluster logging) part of [the lab](https://github.com/openshift-labs/starter-guides)

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

task per_user.yml

##### ADDITIONAL INFORMATION

