### PR TITLE
create external sso realm as cluster idp

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_integreatly/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_integreatly/defaults/main.yml
@@ -76,7 +76,13 @@ ocp4_workload_integreatly_threescale_template_credential_secret: tenant-secret.j
 ocp4_workload_integreatly_threescale_template_tenant_resource: tenant.json.j2
 
 # SSO
+ocp4_workload_integreatly_sso_namespace: redhat-rhmi-rhsso
 ocp4_workload_integreatly_sso_route_name: keycloak-edge
+ocp4_workload_integreatly_sso_idp_realm_name: rhmi-workshop-idp
+ocp4_workload_integreatly_sso_idp_realm_display_name: RHMI Workshop IDP
+ocp4_workload_integreatly_sso_idp_client_secret: openshift
+ocp4_workload_integreatly_sso_idp_username_format: evals%d
+
 
 # 3scale SSO
 ocp4_workload_integreatly_threescale_sso_client_template_resource: keycloakclient-3scale-workshop.yml.j2

--- a/ansible/roles_ocp_workloads/ocp4_workload_integreatly/files/idp/create-sso-idp.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_integreatly/files/idp/create-sso-idp.yml
@@ -47,5 +47,33 @@
         clientSecret: "{{ 'openshift' | b64encode }}"
       type: Opaque
 
-- name: Add SSO IDP to the OpenShift cluster
-  shell: "oc patch oauth cluster --type=json -p '[{\"op\":\"add\", \"path\":\"/spec/identityProviders/-\", \"value\":{ \"name\": \"'{{ ocp4_workload_integreatly_sso_idp_realm_name }}'\", \"mappingMethod\": \"claim\", \"type\": \"OpenID\", \"openID\": { \"ca\": {\"name\": \"''\"}, \"clientID\": \"{{ ocp4_workload_integreatly_sso_idp_realm_name }}-client\", \"clientSecret\": { \"name\": \"'{{ ocp4_workload_integreatly_sso_idp_client_secret }}'\" }, \"issuer\": \"'https://{{ _action_get_cluster_sso_route.resources[0].spec.host }}'/auth/realms/'{{ ocp4_workload_integreatly_sso_idp_realm_name }}'\", \"claims\": { \"preferredUsername\": [\"preferred_username\"], \"email\": [\"email\"], \"name\": [\"name\"] } } } }]'"
+- name: Update cluster OAuth with SSO IDP
+  k8s:
+    state: present
+    merge_type:
+    - strategic-merge
+    - merge
+    definition:
+      apiVersion: config.openshift.io/v1
+      kind: OAuth
+      metadata:
+        name: cluster
+      spec:
+        identityProviders:
+        - name: "{{ ocp4_workload_integreatly_sso_idp_realm_name }}"
+          mappingMethod: claim
+          type: OpenID
+          openID:
+            ca:
+              name: ""
+            clientID: "{{ ocp4_workload_integreatly_sso_idp_realm_name }}-client"
+            clientSecret:
+              name: "{{ ocp4_workload_integreatly_sso_idp_client_secret }}"
+            issuer: "https://{{ _action_get_cluster_sso_route.resources[0].spec.host }}/auth/realms/{{ ocp4_workload_integreatly_sso_idp_realm_name }}"
+            claims:
+              preferredUsername:
+              - preferred_username
+              email:
+              - email
+              name:
+              - name

