### PR TITLE
Add app_deploy_ilt workload

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_app_deploy_ilt/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_app_deploy_ilt/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+become_override: False
+ocp_username: opentlc-mgr
+silent: False

--- a/ansible/roles_ocp_workloads/ocp4_workload_app_deploy_ilt/files/gogs_admin_rules_cluster_role.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_app_deploy_ilt/files/gogs_admin_rules_cluster_role.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: authorization.openshift.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: gogs-admin-rules
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - services/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - gpte.opentlc.com
+  resources:
+  - gogs
+  - gogs/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/ansible/roles_ocp_workloads/ocp4_workload_app_deploy_ilt/files/gogs_crd.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_app_deploy_ilt/files/gogs_crd.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: gogs.gpte.opentlc.com
+spec:
+  group: gpte.opentlc.com
+  names:
+    kind: Gogs
+    listKind: GogsList
+    plural: gogs
+    singular: gogs
+  scope: Namespaced
+  version: v1alpha1
+  subresources:
+    status: {}

--- a/ansible/roles_ocp_workloads/ocp4_workload_app_deploy_ilt/meta/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_app_deploy_ilt/meta/main.yml
@@ -1,0 +1,13 @@
+---
+galaxy_info:
+  role_name: ocp4_workload_app_deploy_ilt
+  author: Wolfgang Kulhanek
+  description: |
+    Set up required objects for the OpenShift 4 Advanced Application Deployment ILT
+  license: MIT
+  min_ansible_version: 2.9
+  platforms: []
+  galaxy_tags:
+  - ocp
+  - openshift
+dependencies: []

--- a/ansible/roles_ocp_workloads/ocp4_workload_app_deploy_ilt/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_app_deploy_ilt/readme.adoc
@@ -1,0 +1,65 @@
+= ocp4_workload_app_deploy_ilt - Configuration for the OpenShift 4 Advanced Application Deployment ILT
+
+== Role overview
+
+* This role configures an OpenShift 4 cluster for use in the OpenShift 4 Advanced Application Deployment ILT. It consists of the following playbooks:
+** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+ environment for the workload deployment.
+*** Debug task will print out: `pre_workload Tasks completed successfully.`
+
+** Playbook: link:./tasks/workload.yml[workload.yml] - Used to configure the cluster
+*** This role creates a route for the image registry, sets up build defaults and removes self-provisioner from all users.
+*** Debug task will print out: `workload Tasks completed successfully.`
+
+** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+ configure the workload after deployment
+*** This role doesn't do anything here
+*** Debug task will print out: `post_workload Tasks completed successfully.`
+
+** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+ delete the workload
+*** This role removes the production customizations
+*** Debug task will print out: `remove_workload Tasks completed successfully.`
+
+== Review the defaults variable file
+
+* This file link:./defaults/main.yml[./defaults/main.yml] contains all the variables you need to define to control the deployment of your workload.
+* The variable *ocp_username* is mandatory to assign the workload to the correct OpenShift user.
+* A variable *silent=True* can be passed to suppress debug messages.
+
+=== Deploy a Workload with the `ocp-workload` playbook [Mostly for testing]
+
+----
+TARGET_HOST="bastion.na4.openshift.opentlc.com"
+OCP_USERNAME="wkulhane-redhat.com"
+WORKLOAD="ocp4_workload-app_deploy_ilt"
+GUID=1001
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=ec2-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"silent=False" \
+    -e"guid=${GUID}" \
+    -e"ACTION=create"
+----
+
+=== To Delete an environment
+
+----
+TARGET_HOST="bastion.na4.openshift.opentlc.com"
+OCP_USERNAME="wkulhane-redhat.com"
+WORKLOAD="ocp4_workload_app_deploy_ilt"
+GUID=1002
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=ec2-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"guid=${GUID}" \
+    -e"ACTION=remove"
+----

