### PR TITLE
Update with new customization options (repos etc)

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_nexus_operator/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_nexus_operator/defaults/main.yml
@@ -9,24 +9,36 @@ ocp4_workload_nexus_operator_project_display: "Sonatype Nexus"
 
 # Nexus Operator Image and Tag
 ocp4_workload_nexus_operator_image: quay.io/gpte-devops-automation/nexus-operator
-ocp4_workload_nexus_operator_image_tag: v0.17
+ocp4_workload_nexus_operator_image_tag: v0.17.1
 
 # Deploy an instance of Nexus into the same project as the operator?
 ocp4_workload_nexus_operator_deploy_nexus_instance: True
+
+# ----------------------------------
+# Nexus Custom Resource to be set up
+# ----------------------------------
 
 # Name of the Nexus Custom Resource
 ocp4_workload_nexus_operator_name: nexus
 
 # Nexus Image and Tag
+# `latest` is not supported due to the rapidly changing nexus container image
+# 3.24.0 is the earliest supported release do to REST API incompatibilities before
 # ocp4_workload_nexus_operator_nexus_image: docker.io/sonatype/nexus3
 ocp4_workload_nexus_operator_nexus_image: registry.connect.redhat.com/sonatype/nexus-repository-manager
-ocp4_workload_nexus_operator_nexus_image_tag: latest
+ocp4_workload_nexus_operator_nexus_image_tag: 3.24.0-ubi-1
+
+# PVC size for Nexus
+ocp4_workload_nexus_operator_volume_size: 20Gi
 
 # Use an HTTPS route for Nexus?
 ocp4_workload_nexus_operator_ssl_route: false
 
-# PVC size for Nexus
-ocp4_workload_nexus_operator_volume_size: 20Gi
+# Route name for the Nexus Route. Only set if you know what you are doing!
+# ocp4_workload_nexus_operator_nexus_route: nexus.apps.clusterdomain
+
+# Route name for the Nexus Container Regisgtry Route. Only set if you know what you are doing!
+# ocp4_workload_nexus_operator_registry_route: nexus-registry.apps.clusterdomain
 
 # Requests and Limits for Nexus
 ocp4_workload_nexus_operator_cpu_request: 2
@@ -37,3 +49,88 @@ ocp4_workload_nexus_operator_memory_limit: 2Gi
 # Set a new admin password for Nexus
 # When not defined (or empty) the generated password from Nexus will be printed to the user.info
 ocp4_workload_nexus_operator_new_admin_password: admin123
+
+# Enable Anonymous read access to repositories 
+ocp4_workload_nexus_operator_enable_anonymous: true
+
+# Delete default repositories in Nexus
+ocp4_workload_nexus_operator_repos_delete_default: true
+
+# Repositories to be set up
+# -------------------------
+# Always two variables. First specifies if a specific type of repository should be set up
+# Second is a YAML array with the repos to be set up.
+
+# The examples below are the defaults that will be set up if no specific repo variables are set
+
+# Maven Proxy Repositories
+ocp4_workload_nexus_operator_repos_maven_proxy_setup: true
+# ocp4_workload_nexus_operator_repos_maven_proxy:
+# - name: maven-central
+#   remote_url: https://repo1.maven.org/maven2/
+#   blob_store: default
+#   strict_content_validation: true
+#   version_policy: release # release, snapshot or mixed
+#   layout_policy: strict # strict or permissive
+# # Do not use `redhat` in your repository name. Somehow that gets converted into *****
+# - name: rh-ga
+#   remote_url: https://maven.repository.redhat.com/ga/
+#   blob_store: default
+#   strict_content_validation: true
+#   version_policy: release # release, snapshot or mixed
+#   layout_policy: strict # strict or permissive
+# - name: jboss
+#   remote_url: https://repository.jboss.org/nexus/content/groups/public
+#   blob_store: default
+#   strict_content_validation: true
+#   version_policy: release # release, snapshot or mixed
+#   layout_policy: strict # strict or permissive
+
+# Maven Hosted Repositories
+ocp4_workload_nexus_operator_repos_maven_hosted_setup: true
+# ocp4_workload_nexus_operator_repos_maven_hosted:
+# - name: releases
+#   blob_store: default
+#   write_policy: allow_once # allow_once or allow
+#   strict_content_validation: true
+#   version_policy: release # release, snapshot or mixed
+#   layout_policy: strict # strict or permissive
+
+# Maven Group
+ocp4_workload_nexus_operator_repos_maven_group_setup: true
+# ocp4_workload_nexus_operator_repos_maven_group:
+# - name: maven-all-public
+#   blob_store: default
+#   strict_content_validation: true
+#   member_repos:
+#   - maven-central
+#   - rh-ga
+#   - jboss
+
+# Docker Hosted Repositories
+ocp4_workload_nexus_operator_repos_docker_hosted_setup: true
+# ocp4_workload_nexus_operator_repos_docker_hosted:
+# - name: docker
+#   http_port: 5000
+#   https_port: 5001
+#   v1_enabled: true
+#   blob_store: default
+#   strict_content_validation: true
+#   write_policy: allow_once # allow_once or allow
+
+# NPM Proxy Repositories
+ocp4_workload_nexus_operator_repos_npm_proxy_setup: true
+# ocp4_workload_nexus_operator_repos_npm_proxy:
+# - name: npm
+#   remote_url: https://registry.npmjs.org
+#   blob_store: default
+#   strict_content_validation: true
+
+# NPM Group Repositories
+ocp4_workload_nexus_operator_repos_npm_group_setup: true
+# ocp4_workload_nexus_operator_repos_npm_group:
+# - name: npm-all
+#   blob_store: default
+#   strict_content_validation: true
+#   member_repos:
+#   - npm