--- a/ansible/roles_ocp_workloads/ocp4_workload_integreatly/files/idp/create-sso-idp.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_integreatly/files/idp/create-sso-idp.yml
@@ -1,0 +1,51 @@
+---
+- name: Get OAuth URL
+  k8s_facts:
+    api_version: route.openshift.io/v1
+    kind: Route
+    name: oauth-openshift
+    namespace: openshift-authentication
+  register: _action_get_oauth_route
+
+- name: Get RHMI Cluster SSO URL
+  k8s_facts:
+    api_version: route.openshift.io/v1
+    kind: Route
+    name: keycloak-edge
+    namespace: redhat-rhmi-rhsso
+  register: _action_get_cluster_sso_route
+
+- name: Set facts for SSO IDP
+  set_fact:
+    ocp4_workload_integreatly_sso_idp_oauth_url: "https://{{ _action_get_oauth_route.resources[0].spec.host }}"
+
+- name: Create expected resources
+  k8s:
+    state: present
+    namespace: redhat-rhmi-rhsso
+    merge_type:
+    - strategic-merge
+    - merge
+    definition: "{{ lookup('template', item) | from_yaml }}"    
+  retries: 3
+  delay: 5
+  register: _create_resources
+  until: _create_resources is succeeded
+  loop:
+  - keycloakrealm-idp.yml.j2
+
+
+- name: Create SSO OAuth Secret
+  k8s:
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: openshift
+        namespace: openshift-config
+      data:
+        clientSecret: "{{ 'openshift' | b64encode }}"
+      type: Opaque
+
+- name: Add SSO IDP to the OpenShift cluster
+  shell: "oc patch oauth cluster --type=json -p '[{\"op\":\"add\", \"path\":\"/spec/identityProviders/-\", \"value\":{ \"name\": \"'{{ ocp4_workload_integreatly_sso_idp_realm_name }}'\", \"mappingMethod\": \"claim\", \"type\": \"OpenID\", \"openID\": { \"ca\": {\"name\": \"''\"}, \"clientID\": \"{{ ocp4_workload_integreatly_sso_idp_realm_name }}-client\", \"clientSecret\": { \"name\": \"'{{ ocp4_workload_integreatly_sso_idp_client_secret }}'\" }, \"issuer\": \"'https://{{ _action_get_cluster_sso_route.resources[0].spec.host }}'/auth/realms/'{{ ocp4_workload_integreatly_sso_idp_realm_name }}'\", \"claims\": { \"preferredUsername\": [\"preferred_username\"], \"email\": [\"email\"], \"name\": [\"name\"] } } } }]'"

--- a/ansible/roles_ocp_workloads/ocp4_workload_integreatly/files/idp/create-sso-idp.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_integreatly/files/idp/create-sso-idp.yml
@@ -15,9 +15,17 @@
     namespace: redhat-rhmi-rhsso
   register: _action_get_cluster_sso_route
 
+- name: Get cluster console resource
+  k8s_facts:
+    api_version: config.openshift.io/v1
+    kind: Console
+    name: cluster
+  register: _action_get_console
+
 - name: Set facts for SSO IDP
   set_fact:
     ocp4_workload_integreatly_sso_idp_oauth_url: "https://{{ _action_get_oauth_route.resources[0].spec.host }}"
+    ocp4_workload_integreatly_console_url: "{{ _action_get_console.resources[0].status.consoleURL }}"
 
 - name: Create expected resources
   k8s:
@@ -77,3 +85,30 @@
               - email
               name:
               - name
+
+- name: Get the RHMI custom resource
+  k8s_facts:
+    api_version: integreatly.org/v1alpha1
+    kind: RHMI
+    name: "{{ ocp4_workload_integreatly_custom_resource_name }}"
+    namespace: "{{ ocp4_workload_integreatly_namespace }}"
+  register: _action_get_rhmi
+
+- name: Set fact for cluster SSO URL
+  set_fact:
+    _cluster_sso_url: "{{ _action_get_rhmi.resources[0].status.stages.authentication.products.rhsso.host }}"
+
+- name: Update cluster logout redirect URL
+  k8s:
+    state: present
+    merge_type:
+    - strategic-merge
+    - merge
+    definition:
+      apiVersion: config.openshift.io/v1
+      kind: Console
+      metadata:
+        name: cluster
+      spec:
+        authentication:
+          logoutRedirect: "{{ _cluster_sso_url }}/auth/realms/{{ ocp4_workload_integreatly_sso_idp_realm_name }}/protocol/openid-connect/logout?redirect_uri={{ _action_get_console.resources[0].status.consoleURL }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_integreatly/sample_vars/ocp4_workload_integreatly_vars.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_integreatly/sample_vars/ocp4_workload_integreatly_vars.yml
@@ -28,8 +28,6 @@ ocp_workloads:
   - ocp4_workload_integreatly
 
 ocp4_workload_authentication_idm_type: htpasswd
