### PR TITLE
ocp4-cluster - Update FIP descriptions and ensure they are set

### DIFF
--- a/ansible/configs/ocp4-cluster/default_vars_osp.yml
+++ b/ansible/configs/ocp4-cluster/default_vars_osp.yml
@@ -121,10 +121,10 @@ provider_network: external
 # Provision Floating IPs for API and Ingress
 additional_fips:
   ocp_api_fip:
-    description: The floating IP of the OpenShift API
+    description: "API {{ cluster_name }}.{{ ocp4_base_domain }}"
     network: "{{ provider_network }}"
   ocp_ingress_fip:
-    description: The floating IP of the OpenShift ingress
+    description: "Ingress {{ cluster_name }}.{{ ocp4_base_domain }}"
     network: "{{ provider_network }}"
 
 # A list of the private networks and subnets to create in the project

--- a/ansible/roles-infra/infra-osp-template-generate/templates/cloud_template_master.j2
+++ b/ansible/roles-infra/infra-osp-template-generate/templates/cloud_template_master.j2
@@ -206,6 +206,10 @@ resources:
     type: OS::Neutron::FloatingIP
     properties:
       floating_network: "{{ additional_fips[fipname].network }}"
+{% if additional_fips[fipname].description is defined %}
+      value_specs:
+        description: "{{ additional_fips[fipname].description }}"
+{% endif %}
 {% endfor %}
 {% endif %}
 

--- a/ansible/roles-infra/infra-osp-template-generate/templates/nested_version/cloud_template_master.j2
+++ b/ansible/roles-infra/infra-osp-template-generate/templates/nested_version/cloud_template_master.j2
@@ -196,6 +196,10 @@ resources:
     type: OS::Neutron::FloatingIP
     properties:
       floating_network: "{{ additional_fips[fipname].network }}"
+{% if additional_fips[fipname].description is defined %}
+      value_specs:
+        description: {{ additional_fips[fipname].description }}
+{% endif %}
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
##### SUMMARY
When deploying OCP4, the description of the floating IPs is used by the installer to identify the floating IP for the API when `lbFloatingIP` is not set in the `install-config.yaml` file. The convention is to set `API` or `Ingress` followed by `<cluster-name>.<ocp4_base_domain>`.

This pull request updates the description is OpenStack default vars to match the convention.
It also update the OpenStack Heat templates to set the description if present. Setting the `description` property doesn't actually set the description on the floating ip. We need to set `value_specs.description` instead.

##### ISSUE TYPE
- Enhancement Pull Request

##### COMPONENT NAME
ocp4-cluster