--- a/ansible/roles_ocp_workloads/ocp4_workload_nexus_operator/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_nexus_operator/tasks/remove_workload.yml
@@ -10,7 +10,7 @@
     seconds: 15
 
 # Delete all objects except the project (there may be other stuff in it)
-- name: Delete OpenShift Objects for Nexus Operator (including the OPENTLC Nexus)
+- name: Delete OpenShift Objects for Nexus Operator
   k8s:
     state: absent
     definition: "{{ lookup('template', item ) | from_yaml }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_nexus_operator/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_nexus_operator/tasks/workload.yml
@@ -3,6 +3,20 @@
   debug:
     msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
 
+- name: Check for valid Nexus image tag
+  assert:
+    that:
+    - ocp4_workload_nexus_operator_nexus_image_tag is not match('latest')
+    fail_msg: "Due to the frequent changes in the Nexus container image, 'latest' is not a valid image tag. Please use a specific version starting with 3.24.0."
+    quiet: true
+
+- name: Check for supported Nexus image version
+  assert:
+    that:
+    - ocp4_workload_nexus_operator_nexus_image_tag is version_compare('3.24', '>=')
+    fail_msg: "Minimum supported Nexus Version is 3.24.0."
+    quiet: true
+
 - name: Create OpenShift Objects for Nexus Operator
   k8s:
     state: present
@@ -16,7 +30,7 @@
   - ./templates/operator.j2
 
 - name: Wait for Nexus operator Pod to be ready
-  k8s_facts:
+  k8s_info:
     api_version: v1
     kind: Deployment
     namespace: "{{ ocp4_workload_nexus_operator_project }}"
@@ -39,7 +53,7 @@
       definition: "{{ lookup('template', './templates/nexus.j2' ) | from_yaml }}"
 
   - name: Wait for Nexus Pod to be ready
-    k8s_facts:
+    k8s_info:
       api_version: v1
       kind: Deployment
       namespace: "{{ ocp4_workload_nexus_operator_project }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_nexus_operator/templates/nexus.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_nexus_operator/templates/nexus.j2
@@ -4,12 +4,54 @@ metadata:
   name: "{{ ocp4_workload_nexus_operator_name }}"
   namespace: "{{ ocp4_workload_nexus_operator_project }}"
 spec:
-  nexusVolumeSize: "{{ ocp4_workload_nexus_operator_volume_size }}"
-  nexusSsl: "{{ ocp4_workload_nexus_operator_ssl_route }}"
   nexusImage: "{{ ocp4_workload_nexus_operator_nexus_image }}"
   nexusImageTag: "{{ ocp4_workload_nexus_operator_nexus_image_tag }}"