-ocp4_workload_authentication_htpasswd_user_base: "{{ ocp4_workload_integreatly_user_base }}"
-ocp4_workload_authentication_htpasswd_user_password: "{{ ocp4_workload_integreatly_user_password }}"
-ocp4_workload_authentication_htpasswd_user_count: "{{ ocp4_workload_integreatly_user_count | int }}"
+ocp4_workload_authentication_htpasswd_user_count: 0
 ocp4_workload_authentication_admin_user: "{{ ocp4_workload_integreatly_admin_username }}"
 ocp4_workload_authentication_htpasswd_admin_password: "{{ ocp4_workload_integreatly_admin_user_password }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_integreatly/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_integreatly/tasks/post_workload.yml
@@ -4,30 +4,6 @@
 
 # Create dedicated admin user
 
-- name: Get current htpasswd secret
-  shell: oc get secret htpasswd-secret -n openshift-config -o json | jq -j '.data.htpasswd' | base64 --decode > /tmp/htpasswd
-
-- name: Backup htpasswd
-  shell: cp /tmp/htpasswd /tmp/htpasswd.backup
-
-- name: Create dedicated admin user
-  shell: htpasswd -B -b /tmp/htpasswd {{ ocp4_workload_integreatly_dedicated_admin_username }} {{ ocp4_workload_integreatly_dedicated_admin_user_password }}
-
-- name: Ensure htpasswd Secret is absent
-  k8s:
-    state: absent
-    api_version: v1
-    kind: Secret
-    name: htpasswd-secret
-    namespace: openshift-config
-  register: _delete_htpasswd_secret
-  until: _delete_htpasswd_secret is succeeded
-  retries: 3
-  delay: 5
-
-- name: Create new htpasswd secret
-  shell: oc create secret generic htpasswd-secret --from-file=htpasswd=/tmp/htpasswd -n openshift-config
-
 - name: Check for dedicated admins
   shell: oc get groups dedicated-admins
   register: group_output
@@ -106,6 +82,56 @@
     _instance_user: "{{ ocp4_workload_integreatly_user_base }}{{ _instance_count | int }}"
     _tenant_admin_secret_name: "{{ ocp4_workload_integreatly_user_base }}{{ _instance_count | int }}-admin-credentials"
 
+# Handle SSO IDP Setup
+
+- name: Create SSO IDP
+  include_tasks: ../files/idp/create-sso-idp.yml
+
+- name: Create evals keycloak users
+  k8s:
+    state: present
+    namespace: "{{ ocp4_workload_integreatly_sso_namespace }}"
+    merge_type:
+    - strategic-merge
+    - merge
+    definition: "{{ lookup('template', 'keycloakuser-idp.yml.j2') | from_yaml }}"
+  retries: 3
+  delay: 5
+  register: _create_resources
+  until: _create_resources is succeeded
+  with_sequence: count={{ ocp4_workload_integreatly_user_count }}
+  loop_control:
+    loop_var: _instance_count
+  vars:
+    _metadata_name: "rhmi-workshop-user-{{ _instance_count }}"
+    _spec_user_username: "{{ ocp4_workload_integreatly_sso_idp_username_format | format(_instance_count | int) }}"
+    _spec_user_firstname: "Evals"
+    _spec_user_lastname: "{{ _instance_count }}"
+    _spec_user_email: "{{ ocp4_workload_integreatly_sso_idp_username_format | format(_instance_count | int) }}@{{ ocp4_workload_integreatly_user_email_host }}"
+    _spec_user_password: "{{ ocp4_workload_integreatly_user_password }}"
+    _spec_realmselector_label_sso: "{{ ocp4_workload_integreatly_sso_idp_realm_name }}"
+
+- name: Create dedicated admin keycloak user
+  k8s:
+    state: present
+    namespace: "{{ ocp4_workload_integreatly_sso_namespace }}"
+    merge_type:
+    - strategic-merge
+    - merge
+    definition: "{{ lookup('template', 'keycloakuser-idp.yml.j2') | from_yaml }}"
+  retries: 3
+  delay: 5
+  register: _create_resources
+  until: _create_resources is succeeded
+  vars:
+    _metadata_name: "rhmi-workshop-user-{{ ocp4_workload_integreatly_dedicated_admin_username }}"
+    _spec_user_username: "{{ ocp4_workload_integreatly_dedicated_admin_username }}"
+    _spec_user_firstname: "Dedicated"
+    _spec_user_lastname: "Admin"
+    _spec_user_email: "{{ ocp4_workload_integreatly_dedicated_admin_username }}@{{ ocp4_workload_integreatly_user_email_host }}"
+    _spec_user_password: "{{ ocp4_workload_integreatly_dedicated_admin_user_password }}"
+    _spec_realmselector_label_sso: "{{ ocp4_workload_integreatly_sso_idp_realm_name }}"
+
 # Create dedicated admin fuse instance
 - name: create dedicated admin fuse instance
   include_tasks: ../files/fuse/create-instance.yml
