### PR TITLE
Change Contributing guidelines

### DIFF
--- a/docs/Contributing.adoc
+++ b/docs/Contributing.adoc
@@ -43,10 +43,14 @@ These are our contribution guidelines for helping out with the project. Any sugg
 ** Use `k8s` and `k8s_info` modules as much as possible and not `oc` command.
 . All tasks AND plays must have names.
 . Roles must have documented variables. This can be documented in either:
-** Role defaults/main.yml (preferred)
+** Role `defaults/main.yml` (preferred)
 ** Role README file
 ** Choose one or the other. If you are commenting your variables in the defaults, your README should just point to this file. Do not split your variable documentation across these.
 . Roles must have `meta/main.yml` with author/contact information for support.
+. Configs must have documented variables. This can be documented in either:
+** Config `default_vars*.yml` (preferred)
+** Config README file
+** Choose one or the other. If you are commenting your variables in the `default_vars.yml`, your README should just point to this file. Do not split your variable documentation across these.
 . Be extra careful with external dependencies. Identify them and make sure the versions are **pinned** (use versions, tags, commit ID, etc.).
 ** External Git repos
 ** Libraries/Modules

--- a/docs/Contributing.adoc
+++ b/docs/Contributing.adoc
@@ -9,13 +9,13 @@ These are our contribution guidelines for helping out with the project. Any sugg
 * The Ansible link:https://docs.ansible.com/ansible/latest/community/code_of_conduct.html[Code of Conduct] still applies.
 * For git messages, branch names, etc., follow link:https://github.com/redhat-cop/agnosticd/blob/development/docs/git-style-guide.adoc[Git Style Guide].
 * Pull Requests should reference an *issue* whenever possible.
-** Completely new functionality e.g. a new role or new config etc, must reference an issue. 
+** Completely new functionality e.g. a new role or new config etc, must reference an issue.
 ** In your Pull Request, specify `closes #NUM` to automatically close the issue when the PR is merged.
 * To contribute, fork and make a pull request against the `development` branch.
 * Use link:https://asciidoctor.org/docs/asciidoc-writers-guide/[asciidoc] for documentation.
 * Pull requests should only change:
 ** One role
-** One config 
+** One config
 ** If more than one, please explain why an exception should apply. Ask yourself, « Can this pull request be separated in several smaller pull requests ? »
 * Pull Request titles:
 ** Must start with `Add | Change | Fix | Remove`
@@ -28,6 +28,7 @@ These are our contribution guidelines for helping out with the project. Any sugg
 * Owner of existing role or config must be set as reviewer.
 ** If new role or config, owner must be identified.
 * If your Pull Request is not ready for review, open it as link:https://github.blog/2019-02-14-introducing-draft-pull-requests/[Draft] or prefix with `WIP` in the title.
+* AgnosticD being part of the Red Hat Community of Practices, the link:https://redhat-cop.github.io/contrib/[Red Hat CoP Contibution Guidelines] applies.
 
 === Code Quality Rules
 
@@ -150,3 +151,4 @@ If you've broken your work up into a set of sequential changes and each commit p
 * link:http://docs.ansible.com/ansible/community.html#community-code-of-conduct[Code of Conduct]
 * link:https://docs.ansible.com/ansible/latest/community/code_of_conduct.html[Ansible Code of Conduct]
 * link:https://github.com/redhat-cop/agnosticd/blob/development/docs/git-style-guide.adoc[Git Style Guide]
+* link:https://redhat-cop.github.io/contrib/[Red Hat CoP Guidelines]

--- a/docs/Contributing.adoc
+++ b/docs/Contributing.adoc
@@ -28,7 +28,9 @@ These are our contribution guidelines for helping out with the project. Any sugg
 * Owner of existing role or config must be set as reviewer.
 ** If new role or config, owner must be identified.
 * If your Pull Request is not ready for review, open it as link:https://github.blog/2019-02-14-introducing-draft-pull-requests/[Draft] or prefix with `WIP` in the title.
-* AgnosticD being part of the Red Hat Community of Practices, the link:https://redhat-cop.github.io/contrib/[Red Hat CoP Contibution Guidelines] applies.
+* AgnosticD is part of the Red Hat Community of Practices; the link:https://redhat-cop.github.io/contrib/[Red Hat CoP Contribution Guidelines] apply.
+
+
 
 === Code Quality Rules
 

--- a/docs/Contributing.adoc
+++ b/docs/Contributing.adoc
@@ -9,7 +9,7 @@ These are our contribution guidelines for helping out with the project. Any sugg
 * The Ansible link:https://docs.ansible.com/ansible/latest/community/code_of_conduct.html[Code of Conduct] still applies.
 * For git messages, branch names, etc., follow link:https://github.com/redhat-cop/agnosticd/blob/development/docs/git-style-guide.adoc[Git Style Guide].
 * Pull Requests should reference an *issue* whenever possible.
-** Completely new functionality e.g. a new role or new config etc, must reference an issue.
+* Pull Requests must contain a well crafted description.
 ** In your Pull Request, specify `closes #NUM` to automatically close the issue when the PR is merged.
 * To contribute, fork and make a pull request against the `development` branch.
 * Use link:https://asciidoctor.org/docs/asciidoc-writers-guide/[asciidoc] for documentation.


### PR DESCRIPTION
##### SUMMARY
In contributing.adoc, point to redhat-cop guidelines.

- Mention redhat-cop guidelines
- Are issues mandatory for PR ?
- Specify where to document config variables

##### ISSUE TYPE
- Docs Pull Request

