### PR TITLE
Fix workload ocp4_workload_kubevirt

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/defaults/main.yml
@@ -2,3 +2,6 @@
 become_override: False
 ocp_username: opentlc-mgr
 silent: False
+kubevirt_channel: "2.3"
+kubevirt_version: "v2.3.0"
+kubevirt_subscription_name: "kubevirt-hyperconverged-operator.{{ kubevirt_version }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/meta/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/meta/main.yml
@@ -4,11 +4,11 @@ galaxy_info:
   author: Mark Li
   description: |
     Deploys Kubevirt HCO on a OCP4 cluster
-platforms: []
-license: GNU General Public License v3.0
-galaxy_tags: 
-- ocp4
-- openshift 
-- kubevirt
-- cnv
+  platforms: []
+  license: GNU General Public License v3.0
+  galaxy_tags: 
+  - ocp4
+  - openshift 
+  - kubevirt
+  - cnv
 dependencies: []

--- a/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/tasks/remove_workload.yml
@@ -3,12 +3,19 @@
   k8s:
     kind: ClusterServiceVersion
     version: v1alpha1
-    name: kubevirt-hyperconverged-operator.v2.3.0
+    name: "kubevirt-hyperconverged-operator.{{ kubevirt_version }}"
     state: absent
 
 - name: Wait for kubevirt resources to disappear
-  pause:
-    seconds: 60
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    name: "{{ kubevirt_subscription_name }}"
+    namespace: openshift-cnv
+  register: result
+  until: "result.resources | length > 0"
+  retries: 30
+  delay: 10
 
 - name: Delete HCO
   k8s:

--- a/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/tasks/workload.yml
@@ -3,16 +3,39 @@
   debug:
     msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
 
-- name: Create Resources for HCO install
+- name: Create project for HCO
   k8s:
     state: present
-    definition: "{{ lookup('file', '{{ item }}') }}"
-  with_items:
-    - 'project.yaml'
-    - 'operatorgroup.yaml'
-    - 'sub.yaml'
-    - 'cnv-hco.yaml'
+    definition: "{{ lookup('file', 'project.yaml') }}"
+
+- name: Create operator group for HCO
+  k8s:
+    state: present
+    definition: "{{ lookup('file', 'operatorgroup.yaml') }}"
+
+- name: Create subscription for HCO
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'subscription.yaml.j2') }}"
+
+- name: Wait for subscription to succeed
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    name: "{{ kubevirt_subscription_name }}"
+    namespace: openshift-cnv
+  register: result
+  until: 
+    - "result.resources | length > 0"
+    - "result.resources[0].status.phase == 'Succeeded'"
+  retries: 30
+  delay: 10
+
+- name: Create the HCO instance
+  k8s:
+    state: present
+    definition: "{{ lookup('file', 'cnv-hco.yaml') }}"
 
 - debug:
-    msg: "remove_workload Tasks completed successfully"
+    msg: "workload Tasks completed successfully"
   when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/templates/subscription.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/templates/subscription.yaml.j2
@@ -4,9 +4,9 @@ metadata:
   name: kubevirt-hyperconverged
   namespace: openshift-cnv
 spec:
-  channel: '2.3'
+  channel: "{{ kubevirt_channel }}"
   installPlanApproval: Automatic
   name: kubevirt-hyperconverged
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: kubevirt-hyperconverged-operator.v2.3.0
+  startingCSV: "kubevirt-hyperconverged-operator.{{ kubevirt_version }}"


### PR DESCRIPTION
##### SUMMARY
The first issue that this PR fixes is the meta/main.yml syntax.
Then, it adds variables for the HCO version.
It also renames sub.yaml into subscription.yaml.j2, while turning it into a template that uses version.
Finally, it adds a task to wait for the subscription to succeed.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_kubevirt
