### PR TITLE
Fix role tasks described as playbooks in readme

### DIFF
--- a/ansible/roles/host-virtualenv/readme.adoc
+++ b/ansible/roles/host-virtualenv/readme.adoc
@@ -2,20 +2,20 @@
 
 == Role overview
 
-* This role set up a Python virtual environment on a host. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role set up a Python virtual environment on a host. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to configure authentication
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to configure authentication
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes authentication from OCP 4. This role does *not* recreate the kubeadmin user - the only way to use OpenShift after removing the workload is via the `system:admin` user from the bastion VM.
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp-workload-3scale-demo/readme.adoc
+++ b/ansible/roles/ocp-workload-3scale-demo/readme.adoc
@@ -3,7 +3,7 @@
 == Role overview
 
 * This is a simple role that does the following:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment
 *** Adds a user to a list of groups defined in the
  link:./defaults/main.yml[defaults file].
@@ -11,12 +11,12 @@
  link:./defaults/main.yml[defaults file] .
 *** Debug task will print out: `pre_workload Tasks Complete`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
  workload, i.e, 3scale, Mobile or some Demo
 *** This role doesn't do anything here
 *** Debug task will print out: `workload Tasks Complete`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks Complete`

--- a/ansible/roles/ocp-workload-appdev-homework/readme.adoc
+++ b/ansible/roles/ocp-workload-appdev-homework/readme.adoc
@@ -3,7 +3,7 @@
 == Role overview
 
 * This is a simple role that does the following:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment
 *** Adds a user to a list of groups defined in the
  link:./defaults/main.yml[defaults file].
@@ -11,12 +11,12 @@
  link:./defaults/main.yml[defaults file] .
 *** Debug task will print out: `pre_workload Tasks Complete`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
  workload, i.e, 3scale, Mobile or some Demo
 *** This role doesn't do anything here
 *** Debug task will print out: `workload Tasks Complete`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks Complete`

--- a/ansible/roles/ocp-workload-codeready-workspaces/readme.adoc
+++ b/ansible/roles/ocp-workload-codeready-workspaces/readme.adoc
@@ -3,7 +3,7 @@
 == Role overview
 
 * This is a simple role that does the following:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment
 *** Adds a user to a list of groups defined in the
  link:./defaults/main.yml[defaults file].
@@ -11,12 +11,12 @@
  link:./defaults/main.yml[defaults file] .
 *** Debug task will print out: `pre_workload Tasks Complete`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
  workload, i.e, 3scale, Mobile or some Demo
 *** This role doesn't do anything here
 *** Debug task will print out: `workload Tasks Complete`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks Complete`

--- a/ansible/roles/ocp-workload-developer-environment/readme.adoc
+++ b/ansible/roles/ocp-workload-developer-environment/readme.adoc
@@ -3,7 +3,7 @@
 == Role overview
 
 * This is a simple role that does the following:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment
 *** Adds a user to a list of groups defined in the
  link:./defaults/main.yml[defaults file].
@@ -11,12 +11,12 @@
  link:./defaults/main.yml[defaults file] .
 *** Debug task will print out: `pre_workload Tasks Complete`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
  workload, i.e, 3scale, Mobile or some Demo
 *** This role doesn't do anything here
 *** Debug task will print out: `workload Tasks Complete`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks Complete`

--- a/ansible/roles/ocp-workload-dm7-qlb-demo/readme.adoc
+++ b/ansible/roles/ocp-workload-dm7-qlb-demo/readme.adoc
@@ -3,7 +3,7 @@
 == Role overview
 
 * This is a simple role that does the following:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment
 *** Adds a user to a list of groups defined in the
  link:./defaults/main.yml[defaults file].
@@ -11,12 +11,12 @@
  link:./defaults/main.yml[defaults file] .
 *** Debug task will print out: `pre_workload Tasks Complete`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
  workload, i.e, 3scale, Mobile or some Demo
 *** This role doesn't do anything here
 *** Debug task will print out: `workload Tasks Complete`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks Complete`

--- a/ansible/roles/ocp-workload-dm7-realtime-event-decisioning/readme.adoc
+++ b/ansible/roles/ocp-workload-dm7-realtime-event-decisioning/readme.adoc
@@ -3,7 +3,7 @@
 == Role overview
 
 * This is a simple role that does the following:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment
 *** Adds a user to a list of groups defined in the
  link:./defaults/main.yml[defaults file].
@@ -11,12 +11,12 @@
  link:./defaults/main.yml[defaults file] .
 *** Debug task will print out: `pre_workload Tasks Complete`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
  workload, i.e, 3scale, Mobile or some Demo
 *** This role doesn't do anything here
 *** Debug task will print out: `workload Tasks Complete`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks Complete`

--- a/ansible/roles/ocp-workload-edge-deployments/readme.adoc
+++ b/ansible/roles/ocp-workload-edge-deployments/readme.adoc
@@ -2,22 +2,22 @@
 
 == Role overview
 
-* This is a working no-op role that can be used to develop new ocp-workload roles. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This is a working no-op role that can be used to develop new ocp-workload roles. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
  workload, i.e, 3scale, Mobile or some Demo
 *** This role only prints the current username for which this role is provisioning.
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role doesn't do anything here
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp-workload-example/readme.adoc
+++ b/ansible/roles/ocp-workload-example/readme.adoc
@@ -3,22 +3,22 @@
 
 == Role overview
 
-* This is a working no-op role that can be used to develop new ocp-workload roles. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This is a working no-op role that can be used to develop new ocp-workload roles. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
  workload, i.e, 3scale, Mobile, some Demo or OpenShift customization
 *** This role only prints the current username for which this role is provisioning.
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role doesn't do anything here
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp-workload-fsi-cc-dispute-demo/readme.adoc
+++ b/ansible/roles/ocp-workload-fsi-cc-dispute-demo/readme.adoc
@@ -3,7 +3,7 @@
 == Role overview
 
 * This is a simple role that does the following:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment
 *** Adds a user to a list of groups defined in the
  link:./defaults/main.yml[defaults file].
@@ -11,12 +11,12 @@
  link:./defaults/main.yml[defaults file] .
 *** Debug task will print out: `pre_workload Tasks Complete`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
  workload, i.e, 3scale, Mobile or some Demo
 *** This role doesn't do anything here
 *** Debug task will print out: `workload Tasks Complete`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks Complete`

--- a/ansible/roles/ocp-workload-fsi-client-onboarding-demo/readme.adoc
+++ b/ansible/roles/ocp-workload-fsi-client-onboarding-demo/readme.adoc
@@ -3,7 +3,7 @@
 == Role overview
 
 * This is a simple role that does the following:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment
 *** Adds a user to a list of groups defined in the
  link:./defaults/main.yml[defaults file].
@@ -11,12 +11,12 @@
  link:./defaults/main.yml[defaults file] .
 *** Debug task will print out: `pre_workload Tasks Complete`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
  workload, i.e, 3scale, Mobile or some Demo
 *** This role doesn't do anything here
 *** Debug task will print out: `workload Tasks Complete`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks Complete`

--- a/ansible/roles/ocp-workload-integreatly-iot/readme.adoc
+++ b/ansible/roles/ocp-workload-integreatly-iot/readme.adoc
@@ -3,20 +3,20 @@
 == Role overview
 
 * This role executes the following tasks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Runs pre-requisitie steps before installing Integreatly
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Runs pre-requisitie steps before installing Integreatly
 *** Clones the Integreatly https://github.com/integr8ly/installation[Github repository] into a specified installation directory
 *** Debug task will print out: `Pre-Workload tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy Integreatly
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy Integreatly
 *** Executes the Integreatly installer which installs a set of Middleware products on the target Openshift workshop cluster
 *** Debug task will print out: `Workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `Post-Workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  uninstall Integreatly
 *** Executes the Integreatly uninstall playbook
 *** Removes locally cloned Integreatly Github repository

--- a/ansible/roles/ocp-workload-integreatly/readme.adoc
+++ b/ansible/roles/ocp-workload-integreatly/readme.adoc
@@ -3,20 +3,20 @@
 == Role overview
 
 * This role executes the following tasks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Runs pre-requisitie steps before installing Integreatly
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Runs pre-requisitie steps before installing Integreatly
 *** Clones the Integreatly https://github.com/integr8ly/installation[Github repository] into a specified installation directory
 *** Debug task will print out: `Pre-Workload tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy Integreatly
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy Integreatly
 *** Executes the Integreatly installer which installs a set of Middleware products on the target Openshift workshop cluster
 *** Debug task will print out: `Workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `Post-Workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  uninstall Integreatly
 *** Executes the Integreatly uninstall playbook
 *** Removes locally cloned Integreatly Github repository

--- a/ansible/roles/ocp-workload-iot-demo/readme.adoc
+++ b/ansible/roles/ocp-workload-iot-demo/readme.adoc
@@ -3,7 +3,7 @@
 == Role overview
 
 * This is a simple role that does the following:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment
 *** Adds a user to a list of groups defined in the
  link:./defaults/main.yml[defaults file].