@@ -139,6 +165,7 @@
   debug:
     msg: "{{ item }}"
   with_items:
+  - "user.info: "
   - "user.info: RHMI v2 Workshop Overview"
   - "user.info: Openshift Master Console: https://{{ _rhmi_custom_resource.resources[0].spec.masterURL }}"
   - "user.info: Solution Explorer URL: {{ _rhmi_custom_resource.resources[0].status.stages['solution-explorer'].products['solution-explorer'].host }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_integreatly/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_integreatly/tasks/post_workload.yml
@@ -2,21 +2,6 @@
 # Implement your Post Workload deployment tasks here
 # --------------------------------------------------
 
-# Create dedicated admin user
-
-- name: Check for dedicated admins
-  shell: oc get groups dedicated-admins
-  register: group_output
-  ignore_errors: True
-
-- name: Create dedicated admin group
-  shell: oc adm groups new dedicated-admins {{ ocp4_workload_integreatly_dedicated_admin_username }}
-  when: group_output.rc == 1
-
-- name: Add dedicated admin user to dedicated admin group
-  shell: oc adm groups add-users dedicated-admins {{ ocp4_workload_integreatly_dedicated_admin_username }}
-  when: group_output.rc != 1
-
 # Handle per-user 3scale tenant setup
 
 - name: Get master host url from route
@@ -105,11 +90,31 @@
   vars:
     _metadata_name: "rhmi-workshop-user-{{ _instance_count }}"
     _spec_user_username: "{{ ocp4_workload_integreatly_sso_idp_username_format | format(_instance_count | int) }}"
-    _spec_user_firstname: "Evals"
-    _spec_user_lastname: "{{ _instance_count }}"
     _spec_user_email: "{{ ocp4_workload_integreatly_sso_idp_username_format | format(_instance_count | int) }}@{{ ocp4_workload_integreatly_user_email_host }}"
     _spec_user_password: "{{ ocp4_workload_integreatly_user_password }}"
     _spec_realmselector_label_sso: "{{ ocp4_workload_integreatly_sso_idp_realm_name }}"
