### PR TITLE
Fix completion_callbacks.yml, add tests to work with ancient versions of ansible (2.7)

### DIFF
--- a/ansible/completion_callback.yml
+++ b/ansible/completion_callback.yml
@@ -10,6 +10,10 @@
   tasks:
     - name: Attempt completion callback
       when:
+      - __meta__ is defined
+      - __meta__.callback is defined
+      - __meta__.callback.url | default('') != ''
+      - __meta__.callback.token | default('') != ''
       - agnosticd_callback_url != ''
       - agnosticd_callback_token != ''
       vars:


### PR DESCRIPTION
This commit, if applied, fixes the following error:

fatal: [localhost]: FAILED! => {"msg": "The conditional check 'agnosticd_callback_url != ''' failed. The error was: error while evaluating conditional (agnosticd_callback_url != ''): 'dict object' has no attribute 'callback'\n\nThe error appears to have been in '/tmp/sandboxes-gpte-OCP4_WORKSHOP_CCN_RS_DEV_TRACK_SFDC_LARGE-prod-ccn2-99d2-...

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
