### PR TITLE
Fix functionality for agnosticd_callback_* vars

### DIFF
--- a/ansible/completion_callback.yml
+++ b/ansible/completion_callback.yml
@@ -5,15 +5,13 @@
     # default __meta__ to prevent errors on older ansible versions
     __meta__:
       callback: {}
-    agnosticd_callback_url: "{{ __meta__.callback.url | default('') }}"
-    agnosticd_callback_token: "{{ __meta__.callback.token | default('') }}"
+    agnosticd_callback_url: >-
+      {{ __meta__.callback.url | default('') if __meta__ is defined and __meta__.callback is defined else '' }}
+    agnosticd_callback_token: >-
+      {{ __meta__.callback.token | default('') if __meta__ is defined and __meta__.callback is defined else '' }}
   tasks:
     - name: Attempt completion callback
       when:
-      - __meta__ is defined
-      - __meta__.callback is defined
-      - __meta__.callback.url | default('') != ''
-      - __meta__.callback.token | default('') != ''
       - agnosticd_callback_url != ''
       - agnosticd_callback_token != ''
       vars:

--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -19,6 +19,8 @@ include::Preparing_your_workstation.adoc[]
 include::Creating_an_OpenShift_Workload.adoc[]
 include::First_OSP_Env_walkthrough.adoc[leveloffset=1]
 
+include::Variables.adoc[]
+
 include::User_Info.adoc[]
 
 include::Contributing.adoc[]

--- a/docs/Variables.adoc
+++ b/docs/Variables.adoc
@@ -1,0 +1,42 @@
+== AgnosticD Variables
+
+Variables used by specific configs and roles should be documented along with the config and role.
+Variables that used by Ansible core or have a common meaning across many configs are documented here.
+
+NOTE: At the time of this writing this list is known to be an incomplete.
+
+=== Core Required Variables
+
+[options="header",cols="1,4"]
+|============================
+| `cloud_provider`
+| Cloud provider.
+Required variable, but may be set to `none` where not applicable.
+
+| `env_type`
+| Config name which should match to a subdirectory under `ansible/configs/`.
+
+| `guid`
+| Unique ID used in labels, tags, metadata, and resource naming throughout the config to identify resources and prevent conflicts.
+
+| `ACTION`
+| Action to be performed by the lifecycle playbook or workload.
+|============================
+
+=== Core Variables
+
+[options="header",cols="1,4"]
+|============================
+| Name
+| Description
+
+| `agonsticd_callback_token`
+| Authentication Bearer token used to callback with information and data collected from `agnosticd_user_info`.
+This is used to integrate AgnosticD with external systems including Babylon and GUID Grabber.
+Default value `__meta__.callback.token`.
+
+| `agonsticd_callback_url`
+| API URL used to callback with information and data collected from `agnosticd_user_info`.
+This is used to integrate AgnosticD with external systems including Babylon and GUID Grabber.
+Default value `__meta__.callback.url`.
+|============================


### PR DESCRIPTION
The variables agnosticd_callback_url and agnosticd_callback_token should
be functionaly when set and __meta__ vars are not set. This is required
for GUID Grabber bookbag integration.