### PR TITLE
Change documentation ocp4-ha-lab to move from env_vars.yml to default_vars.yml

### DIFF
--- a/ansible/configs/ocp4-ha-lab/README.adoc
+++ b/ansible/configs/ocp4-ha-lab/README.adoc
@@ -10,7 +10,7 @@ The following config includes:
 
 == Review the Env_Type variable file
 
-* This file link:./env_vars.yml[./env_vars.yml] contains all the variables you need to define to control the deployment of your environment.  These are the deafults.
+* This file link:./default_vars.yml[./default_vars.yml] contains all the variables you need to define to control the deployment of your environment.  These are the deafults.
 
 * Override the defaults for your environment by creating your own myenvironment-variables.yml file, as below.
 


### PR DESCRIPTION
##### SUMMARY
Changes the ocp4-ha-lab docs replacing env_vars.yml to default_vars.yml
Fixes #2034 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ocp4-ha-lab


