### PR TITLE
Fix to use secure protocol to download OpenTLC IPA certificate

### DIFF
--- a/ansible/configs/ocp-gpu-single-node/env_vars.yml
+++ b/ansible/configs/ocp-gpu-single-node/env_vars.yml
@@ -58,7 +58,7 @@ glusterfs_device_size: 500
 
 ocp_report: false
 remove_self_provisioners: false
-idm_ca_url: http://ipa.opentlc.com/ipa/config/ca.crt
+idm_ca_url: https://gpte-public.s3.amazonaws.com/opentlc_ipa_ca.crt
 zabbix_host: 23.246.247.58
 
 # Options for container_runtime: docker, cri-o

--- a/ansible/configs/ocp-implementation-lab/env_vars.yml
+++ b/ansible/configs/ocp-implementation-lab/env_vars.yml
@@ -193,7 +193,7 @@ glusterfs_image_tag: v3.11
 
 ocp_report: false
 remove_self_provisioners: false
-idm_ca_url: http://ipa.opentlc.com/ipa/config/ca.crt
+idm_ca_url: https://gpte-public.s3.amazonaws.com/opentlc_ipa_ca.crt
 zabbix_host: 23.246.247.58
 
 # Options for container_runtime: docker, cri-o

--- a/ansible/configs/ocp-workshop-with-clientvms/env_vars.yml
+++ b/ansible/configs/ocp-workshop-with-clientvms/env_vars.yml
@@ -78,7 +78,7 @@ glusterfs_image_tag: v3.11
 
 ocp_report: false
 remove_self_provisioners: false
-idm_ca_url: http://ipa.opentlc.com/ipa/config/ca.crt
+idm_ca_url: https://gpte-public.s3.amazonaws.com/opentlc_ipa_ca.crt
 zabbix_host: 23.246.247.58
 
 # Options for container_runtime: docker, cri-o

--- a/ansible/configs/ocp-workshop/env_vars.yml
+++ b/ansible/configs/ocp-workshop/env_vars.yml
@@ -83,7 +83,7 @@ glusterfs_image_tag: v3.11
 
 ocp_report: false
 remove_self_provisioners: false
-idm_ca_url: http://ipa1.opentlc.com/ipa/config/ca.crt
+idm_ca_url: https://gpte-public.s3.amazonaws.com/opentlc_ipa_ca.crt
 zabbix_host: 23.246.247.58
 
 # Options for container_runtime: docker, cri-o

--- a/ansible/configs/ocp4-ha-lab/default_vars.yml
+++ b/ansible/configs/ocp4-ha-lab/default_vars.yml
@@ -44,7 +44,7 @@ smoke_tests: false
 ## Valid options are none, htpasswd, ldap (and maybe in the future sso)
 ## For LDAP a bindPassword needs to be passed via the command line
 install_idm: "none"
-idm_ca_url: http://ipa.opentlc.com/ipa/config/ca.crt
+idm_ca_url: https://gpte-public.s3.amazonaws.com/opentlc_ipa_ca.crt
 
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`

--- a/ansible/configs/ocp4-workshop/env_vars.yml
+++ b/ansible/configs/ocp4-workshop/env_vars.yml
@@ -66,7 +66,7 @@ smoke_tests: false
 ## For LDAP a bindPassword needs to be passed via the command line
 ## Another valid option is local-ldap if you use the ocp4-workload-idm workload
 install_idm: "none"
-idm_ca_url: http://ipa.opentlc.com/ipa/config/ca.crt
+idm_ca_url: https://gpte-public.s3.amazonaws.com/opentlc_ipa_ca.crt
 auth_remove_kubeadmin: true
 # htpasswd idm user vars
 user_count: "{{ 1 + user_count_end|int - user_count_start|int }}"

--- a/ansible/roles/ocp4-workload-authentication/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-authentication/defaults/main.yml
@@ -24,7 +24,7 @@ ocp4_workload_authentication_defaults:
 
   # LDAP settings
   ldap_url: ldaps://ipa1.opentlc.com:636/cn=users,cn=accounts,dc=opentlc,dc=com?uid
-  ldap_ca_url: http://ipa1.opentlc.com/ipa/config/ca.crt
+  ldap_ca_url: https://gpte-public.s3.amazonaws.com/opentlc_ipa_ca.crt
   ldap_bind_dn: "uid=ose-mwl-auth,cn=users,cn=accounts,dc=opentlc,dc=com"
 
   # Remove Kubeadmin user upon successful installation of Authentication

--- a/ansible/roles_ocp_workloads/ocp4_workload_authentication/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_authentication/defaults/main.yml
@@ -29,7 +29,7 @@ ocp4_workload_authentication_htpasswd_add_default_users: true
 # LDAP settings
 # -----------------------------------------------
 ocp4_workload_authentication_ldap_url: ldaps://ipa1.opentlc.com:636/cn=users,cn=accounts,dc=opentlc,dc=com?uid
-ocp4_workload_authentication_ldap_ca_url: http://ipa1.opentlc.com/ipa/config/ca.crt
+ocp4_workload_authentication_ldap_ca_url: https://gpte-public.s3.amazonaws.com/opentlc_ipa_ca.crt
 ocp4_workload_authentication_ldap_bind_dn: "uid=ose-mwl-auth,cn=users,cn=accounts,dc=opentlc,dc=com"
 ocp4_workload_authentication_ldap_bind_password: "<FROM SECRET>"
 


### PR DESCRIPTION
##### SUMMARY

This fixes a number of places in the AgnosticD code where an insecure protocol is used to fetch the OpenTLC IPA certificate authority cert and so fixes a potential man-in-the-middle attack vulnerability.

The old location was http://ipa1.opentlc.com/ipa/config/ca.crt
The new location uses AWS S3: https://gpte-public.s3.amazonaws.com/opentlc_ipa_ca.crt

##### ISSUE TYPE

- Security Pull Request

##### COMPONENT NAME

Configs, some of which may be abandoned/unused:

ocp4-ha-lab, ocp4-workshop, ocp-workshop, ocp-implementation-lab, ocp-workshop-with-clientvms, ocp-gpu-single-node

Roles: ocp4-workload-authentication