### PR TITLE
Change role ocp-infra-osp-fip to support nsupdate algorithm in nsupdate calls

### DIFF
--- a/ansible/roles/ocp-infra-osp-fip/defaults/main.yml
+++ b/ansible/roles/ocp-infra-osp-fip/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+key_algorithm: hmac-md5

--- a/ansible/roles/ocp-infra-osp-fip/defaults/main.yml
+++ b/ansible/roles/ocp-infra-osp-fip/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-key_algorithm: hmac-md5
+ddns_key_algorithm: hmac-md5

--- a/ansible/roles/ocp-infra-osp-fip/tasks/main.yml
+++ b/ansible/roles/ocp-infra-osp-fip/tasks/main.yml
@@ -31,7 +31,7 @@
     ttl: 5
     value: "{{ item.name }}"
     key_name: "{{ ddns_key_name }}"
-    key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
+    key_algorithm: "{{ ddns_key_algorithm }}"
     key_secret: "{{ ddns_key_secret }}"
   loop:
     - name: "{{ ocp_api_fip }}"

--- a/ansible/roles/ocp-infra-osp-fip/tasks/main.yml
+++ b/ansible/roles/ocp-infra-osp-fip/tasks/main.yml
@@ -31,6 +31,7 @@
     ttl: 5
     value: "{{ item.name }}"
     key_name: "{{ ddns_key_name }}"
+    key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
     key_secret: "{{ ddns_key_secret }}"
   loop:
     - name: "{{ ocp_api_fip }}"


### PR DESCRIPTION
##### SUMMARY
Follow-up of https://github.com/redhat-cop/agnosticd/pull/1968 to add the `key_algorithm` to `nsupdate` call in `ocp-infra-osp-fip` role.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp-infra-osp-fip