@@ -11,12 +11,12 @@
  link:./defaults/main.yml[defaults file] .
 *** Debug task will print out: `pre_workload Tasks Complete`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
  workload, i.e, 3scale, Mobile or some Demo
 *** This role doesn't do anything here
 *** Debug task will print out: `workload Tasks Complete`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks Complete`

--- a/ansible/roles/ocp-workload-odo-workshop/readme.adoc
+++ b/ansible/roles/ocp-workload-odo-workshop/readme.adoc
@@ -3,31 +3,31 @@
 == Role overview
 
 * This is a simple role that does the following:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment
 *** Copies ~/.kube/config to a temp directory and sets the KUBECONFIG env variable.
 *** Debug task will print out: `pre_workload Tasks Complete`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the 
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the 
  odo lab environment.
 *** Creates a new project and a deployment for the learning portal.
 *** Debug task will print out: `workload Tasks Complete`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** Removes the temp .kube/config file.
 *** Debug task will print out: `post_workload Tasks Complete`
 
-** Playbook: link:./tasks/pre_remove_workload.yml[pre_remove_workload.yml] - Sets up an
+** Tasks: link:./tasks/pre_remove_workload.yml[pre_remove_workload.yml] - Sets up an
  environment for the workload removal
 *** Copies ~/.kube/config to a temp directory and sets the KUBECONFIG env variable.
 *** Debug task will print out: `pre_workload Removal Tasks Complete`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to clean up the environment and delete all resources.
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to clean up the environment and delete all resources.
 *** Deletes resources and projects that were created.
 *** Debug task will print out: `workload Removal Tasks Complete`
 
-** Playbook: link:./tasks/post_remove_workload.yml[post_remove_workload.yml] - Used to
+** Tasks: link:./tasks/post_remove_workload.yml[post_remove_workload.yml] - Used to
  configure the workload after deployment
 *** Removes the temp .kube/config file.
 *** Debug task will print out: `post_workload Removal Tasks Complete`

--- a/ansible/roles/ocp-workload-openshift-applier/readme.adoc
+++ b/ansible/roles/ocp-workload-openshift-applier/readme.adoc
@@ -3,18 +3,18 @@
 == Role overview
 
 * This role uses the [openshift-applier](https://github.com/redhat-cop/openshift-applier)
- to manage content within an OpenShift Container Platform. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Not used.
+ to manage content within an OpenShift Container Platform. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Not used.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to
  execute the openshift-applier role.
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Not used.
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Not used.
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Not Used.
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Not Used.
 *** Debug task will print out: `remove_workload Tasks completed successfully.`
 
 ** Note: the workload accepts 'openshift_cluster_content' as a dictionary, or

--- a/ansible/roles/ocp-workload-optaweb-employee-rostering/readme.adoc
+++ b/ansible/roles/ocp-workload-optaweb-employee-rostering/readme.adoc
@@ -3,7 +3,7 @@
 == Role overview
 
 * This is a simple role that does the following:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment
 *** Adds a user to a list of groups defined in the
  link:./defaults/main.yml[defaults file].
@@ -11,12 +11,12 @@
  link:./defaults/main.yml[defaults file] .
 *** Debug task will print out: `pre_workload Tasks Complete`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
  workload, i.e, 3scale, Mobile or some Demo
 *** This role doesn't do anything here
 *** Debug task will print out: `workload Tasks Complete`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks Complete`

--- a/ansible/roles/ocp-workload-optaweb-vrp/readme.adoc
+++ b/ansible/roles/ocp-workload-optaweb-vrp/readme.adoc
@@ -3,7 +3,7 @@
 == Role overview
 
 * This is a simple role that does the following:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment
 *** Adds a user to a list of groups defined in the
  link:./defaults/main.yml[defaults file].
@@ -11,12 +11,12 @@
  link:./defaults/main.yml[defaults file] .
 *** Debug task will print out: `pre_workload Tasks Complete`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
  workload, i.e, 3scale, Mobile or some Demo
 *** This role doesn't do anything here
 *** Debug task will print out: `workload Tasks Complete`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks Complete`

--- a/ansible/roles/ocp-workload-pam-order-it-hardware/readme.adoc
+++ b/ansible/roles/ocp-workload-pam-order-it-hardware/readme.adoc
@@ -3,7 +3,7 @@
 == Role overview
 
 * This is a simple role that does the following:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment
 *** Adds a user to a list of groups defined in the
  link:./defaults/main.yml[defaults file].
@@ -11,12 +11,12 @@
  link:./defaults/main.yml[defaults file] .
 *** Debug task will print out: `pre_workload Tasks Complete`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
  workload, i.e, 3scale, Mobile or some Demo
 *** This role doesn't do anything here
 *** Debug task will print out: `workload Tasks Complete`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks Complete`

--- a/ansible/roles/ocp-workload-pam7-cc-dispute-dmn-pmml/readme.adoc
+++ b/ansible/roles/ocp-workload-pam7-cc-dispute-dmn-pmml/readme.adoc
@@ -3,7 +3,7 @@
 == Role overview
 
 * This is a simple role that does the following:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment
 *** Adds a user to a list of groups defined in the
  link:./defaults/main.yml[defaults file].
@@ -11,12 +11,12 @@
  link:./defaults/main.yml[defaults file] .
 *** Debug task will print out: `pre_workload Tasks Complete`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
  workload, i.e, 3scale, Mobile or some Demo
 *** This role doesn't do anything here
 *** Debug task will print out: `workload Tasks Complete`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks Complete`

--- a/ansible/roles/ocp-workload-pam7-offer-management-dmn-pmml/readme.adoc
+++ b/ansible/roles/ocp-workload-pam7-offer-management-dmn-pmml/readme.adoc
@@ -3,7 +3,7 @@
 == Role overview
 
 * This is a simple role that does the following:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment
 *** Adds a user to a list of groups defined in the
  link:./defaults/main.yml[defaults file].
@@ -11,12 +11,12 @@
  link:./defaults/main.yml[defaults file] .
 *** Debug task will print out: `pre_workload Tasks Complete`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
  workload, i.e, 3scale, Mobile or some Demo
 *** This role doesn't do anything here
 *** Debug task will print out: `workload Tasks Complete`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks Complete`

--- a/ansible/roles/ocp-workload-parksmap-demo/readme.adoc
+++ b/ansible/roles/ocp-workload-parksmap-demo/readme.adoc
@@ -3,7 +3,7 @@
 == Role overview
 
 * This is a simple role that does the following:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment
 *** Adds a user to a list of groups defined in the
  link:./defaults/main.yml[defaults file].
@@ -11,12 +11,12 @@
  link:./defaults/main.yml[defaults file] .
 *** Debug task will print out: `pre_workload Tasks Complete`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
  workload, i.e, 3scale, Mobile or some Demo
 *** This role doesn't do anything here
 *** Debug task will print out: `workload Tasks Complete`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks Complete`

--- a/ansible/roles/ocp-workload-rhte19-optaplanner-101-lab-infra/readme.adoc
+++ b/ansible/roles/ocp-workload-rhte19-optaplanner-101-lab-infra/readme.adoc
@@ -3,7 +3,7 @@
 == Role overview
 
 * This is a simple role that does the following:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment
 *** Adds a user to a list of groups defined in the
  link:./defaults/main.yml[defaults file].
@@ -11,12 +11,12 @@
  link:./defaults/main.yml[defaults file] .
 *** Debug task will print out: `pre_workload Tasks Complete`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
  workload, i.e, 3scale, Mobile or some Demo
 *** This role doesn't do anything here
 *** Debug task will print out: `workload Tasks Complete`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks Complete`

--- a/ansible/roles/ocp-workload-rhte19-shadowman/readme.adoc
+++ b/ansible/roles/ocp-workload-rhte19-shadowman/readme.adoc
@@ -3,7 +3,7 @@
 == Role overview
 
 * This is a simple role that does the following:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment
 *** Adds a user to a list of groups defined in the
  link:./defaults/main.yml[defaults file].
@@ -11,12 +11,12 @@
  link:./defaults/main.yml[defaults file] .
 *** Debug task will print out: `pre_workload Tasks Complete`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
  workload, i.e, 3scale, Mobile or some Demo
 *** This role doesn't do anything here
 *** Debug task will print out: `workload Tasks Complete`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks Complete`

--- a/ansible/roles/ocp-workload-starter-workshop/readme.adoc
+++ b/ansible/roles/ocp-workload-starter-workshop/readme.adoc
@@ -3,7 +3,7 @@
 == Role overview
 
 * This is a simple role that does the following:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment
 *** Adds a user to a list of groups defined in the
  link:./defaults/main.yml[defaults file].
@@ -11,12 +11,12 @@
  link:./defaults/main.yml[defaults file] .
 *** Debug task will print out: `pre_workload Tasks Complete`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
  workload, i.e, 3scale, Mobile or some Demo
 *** This role doesn't do anything here
 *** Debug task will print out: `workload Tasks Complete`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks Complete`

--- a/ansible/roles/ocp-workload-terminal/readme.adoc
+++ b/ansible/roles/ocp-workload-terminal/readme.adoc
@@ -2,21 +2,21 @@
 
 == Role overview
 
-* This role installs a Terminal application into an OpenShift Cluster. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role installs a Terminal application into an OpenShift Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the Terminal Application
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the Terminal Application
 *** This role creates a project, deploys the terminal application and creates a route for the application.
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes the terminal project
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp4-workload-ai-spam-demo-odh/readme.adoc
+++ b/ansible/roles/ocp4-workload-ai-spam-demo-odh/readme.adoc
@@ -11,20 +11,20 @@ The individual workload task includes
 
 == Role overview
 
