### PR TITLE
Revert "infra-osp-resources-destroy - Fix Heat stack deletion"

### DIFF
--- a/ansible/roles-infra/infra-osp-resources-destroy/tasks/heat.yml
+++ b/ansible/roles-infra/infra-osp-resources-destroy/tasks/heat.yml
@@ -1,12 +1,8 @@
 ---
-- name: Get OpenStack project id
-  set_fact:
-    osp_project_id: "{{ osp_project_id | default(osp_project_info[0].id) }}"
-
 - environment:
     OS_AUTH_URL: "{{ osp_auth_url }}"
-    OS_USERNAME: "{{ osp_auth_username_member | default(osp_auth_username) }}"
-    OS_PASSWORD: "{{ osp_auth_password_member | default(osp_auth_password) }}"
+    OS_USERNAME: "{{ osp_auth_username }}"
+    OS_PASSWORD: "{{ osp_auth_password }}"
     OS_PROJECT_NAME: "{{ osp_project_name }}"
     OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
     OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"
@@ -14,7 +10,7 @@
   # There is no module that allows retrieving this data.
   - name: Get a list of stacks in the project
     command: >-
-      openstack stack list --property tenant={{ osp_project_id }} -f value --column ID
+      openstack stack list --property tenant={{ osp_project_info[0].id }} -f value --column ID
     register: r_stacks
 
   # The os_stack module doesn't allow deleting by ID and name is not safe to use since there could
@@ -28,3 +24,4 @@
     until: r_hot_out is succeeded
     register: r_hot_out
     loop: "{{ r_stacks.stdout_lines }}"
+  


### PR DESCRIPTION
Reverts redhat-cop/agnosticd#1995

The exact thing that I was worried about happened...we have `osp_auth_username_member` defined (from defaults) and no `osp_auth_password_member`, so it was mixing users and passwords and failing. We use `osp_auth_username_member` in an additional task for cleaning up keypairs, so I need that defined in defaults if not explicit.

This cleanup needs to go back for a deeper review. In the meantime, cleaning up *inside* a sandbox just won't work and that is not what this was intended for in it's initial and current state.

@fdupont-redhat 