--- a/ansible/roles_ocp_workloads/ocp4_workload_app_deploy_ilt/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_app_deploy_ilt/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+# Do not modify this file
+
+- name: Running Pre Workload Tasks
+  include_tasks:
+    file: ./pre_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload Tasks
+  include_tasks:
+    file: ./workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  include_tasks:
+    file: ./post_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload removal Tasks
+  include_tasks:
+    file: ./remove_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles_ocp_workloads/ocp4_workload_app_deploy_ilt/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_app_deploy_ilt/tasks/post_workload.yml
@@ -1,0 +1,29 @@
+---
+# Implement your Post Workload deployment tasks here
+# --------------------------------------------------
+
+
+
+
+# Leave these as the last tasks in the playbook
+# ---------------------------------------------
+
+# For deployment onto a dedicated cluster (as part of the
+# cluster deployment) set workload_shared_deployment to False
+# This is the default so it does not have to be set explicitely
+- name: post_workload tasks complete
+  debug:
+    msg: "Post-Workload tasks completed successfully."
+  when:
+  - not silent|bool
+  - not workload_shared_deployment|default(False)
+
+# For RHPDS deployment (onto a shared cluster) set
+# workload_shared_deployment to True
+# (in the deploy script or AgnosticV configuration)
+- name: post_workload tasks complete
+  debug:
+    msg: "Post-Software checks completed successfully"
+  when:
+  - not silent|bool
+  - workload_shared_deployment|default(False)

--- a/ansible/roles_ocp_workloads/ocp4_workload_app_deploy_ilt/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_app_deploy_ilt/tasks/pre_workload.yml
@@ -1,0 +1,29 @@
+---
+# Implement your Pre Workload deployment tasks here
+# -------------------------------------------------
+
+
+
+
+# Leave these as the last tasks in the playbook
+# ---------------------------------------------
+
+# For deployment onto a dedicated cluster (as part of the
+# cluster deployment) set workload_shared_deployment to False
+# This is the default so it does not have to be set explicitely
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Workload tasks completed successfully."
+  when:
+  - not silent|bool
+  - not workload_shared_deployment|default(False)
+
+# For RHPDS deployment (onto a shared cluster) set
+# workload_shared_deployment to True
+# (in the deploy script or AgnosticV configuration)
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Software checks completed successfully"
+  when:
+  - not silent|bool
+  - workload_shared_deployment|default(False)

--- a/ansible/roles_ocp_workloads/ocp4_workload_app_deploy_ilt/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_app_deploy_ilt/tasks/remove_workload.yml
@@ -1,0 +1,18 @@
+---
+# Implement your workload removal tasks here
+# ------------------------------------------
+
+- name: Delete Objects for Operators Lab
+  k8s:
+    state: absent
+    definition: "{{ lookup('file', item ) | from_yaml }}"
+  loop:
+  - './files/gogs_crd.yaml'
+  - './files/gogs_admin_rules_cluster_role.yaml'
+
+# Leave this as the last task in the playbook.
+# --------------------------------------------
+- name: remove_workload tasks complete
+  debug:
+    msg: "Remove Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_app_deploy_ilt/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_app_deploy_ilt/tasks/workload.yml
@@ -1,0 +1,19 @@
+---
+- name: Setting up workload for user
+  debug:
+    msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
+
+- name: Create Objects for Operators Lab
+  k8s:
+    state: present
+    definition: "{{ lookup('file', item ) | from_yaml }}"
+  loop:
+  - './files/gogs_crd.yaml'
+  - './files/gogs_admin_rules_cluster_role.yaml'
+
+# Leave this as the last task in the playbook.
+# --------------------------------------------
+- name: workload tasks complete
+  debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent|bool


### PR DESCRIPTION

##### SUMMARY
Add a new workload to configure a cluster for use in the OpenShift Advanced Application Deployment ILT.

This workload adds the gogs CRD and gogs-admin-rules cluster role to the cluster.

##### ISSUE TYPE
- New role Pull Request

##### COMPONENT NAME
ocp4_workload_app_deploy_ilt
