### PR TITLE
infra-osp-resources-destroy - Fix Heat stack deletion

### DIFF
--- a/ansible/roles-infra/infra-osp-resources-destroy/tasks/heat.yml
+++ b/ansible/roles-infra/infra-osp-resources-destroy/tasks/heat.yml
@@ -5,8 +5,8 @@
 
 - environment:
     OS_AUTH_URL: "{{ osp_auth_url }}"
-    OS_USERNAME: "{{ osp_auth_username_member | d(osp_auth_username) }}"
-    OS_PASSWORD: "{{ osp_auth_password_member | d(osp_auth_password) }}"
+    OS_USERNAME: "{{ osp_auth_username_member | default(osp_auth_username) }}"
+    OS_PASSWORD: "{{ osp_auth_password_member | default(osp_auth_password) }}"
     OS_PROJECT_NAME: "{{ osp_project_name }}"
     OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
     OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"

--- a/ansible/roles-infra/infra-osp-resources-destroy/tasks/heat.yml
+++ b/ansible/roles-infra/infra-osp-resources-destroy/tasks/heat.yml
@@ -1,4 +1,8 @@
 ---
+- name: Get OpenStack project id
+  set_fact:
+    osp_project_id: "{{ osp_project_id | default(osp_project_info[0].id) }}"
+
 - environment:
     OS_AUTH_URL: "{{ osp_auth_url }}"
     OS_USERNAME: "{{ osp_auth_username_member | d(osp_auth_username) }}"
@@ -10,7 +14,7 @@
   # There is no module that allows retrieving this data.
   - name: Get a list of stacks in the project
     command: >-
-      openstack stack list --property tenant={{ osp_project_id | default(osp_project_info[0].id) }} -f value --column ID
+      openstack stack list --property tenant={{ osp_project_id }} -f value --column ID
     register: r_stacks
 
   # The os_stack module doesn't allow deleting by ID and name is not safe to use since there could

--- a/ansible/roles-infra/infra-osp-resources-destroy/tasks/heat.yml
+++ b/ansible/roles-infra/infra-osp-resources-destroy/tasks/heat.yml
@@ -1,8 +1,8 @@
 ---
 - environment:
     OS_AUTH_URL: "{{ osp_auth_url }}"
-    OS_USERNAME: "{{ osp_auth_username }}"
-    OS_PASSWORD: "{{ osp_auth_password }}"
+    OS_USERNAME: "{{ osp_auth_username_member | d(osp_auth_username) }}"
+    OS_PASSWORD: "{{ osp_auth_password_member | d(osp_auth_password) }}"
     OS_PROJECT_NAME: "{{ osp_project_name }}"
     OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
     OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"
@@ -10,7 +10,7 @@
   # There is no module that allows retrieving this data.
   - name: Get a list of stacks in the project
     command: >-
-      openstack stack list --property tenant={{ osp_project_info[0].id }} -f value --column ID
+      openstack stack list --property tenant={{ osp_project_info[0].id | d(osp_project_id) }} -f value --column ID
     register: r_stacks
 
   # The os_stack module doesn't allow deleting by ID and name is not safe to use since there could
@@ -24,4 +24,3 @@
     until: r_hot_out is succeeded
     register: r_hot_out
     loop: "{{ r_stacks.stdout_lines }}"
-  

--- a/ansible/roles-infra/infra-osp-resources-destroy/tasks/heat.yml
+++ b/ansible/roles-infra/infra-osp-resources-destroy/tasks/heat.yml
@@ -10,7 +10,7 @@
   # There is no module that allows retrieving this data.
   - name: Get a list of stacks in the project
     command: >-
-      openstack stack list --property tenant={{ osp_project_info[0].id | d(osp_project_id) }} -f value --column ID
+      openstack stack list --property tenant={{ osp_project_id | default(osp_project_info[0].id) }} -f value --column ID
     register: r_stacks
 
   # The os_stack module doesn't allow deleting by ID and name is not safe to use since there could


### PR DESCRIPTION
##### SUMMARY
The OpenStack roles now use `osp_auth_username_member` and `osp_auth_password_member` as credentials. The Heat stack deletion tasks file was still using `osp_auth_username` and `osp_auth_password`. This pull request updates the variable names and allows to use the _old_ names for backward compatibility.

The project detection may also fail in the case where it was not created by AgnosticD. Because the user can provide an existing project id, the pull request also allows to fall back to `osp_project_id` variable.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
infra-osp-template-create