### PR TITLE
Update role host-ocp4-destroy

### DIFF
--- a/ansible/roles/host-ocp4-destroy/.yamllint
+++ b/ansible/roles/host-ocp4-destroy/.yamllint
@@ -1,0 +1,14 @@
+---
+extends: default
+
+rules:
+  comments:
+    require-starting-space: false
+  comments-indentation: disable
+  indentation:
+    level: warning
+    indent-sequences: consistent
+  line-length:
+    level: warning
+    max: 120
+    allow-non-breakable-inline-mappings: true

--- a/ansible/roles/host-ocp4-destroy/defaults/main.yml
+++ b/ansible/roles/host-ocp4-destroy/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
+# Just in case it isn't set earlier
 gcp_credentials_file: '{{ output_dir }}/gcp_credentials_file_{{ guid }}.json'
+# This needs to match what is in ocp4-cluster default_vars.yml
 cluster_name: 'cluster-{{ guid }}'

--- a/ansible/roles/host-ocp4-destroy/defaults/main.yml
+++ b/ansible/roles/host-ocp4-destroy/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 gcp_credentials_file: '{{ output_dir }}/gcp_credentials_file_{{ guid }}.json'
+cluster_name: 'cluster-{{ guid }}'

--- a/ansible/roles/host-ocp4-destroy/meta/main.yml
+++ b/ansible/roles/host-ocp4-destroy/meta/main.yml
@@ -1,0 +1,10 @@
+---
+galaxy_info:
+  author: Vince Power <vpower@redhat.com>
+  description: Runs the OCP4 installer destroy cluster option
+  company: Red Hat
+  license: BSD
+  min_ansible_version: 2.9
+  galaxy_tags: []
+
+dependencies: []

--- a/ansible/roles/host-ocp4-destroy/tasks/azure_prereqs.yml
+++ b/ansible/roles/host-ocp4-destroy/tasks/azure_prereqs.yml
@@ -13,4 +13,3 @@
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
     mode: 0600
-

--- a/ansible/roles/host-ocp4-destroy/tasks/azure_prereqs.yml
+++ b/ansible/roles/host-ocp4-destroy/tasks/azure_prereqs.yml
@@ -16,4 +16,5 @@
 
 #  This needs to match what is in ocp4-cluster default_vars_azure.yml
 - name: Setting the Azure specific cluster namei
-  set_fact: cluster_name: "ocp4-{{ guid }}-ipi"
+  set_fact:
+    cluster_name: "ocp4-{{ guid }}-ipi"

--- a/ansible/roles/host-ocp4-destroy/tasks/azure_prereqs.yml
+++ b/ansible/roles/host-ocp4-destroy/tasks/azure_prereqs.yml
@@ -13,3 +13,7 @@
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
     mode: 0600
+
+#  This needs to match what is in ocp4-cluster default_vars_azure.yml
+- name: Setting the Azure specific cluster namei
+  set_fact: cluster_name: "ocp4-{{ guid }}-ipi"

--- a/ansible/roles/host-ocp4-destroy/tasks/gcp_prereqs.yml
+++ b/ansible/roles/host-ocp4-destroy/tasks/gcp_prereqs.yml
@@ -12,5 +12,4 @@
     dest: "/home/{{ ansible_user }}/.gcp/osServiceAccount.json"
     mode: 0600
     owner: "{{ ansible_user }}"
-  become: no
-
+  become: false

--- a/ansible/roles/host-ocp4-destroy/tasks/main.yml
+++ b/ansible/roles/host-ocp4-destroy/tasks/main.yml
@@ -17,7 +17,7 @@
 - name: Showing cluster_name to be removed
   debug:
     var: cluster_name
-    #verbosity: 2
+    verbosity: 2
 
 - name: stat if there is a cluster installed
   stat:

--- a/ansible/roles/host-ocp4-destroy/tasks/main.yml
+++ b/ansible/roles/host-ocp4-destroy/tasks/main.yml
@@ -14,6 +14,11 @@
   failed_when: r_check_openshift_install_running.rc == 0
   changed_when: false
 
+- name: Showing cluster_name to be removed
+  debug:
+    var: cluster_name
+    #verbosity: 2
+
 - name: stat if there is a cluster installed
   stat:
     path: "/home/{{ ansible_user }}/{{ cluster_name }}/metadata.json"

--- a/ansible/roles/host-ocp4-destroy/tasks/main.yml
+++ b/ansible/roles/host-ocp4-destroy/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - name: Set up cloud provider specific prerequisites
   when:
   - cloud_provider == "azure" or
@@ -13,18 +14,13 @@
   failed_when: r_check_openshift_install_running.rc == 0
   changed_when: false
 
-- name: Set cluster-name to default value if not set
-  when: cluster_name | default("") | length == 0
-  set_fact:
-    cluster_name: "cluster-{{ guid }}"
-
 - name: stat if there is a cluster installed
   stat:
     path: "/home/{{ ansible_user }}/{{ cluster_name }}/metadata.json"
   register: r_stat_metadata_json
 
 - name: Run openshift-installer destroy cluster
-  become: no
+  become: false
   tags:
   - run_installer
   command: openshift-install destroy cluster --dir=/home/{{ ansible_user }}/{{ cluster_name }}


### PR DESCRIPTION
##### SUMMARY
Updating host-ocp4-destroy to set the cluster_name default value using defaults instead of a task, added an azure specific set_fact for cluster_name in the azure prereqs, and updated yamllint and meta because I'm touching the role so why not.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
roles/host-ocp4-destroy

##### ADDITIONAL INFORMATION
Seems like a better way to hand having a default value when we might want more cloud specific overrides later on