### PR TITLE
host-ocp4-provisioner - Allow non Default user domain in OpenStack

### DIFF
--- a/ansible/roles/host-ocp4-provisioner/templates/clouds.yaml.j2
+++ b/ansible/roles/host-ocp4-provisioner/templates/clouds.yaml.j2
@@ -11,7 +11,7 @@ clouds:
 {% endif %}
       project_name: "{{ osp_project_name }}"
       project_id: "{{ hostvars['localhost']['osp_project_info'][0].id | default(osp_project_id) }}"
-      user_domain_name: "Default"
+      user_domain_name: "{{ hostvars['localhost']['osp_auth_user_domain'] | d('Default') }}"
     region_name: "regionOne"
     interface: "public"
     identity_api_version: 3


### PR DESCRIPTION
##### SUMMARY
When provisioning hosts for OCP4 on OpenStack, the user domain can be different from "Default". This pull request allows setting an `ocp4_auth_user_domain`, that will anyway default to "Default" for backward compatibility.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
host-ocp4-provisioner