### PR TITLE
Need separator to be other than comma for auto testing of CI

### DIFF
--- a/ansible/roles/ocp4-workload-ccnrd/tasks/remove_workload.yml
+++ b/ansible/roles/ocp4-workload-ccnrd/tasks/remove_workload.yml
@@ -15,7 +15,7 @@
 
 - name: create module list
   set_fact:
-    modules: "{{ module_type.split(',') | map('trim') | list }}"
+    modules: "{{ module_type.split(';') | map('trim') | list }}"
 
 - name: Selected Modules
   debug:

--- a/ansible/roles/ocp4-workload-ccnrd/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-ccnrd/tasks/workload.yml
@@ -19,7 +19,7 @@
 
 - name: create module list
   set_fact:
-    modules: "{{ module_type.split(',') | map('trim') | list }}"
+    modules: "{{ module_type.split(';') | map('trim') | list }}"
 
 - name: Selected Modules
   debug:


### PR DESCRIPTION
##### SUMMARY
Need separator to be other than comma for auto testing of CI. This is required for Jenkins testing as all CloudForm input parameter also comma separated.

##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME
ocp4-workload-ccnrd role --> task --> workload and remove workload