### PR TITLE
Fixe to windows ansible 2.9.10 become issue

### DIFF
--- a/ansible/configs/ansible-windows/files/hosts_template.j2
+++ b/ansible/configs/ansible-windows/files/hosts_template.j2
@@ -9,7 +9,6 @@ ansible_connection=winrm
 ansible_user=Administrator
 ansible_password={{ windows_password }}
 ansible_winrm_server_cert_validation=ignore
-ansible_become=false
 
 [supports]
 {% for host in groups['supports'] %}
@@ -21,5 +20,4 @@ ansible_become=false
 ### Ansible Vars
 ########################################################################### #}
 timeout=60
-ansible_become=yes
 ansible_user={{remote_user}}


### PR DESCRIPTION
##### SUMMARY
Ansible 2.9.10 introduces a bug when used with Windows machines when inventory contains **any** `become` references

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
ansible-windows config

##### ADDITIONAL INFORMATION
Simply removes the 2 become references from the Jinja /etc/ansible/hosts files which are not necessary