### PR TITLE
Ocp4 workload kubevirt allow time for subscription status

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/meta/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   role_name: ocp4_workload_kubevirt
-  author: Mark Li
+  author: Fabien Dupont <fdupont@redhat.com>
   description: |
     Deploys Kubevirt HCO on a OCP4 cluster
   platforms: []

--- a/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/tasks/workload.yml
@@ -13,6 +13,10 @@
     state: present
     definition: "{{ lookup('file', 'operatorgroup.yaml') }}"
 
+- name: Waiting 5 seconds to ensure the operator group is created
+  pause:
+    seconds: 5
+
 - name: Create subscription for HCO
   k8s:
     state: present

--- a/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/tasks/workload.yml
@@ -13,9 +13,15 @@
     state: present
     definition: "{{ lookup('file', 'operatorgroup.yaml') }}"
 
-- name: Waiting 5 seconds to ensure the operator group is created
-  pause:
-    seconds: 5
+- name: Wait for operator group to be present
+  k8s_info:
+    api_version: operators.coreos.com/v1
+    kind: OperatorGroup
+    name: cnv
+    namespace: openshift-cnv
+  register: result
+  until:
+    - "result.resources | length > 0"
 
 - name: Create subscription for HCO
   k8s:
@@ -29,7 +35,7 @@
     name: "{{ kubevirt_subscription_name }}"
     namespace: openshift-cnv
   register: result
-  until: 
+  until:
     - "result.resources | length > 0"
     - "result.resources[0].status is defined"
     - "result.resources[0].status.phase == 'Succeeded'"

--- a/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/tasks/workload.yml
@@ -27,6 +27,7 @@
   register: result
   until: 
     - "result.resources | length > 0"
+    - "result.resources[0].status is defined"
     - "result.resources[0].status.phase == 'Succeeded'"
   retries: 30
   delay: 10


### PR DESCRIPTION
##### SUMMARY
It may happen that the Subscription CR is not picked by the controller when we check its status, so the `status` property doesn't exist yet. This pull request allows an empty `status` property.

It also adds a small pause to be sure that the operator group is created.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_kubevirt