-* This is a workshop role to setup the Open Data Hub project for a specific user. This role requires that the infrastructure has all Open Data Hub required and dependent CRDS loaded and Rook Ceph Object storage has been installed. This role must be run after the link:../ocp4-workload-rhte-analytics_data_ocp_infra[ocp4-workload-rhte-analytics_data_ocp_infra] role. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment
+* This is a workshop role to setup the Open Data Hub project for a specific user. This role requires that the infrastructure has all Open Data Hub required and dependent CRDS loaded and Rook Ceph Object storage has been installed. This role must be run after the link:../ocp4-workload-rhte-analytics_data_ocp_infra[ocp4-workload-rhte-analytics_data_ocp_infra] role. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Creates the each user's project space, adds the ODH ClusterServiceVersion to the project, deploys the opendatahub-operator and *OPTIONAL* deploys Open Data Hub
+** Tasks: link:./tasks/workload.yml[workload.yml] - Creates the each user's project space, adds the ODH ClusterServiceVersion to the project, deploys the opendatahub-operator and *OPTIONAL* deploys Open Data Hub
 *** This role only prints the current username for which this role is provisioning.
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Deletes the project created for each user
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Deletes the project created for each user
 *** Debug task will print out: `remove_workload Tasks completed successfully.`
 
 == Review the defaults variable file

--- a/ansible/roles/ocp4-workload-ausgeben-infra/readme.adoc
+++ b/ansible/roles/ocp4-workload-ausgeben-infra/readme.adoc
@@ -2,20 +2,20 @@
 
 == Role overview
 
-* This role deploys the ausgeben app to hand out credentials. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role deploys the ausgeben app to hand out credentials. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy homeroom
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy homeroom
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** Debug task will print out: `remove_workload Tasks completed successfully.`
 

--- a/ansible/roles/ocp4-workload-authentication/readme.adoc
+++ b/ansible/roles/ocp4-workload-authentication/readme.adoc
@@ -2,20 +2,20 @@
 
 == Role overview
 
-* This role enables authentication on an OpenShift 4 Cluster. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role enables authentication on an OpenShift 4 Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to configure authentication
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to configure authentication
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes authentication from OCP 4. This role does *not* recreate the kubeadmin user - the only way to use OpenShift after removing the workload is via the `system:admin` user from the bastion VM.
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp4-workload-automation-broker/readme.adoc
+++ b/ansible/roles/ocp4-workload-automation-broker/readme.adoc
@@ -2,21 +2,21 @@
 
 == Role overview
 
-* This role installs the Automation Broker into an OpenShift Cluster. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role installs the Automation Broker into an OpenShift Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the Automation Broker
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the Automation Broker
 *** This role creates a namespace (project), deploys the automation broker operator, then deploys 
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes the Automation Broker
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp4-workload-aws-jumpbox/readme.adoc
+++ b/ansible/roles/ocp4-workload-aws-jumpbox/readme.adoc
@@ -1,4 +1,4 @@
-= ocp-workload-aws-jumpbox - Set up AWS Jumpbox Playbooks on Bastion
+= ocp-workload-aws-jumpbox - Set up AWS Jumpbox Taskss on Bastion
 
 == Role overview
 
@@ -8,20 +8,20 @@ Once this role has been executed there is a directory `/opt/jumpbox` with the ne
 
 Currently only `eu-central-1`, `us-east-1` and `us-east-2` are supported. This is because only for these three regions the AMI for the RHEL 8 image is specified.
 
-. The role consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+. The role consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Install the Jumpbox Playbooks onto the Bastion
+** Tasks: link:./tasks/workload.yml[workload.yml] - Install the Jumpbox Playbooks onto the Bastion
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role doesn't do anything here
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp4-workload-build-an-operator-homeroomlab/readme.adoc
+++ b/ansible/roles/ocp4-workload-build-an-operator-homeroomlab/readme.adoc
@@ -3,31 +3,31 @@
 == Role overview
 
 * This is a simple role that does the following:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment
 *** Copies ~/.kube/config to a temp directory and sets the KUBECONFIG env variable.
 *** Debug task will print out: `pre_workload Tasks Complete`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the 
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the 
  lab environment.
 *** Creates a new project and a deployment for the learning portal.
 *** Debug task will print out: `workload Tasks Complete`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** Removes the temp .kube/config file.
 *** Debug task will print out: `post_workload Tasks Complete`
 
-** Playbook: link:./tasks/pre_remove_workload.yml[pre_remove_workload.yml] - Sets up an
+** Tasks: link:./tasks/pre_remove_workload.yml[pre_remove_workload.yml] - Sets up an
  environment for the workload removal
 *** Copies ~/.kube/config to a temp directory and sets the KUBECONFIG env variable.
 *** Debug task will print out: `pre_workload Removal Tasks Complete`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to clean up the environment and delete all resources.
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to clean up the environment and delete all resources.
 *** Deletes resources and projects that were created.
 *** Debug task will print out: `workload Removal Tasks Complete`
 
-** Playbook: link:./tasks/post_remove_workload.yml[post_remove_workload.yml] - Used to
+** Tasks: link:./tasks/post_remove_workload.yml[post_remove_workload.yml] - Used to
  configure the workload after deployment
 *** Removes the temp .kube/config file.
 *** Debug task will print out: `post_workload Removal Tasks Complete`

--- a/ansible/roles/ocp4-workload-build-your-own-operator/readme.adoc
+++ b/ansible/roles/ocp4-workload-build-your-own-operator/readme.adoc
@@ -3,31 +3,31 @@
 == Role overview
 
 * This is a simple role that does the following:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment
 *** Copies ~/.kube/config to a temp directory and sets the KUBECONFIG env variable.
 *** Debug task will print out: `pre_workload Tasks Complete`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the 
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the 
  lab environment.
 *** Creates a new project and a deployment for the learning portal.
 *** Debug task will print out: `workload Tasks Complete`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** Removes the temp .kube/config file.
 *** Debug task will print out: `post_workload Tasks Complete`
 
-** Playbook: link:./tasks/pre_remove_workload.yml[pre_remove_workload.yml] - Sets up an
+** Tasks: link:./tasks/pre_remove_workload.yml[pre_remove_workload.yml] - Sets up an
  environment for the workload removal
 *** Copies ~/.kube/config to a temp directory and sets the KUBECONFIG env variable.
 *** Debug task will print out: `pre_workload Removal Tasks Complete`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to clean up the environment and delete all resources.
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to clean up the environment and delete all resources.
 *** Deletes resources and projects that were created.
 *** Debug task will print out: `workload Removal Tasks Complete`
 
-** Playbook: link:./tasks/post_remove_workload.yml[post_remove_workload.yml] - Used to
+** Tasks: link:./tasks/post_remove_workload.yml[post_remove_workload.yml] - Used to
  configure the workload after deployment
 *** Removes the temp .kube/config file.
 *** Debug task will print out: `post_workload Removal Tasks Complete`

--- a/ansible/roles/ocp4-workload-cluster-autoscale/readme.adoc
+++ b/ansible/roles/ocp4-workload-cluster-autoscale/readme.adoc
@@ -5,20 +5,20 @@
 * This role configures the cluster autoscaler and creates machine autoscalers
   for the default worker pool. It assumes a default cluster size of 3 workers
   and will allow the cluster to scale up to 9 workers. It consists of the
-  following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+  following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to set up autoscalers
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to set up autoscalers
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes the infrastructure nodes (DANGER!!!)
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp4-workload-debugging-workshop/readme.adoc
+++ b/ansible/roles/ocp4-workload-debugging-workshop/readme.adoc
@@ -2,20 +2,20 @@
 
 == Role overview
 
-* This role enables the Workshop Operator on an OpenShift 4 Cluster. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role enables the Workshop Operator on an OpenShift 4 Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the Workshop Operator and then deploy a Workshop instance
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the Workshop Operator and then deploy a Workshop instance
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes the Workshop Instance and Workshop operator from OCP 4. This role does *not* remove the project - there may be other items in it.
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp4-workload-dil-streaming/readme.adoc
+++ b/ansible/roles/ocp4-workload-dil-streaming/readme.adoc
@@ -3,7 +3,7 @@
 == Role overview
 
 * This is a simple role that does the following:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment
 *** Adds a user to a list of groups defined in the
  link:./defaults/main.yml[defaults file].