+  nexusVolumeSize: "{{ ocp4_workload_nexus_operator_volume_size }}"
+
+  nexusSsl: "{{ ocp4_workload_nexus_operator_ssl_route }}"
+{% if ocp4_workload_nexus_operator_nexus_route | default("") | length > 0 %}  
+  nexusRoute: "{{ ocp4_workload_nexus_operator_nexus_route }}"
+{% endif %}
+{% if ocp4_workload_nexus_operator_registry_route | default("") | length > 0 %}  
+  nexusRoute: "{{ ocp4_workload_nexus_operator_registry_route }}"
+{% endif %}
+
   nexusCpuRequest: "{{ ocp4_workload_nexus_operator_cpu_request }}"
   nexusCpuLimit: "{{ ocp4_workload_nexus_operator_cpu_limit }}"
   nexusMemoryRequest: "{{ ocp4_workload_nexus_operator_memory_request }}"
   nexusMemoryLimit: "{{ ocp4_workload_nexus_operator_memory_limit }}"
+
   nexusNewAdminPassword: "{{ ocp4_workload_nexus_operator_new_admin_password }}"
+  nexusEnableAnonymous: "{{ ocp4_workload_nexus_operator_enable_anonymous }}"
+
+  nexusReposDeleteDefault: "{{ ocp4_workload_nexus_operator_repos_delete_default }}"
+
+  nexusReposMavenProxySetup: "{{ ocp4_workload_nexus_operator_repos_maven_proxy_setup }}"
+{% if ocp4_workload_nexus_operator_repos_maven_proxy | default("") | length > 0 %}
+  nexusReposMavenProxy: "{{ ocp4_workload_nexus_operator_repos_maven_proxy }}"
+{% endif %}
+
+  nexusReposMavenHostedSetup: "{{ ocp4_workload_nexus_operator_repos_maven_hosted_setup }}"
+{% if ocp4_workload_nexus_operator_repos_maven_hosted | default("") | length > 0 %}
+  nexusReposMavenHosted: "{{ ocp4_workload_nexus_operator_repos_maven_hosted }}"
+{% endif %}
+
+  nexusReposMavenGroupSetup: "{{ ocp4_workload_nexus_operator_repos_maven_group_setup }}"
+{% if ocp4_workload_nexus_operator_repos_maven_group | default("") | length > 0 %}
+  nexusReposMavenGroup: "{{ ocp4_workload_nexus_operator_repos_maven_group }}"
+{% endif %}
+
+  nexusReposDockerHostedSetup: "{{ ocp4_workload_nexus_operator_repos_docker_hosted_setup }}"
+{% if ocp4_workload_nexus_operator_repos_docker_hosted | default("") | length > 0 %}
+  nexusReposDockerHosted: "{{ ocp4_workload_nexus_operator_repos_docker_hosted }}"
+{% endif %}
+
+  nexusReposNpmProxySetup: "{{ ocp4_workload_nexus_operator_repos_npm_proxy_setup }}"
+{% if ocp4_workload_nexus_operator_repos_npm_proxy | default("") | length > 0 %}
+  nexusReposNpmProxy: "{{ ocp4_workload_nexus_operator_repos_npm_proxy }}"
+{% endif %}
+
+  nexusReposNpmGroupSetup: "{{ ocp4_workload_nexus_operator_repos_npm_group_setup }}"
+{% if ocp4_workload_nexus_operator_repos_npm_group | default("") | length > 0 %}
+  nexusReposNpmGroup: "{{ ocp4_workload_nexus_operator_repos_npm_group }}"
+{% endif %}


### PR DESCRIPTION
##### SUMMARY

* Re-enable the capability in Nexus Operator to customize Nexus Repositories
* Add checks for Nexus Image (`latest` is no longer valid due to frequently changing Nexus container images). Minimum image is now `3.24.0` (for Dockerhub nexus images) or `3.24.0-ubi-1` for Redhat Registry nexus images
* Add additional settings to specify how the repositories should be customized
* Added flag to enable/disable anonymous access

Additional related changes in the Operator
* Remove Groovy Scripts from Operator, replace with REST API calls

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
OpenShift 4 Workload: Nexus Operator

##### ADDITIONAL INFORMATION
The capability to customize repositories was lost in the operator during the last round of updates and fixes. This re-enables this capability - and in a much better way.