### PR TITLE
Fix role host-ocp4-provisioner

### DIFF
--- a/ansible/roles/host-ocp4-provisioner/tasks/osp_prereqs.yml
+++ b/ansible/roles/host-ocp4-provisioner/tasks/osp_prereqs.yml
@@ -38,6 +38,9 @@
     dest: "/home/{{ ansible_user }}/.config/openstack/clouds.yaml"
     owner: "{{ ansible_user }}"
     mode: 0700
+  vars:
+    osp_auth_username_member: "{{ hostvars['localhost']['osp_auth_username_member'] }}"
+    osp_auth_password_member: "{{ hostvars['localhost']['osp_auth_password_member'] }}"
 
 - name: Add environment variables for API and Ingress FIPs
   lineinfile:


### PR DESCRIPTION

##### SUMMARY
With the change to use `osp_auth_username|password_member` vars for the OSP cloud provider to actually create things, this role was failing when generating the `clouds.yaml` file on the bastion node. This is because the fact that set these values was associated with the localhost running agnosticd and not the bastion where the task that generated the `clouds.yaml` was being run.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
host-ocp4-provisioner