@@ -11,12 +11,12 @@
  link:./defaults/main.yml[defaults file] .
 *** Debug task will print out: `pre_workload Tasks Complete`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
  workload, i.e, 3scale, Mobile or some Demo
 *** This role doesn't do anything here
 *** Debug task will print out: `workload Tasks Complete`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks Complete`

--- a/ansible/roles/ocp4-workload-enable-lets-encrypt-certificates/readme.adoc
+++ b/ansible/roles/ocp4-workload-enable-lets-encrypt-certificates/readme.adoc
@@ -2,20 +2,20 @@
 
 == Role overview
 
-* This role enables the Service Broker on an OpenShift 4 Cluster. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role enables the Service Broker on an OpenShift 4 Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to enable the Service Broker
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to enable the Service Broker
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes the service broker from OCP 4
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp4-workload-enable-service-broker/readme.adoc
+++ b/ansible/roles/ocp4-workload-enable-service-broker/readme.adoc
@@ -2,20 +2,20 @@
 
 == Role overview
 
-* This role enables the Service Broker on an OpenShift 4 Cluster. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role enables the Service Broker on an OpenShift 4 Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to enable the Service Broker
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to enable the Service Broker
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes the service broker from OCP 4
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp4-workload-homeroomlab-building-images/readme.adoc
+++ b/ansible/roles/ocp4-workload-homeroomlab-building-images/readme.adoc
@@ -3,31 +3,31 @@
 == Role overview
 
 * This is a simple role that does the following:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment
 *** Copies ~/.kube/config to a temp directory and sets the KUBECONFIG env variable.
 *** Debug task will print out: `pre_workload Tasks Complete`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the 
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the 
  lab environment.
 *** Creates a new project and a deployment for the learning portal.
 *** Debug task will print out: `workload Tasks Complete`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** Removes the temp .kube/config file.
 *** Debug task will print out: `post_workload Tasks Complete`
 
-** Playbook: link:./tasks/pre_remove_workload.yml[pre_remove_workload.yml] - Sets up an
+** Tasks: link:./tasks/pre_remove_workload.yml[pre_remove_workload.yml] - Sets up an
  environment for the workload removal
 *** Copies ~/.kube/config to a temp directory and sets the KUBECONFIG env variable.
 *** Debug task will print out: `pre_workload Removal Tasks Complete`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to clean up the environment and delete all resources.
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to clean up the environment and delete all resources.
 *** Deletes resources and projects that were created.
 *** Debug task will print out: `workload Removal Tasks Complete`
 
-** Playbook: link:./tasks/post_remove_workload.yml[post_remove_workload.yml] - Used to
+** Tasks: link:./tasks/post_remove_workload.yml[post_remove_workload.yml] - Used to
  configure the workload after deployment
 *** Removes the temp .kube/config file.
 *** Debug task will print out: `post_workload Removal Tasks Complete`

--- a/ansible/roles/ocp4-workload-homeroomlab-dev-tools/readme.adoc
+++ b/ansible/roles/ocp4-workload-homeroomlab-dev-tools/readme.adoc
@@ -3,31 +3,31 @@
 == Role overview
 
 * This is a simple role that does the following:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment
 *** Copies ~/.kube/config to a temp directory and sets the KUBECONFIG env variable.
 *** Debug task will print out: `pre_workload Tasks Complete`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the 
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the 
  lab environment.
 *** Creates a new project and a deployment for the learning portal.
 *** Debug task will print out: `workload Tasks Complete`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** Removes the temp .kube/config file.
 *** Debug task will print out: `post_workload Tasks Complete`
 
-** Playbook: link:./tasks/pre_remove_workload.yml[pre_remove_workload.yml] - Sets up an
+** Tasks: link:./tasks/pre_remove_workload.yml[pre_remove_workload.yml] - Sets up an
  environment for the workload removal
 *** Copies ~/.kube/config to a temp directory and sets the KUBECONFIG env variable.
 *** Debug task will print out: `pre_workload Removal Tasks Complete`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to clean up the environment and delete all resources.
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to clean up the environment and delete all resources.
 *** Deletes resources and projects that were created.
 *** Debug task will print out: `workload Removal Tasks Complete`
 
-** Playbook: link:./tasks/post_remove_workload.yml[post_remove_workload.yml] - Used to
+** Tasks: link:./tasks/post_remove_workload.yml[post_remove_workload.yml] - Used to
  configure the workload after deployment
 *** Removes the temp .kube/config file.
 *** Debug task will print out: `post_workload Removal Tasks Complete`

--- a/ansible/roles/ocp4-workload-homeroomlab-k8s-fundamentals/readme.adoc
+++ b/ansible/roles/ocp4-workload-homeroomlab-k8s-fundamentals/readme.adoc
@@ -3,31 +3,31 @@
 == Role overview
 
 * This is a simple role that does the following:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment
 *** Copies ~/.kube/config to a temp directory and sets the KUBECONFIG env variable.
 *** Debug task will print out: `pre_workload Tasks Complete`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the 
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the 
  lab environment.
 *** Creates a new project and a deployment for the learning portal.
 *** Debug task will print out: `workload Tasks Complete`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** Removes the temp .kube/config file.
 *** Debug task will print out: `post_workload Tasks Complete`
 
-** Playbook: link:./tasks/pre_remove_workload.yml[pre_remove_workload.yml] - Sets up an
+** Tasks: link:./tasks/pre_remove_workload.yml[pre_remove_workload.yml] - Sets up an
  environment for the workload removal
 *** Copies ~/.kube/config to a temp directory and sets the KUBECONFIG env variable.
 *** Debug task will print out: `pre_workload Removal Tasks Complete`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to clean up the environment and delete all resources.
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to clean up the environment and delete all resources.
 *** Deletes resources and projects that were created.
 *** Debug task will print out: `workload Removal Tasks Complete`
 
-** Playbook: link:./tasks/post_remove_workload.yml[post_remove_workload.yml] - Used to
+** Tasks: link:./tasks/post_remove_workload.yml[post_remove_workload.yml] - Used to
  configure the workload after deployment
 *** Removes the temp .kube/config file.
 *** Debug task will print out: `post_workload Removal Tasks Complete`

--- a/ansible/roles/ocp4-workload-infra-nodes/readme.adoc
+++ b/ansible/roles/ocp4-workload-infra-nodes/readme.adoc
@@ -2,18 +2,18 @@
 
 == Role overview
 
-* This role creates infrastructure nodes in an OpenShift 4 Cluster. It creates an infra machineset for each availability zone found and then scales the machinesets to the number of infra nodes desired. It does the same for Elasticsearch Machinesets if desired. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment.
+* This role creates infrastructure nodes in an OpenShift 4 Cluster. It creates an infra machineset for each availability zone found and then scales the machinesets to the number of infra nodes desired. It does the same for Elasticsearch Machinesets if desired. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to create the infra nodes
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to create the infra nodes
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to delete the workload
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to delete the workload
 *** This role removes the infrastructure nodes (DANGER!!!). It will not remove node selectors from infra components. This will have to be done manually.
 *** Debug task will print out: `remove_workload Tasks completed successfully.`
 

--- a/ansible/roles/ocp4-workload-istio-controlplane-infra/readme.adoc
+++ b/ansible/roles/ocp4-workload-istio-controlplane-infra/readme.adoc
@@ -2,20 +2,20 @@
 
 == Role overview
 
-* This role deploys the service mesh operators. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role deploys the service mesh operators. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy Istio
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy Istio
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes the logging deployment and project but not the operator configs
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp4-workload-istio-controlplane-student/readme.adoc
+++ b/ansible/roles/ocp4-workload-istio-controlplane-student/readme.adoc
@@ -2,20 +2,20 @@
 
 == Role overview
 
-* This role deploys the Istio control plane as a student workload. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role deploys the Istio control plane as a student workload. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy Istio
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy Istio
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes the logging deployment and project but not the operator configs
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp4-workload-istio-tutorial-student/readme.adoc
+++ b/ansible/roles/ocp4-workload-istio-tutorial-student/readme.adoc
@@ -2,20 +2,20 @@
 
 == Role overview
 
-* This role deploys the Istio bookinfo app. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role deploys the Istio bookinfo app. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the app
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the app
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes the logging deployment and project but not the operator configs
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp4-workload-istio-workshop-homeroom/readme.adoc
+++ b/ansible/roles/ocp4-workload-istio-workshop-homeroom/readme.adoc
@@ -2,20 +2,20 @@
 
 == Role overview
 
-* This role deploys the service mesh workshop labguide (homeroom). It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role deploys the service mesh workshop labguide (homeroom). It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy homeroom
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy homeroom
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes the logging deployment and project but not the operator configs
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp4-workload-jdg-workshop/readme.adoc
+++ b/ansible/roles/ocp4-workload-jdg-workshop/readme.adoc
@@ -2,20 +2,20 @@
 
 == Role overview
 
-* This role deploys logging into an OpenShift 4 Cluster. It depends on infrastructure nodes existing. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role deploys logging into an OpenShift 4 Cluster. It depends on infrastructure nodes existing. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy logging
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy logging
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes the logging deployment and project but not the operator configs
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp4-workload-kube-federation/readme.adoc
+++ b/ansible/roles/ocp4-workload-kube-federation/readme.adoc
@@ -2,21 +2,21 @@
 
 == Role overview
 
-* This role installs Kube Federation into an OpenShift Cluster. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role installs Kube Federation into an OpenShift Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy Kube Federation
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy Kube Federation
 *** This role creates a namespace (project) and deploys the operator
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes Kube Federation
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp4-workload-logging/readme.adoc
+++ b/ansible/roles/ocp4-workload-logging/readme.adoc
@@ -3,18 +3,18 @@
 == Role overview
 
 * This role deploys cluster logging into an OpenShift 4 Cluster. It depends on infrastructure nodes existing (run `ocp4-workload-infra-nodes` workload first).
-It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment.
+It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy logging
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy logging
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to delete the workload
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to delete the workload
 *** This role removes the logging deployment and project but not the operator configs
 *** Debug task will print out: `remove_workload Tasks completed successfully.`
 

--- a/ansible/roles/ocp4-workload-machinesets/readme.adoc
+++ b/ansible/roles/ocp4-workload-machinesets/readme.adoc
@@ -2,18 +2,18 @@
 
 == Role overview
 
-* This role creates additional MachineSets in an OpenShift 4 Cluster. For each MachineSet group it creates a machineset for each availability zone found (if the cloud platform supports availability zones) and then scales the machinesets to the number of replicas desired. Optionally this role also sets up a MachineAutoscaler for the created MachineSet(s). It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment.
+* This role creates additional MachineSets in an OpenShift 4 Cluster. For each MachineSet group it creates a machineset for each availability zone found (if the cloud platform supports availability zones) and then scales the machinesets to the number of replicas desired. Optionally this role also sets up a MachineAutoscaler for the created MachineSet(s). It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to create the infra nodes
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to create the infra nodes
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to delete the workload
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to delete the workload
 *** This role removes the infrastructure nodes (DANGER!!!). It will not remove node selectors from infra components. This will have to be done manually.
 *** Debug task will print out: `remove_workload Tasks completed successfully.`
 

--- a/ansible/roles/ocp4-workload-minio/readme.adoc
+++ b/ansible/roles/ocp4-workload-minio/readme.adoc
@@ -2,21 +2,21 @@
 
 == Role overview
 
-* This role installs Minio Object Storage into an OpenShift Cluster. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role installs Minio Object Storage into an OpenShift Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy Minio Object Storage
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy Minio Object Storage
 *** This role creates a namespace (project), creates a PVC, Deployment and Service for Minio
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes the Minio Object Storage project (and therefore Minio Object Storage)
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp4-workload-ml-workflows-workshop/readme.adoc
+++ b/ansible/roles/ocp4-workload-ml-workflows-workshop/readme.adoc
@@ -2,22 +2,22 @@
 
 == Role overview
 
-* This is a working no-op role that can be used to develop new ocp-workload roles. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This is a working no-op role that can be used to develop new ocp-workload roles. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
  workload, i.e, 3scale, Mobile or some Demo
 *** This role only prints the current username for which this role is provisioning.
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role doesn't do anything here
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp4-workload-nexus-operator/readme.adoc
+++ b/ansible/roles/ocp4-workload-nexus-operator/readme.adoc
@@ -2,20 +2,20 @@
 
 == Role overview
 
-* This role enables the Nexus Operator on an OpenShift 4 Cluster. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role enables the Nexus Operator on an OpenShift 4 Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the Nexus Operator and then deploy a shared Nexus instance
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the Nexus Operator and then deploy a shared Nexus instance
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes the shared Nexus and Nexus operator from OCP 4. This role does *not* remove the project - there may be other items in it.
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp4-workload-open-data-hub-infra/readme.adoc
+++ b/ansible/roles/ocp4-workload-open-data-hub-infra/readme.adoc
@@ -6,21 +6,21 @@ Roles that depends on this infra
 
 == Role overview
 
-* This role deploys the Istio bookinfo app. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role deploys the Istio bookinfo app. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Git clone from repos
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the app
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the app
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** Clean git artifacts from /tmp/
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes the logging deployment and project but not the operator configs
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp4-workload-open-data-hub-student/readme.adoc
+++ b/ansible/roles/ocp4-workload-open-data-hub-student/readme.adoc
@@ -6,21 +6,21 @@ Dependent roles
 
 == Role overview
 
-* This role deploys app. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role deploys app. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Git clone from repos
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the app
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the app
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** Clean git artifacts from /tmp/
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes the logging deployment and project but not the operator configs
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp4-workload-open-data-hub/readme.adoc
+++ b/ansible/roles/ocp4-workload-open-data-hub/readme.adoc
@@ -2,24 +2,24 @@
 
 == Role overview
 
-* This role deploys the Istio bookinfo app. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role deploys the Istio bookinfo app. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Git clone from repos
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the app
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the app
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/per_user_workload.yml[per_user_workload.yml] - Used to deploy per user workload
+** Tasks: link:./tasks/per_user_workload.yml[per_user_workload.yml] - Used to deploy per user workload
 *** Debug task will print out: `Per User Workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** Clean git artifacts from /tmp/
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes the logging deployment and project but not the operator configs
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp4-workload-opentlc-production/readme.adoc
+++ b/ansible/roles/ocp4-workload-opentlc-production/readme.adoc
@@ -2,21 +2,21 @@
 
 == Role overview
 
