### PR TITLE
Feature update  osp-sandbox config secrets template to use _member postfix

### DIFF
--- a/ansible/configs/osp-sandbox/files/secret.yaml.j2
+++ b/ansible/configs/osp-sandbox/files/secret.yaml.j2
@@ -8,8 +8,8 @@ osp_cluster_dns_zone: {{ student_dns_zone }}
 # OpenStack Auth
 osp_auth_project_domain: default
 osp_auth_user_domain: default
-osp_auth_username: "{{ guid }}-user"
-osp_auth_password: "{{ hostvars['localhost']['heat_user_password'] }}"
+osp_auth_username_member: "{{ guid }}-user"
+osp_auth_password_member: "{{ hostvars['localhost']['heat_user_password'] }}"
 osp_auth_url: "{{ osp_auth_url }}"
 osp_project_name: "{{ guid }}-project"
 osp_project_id: "{{ hostvars['localhost']['osp_project_info'][0].id }}"


### PR DESCRIPTION
##### SUMMARY
OSP Sandbox deploys need osp user and password vars with the postfix `_member`. This enhancement deploys the secrets.yaml file with the prefix already added and "ready to go"

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
osp-sandbox

##### ADDITIONAL INFORMATION
Some configs 