+
+- name: Create admin keycloak user
+  k8s:
+    state: present
+    namespace: "{{ ocp4_workload_integreatly_sso_namespace }}"
+    merge_type:
+    - strategic-merge
+    - merge
+    definition: "{{ lookup('template', 'keycloakuser-idp.yml.j2') | from_yaml }}"
+  retries: 3
+  delay: 5
+  register: _create_resources
+  until: _create_resources is succeeded
+  vars:
+    _metadata_name: "rhmi-workshop-user-{{ ocp4_workload_integreatly_admin_username }}"
+    _spec_user_username: "{{ ocp4_workload_integreatly_admin_username }}"
+    _spec_user_email: "{{ ocp4_workload_integreatly_admin_username }}@{{ ocp4_workload_integreatly_user_email_host }}"
+    _spec_user_password: "{{ ocp4_workload_integreatly_admin_user_password }}"
+    _spec_realmselector_label_sso: "{{ ocp4_workload_integreatly_sso_idp_realm_name }}"
+
+- name: Add cluster-admin role to admin user
+  shell: oc adm policy add-cluster-role-to-user cluster-admin {{ ocp4_workload_integreatly_admin_username }}
 
 - name: Create dedicated admin keycloak user
   k8s:
@@ -126,11 +131,22 @@
   vars:
     _metadata_name: "rhmi-workshop-user-{{ ocp4_workload_integreatly_dedicated_admin_username }}"
     _spec_user_username: "{{ ocp4_workload_integreatly_dedicated_admin_username }}"
-    _spec_user_firstname: "Dedicated"
-    _spec_user_lastname: "Admin"
     _spec_user_email: "{{ ocp4_workload_integreatly_dedicated_admin_username }}@{{ ocp4_workload_integreatly_user_email_host }}"
     _spec_user_password: "{{ ocp4_workload_integreatly_dedicated_admin_user_password }}"
     _spec_realmselector_label_sso: "{{ ocp4_workload_integreatly_sso_idp_realm_name }}"
+
+- name: Check for dedicated admins
+  shell: oc get groups dedicated-admins
+  register: group_output
+  ignore_errors: True
+
+- name: Create dedicated admin group
+  shell: oc adm groups new dedicated-admins {{ ocp4_workload_integreatly_dedicated_admin_username }}
+  when: group_output.rc == 1
+
+- name: Add dedicated admin user to dedicated admin group
+  shell: oc adm groups add-users dedicated-admins {{ ocp4_workload_integreatly_dedicated_admin_username }}
+  when: group_output.rc != 1
 
 # Create dedicated admin fuse instance
 - name: create dedicated admin fuse instance

--- a/ansible/roles_ocp_workloads/ocp4_workload_integreatly/templates/keycloakrealm-idp.yml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_integreatly/templates/keycloakrealm-idp.yml.j2
@@ -20,6 +20,7 @@ spec:
       secret: {{ ocp4_workload_integreatly_sso_idp_client_secret }}
       redirectUris:
         - {{ ocp4_workload_integreatly_sso_idp_oauth_url }}/oauth2callback/{{ ocp4_workload_integreatly_sso_idp_realm_name }}
+        - {{ ocp4_workload_integreatly_console_url }}
       directAccessGrantsEnabled: true
       enabled: true
       clientAuthenticatorType: client-secret

