### PR TITLE
ocp4-cluster - Fix FIP DNS records deletion

### DIFF
--- a/ansible/configs/ocp4-cluster/destroy_env.yml
+++ b/ansible/configs/ocp4-cluster/destroy_env.yml
@@ -20,7 +20,7 @@
       nsupdate:
         server: "{{ osp_cluster_dns_server }}"
         zone: "{{ osp_cluster_dns_zone }}"
-        record: "{{ item }}.{{ guid }}"
+        record: "{{ item }}.cluster-{{ guid }}"
         type: A
         key_name: "{{ ddns_key_name }}"
         key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"


### PR DESCRIPTION
##### SUMMARY
When the DNS records for the OCP4 floating IPs are created by AgnosticD, the names are `api.cluster-{{ guid }}` and `*.apps.cluster-{{ guid }}`. In the destruction tasks, the `cluster-` part is missing, so the records are not removed. This pull request fixes that.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-cluster