### PR TITLE
Change host-ocp4-destroy default variable (1/2)

### DIFF
--- a/ansible/roles/host-ocp4-destroy/defaults/main.yml
+++ b/ansible/roles/host-ocp4-destroy/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 gcp_credentials_file: '{{ output_dir }}/gcp_credentials_file_{{ guid }}.json'
+cluster_name: "cluster-{{ guid }}"


### PR DESCRIPTION
##### SUMMARY
Setting default variable using defaults/main.yml instead of using when in the task which overwrites non-standard names

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
roles/host-ocp4-destroy

##### ADDITIONAL INFORMATION
This is part 1 of 2

Part 2 - https://github.com/redhat-cop/agnosticd/pull/2150