### PR TITLE
Changed default namespace to open-cluster-management

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm/defaults/main.yml
@@ -3,7 +3,7 @@ become_override: False
 ocp_username: opentlc-mgr
 silent: False
 
-ocp4_workload_rhacm_acm_project: "advanced-cluster-management"
+ocp4_workload_rhacm_acm_project: "open-cluster-management"
 ocp4_workload_rhacm_acm_release: "release-1.0"
 ocp4_workload_rhacm_acm_csv: "advanced-cluster-management.v1.0.1"
 ocp4_workload_rhacm_etcd_csv: "etcdoperator.v0.9.4"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
As per discussions with Nate, we're going to change default namespace for the ocp4_workload_rhacm workload from `advanced-cluster-management` to `open-cluster-management` to better align with the documentation.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_rhacm
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
