### PR TITLE
host-ocp4-installer - Allow more variables in install-config.yaml

### DIFF
--- a/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
+++ b/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
@@ -85,7 +85,7 @@ platform:
   openstack:
     cloud: {{ osp_cloud_name }}
     computeFlavor: {{ worker_instance_type }}
-    externalNetwork: {{ provider_network }}
+    externalNetwork: {{ provider_network | d('external') }}
     lbFloatingIP: {{ hostvars.localhost.ocp_api_fip }}
     octaviaSupport: "{{ osp_octavia_support | d('1') }}"
     region: ""

--- a/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
+++ b/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
@@ -59,7 +59,7 @@ networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
-  machineCIDR: 10.0.0.0/16
+  machineCIDR: {{ ocp4_machine_cidr | d('10.0.0.0/16') }}
   serviceNetwork:
   - 172.30.0.0/16
   networkType: OpenshiftSDN
@@ -85,11 +85,11 @@ platform:
   openstack:
     cloud: {{ osp_cloud_name }}
     computeFlavor: {{ worker_instance_type }}
-    externalNetwork: external
+    externalNetwork: {{ provider_network }}
     lbFloatingIP: {{ hostvars.localhost.ocp_api_fip }}
-    octaviaSupport: "1"
+    octaviaSupport: "{{ osp_octavia_support | d('1') }}"
     region: ""
-    trunkSupport: "0"
+    trunkSupport: "{{ osp_trunk_support | d('0') }}"
 {% if rhcos_image_name is defined %}
     clusterOSImage: {{ rhcos_image_name }}
 {% endif %}


### PR DESCRIPTION
##### SUMMARY
When deploying OCP4 on OpenStack, the platform may have some features enabled, or not, such as Octavia for load balancing, and trunk support. The current template as fixed values for these two properties. This pull request allows setting them via variables, while defaulting to the current values.

Also, in OpenStack, the machine network may overlap with existing networks out of OpenStack. This pull request allows setting the `machineCIDR` property from a variable, while defaulting to `10.0.0.0/16` for backward compatibility.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
host-ocp4-installer