### PR TITLE
Updating epel installer url with cloudform url

### DIFF
--- a/ansible/configs/ans-tower-lab/pre_software.yml
+++ b/ansible/configs/ans-tower-lab/pre_software.yml
@@ -63,7 +63,7 @@
       
     - name: Install epel repository
       yum:
-        name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+        name: http://d3s3zqyaz8cp2d.cloudfront.net/repos/epel/Packages/e/epel-release-7-11.noarch.rpm
         state: present
 
 

--- a/ansible/configs/ansible-advanced/pre_software.yml
+++ b/ansible/configs/ansible-advanced/pre_software.yml
@@ -63,7 +63,7 @@
       
     - name: Install epel repository
       yum:
-        name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+        name: http://d3s3zqyaz8cp2d.cloudfront.net/repos/epel/Packages/e/epel-release-7-11.noarch.rpm
         state: present
 
 

--- a/ansible/configs/ansible-provisioner/post_software.yml
+++ b/ansible/configs/ansible-provisioner/post_software.yml
@@ -51,7 +51,7 @@
 
     - name: Install EPEL (for python-pip and ansible)
       package:
-        name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+        name: "http://d3s3zqyaz8cp2d.cloudfront.net/repos/epel/Packages/e/epel-release-7-11.noarch.rpm"
         use: yum
         state: installed
 

--- a/ansible/configs/satellite-infrastructure/pre_software.yml
+++ b/ansible/configs/satellite-infrastructure/pre_software.yml
@@ -55,7 +55,7 @@
 
     - name: Install epel repository
       yum:
-        name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+        name: http://d3s3zqyaz8cp2d.cloudfront.net/repos/epel/Packages/e/epel-release-7-11.noarch.rpm
         state: present
         
     - name: Install pip from epel

--- a/ansible/configs/satellite-vm/pre_software.yml
+++ b/ansible/configs/satellite-vm/pre_software.yml
@@ -75,7 +75,7 @@
   become: true
   tasks:
     - yum:
-        name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+        name: http://d3s3zqyaz8cp2d.cloudfront.net/repos/epel/Packages/e/epel-release-7-11.noarch.rpm
         state: present
     - package:
         name: rubygem-ruby-libvirt

--- a/ansible/configs/smart-management/pre_software.yml
+++ b/ansible/configs/smart-management/pre_software.yml
@@ -39,7 +39,7 @@
   tasks:
     - name: Install epel repository
       yum:
-        name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+        name: http://d3s3zqyaz8cp2d.cloudfront.net/repos/epel/Packages/e/epel-release-7-11.noarch.rpm
         state: present
 
 
@@ -64,7 +64,7 @@
   tasks:
     - name: Install epel repository
       yum:
-        name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+        name: http://d3s3zqyaz8cp2d.cloudfront.net/repos/epel/Packages/e/epel-release-7-11.noarch.rpm
         state: present
 
     - name: Setup strong satellite admim password

--- a/ansible/roles/rhel-epel/defaults/main.yml
+++ b/ansible/roles/rhel-epel/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-epel_url_7: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+epel_url_7: http://d3s3zqyaz8cp2d.cloudfront.net/repos/epel/Packages/e/epel-release-7-11.noarch.rpm
 epel_url_8: https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 
 ...


### PR DESCRIPTION
##### SUMMARY
Updating epel installer url with cloudform url: http://d3s3zqyaz8cp2d.cloudfront.net/repos/epel/Packages/e/epel-release-7-11.noarch.rpm in the place of https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
We can use our CloudForms repo.

##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME
Ansible deployer affected some CI.