### PR TITLE
Fix LetsEncrypt renewal hook

### DIFF
--- a/ansible/roles/ocp4-workload-enable-lets-encrypt-certificates/files/deploy_certs.sh
+++ b/ansible/roles/ocp4-workload-enable-lets-encrypt-certificates/files/deploy_certs.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+cd ${HOME}/certbot/renewal-hooks/deploy/
 ansible-playbook ./deploy_certs.yml

--- a/ansible/roles/ocp4-workload-idm/files/deploy_certs.sh
+++ b/ansible/roles/ocp4-workload-idm/files/deploy_certs.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+cd ${HOME}/certbot/renewal-hooks/deploy/
 ansible-playbook ./deploy_certs.yml \
   -e "_certbot_domain={{ idm_dns_name }}" \
   -e "idm_dm_password={{ idm_dm_password }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_le_certificates/files/deploy_certs.sh
+++ b/ansible/roles_ocp_workloads/ocp4_workload_le_certificates/files/deploy_certs.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+cd ${HOME}/certbot/renewal-hooks/deploy/
 ansible-playbook ./deploy_certs.yml


### PR DESCRIPTION
This commit, if applied, fixes the following error:

```
Running post-hook command: /home/ec2-user/certbot/renewal-hooks/deploy/deploy_certs.sh
post-hook command "/home/ec2-user/certbot/renewal-hooks/deploy/deploy_certs.sh" returned error code 1
Error output from post-hook command deploy_certs.sh:
ERROR! the playbook: ./deploy_certs.yml could not be found
```

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

