### PR TITLE
Updated to start and enable firewalld if boolean| true

### DIFF
--- a/ansible/roles/a_simple_webserver/handlers/main.yml
+++ b/ansible/roles/a_simple_webserver/handlers/main.yml
@@ -4,6 +4,7 @@
   service:
     name: "{{ a_simple_webserver_service }}"
     state: started
+    enabled: true
 
 - name: Reload_webserver
   service:

--- a/ansible/roles/a_simple_webserver/tasks/pre_install.yml
+++ b/ansible/roles/a_simple_webserver/tasks/pre_install.yml
@@ -1,16 +1,23 @@
 ---
 
 - when: firewalld_active | bool
-  name: Open up firewall port(s)
-  firewalld:
-    port: "{{ port }}/tcp"
-    permanent: yes
-    state: enabled
-    immediate: true
-  loop: "{{ a_simple_webserver_ports }}"  
-  loop_control:
-    loop_var: port
-  tags:
-    - security
+  block:
+    - name: Start & Enable firewalld
+      service:
+        name: firewalld
+        state: started
+        enabled: true
+
+    - name: Open up firewall port(s)
+      firewalld:
+        port: "{{ port }}/tcp"
+        permanent: yes
+        state: enabled
+        immediate: true
+      loop: "{{ a_simple_webserver_ports }}"  
+      loop_control:
+        loop_var: port
+      tags:
+        - security
 
 ...

--- a/ansible/roles/a_simple_webserver/tasks/smoketest.yml
+++ b/ansible/roles/a_simple_webserver/tasks/smoketest.yml
@@ -30,6 +30,8 @@
   notify:
     - Reload_webserver
 
+- meta: flush_handlers
+
 - name: Smoketest webserver locally from itself
   uri:
     url: "http://localhost:{{ a_simple_webserver_ports[0] }}"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Changed a_simple_webserver role to start and enable firewalld if the service is to be used. I also added a flush handlers during the smoke test.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
