### PR TITLE
install required jaeger operator before service mesh install for m4

### DIFF
--- a/ansible/roles/ocp4-workload-ccnrd/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-ccnrd/tasks/workload.yml
@@ -105,7 +105,7 @@
   include_tasks: install-rhamt.yaml
 
 - name: Look for jaeger subscription
-  when: ("m2" in modules or "m3" in modules)
+  when: ("m2" in modules or "m3" in modules or "m4" in modules)
   k8s_facts:
     api_version: operators.coreos.com/v1alpha1
     kind: Subscription
@@ -114,7 +114,7 @@
   register: r_jaeger_sub
 
 - name: Create Jaeger
-  when: ("m2" in modules or "m3" in modules) and (r_jaeger_sub.resources | list | length == 0)
+  when: ("m2" in modules or "m3" in modules or "m4" in modules) and (r_jaeger_sub.resources | list | length == 0)
   include_tasks: install-jaeger.yaml
 
 - name: Look for service mesh subscription


### PR DESCRIPTION

##### SUMMARY
Add required Jaeger operator whenever istio is installed.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`ocp4-workload-ccnrd`

