### PR TITLE
Change Azure cloud provider to support custom Windows pwd

### DIFF
--- a/ansible/cloud_providers/azure_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/azure_infrastructure_deployment.yml
@@ -99,8 +99,7 @@
 
     - name: If windows password set pass it to parameters
       set_fact:
-        adminPassword: '"adminPassword": { "value": "{{ windows_password }}" },'
-      when: windows_password is defined
+        adminPassword: '{% if windows_password is defined %}"adminPassword": { "value": "{{ windows_password }}" },{% endif %}'
 
     - name: Check if the parameter file exists
       stat:

--- a/ansible/cloud_providers/azure_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/azure_infrastructure_deployment.yml
@@ -97,6 +97,11 @@
         - windows_password is not defined
         - generated_windows_password is defined
 
+    - name: If windows password set pass it to parameters
+      set_fact:
+        adminPassword: '"adminPassword": { "value": "{{ windows_password }}" },'
+      when: windows_password is defined
+
     - name: Check if the parameter file exists
       stat:
         path: "{{params_dest}}"
@@ -106,7 +111,7 @@
       copy:
         content: |
           {
-            "adminUsername": { "value": "{{remote_user}}" },
+            "adminUsername": { "value": "{{remote_user}}" }, {{ adminPassword }}
             "sshKeyData": { "value": "{{ssh_key_data}}"},
             "DNSZone": { "value": "{{HostedZoneId}}"},
             "guid": { "value": "{{guid}}"},


### PR DESCRIPTION
##### SUMMARY
All the logic exists to create a custom password, but we missed passing it to the parameters file.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Azure cloud provider

##### ADDITIONAL INFORMATION
This is a complete oversight on my part. When testing you should override things you pass in the default password as a parameter you don't notice it isn't getting overridden.