### PR TITLE
Change config ocp4-disconnected-osp-lab

### DIFF
--- a/ansible/configs/ocp4-disconnected-osp-lab/destroy_env.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/destroy_env.yml
@@ -17,7 +17,7 @@
       nsupdate:
         server: "{{ osp_cluster_dns_server }}"
         zone: "{{ osp_cluster_dns_zone }}"
-        record: "{{ item }}.{{ guid }}"
+        record: "{{ item }}.cluster-{{ guid }}"
         type: A
         port: "{{ osp_cluster_dns_port | d('53') }}"
         key_name: "{{ ddns_key_name }}"


### PR DESCRIPTION
##### SUMMARY
In the `destroy_env.yml`, this config was not using the correct base domain to cleanup the API & wildcard DNS entries. This small change fixes that to delete the records with `cluster-guid` instead of just `guid`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-disconnected-osp-lab

