### PR TITLE
OSP - User _member variable for username and password

### DIFF
--- a/ansible/configs/ocp4-disconnected-osp-lab/files/clouds.yaml.j2
+++ b/ansible/configs/ocp4-disconnected-osp-lab/files/clouds.yaml.j2
@@ -2,15 +2,10 @@ clouds:
   {{ osp_project_name }}:
     auth:
       auth_url: "{{ osp_auth_url }}"
-{% if osp_project_create | bool %}
-      username: "{{ guid }}-user"
-      password: "{{ hostvars['localhost']['heat_user_password'] }}"
-{% else %}
       username: "{{ osp_auth_username_member }}"
       password: "{{ osp_auth_password_member }}"
-{% endif %}
       project_name: "{{ osp_project_name }}"
-      project_id: "{{ hostvars['localhost']['osp_project_info'][0].id | d(osp_project_id) }}"
+      project_id: "{{ hostvars['localhost']['osp_project_info'][0].id | default(osp_project_id) }}"
       user_domain_name: "Default"
     region_name: "regionOne"
     interface: "public"

--- a/ansible/configs/ocp4-disconnected-osp-lab/files/clouds.yaml.j2
+++ b/ansible/configs/ocp4-disconnected-osp-lab/files/clouds.yaml.j2
@@ -2,11 +2,16 @@ clouds:
   {{ osp_project_name }}:
     auth:
       auth_url: "{{ osp_auth_url }}"
+{% if osp_project_create | bool %}
       username: "{{ guid }}-user"
-      project_name: "{{ osp_project_name }}"
-      project_id: "{{ hostvars['localhost']['osp_project_info'][0].id }}"
-      user_domain_name: "Default"
       password: "{{ hostvars['localhost']['heat_user_password'] }}"
+{% else %}
+      username: "{{ osp_auth_username_member }}"
+      password: "{{ osp_auth_password_member }}"
+{% endif %}
+      project_name: "{{ osp_project_name }}"
+      project_id: "{{ hostvars['localhost']['osp_project_info'][0].id | default(osp_project_id) }}"
+      user_domain_name: "Default"
     region_name: "regionOne"
     interface: "public"
     identity_api_version: 3

--- a/ansible/configs/ocp4-disconnected-osp-lab/files/clouds.yaml.j2
+++ b/ansible/configs/ocp4-disconnected-osp-lab/files/clouds.yaml.j2
@@ -10,7 +10,7 @@ clouds:
       password: "{{ osp_auth_password_member }}"
 {% endif %}
       project_name: "{{ osp_project_name }}"
-      project_id: "{{ hostvars['localhost']['osp_project_info'][0].id | default(osp_project_id) }}"
+      project_id: "{{ hostvars['localhost']['osp_project_info'][0].id | d(osp_project_id) }}"
       user_domain_name: "Default"
     region_name: "regionOne"
     interface: "public"

--- a/ansible/roles/host-ocp4-provisioner/templates/clouds.yaml.j2
+++ b/ansible/roles/host-ocp4-provisioner/templates/clouds.yaml.j2
@@ -2,13 +2,8 @@ clouds:
   {{ osp_cloud_name }}:
     auth:
       auth_url: "{{ osp_auth_url }}"
-{% if osp_project_create | bool %}
-      username: "{{ guid }}-user"
-      password: "{{ hostvars['localhost']['heat_user_password'] }}"
-{% else %}
-      username: "{{ osp_auth_username_member | d(osp_auth_username) }}"
-      password: "{{ osp_auth_password_member | d(osp_auth_password) }}"
-{% endif %}
+      username: "{{ osp_auth_username_member }}"
+      password: "{{ osp_auth_password_member }}"
       project_name: "{{ osp_project_name }}"
       project_id: "{{ hostvars['localhost']['osp_project_info'][0].id | default(osp_project_id) }}"
       user_domain_name: "Default"

--- a/ansible/roles/host-ocp4-provisioner/templates/clouds.yaml.j2
+++ b/ansible/roles/host-ocp4-provisioner/templates/clouds.yaml.j2
@@ -6,8 +6,8 @@ clouds:
       username: "{{ guid }}-user"
       password: "{{ hostvars['localhost']['heat_user_password'] }}"
 {% else %}
-      username: "{{ osp_auth_username }}"
-      password: "{{ osp_auth_password }}"
+      username: "{{ osp_auth_username_member | d(osp_auth_username) }}"
+      password: "{{ osp_auth_password_member | d(osp_auth_password) }}"
 {% endif %}
       project_name: "{{ osp_project_name }}"
       project_id: "{{ hostvars['localhost']['osp_project_info'][0].id | default(osp_project_id) }}"


### PR DESCRIPTION
##### SUMMARY
Recently, the `osp_auth_username_member` and `osp_auth_password_member` were introduced. The `ocp4-disconnected-osp-lab` and `host-ocp4-provisioner` roles don't use it to expand the `clouds.yaml.j2` template. This pull request adds the support for them.

The `ocp4-disconnected-osp-lab` also didn't support the ability to use an existing project, so the pull request checks if `osp_project_create` is set and uses existing user if yes, like `host-ocp4-provisioner` does.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-disconnected-osp-lab
host-ocp4-provisioner