### PR TITLE
do not create per-user pull secret files

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_integreatly/files/fuse/create-instance.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_integreatly/files/fuse/create-instance.yml
@@ -47,7 +47,7 @@
   until: syndesis_pull_secret is succeeded
 
 - set_fact:
-    _instance_pull_secret_file: "{{ ocp4_workload_integreatly_tmp_dir }}/instance-{{ _instance_user }}-fuse-pull-secret.yaml"
+    _instance_pull_secret_file: "{{ ocp4_workload_integreatly_tmp_dir }}/instance-fuse-pull-secret.yaml"
 
 - name: copy syndesis pull secret 
   copy:


### PR DESCRIPTION
creating a new file per pull secret can cause inode issues on
hosts running the role, as a new file is created for each run of
the pull secret copy

this commit will reuse the same file for all pull secrets to avoid
this issue occuring

components:
- role, ocp4_workload_integreatly