### PR TITLE
Updated roles-infra/infra-osp-dns to remove errors.

### DIFF
--- a/ansible/roles-infra/infra-osp-dns/tasks/instance_loop.yml
+++ b/ansible/roles-infra/infra-osp-dns/tasks/instance_loop.yml
@@ -8,7 +8,7 @@
   vars:
     _instance_name: "{{ _instance.name }}"
 
-- when: _instance.count > 1
+- when: _instance.count|int > 1
   block:
     - loop: "{{ range(1, _instance.count | int + 1) | list }}"
       loop_control:

--- a/ansible/roles-infra/infra-osp-dns/tasks/instance_loop.yml
+++ b/ansible/roles-infra/infra-osp-dns/tasks/instance_loop.yml
@@ -3,7 +3,7 @@
   fail:
     msg: "Instance {{ _instance.name }} doesn't have a 'count'"
 
-- when: _instance.count == 1
+- when: _instance.count|int == 1
   include_tasks: nested_loop.yml
   vars:
     _instance_name: "{{ _instance.name }}"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Error when provisioning more than 1 instance count. Failed on fatal: [localhost]: FAILED! => {"msg": "The conditional check '_instance.count > 1' failed. The error was: Unexpected templating type error occurred on ({% if _instance.count > 1 %} True {% else %} False {% endif %}): '>' not supported between instances of 'str' and 'int'
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

ansible/roles-infra/infra-osp-dns

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Deploying configs/ansible-tower-implementation, using osp_vars.yml on sandbox environment caused this error to appear.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
