### PR TITLE
Update epel-release rpm for ansible tower implementation

### DIFF
--- a/ansible/configs/ansible-tower-implementation/pre_software.yml
+++ b/ansible/configs/ansible-tower-implementation/pre_software.yml
@@ -25,7 +25,7 @@
   tasks:
     - name: Install epel repository
       package:
-        name: http://admin.na.shared.opentlc.com/repos/epel/Packages/e/epel-release-7-11.noarch.rpm
+        name: http://d3s3zqyaz8cp2d.cloudfront.net/repos/epel/Packages/e/epel-release-7-11.noarch.rpm
         state: present
 
 - hosts: bastions

--- a/ansible/configs/ansible-tower-implementation/pre_software.yml
+++ b/ansible/configs/ansible-tower-implementation/pre_software.yml
@@ -25,7 +25,7 @@
   tasks:
     - name: Install epel repository
       package:
-        name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+        name: http://admin.na.shared.opentlc.com/repos/epel/Packages/e/epel-release-7-11.noarch.rpm
         state: present
 
 - hosts: bastions


### PR DESCRIPTION
SUMMARY
Update epel-release rpm for ansible tower implementation. URL: http://d3s3zqyaz8cp2d.cloudfront.net/repos/epel/Packages/e/epel-release-7-11.noarch.rpm

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-tower-implementation pre software config