--- a/ansible/roles_ocp_workloads/ocp4_workload_integreatly/templates/keycloakrealm-idp.yml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_integreatly/templates/keycloakrealm-idp.yml.j2
@@ -1,0 +1,99 @@
+apiVersion: keycloak.org/v1alpha1
+kind: KeycloakRealm
+metadata:
+  name: {{ ocp4_workload_integreatly_sso_idp_realm_name }}
+  labels:
+    sso: {{ ocp4_workload_integreatly_sso_idp_realm_name }}
+spec:
+  instanceSelector:
+    matchLabels:
+      sso: integreatly
+  realm:
+    displayName: {{ ocp4_workload_integreatly_sso_idp_realm_display_name }}
+    enabled: true
+    id: {{ ocp4_workload_integreatly_sso_idp_realm_name }}
+    realm: {{ ocp4_workload_integreatly_sso_idp_realm_name }}
+    clients:
+    - id: {{ ocp4_workload_integreatly_sso_idp_realm_name }}-client
+      clientId: {{ ocp4_workload_integreatly_sso_idp_realm_name }}-client
+      rootUrl: {{ ocp4_workload_integreatly_sso_idp_oauth_url }}
+      secret: {{ ocp4_workload_integreatly_sso_idp_client_secret }}
+      redirectUris:
+        - {{ ocp4_workload_integreatly_sso_idp_oauth_url }}/oauth2callback/{{ ocp4_workload_integreatly_sso_idp_realm_name }}
+      directAccessGrantsEnabled: true
+      enabled: true
+      clientAuthenticatorType: client-secret
+      fullScopeAllowed: true
+      access:
+        configure: true
+        manage: true
+        view: true
+      standardFlowEnabled: true
+      webOrigins:
+        - {{ ocp4_workload_integreatly_sso_idp_oauth_url }}
+        - {{ ocp4_workload_integreatly_sso_idp_oauth_url }}/*
+      protocolMappers:
+        - config:
+            access.token.claim: 'true'
+            claim.name: given_name
+            id.token.claim: 'true'
+            jsonType.label: String
+            user.attribute: firstName
+            userinfo.token.claim: 'true'
+          consentRequired: true
+          consentText: '${givenName}'
+          name: given name
+          protocol: openid-connect
+          protocolMapper: oidc-usermodel-property-mapper
+        - config:
+            access.token.claim: 'true'
+            id.token.claim: 'true'
+            userinfo.token.claim: 'true'
+          consentRequired: true
+          consentText: '${fullName}'
+          name: full name
+          protocol: openid-connect
+          protocolMapper: oidc-full-name-mapper
+        - config:
+            access.token.claim: 'true'
+            claim.name: family_name
+            id.token.claim: 'true'
+            jsonType.label: String
+            user.attribute: lastName
+            userinfo.token.claim: 'true'
+          consentRequired: true
+          consentText: '${familyName}'
+          name: family name
+          protocol: openid-connect
+          protocolMapper: oidc-usermodel-property-mapper
+        - config:
+            attribute.name: Role
+            attribute.nameformat: Basic
+            single: 'false'
+          consentText: '${familyName}'
+          name: role list
+          protocol: saml
+          protocolMapper: saml-role-list-mapper
+        - config:
+            access.token.claim: 'true'
+            claim.name: email
+            id.token.claim: 'true'
+            jsonType.label: String
+            user.attribute: email
+            userinfo.token.claim: 'true'
+          consentRequired: true
+          consentText: '${email}'
+          name: email
+          protocol: openid-connect
+          protocolMapper: oidc-usermodel-property-mapper
+        - config:
+            access.token.claim: 'true'
+            claim.name: preferred_username
+            id.token.claim: 'true'
+            jsonType.label: String
+            user.attribute: username
+            userinfo.token.claim: 'true'
+          consentText: n.a.
+          name: username
+          protocol: openid-connect
+          protocolMapper: oidc-usermodel-property-mapper

--- a/ansible/roles_ocp_workloads/ocp4_workload_integreatly/templates/keycloakuser-idp.yml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_integreatly/templates/keycloakuser-idp.yml.j2
@@ -1,0 +1,25 @@
+apiVersion: keycloak.org/v1alpha1
+kind: KeycloakUser
+metadata:
+  name: {{ _metadata_name }}
+  labels:
+    app: sso
+spec:
+  user:
+    username: {{ _spec_user_username }}
+    email: "{{ _spec_user_email }}"
+    enabled: True
+    emailVerified: True
+    credentials:
+      - type: "password"
+        value: "{{ _spec_user_password }}"
+    realmRoles:
+      - "offline_access"
+    clientRoles:
+      account:
+        - "manage-account"
+      realm-management:
+        - "manage-users"
+  realmSelector:
+    matchLabels:
+      sso: {{ _spec_realmselector_label_sso }}


### PR DESCRIPTION
add an additional sso realm idp for the rhmi 2.x role. this replaces
the current htpasswd approach.

components:
- role, ocp4_workload_integreatly

verification:
- an install of this role completes against a 4.4 workshop
- the login screen for the cluster presents two identitity providers
- you can login to the rhmi identity provider using the users provided
  in the logged details