### PR TITLE
Fix role osp-generate-template cloud_template_master.j2

### DIFF
--- a/ansible/roles-infra/infra-osp-template-generate/templates/cloud_template_master.j2
+++ b/ansible/roles-infra/infra-osp-template-generate/templates/cloud_template_master.j2
@@ -104,7 +104,7 @@ resources:
   #############
 {% for instance in instances %}
   {% for myinstanceindex in range(instance.count|int) %}
-    {% set iname = instance.name if instance.count == 1 else [instance.name, loop.index0] | join() %}
+    {% set iname = instance.name if instance.count|int == 1 else [instance.name, loop.index0] | join() %}
   ########### {{ iname }} ###########
   port_{{ iname }}:
     type: OS::Neutron::Port


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When using filters with the instance.count variable, it was interpreted as a string. This was causing single server instance counts to become numbered, breaking the later dns logic (below from infra-osp-dns/tasks/nested_loop.yml)

                     ansible_facts.openstack_servers[?name=='{{ _instance_name }}'].public_v4 | [0]

This is resolved by adding the integer filter into the logic of the template. This was already in place for most sections, fixed it in this one case.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

roles-infra/osp-generate-template

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Steps to reproduce:
Step 1: Filter like so within an instance dictionary for count

instances:
- name: "tower"
  count: "{{ tower_instance_count | default(1) }}"

tower_instance_count: 1

Step 2: Launch config and view the saved osp_cloud_master_template.yaml

  ########### tower0 ###########
  port_tower0:
    type: OS::Neutron::Port
    properties:
      network: { get_resource: default-network }
      security_groups:


<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