-* This role configures an OpenShift 4 cluster for OpenTLC/RHPDS production use. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role configures an OpenShift 4 cluster for OpenTLC/RHPDS production use. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to configure the cluster
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to configure the cluster
 *** This role creates a route for the image registry, sets up build defaults and removes self-provisioner from all users.
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes the production customizations
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp4-workload-pipelines/readme.adoc
+++ b/ansible/roles/ocp4-workload-pipelines/readme.adoc
@@ -2,21 +2,21 @@
 
 == Role overview
 
-* This role installs OpenShift Pipelines (backed by Tekton) into an OpenShift Cluster. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role installs OpenShift Pipelines (backed by Tekton) into an OpenShift Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy OpenShift Pipelines
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy OpenShift Pipelines
 *** This role creates a namespace (project) and deploys the operator. It will then create the Pipelines Install object that deploys the controllers etc.
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes OpenShift Pipelines
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp4-workload-project-request-template/readme.adoc
+++ b/ansible/roles/ocp4-workload-project-request-template/readme.adoc
@@ -2,20 +2,20 @@
 
 == Role overview
 
-* This role enables the Service Broker on an OpenShift 4 Cluster. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role enables the Service Broker on an OpenShift 4 Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to enable the Service Broker
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to enable the Service Broker
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes the service broker from OCP 4
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp4-workload-quarkus-workshop/readme.adoc
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/readme.adoc
@@ -2,20 +2,20 @@
 
 == Role overview
 
-* This role deploys logging into an OpenShift 4 Cluster. It depends on infrastructure nodes existing. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role deploys logging into an OpenShift 4 Cluster. It depends on infrastructure nodes existing. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy logging
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy logging
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes the logging deployment and project but not the operator configs
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp4-workload-quay-operator/readme.adoc
+++ b/ansible/roles/ocp4-workload-quay-operator/readme.adoc
@@ -6,21 +6,21 @@
 
 * The Operator source is at https://github.com/redhat-cop/quay-operator.
 
-* The role consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* The role consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy Red Hat Quay Registry Operator
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy Red Hat Quay Registry Operator
 *** This role creates a namespace (project), operator and a Quay instance
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes the Red Hat Quay Registry project (and therefore Red Hat Quay Registry)
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp4-workload-rhte-a0007-shared/readme.adoc
+++ b/ansible/roles/ocp4-workload-rhte-a0007-shared/readme.adoc
@@ -2,21 +2,21 @@
 
 == Role overview
 
-* This role grants cluster-admin permissions to a user. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role grants cluster-admin permissions to a user. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to grant cluster-admin
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to grant cluster-admin
 *** This role grants cluster-admin permissions to ocp_username
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes cluster-admin from the user
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp4-workload-rhte-a0009/readme.adoc
+++ b/ansible/roles/ocp4-workload-rhte-a0009/readme.adoc
@@ -2,20 +2,20 @@
 
 == Role overview
 
-* This role enables the Workshop Operator on an OpenShift 4 Cluster. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role enables the Workshop Operator on an OpenShift 4 Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the Workshop Operator and then deploy a Workshop instance
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the Workshop Operator and then deploy a Workshop instance
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes the Workshop Instance and Workshop operator from OCP 4. This role does *not* remove the project - there may be other items in it.
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/readme.adoc
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/readme.adoc
@@ -9,20 +9,20 @@ Infrastructure tasks include:
 
 == Role overview
 
-* This is an infrastructure role to deploy the dependencies required for Open Data Hub infrastructure: Rook Ceph Object Storage, dependent CRDs, ClusterRoles. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment
+* This is an infrastructure role to deploy the dependencies required for Open Data Hub infrastructure: Rook Ceph Object Storage, dependent CRDs, ClusterRoles. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy Rook Ceph Object Storage and required CRDs for ODH deployment
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy Rook Ceph Object Storage and required CRDs for ODH deployment
 *** This role only prints the current username for which this role is provisioning.
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Attempts to remove the Rook Ceph deployment
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Attempts to remove the Rook Ceph deployment
 *** Debug task will print out: `remove_workload Tasks completed successfully.`
 
 == Review the defaults variable file

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/readme.adoc
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/readme.adoc
@@ -13,20 +13,20 @@ Role assumes that OCP user accounts have been created on the cluster in the form
 
 == Role overview
 
-* This is a workshop role to setup the Open Data Hub project for a specific user. This role requires that the infrastructure has all Open Data Hub required and dependent CRDS loaded and Rook Ceph Object storage has been installed. This role must be run after the link:../ocp4-workload-rhte-analytics_data_ocp_infra[ocp4-workload-rhte-analytics_data_ocp_infra] role. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment
+* This is a workshop role to setup the Open Data Hub project for a specific user. This role requires that the infrastructure has all Open Data Hub required and dependent CRDS loaded and Rook Ceph Object storage has been installed. This role must be run after the link:../ocp4-workload-rhte-analytics_data_ocp_infra[ocp4-workload-rhte-analytics_data_ocp_infra] role. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Creates the each user's project space, adds the ODH ClusterServiceVersion to the project, deploys the opendatahub-operator and *OPTIONAL* deploys Open Data Hub
+** Tasks: link:./tasks/workload.yml[workload.yml] - Creates the each user's project space, adds the ODH ClusterServiceVersion to the project, deploys the opendatahub-operator and *OPTIONAL* deploys Open Data Hub
 *** This role only prints the current username for which this role is provisioning.
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Deletes the project created for each user
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Deletes the project created for each user
 *** Debug task will print out: `remove_workload Tasks completed successfully.`
 
 == Review the defaults variable file

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop_s2020/readme.adoc
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop_s2020/readme.adoc
@@ -11,20 +11,20 @@ The individual workload task includes
 
 == Role overview
 
