### PR TITLE
fix role infra-osp-resources-destroy

### DIFF
--- a/ansible/roles-infra/infra-osp-resources-destroy/tasks/keypairs.yml
+++ b/ansible/roles-infra/infra-osp-resources-destroy/tasks/keypairs.yml
@@ -8,6 +8,12 @@
     OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"
 
   block:
+  - name: Make sure this is not changing admin user
+    assert:
+      that: 
+      - _keypair_owner != osp_auth_username
+      fail_msg: "The osp_auth_username_member is set to the admin user and would break things. Fix this."
+
   - name: Get user info
     os_user_facts:
       name: "{{ _keypair_owner }}"


### PR DESCRIPTION
##### SUMMARY
The current version of this role will allow you to delete the admin account if you know it's username and password and you set the `osp_auth_username_member` var to an incorrect value. This change adds a check into the task list that will ensure the user that it will be deleting is not the same as the `osp_auth_username`, which would be the admin account.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
infra-osp-resources-destroy


