### PR TITLE
Fix osp dry run to support sandbox via _member postfixes for auth

### DIFF
--- a/ansible/roles-infra/infra-osp-dry-run/tasks/main.yml
+++ b/ansible/roles-infra/infra-osp-dry-run/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 - environment:
     OS_AUTH_URL: "{{ osp_auth_url }}"
-    OS_USERNAME: "{{ osp_auth_username }}"
-    OS_PASSWORD: "{{ osp_auth_password }}"
+    OS_USERNAME: "{{ osp_auth_username | default(osp_auth_username_member) }}"
+    OS_PASSWORD: "{{ osp_auth_password | default(osp_auth_password_member) }}"
     OS_PROJECT_NAME: "{{ infra_osp_dry_run_project_name }}"
     OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
     OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"

--- a/ansible/roles-infra/infra-osp-dry-run/tasks/main.yml
+++ b/ansible/roles-infra/infra-osp-dry-run/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 - environment:
     OS_AUTH_URL: "{{ osp_auth_url }}"
-    OS_USERNAME: "{{ osp_auth_username | default(osp_auth_username_member) }}"
-    OS_PASSWORD: "{{ osp_auth_password | default(osp_auth_password_member) }}"
+    OS_USERNAME: "{{ osp_auth_username_member | default(osp_auth_username) }}"
+    OS_PASSWORD: "{{ osp_auth_password_member | default(osp_auth_password) }}"
     OS_PROJECT_NAME: "{{ infra_osp_dry_run_project_name }}"
     OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
     OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"


### PR DESCRIPTION
##### SUMMARY
OSP sandboxes use an auth postfix _member. This adds support to dry run so it will succeed on both sandbox and non-sandbox deploys

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
roles-infra/infra-osp-dry-run


##### ADDITIONAL INFORMATION

