### PR TITLE
ocp4_workload_amq_streams_dev_exp: deployment fails when guid is has no alphabetical characters

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_amq_streams_dev_exp/templates/clusterresourcequota.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_amq_streams_dev_exp/templates/clusterresourcequota.j2
@@ -23,5 +23,4 @@ spec:
     labels:
       matchLabels:
         workload: ocp4-workload-amq-streams-dev-experienced
-        guid: {{ guid }}
-
+        guid: '{{ guid }}'

--- a/ansible/roles_ocp_workloads/ocp4_workload_amq_streams_dev_exp/templates/namespace.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_amq_streams_dev_exp/templates/namespace.j2
@@ -7,7 +7,7 @@ metadata:
     openshift.io/requester: '{{ ocp_username }}'
   labels:
     workload: ocp4-workload-amq-streams-dev-experienced
-    guid: {{ guid }}
+    guid: '{{ guid }}'
   name: '{{ ocp4_workload_amq_streams_dev_exp_project }}'
 spec:
   finalizers:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

role: roles_ocp_workloads/ocp4_workload_amq_streams_dev_exp

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
The role breaks when guid contains no alfabetical characters. This PR fixes this. Tesed sucessfully with guid 1234