-* This is a workshop role to setup the Open Data Hub project for a specific user. This role requires that the infrastructure has all Open Data Hub required and dependent CRDS loaded and Rook Ceph Object storage has been installed. This role must be run after the link:../ocp4-workload-rhte-analytics_data_ocp_infra[ocp4-workload-rhte-analytics_data_ocp_infra] role. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment
+* This is a workshop role to setup the Open Data Hub project for a specific user. This role requires that the infrastructure has all Open Data Hub required and dependent CRDS loaded and Rook Ceph Object storage has been installed. This role must be run after the link:../ocp4-workload-rhte-analytics_data_ocp_infra[ocp4-workload-rhte-analytics_data_ocp_infra] role. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Creates the each user's project space, adds the ODH ClusterServiceVersion to the project, deploys the opendatahub-operator and *OPTIONAL* deploys Open Data Hub
+** Tasks: link:./tasks/workload.yml[workload.yml] - Creates the each user's project space, adds the ODH ClusterServiceVersion to the project, deploys the opendatahub-operator and *OPTIONAL* deploys Open Data Hub
 *** This role only prints the current username for which this role is provisioning.
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Deletes the project created for each user
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Deletes the project created for each user
 *** Debug task will print out: `remove_workload Tasks completed successfully.`
 
 == Review the defaults variable file

--- a/ansible/roles/ocp4-workload-rhte-gitops-app-portability-verification/readme.adoc
+++ b/ansible/roles/ocp4-workload-rhte-gitops-app-portability-verification/readme.adoc
@@ -2,21 +2,21 @@
 
 == Role overview
 
-* This role verifies GitOps RHTE 2019 Lab into an OpenShift Cluster. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment.
+* This role verifies GitOps RHTE 2019 Lab into an OpenShift Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment.
 *** This role doesn't do anything here
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy ArgoCD
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy ArgoCD
 *** This role runs the verifications
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role doesn't do anything here
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp4-workload-rhte-gitops-app-portability/readme.adoc
+++ b/ansible/roles/ocp4-workload-rhte-gitops-app-portability/readme.adoc
@@ -2,20 +2,20 @@
 
 == Role overview
 
-* This role installs GitOps RHTE 2019 Lab into an OpenShift Cluster. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment.
+* This role installs GitOps RHTE 2019 Lab into an OpenShift Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy ArgoCD
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy ArgoCD
 *** This role creates a namespace (project) for ArgoCD and Gogs and deploys them
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes Argo CD, Gogs and related resources
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp4-workload-rhte-keynote-ai-infra/readme.adoc
+++ b/ansible/roles/ocp4-workload-rhte-keynote-ai-infra/readme.adoc
@@ -9,20 +9,20 @@ Infrastructure tasks include:
 
 == Role overview
 
-* This is an infrastructure role to deploy the dependencies required for Open Data Hub infrastructure: Rook Ceph Object Storage, dependent CRDs, ClusterRoles. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment
+* This is an infrastructure role to deploy the dependencies required for Open Data Hub infrastructure: Rook Ceph Object Storage, dependent CRDs, ClusterRoles. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy Rook Ceph Object Storage and required CRDs for ODH deployment
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy Rook Ceph Object Storage and required CRDs for ODH deployment
 *** This role only prints the current username for which this role is provisioning.
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Attempts to remove the Rook Ceph deployment
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Attempts to remove the Rook Ceph deployment
 *** Debug task will print out: `remove_workload Tasks completed successfully.`
 
 == Review the defaults variable file

--- a/ansible/roles/ocp4-workload-rhte-keynote-ai-odh-setup/readme.adoc
+++ b/ansible/roles/ocp4-workload-rhte-keynote-ai-odh-setup/readme.adoc
@@ -11,20 +11,20 @@ The individual workload task includes
 
 == Role overview
 
-* This is a workshop role to setup the Open Data Hub project for a specific user. This role requires that the infrastructure has all Open Data Hub required and dependent CRDS loaded and Rook Ceph Object storage has been installed. This role must be run after the link:../ocp4-workload-rhte-analytics_data_ocp_infra[ocp4-workload-rhte-analytics_data_ocp_infra] role. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment
+* This is a workshop role to setup the Open Data Hub project for a specific user. This role requires that the infrastructure has all Open Data Hub required and dependent CRDS loaded and Rook Ceph Object storage has been installed. This role must be run after the link:../ocp4-workload-rhte-analytics_data_ocp_infra[ocp4-workload-rhte-analytics_data_ocp_infra] role. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Creates the each user's project space, adds the ODH ClusterServiceVersion to the project, deploys the opendatahub-operator and *OPTIONAL* deploys Open Data Hub
+** Tasks: link:./tasks/workload.yml[workload.yml] - Creates the each user's project space, adds the ODH ClusterServiceVersion to the project, deploys the opendatahub-operator and *OPTIONAL* deploys Open Data Hub
 *** This role only prints the current username for which this role is provisioning.
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Deletes the project created for each user
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Deletes the project created for each user
 *** Debug task will print out: `remove_workload Tasks completed successfully.`
 
 == Review the defaults variable file

--- a/ansible/roles/ocp4-workload-security-compliance-lab/readme.adoc
+++ b/ansible/roles/ocp4-workload-security-compliance-lab/readme.adoc
@@ -3,7 +3,7 @@
 == Role overview
 
 * This is a simple role that does the following:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment
 *** Adds a user to a list of groups defined in the
  link:./defaults/main.yml[defaults file].
