### PR TITLE
Lock RHEL release in the Bastion host

### DIFF
--- a/ansible/configs/sap-rhvh/pre_software.yml
+++ b/ansible/configs/sap-rhvh/pre_software.yml
@@ -67,9 +67,15 @@
       with_items:
         - 'rhel-7-server-rhvh-4-rpms'
 
+- name: Lock RHEL release
+  hosts: bastions
+  become: true
+  gather_facts: False
+  tasks:
+    - command: subscription-manager release --set=8.1
+
 - name: Configure Bastion Common Files
-  hosts:
-    - bastions
+  hosts: bastions
   become: true
   gather_facts: False
   roles:


### PR DESCRIPTION
##### SUMMARY
Lock RHEL release to prevent metadata pull issues

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
sap-rhvh
