### PR TITLE
Change host-ocp4-destroy default variable (2/2)

### DIFF
--- a/ansible/roles/host-ocp4-destroy/tasks/main.yml
+++ b/ansible/roles/host-ocp4-destroy/tasks/main.yml
@@ -13,11 +13,6 @@
   failed_when: r_check_openshift_install_running.rc == 0
   changed_when: false
 
-- name: Set cluster-name to default value if not set
-  when: cluster_name | default("") | length == 0
-  set_fact:
-    cluster_name: "cluster-{{ guid }}"
-
 - name: stat if there is a cluster installed
   stat:
     path: "/home/{{ ansible_user }}/{{ cluster_name }}/metadata.json"


### PR DESCRIPTION
##### SUMMARY
Removing the set_fact from tasks/main.yml because the variable now has a default set in defaults/main.yml

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
roles/host-ocp4-destroy

##### ADDITIONAL INFORMATION
This is part 2 of 2

Part 1 - https://github.com/redhat-cop/agnosticd/pull/2149