### PR TITLE
Change config rhel8lab to add user info messages

### DIFF
--- a/ansible/configs/rhel8lab/post_software.yml
+++ b/ansible/configs/rhel8lab/post_software.yml
@@ -35,6 +35,59 @@
           bookbag_os_username: "{{ guid }}-user"
           bookbag_os_password: "{{ hostvars.localhost.heat_user_password }}"
           bookbag_os_project_name: "{{ guid }}-project"
+          
+# for testing user info, from
+# https://github.com/redhat-cop/agnosticd/blob/d4e62c36ce7b55422aaca3adbb0db3b115faaab7/ansible/configs/ocp4-cluster/post_software.yml#L293-L315
+- name: Step 005.6 Print Student Info
+  hosts: localhost
+  gather_facts: false
+  become: false
+  tasks:
+  - name: Print Student Information
+    when: install_student_user | bool
+    block:
+    - name: Store bastion hostname as a fact
+      set_fact:
+        bastion_hostname: "{{groups['bastions'].0 }}"
+    - name: print out user.info
+      debug:
+        msg: "{{ item }}"
+      loop:
+      - "user.info: You can access your bastion via SSH:"
+      - "user.info: ssh {{ student_name }}@bastion.{{ guid }}{{ subdomain_base_suffix if cloud_provider == 'ec2' else '.'+ocp4_base_domain }}"
+      - "user.info: "
+      - "user.info: Make sure you use the username '{{ student_name }}' and the password '{{ hostvars[bastion_hostname]['student_password'] }}' when prompted."
+    - name: print out user.info
+      debug:
+        msg: "user.info: kubeadmin password {{ hostvars[bastion_hostname]['kubeadmin_password']['content'] | b64decode }}"
+      when: cloud_provider == "azure" or cloud_provider == "gcp"
+
+# for testing, from https://github.com/redhat-cop/agnosticd/blob/development/ansible/configs/osp-sandbox/post_software.yml
+- name: print out user.info
+  debug:
+    msg: "{{ item }}"
+  loop:
+    - "user.info: You can access your bastion via SSH:"
+    - "user.info: ssh {{ student_name }}@bastion.{{ guid }}.{{ osp_cluster_dns_zone }}"
+    - "user.info: "
+    - "user.info: Make sure you use the username '{{ student_name }}' and the password '{{ hostvars['bastion']['student_password'] }}' when prompted."
+    - "user.info: "
+    - "user.info: Your base domain is '{{ student_dns_zone | default(osp_cluster_dns_zone) }}'"
+    - "user.info: "
+    - "user.info: For reference, the data you need to create your clouds.yaml file is:"
+    - "user.info: "
+    - "user.info: clouds:"
+    - "user.info:   {{ osp_project_name }}:"
+    - "user.info:     auth:"
+    - "user.info:       auth_url: {{ osp_auth_url }}"
+    - "user.info:       username: {{ guid }}-user"
+    - "user.info:       project_name: {{ osp_project_name }}"
+    - "user.info:       project_id: {{ hostvars['localhost']['osp_project_info'][0].id }}"
+    - "user.info:       user_domain_name: Default"
+    - "user.info:       password: {{ hostvars['localhost']['heat_user_password'] }}"
+    - "user.info:     region_name: regionOne"
+    - "user.info:     interface: public"
+    - "user.info:     identity_api_version: 3"
 
 - name: PostSoftware flight-check
   hosts: localhost


### PR DESCRIPTION
closes #1642 

Added code from 2 different existing configs to try to get student and access info printed when deploying
to Novello/OSP provider

1. https://github.com/redhat-cop/agnosticd/blob/d4e62c36ce7b55422aaca3adbb0db3b115faaab7/ansible/configs/ocp4-cluster/post_software.yml#L293-L315
2. https://github.com/redhat-cop/agnosticd/blob/development/ansible/configs/osp-sandbox/post_software.yml

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
