### PR TITLE
Fix config sap-hana sap-rhvh sap-smart: in OSP heat, create SG only when used in 'instances'

### DIFF
--- a/ansible/configs/sap-hana/files/cloud_providers/osp_cloud_template_master.j2
+++ b/ansible/configs/sap-hana/files/cloud_providers/osp_cloud_template_master.j2
@@ -55,7 +55,8 @@ resources:
   ###################
   # Security groups #
   ###################
-{% for security_group in security_groups | list + default_security_groups | list %}
+{% for security_group in security_groups | list + default_security_groups | list
+   if security_group.name in used_security_groups %}
   {{ security_group['name'] }}:
     type: OS::Neutron::SecurityGroup
     properties:

--- a/ansible/configs/sap-rhvh/files/cloud_providers/osp_cloud_template_master.j2
+++ b/ansible/configs/sap-rhvh/files/cloud_providers/osp_cloud_template_master.j2
@@ -56,7 +56,8 @@ resources:
   ###################
   # Security groups #
   ###################
-{% for security_group in security_groups | list + default_security_groups | list %}
+{% for security_group in security_groups | list + default_security_groups | list
+   if security_group.name in used_security_groups %}
   {{ security_group['name'] }}:
     type: OS::Neutron::SecurityGroup
     properties:

--- a/ansible/configs/sap-smart/files/cloud_providers/osp_cloud_template_master.j2
+++ b/ansible/configs/sap-smart/files/cloud_providers/osp_cloud_template_master.j2
@@ -55,7 +55,8 @@ resources:
   ###################
   # Security groups #
   ###################
-{% for security_group in security_groups | list + default_security_groups | list %}
+{% for security_group in security_groups | list + default_security_groups | list
+   if security_group.name in used_security_groups %}
   {{ security_group['name'] }}:
     type: OS::Neutron::SecurityGroup
     properties:


### PR DESCRIPTION
##### SUMMARY
This commit follows #1702 and #1744 

Apply the fix on the standalone templates as well, so security groups not used
at deployment are not created in the heat template.

@makentenza must approve this PR before it is merged.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
configs:
- sap-hana
- sap-rhvh
- sap-smart
