### PR TITLE
Change doc Contributing.adoc, add link to yamllint ex and doc

### DIFF
--- a/docs/Contributing.adoc
+++ b/docs/Contributing.adoc
@@ -34,7 +34,7 @@ These are our contribution guidelines for helping out with the project. Any sugg
 
 === Code Quality Rules
 
-. A YAML `.yamllint` file should be added to every role and config when any substantial change is applied to the role or config, all new roles and configs must include a `.yamllint`.
+. A YAML `.yamllint` file should be added to every role and config when any substantial change is applied to the role or config, all new roles and configs must include a `.yamllint`. You will find a good example link:../ansible/roles-infra/infra-azure-template-destroy/.yamllint[here].  See also link:https://yamllint.readthedocs.io/en/stable/[Official yamllint documentation].
 . All tasks should be in YAML literal. No `foo=bar` inline notation. See <<yamlliteral,here>>.
 . Indentation is 2 white-spaces.
 . No in-line JSON format in Ansible


### PR DESCRIPTION
closes #2135

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
`docs/Contributing.adoc`