@@ -11,12 +11,12 @@
  link:./defaults/main.yml[defaults file] .
 *** Debug task will print out: `pre_workload Tasks Complete`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
  workload, i.e, 3scale, Mobile or some Demo
 *** This role doesn't do anything here
 *** Debug task will print out: `workload Tasks Complete`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks Complete`

--- a/ansible/roles/ocp4-workload-serverless/readme.adoc
+++ b/ansible/roles/ocp4-workload-serverless/readme.adoc
@@ -2,21 +2,21 @@
 
 == Role overview
 
-* This role installs OpenShift Serverless (backed by KNative) into an OpenShift Cluster. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role installs OpenShift Serverless (backed by KNative) into an OpenShift Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy OpenShift Serverless
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy OpenShift Serverless
 *** This role creates a namespace (project) and deploys the operator. It will then create the KNativeServing object that deploys the controllers etc.
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes OpenShift Serverless
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp4-workload-servicemesh/readme.adoc
+++ b/ansible/roles/ocp4-workload-servicemesh/readme.adoc
@@ -2,21 +2,21 @@
 
 == Role overview
 
-* This role installs OpenShift Service Mesh into an OpenShift Cluster. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role installs OpenShift Service Mesh into an OpenShift Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy OpenShift Service Mesh
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy OpenShift Service Mesh
 *** This role creates a namespace (project) and deploys the operator. It will then optinally create the ServiceMeshControlPlane and Service Mesh Member Roll.
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes OpenShift Service Mesh
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp4-workload-tektoncd-foundations/readme.adoc
+++ b/ansible/roles/ocp4-workload-tektoncd-foundations/readme.adoc
@@ -3,21 +3,21 @@
 == Role overview
 
 * This role is used to prepare an environment for working through the foundations of link:https://tekton.dev[Tekton]. 
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
  workload, i.e, 3scale, Mobile or some Demo
 *** This role only prints the current username for which this role is provisioning.
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role doesn't do anything here
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp4-workload-template-service-broker/readme.adoc
+++ b/ansible/roles/ocp4-workload-template-service-broker/readme.adoc
@@ -2,21 +2,21 @@
 
 == Role overview
 
-* This role installs the Template Service Broker into an OpenShift Cluster. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role installs the Template Service Broker into an OpenShift Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the Template Service Broker
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the Template Service Broker
 *** This role creates a namespace (project), deploys the automation broker operator, then deploys 
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes the Template Service Broker
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp4-workload-userquota-operator/readme.adoc
+++ b/ansible/roles/ocp4-workload-userquota-operator/readme.adoc
@@ -2,20 +2,20 @@
 
 == Role overview
 
-* This role enables the User Quota Operator on an OpenShift 4 Cluster. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role enables the User Quota Operator on an OpenShift 4 Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to enable the User Quota Operator
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to enable the User Quota Operator
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes the user quota operator from OCP 4. It also removes all created cluster resource quotas
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles/ocp4-workload-workshop-admin-storage/readme.adoc
+++ b/ansible/roles/ocp4-workload-workshop-admin-storage/readme.adoc
@@ -5,26 +5,26 @@
 
 == Role overview
 
-* This role deploys the labguide app. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role deploys the labguide app. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Runs link:./tasks/clean-admin.yml[clean-admin.yml]
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/clean-admin.yml[clean-admin.yml] - Used to
+** Tasks: link:./tasks/clean-admin.yml[clean-admin.yml] - Used to
  clear out resources related to the admin application admin to avoid conflicts
  *** Runs in link:./tasks/pre_workload.yml[pre_workload.yml] and during link:./tasks/remove_workload.yml[remove_workload.yml]
 
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the app
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the app
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** Runs link:./tasks/clean-admin.yml[clean-admin.yml]
 *** This role removes the logging deployment and project but not the operator configs

--- a/ansible/roles/ocp4-workload-workshop-dashboard-cluster-admin-student/readme.adoc
+++ b/ansible/roles/ocp4-workload-workshop-dashboard-cluster-admin-student/readme.adoc
@@ -15,26 +15,26 @@ Customizable parameters, see examples in link:./defaults/main.yml[./defaults/mai
 
 == Role overview
 
-* This role deploys the labguide app. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role deploys the labguide app. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Runs link:./tasks/clean-environment.yml[clean-environment.yml]
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/clean-admin.yml[clean-admin.yml] - Used to
+** Tasks: link:./tasks/clean-admin.yml[clean-admin.yml] - Used to
  clear out resources related to the admin application admin to avoid conflicts
  *** Runs in link:./tasks/pre_workload.yml[pre_workload.yml] and during link:./tasks/remove_workload.yml[remove_workload.yml]
 
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the app
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the app
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** Runs link:./tasks/clean-admin.yml[clean-admin.yml]
 *** This role removes the logging deployment and project but not the operator configs

--- a/ansible/roles/ocp4-workload-workshopper/readme.adoc
+++ b/ansible/roles/ocp4-workload-workshopper/readme.adoc
@@ -2,20 +2,20 @@
 
 == Role overview
 
-* This role deploys the Istio control plane. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role deploys the Istio control plane. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy workshopper
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy workshopper
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes the logging deployment and project but not the operator configs
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles_ocp_workloads/ocp4_workload_app_deploy_ilt/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_app_deploy_ilt/readme.adoc
@@ -2,21 +2,21 @@
 
 == Role overview
 
-* This role configures an OpenShift 4 cluster for use in the OpenShift 4 Advanced Application Deployment ILT. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role configures an OpenShift 4 cluster for use in the OpenShift 4 Advanced Application Deployment ILT. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to configure the cluster
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to configure the cluster
 *** This role creates a route for the image registry, sets up build defaults and removes self-provisioner from all users, installs Gogs.
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes the production customizations
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles_ocp_workloads/ocp4_workload_authentication/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_authentication/readme.adoc
@@ -2,20 +2,20 @@
 
 == Role overview
 
-* This role enables authentication on an OpenShift 4 Cluster. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role enables authentication on an OpenShift 4 Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to configure authentication
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to configure authentication
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes authentication from OCP 4. This role does *not* recreate the kubeadmin user - the only way to use OpenShift after removing the workload is via the `system:admin` user from the bastion VM.
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles_ocp_workloads/ocp4_workload_example/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_example/readme.adoc
@@ -24,7 +24,7 @@
 * The variable *ocp_username* is mandatory to assign the workload to the correct OpenShift user.
 * A variable *silent=True* can be passed to suppress debug messages.
 * You can modify any of these default values by adding `-e "variable_name=variable_value"` to the command line
-* You can modify any of these default values by adding `-e "variable_name=variable_value"` to the command line 
+* You can modify any of these default values by adding `-e "variable_name=variable_value"` to the command line
 * Your deployer will override any of these variables (usually CloudForms)
 * Add long-name scoped workload parameters. Example: `ocp4_workload_example_machineconfigpool_name: worker`
 
@@ -98,9 +98,9 @@ ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
 
 == Deploying a Workload with AgnosticV
 
-When creating a configuration in AgnosticV that includes the deployment of the workload you can specify the variables straight in the AgnosticV config. 
+When creating a configuration in AgnosticV that includes the deployment of the workload you can specify the variables straight in the AgnosticV config.
 AgnosticV configs are usually created by combining a `common.yaml` file with either `dev.yaml`, `test.yaml` or `prod.yaml`.
-You can specify different variables in each of these files. 
+You can specify different variables in each of these files.
 For example you could have common values defined in the `common.yaml` file and then specific values overriding the common ones for development or production environments in `dev.yaml` or `prod.yaml`.
 
 AgnosticV merges the definition files starting with `common.yaml` and then adding/overwriting what comes from either `dev.yaml` or `prod.yaml`.

--- a/ansible/roles_ocp_workloads/ocp4_workload_example/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_example/readme.adoc
@@ -2,19 +2,19 @@
 
 == Role overview
 
-* This is a working no-op role that can be used to develop new OpenShift 4 workload roles. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment
+* This is a working no-op role that can be used to develop new OpenShift 4 workload roles. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual workload, i.e, 3scale, Mobile, some Demo or OpenShift customization
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual workload, i.e, 3scale, Mobile, some Demo or OpenShift customization
 *** This role only prints the current username for which this role is provisioning.
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to delete the workload
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to delete the workload
 *** This role doesn't do anything here
 *** Debug task will print out: `remove_workload Tasks completed successfully.`
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_example_dedicated_cluster/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_example_dedicated_cluster/readme.adoc
@@ -14,7 +14,7 @@ This role builds upon `ocp4_workshop_example_shared_cluster` to prepare a dedica
 
 Admin access to the cluster is required.
 
-This role is meant to be run after serveral important depenendent roles, including setup of 
+This role is meant to be run after serveral important depenendent roles, including setup of
 * Let's Encrypt certificates
 * htpasswd authentication for multiple users
 * a project request template
@@ -201,7 +201,7 @@ cloud_provider: none
 # --- Config
 env_type: ocp4-cluster
 ocp_workload: ocp4_workload_example_dedicated_cluster
-# If your workload requires sudo, additional privileges are required.  
+# If your workload requires sudo, additional privileges are required.
 # For now, workload must be run as ec2-user (or cloud-user on OpenStack)
 ansible_user: ec2-user
 ansible_ssh_private_key_file: /home/opentlc-mgr/.ssh/opentlc_admin_backdoor.pem

--- a/ansible/roles_ocp_workloads/ocp4_workload_example_dedicated_cluster/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_example_dedicated_cluster/readme.adoc
@@ -32,23 +32,23 @@ For more information on dedicated clusters and setting up self-provisioner capab
 
 == Role overview
 
-* This is a working simple role that can be used to develop new OpenShift 4 workload roles on dedicated clusters. It consists of the following playbooks:
+* This is a working simple role that can be used to develop new OpenShift 4 workload roles on dedicated clusters. It consists of the following tasks files:
 
-=== Playbooks
+=== Task Files
 
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual workload, i.e, 3scale, Mobile, some Demo or OpenShift customization
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual workload, i.e, 3scale, Mobile, some Demo or OpenShift customization
 *** Read this role for our recommended best practices for working with ansible and OpenShift
 *** This role creates an OpenShift project, deploys a simple application, and notifies on success or failure.
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
 *** This role doesn't do anything
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to delete the workload
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to delete the workload
 *** This role deletes the OpenShift projected created for the user.
 *** Debug task will print out: `remove_workload Tasks completed successfully.`
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_example_shared_cluster/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_example_shared_cluster/readme.adoc
@@ -23,23 +23,23 @@ For more information on dedicated clusters and setting up self-provisioner capab
 
 == Role overview
 
-* This is a working simple role that can be used to develop new OpenShift 4 workload roles on shared clusters. It consists of the following playbooks:
+* This is a working simple role that can be used to develop new OpenShift 4 workload roles on shared clusters. It consists of the following tasks files:
 
-=== Playbooks
+=== Tasks Files
 
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual workload, i.e, 3scale, Mobile, some Demo or OpenShift customization
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual workload, i.e, 3scale, Mobile, some Demo or OpenShift customization
 *** Read this role for our recommended best practices for working with ansible and OpenShift
 *** This role creates an OpenShift project, deploys a simple application, and notifies on success or failure.
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
 *** This role doesn't do anything
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to delete the workload
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to delete the workload
 *** This role deletes the OpenShift project created for the user.
 *** Debug task will print out: `remove_workload Tasks completed successfully.`
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_fuse_online/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_fuse_online/readme.adoc
@@ -4,22 +4,22 @@
 
 * This role installs Fuse Online into an OpenShift Cluster. +
 The role is primarily meant to provide the lab environment for the GPTE Fuse Foundations Part I course. +
-It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment. Deploys cluster resource quota for thenamespace created by this workload.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Deploys Fuse Online
+** Tasks: link:./tasks/workload.yml[workload.yml] - Deploys Fuse Online
 *** This role creates a namespace (project) and deploys the Fuse Online operator. It will then create the custom resource for a Fuse Online deployment.
 *** This role also deploys a application (catalog service) which is used in the labs of the Fuse Foundations Part I course.
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes the namespace where Fuse Online was deployed. It also removes the cluster resource quota.
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles_ocp_workloads/ocp4_workload_integreatly/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_integreatly/readme.adoc
@@ -2,18 +2,18 @@
 
 == Role overview
 
-This role will install the Red Hat Managed Integration (RHMI) offering on a target RHPDS OCP4 environment. It consists of the following playbooks: 
+This role will install the Red Hat Managed Integration (RHMI) offering on a target RHPDS OCP4 environment. It consists of the following tasks files:
 
-* Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment.
+* Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment.
 ** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-* Playbook: link:./tasks/workload.yml[workload.yml] - Used to install RHMI (Integreatly)
+* Tasks: link:./tasks/workload.yml[workload.yml] - Used to install RHMI (Integreatly)
 ** Debug task will print out: `workload Tasks completed successfully.`
 
-* Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
+* Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
 ** Debug task will print out: `post_workload Tasks completed successfully.`
 
-* Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to delete the workload
+* Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to delete the workload
 ** Debug task will print out: `remove_workload Tasks completed successfully.`
 
 == Review the defaults variable file

--- a/ansible/roles_ocp_workloads/ocp4_workload_integreatly_minio/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_integreatly_minio/readme.adoc
@@ -2,18 +2,18 @@
 
 == Role overview
 
-This role will install the Red Hat Managed Integration (RHMI) offering on a target RHPDS OCP4 environment. It consists of the following playbooks: 
+This role will install the Red Hat Managed Integration (RHMI) offering on a target RHPDS OCP4 environment. It consists of the following tasks files:
 
-* Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment.
+* Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment.
 ** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-* Playbook: link:./tasks/workload.yml[workload.yml] - Used to install RHMI (Integreatly)
+* Tasks: link:./tasks/workload.yml[workload.yml] - Used to install RHMI (Integreatly)
 ** Debug task will print out: `workload Tasks completed successfully.`
 
-* Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
+* Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
 ** Debug task will print out: `post_workload Tasks completed successfully.`
 
-* Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to delete the workload
+* Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to delete the workload
 ** Debug task will print out: `remove_workload Tasks completed successfully.`
 
 == Review the defaults variable file

--- a/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/readme.adoc
@@ -1,22 +1,22 @@
-= ocp4_workload_kubevirt - Deploy KubeVirt to an OpenShift Cluster 
+= ocp4_workload_kubevirt - Deploy KubeVirt to an OpenShift Cluster
 
 == Role overview
 
-* This role installs Kubevirt HyperConverged Operator into an OpenShift Cluster. It consists of following playbooks:
-** Playbook: pre_workload.yml - Sets up an environment for the workload environment.
+* This role installs Kubevirt HyperConverged Operator into an OpenShift Cluster. It consists of following tasks files:
+** Tasks: pre_workload.yml - Sets up an environment for the workload environment.
 *** Debug task will print out: `Pre-Workload tasks completed successfully.`
 
-** Playbook: workload.yml - Used to deploy Kubevirt Hyperconverged Operator
-*** This playbook creates following OCP resources: 
+** Tasks: workload.yml - Used to deploy Kubevirt Hyperconverged Operator
+*** This playbook creates following OCP resources:
 **** namespace (project) `openshift-cnv`. The mandatory namespace for installing CNV to
-**** subscription to CNV 
+**** subscription to CNV
 **** KubeVrit HCO
 
-** Playbook: post_workload.yml - Used to configure the workload after deployment
+** Tasks: post_workload.yml - Used to configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: workload Tasks completed successfully.
 
-** Playbook: remove_workload.yml - Used to delete the workload
+** Tasks: remove_workload.yml - Used to delete the workload
 *** This role removes Kubevirt HyperConverged Operator and its subscription.
 *** Debug task will print out: `remove_workload Tasks completed successfully.`
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_le_certificates/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_le_certificates/readme.adoc
@@ -2,20 +2,20 @@
 
 == Role overview
 
-* This role requests and installs certificates from Let's Encrypt for an OpenShift 4 Cluster. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role requests and installs certificates from Let's Encrypt for an OpenShift 4 Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to create the certificates
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to create the certificates
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes the certificates from OCP 4
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles_ocp_workloads/ocp4_workload_logging/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_logging/readme.adoc
@@ -3,18 +3,18 @@
 == Role overview
 
 * This role deploys cluster logging into an OpenShift 4 Cluster. Optionally it can use existing Infra or Elasticsearch nodes (run `ocp4_workload_machinesets` workload first).
-It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment.
+It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy logging
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy logging
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to delete the workload
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to delete the workload
 *** This role removes the logging deployment and project but not the operator configs
 *** Debug task will print out: `remove_workload Tasks completed successfully.`
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_machinesets/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_machinesets/readme.adoc
@@ -2,18 +2,18 @@
 
 == Role overview
 
-* This role creates additional MachineSets in an OpenShift 4 Cluster. For each MachineSet group it creates a machineset for each availability zone found (if the cloud platform supports availability zones) and then scales the machinesets to the number of replicas desired. Optionally this role also sets up a MachineAutoscaler for the created MachineSet(s). It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment.
+* This role creates additional MachineSets in an OpenShift 4 Cluster. For each MachineSet group it creates a machineset for each availability zone found (if the cloud platform supports availability zones) and then scales the machinesets to the number of replicas desired. Optionally this role also sets up a MachineAutoscaler for the created MachineSet(s). It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to create the infra nodes
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to create the infra nodes
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to delete the workload
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to delete the workload
 *** This role removes the infrastructure nodes (DANGER!!!). It will not remove node selectors from infra components. This will have to be done manually.
 *** Debug task will print out: `remove_workload Tasks completed successfully.`
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_nexus_operator/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_nexus_operator/readme.adoc
@@ -2,20 +2,20 @@
 
 == Role overview
 
-* This role enables the Nexus Operator on an OpenShift 4 Cluster. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role enables the Nexus Operator on an OpenShift 4 Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the Nexus Operator and then deploy a shared Nexus instance
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the Nexus Operator and then deploy a shared Nexus instance
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes the shared Nexus and Nexus operator from OCP 4. This role does *not* remove the project - there may be other items in it.
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles_ocp_workloads/ocp4_workload_opentlc_production/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_opentlc_production/readme.adoc
@@ -2,21 +2,21 @@
 
 == Role overview
 
-* This role configures an OpenShift 4 cluster for OpenTLC/RHPDS production use. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role configures an OpenShift 4 cluster for OpenTLC/RHPDS production use. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to configure the cluster
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to configure the cluster
 *** This role creates a route for the image registry, sets up build defaults and removes self-provisioner from all users.
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes the production customizations
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles_ocp_workloads/ocp4_workload_pipelines/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_pipelines/readme.adoc
@@ -2,21 +2,21 @@
 
 == Role overview
 
-* This role installs OpenShift Pipelines (backed by Tekton) into an OpenShift Cluster. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role installs OpenShift Pipelines (backed by Tekton) into an OpenShift Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy OpenShift Pipelines
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy OpenShift Pipelines
 *** This role creates a namespace (project) and deploys the operator. It will then create the Pipelines Install object that deploys the controllers etc.
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes OpenShift Pipelines
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles_ocp_workloads/ocp4_workload_project_request_template/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_project_request_template/readme.adoc
@@ -2,20 +2,20 @@
 
 == Role overview
 
-* This role enables the Project Request Template on an OpenShift 4 Cluster. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role enables the Project Request Template on an OpenShift 4 Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to enable the Service Broker
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to enable the Service Broker
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes the service broker from OCP 4
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/readme.adoc
@@ -6,21 +6,21 @@
 
 * The Operator source is at https://github.com/redhat-cop/quay-operator.
 
-* The role consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* The role consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy Red Hat Quay Registry Operator
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy Red Hat Quay Registry Operator
 *** This role creates a namespace (project), operator and a Quay instance
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes the Red Hat Quay Registry project (and therefore Red Hat Quay Registry)
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm/readme.adoc
@@ -2,20 +2,20 @@
 
 == Role overview
 
-* This role installs Red Hat ACM into an OpenShift Cluster. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment.
+* This role installs Red Hat ACM into an OpenShift Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy ACM
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy ACM
 *** This role deploys ACM (project)
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role uninstalls ACM and related resources
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/readme.adoc
@@ -2,21 +2,21 @@
 
 == Role overview
 
-* This role installs OpenShift Serverless (backed by KNative) into an OpenShift Cluster. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role installs OpenShift Serverless (backed by KNative) into an OpenShift Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy OpenShift Serverless
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy OpenShift Serverless
 *** This role creates a namespace (project) and deploys the operator. It will then create the KNativeServing object that deploys the controllers etc.
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes OpenShift Serverless
 *** Debug task will print out: `remove_workload Tasks completed successfully.`

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh/readme.adoc
@@ -2,21 +2,21 @@
 
 == Role overview
 
-* This role installs OpenShift Service Mesh into an OpenShift Cluster. It consists of the following playbooks:
-** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+* This role installs OpenShift Service Mesh into an OpenShift Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy OpenShift Service Mesh
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy OpenShift Service Mesh
 *** This role creates a namespace (project) and deploys the operator. It will then optinally create the ServiceMeshControlPlane and Service Mesh Member Roll.
 *** Debug task will print out: `workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
  configure the workload after deployment
 *** This role doesn't do anything here
 *** Debug task will print out: `post_workload Tasks completed successfully.`
 
-** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
 *** This role removes OpenShift Service Mesh
 *** Debug task will print out: `remove_workload Tasks completed successfully.`


### PR DESCRIPTION
##### SUMMARY

In many many of our ansible roles readme files we have tasks files that are called "playbooks". This is confusing as they are not playbooks. This starts us towards fixing this issue.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

Various roles.