### PR TITLE
update URL to match CRW 2.2 changes

### DIFF
--- a/ansible/roles/ocp4-workload-quarkus-workshop/tasks/install-guides.yaml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/tasks/install-guides.yaml
@@ -15,7 +15,7 @@
     -e MASTER_URL={{ master_url }}
     -e CONSOLE_URL={{ console_url }}
     -e CHE_URL=https://codeready-codeready.{{ route_subdomain }}
-    -e KEYCLOAK_URL=https://keycloak-codeready.{{ route_subdomain }}
+    -e KEYCLOAK_URL=https://secure-rhsso-rhsso.{{ route_subdomain }}
     -e ROUTE_SUBDOMAIN={{ route_subdomain }}
     -e CONTENT_URL_PREFIX='https://raw.githubusercontent.com/RedHat-Middleware-Workshops/quarkus-workshop/ocp-4.4/docs/'
     -e WORKSHOPS_URLS="https://raw.githubusercontent.com/RedHat-Middleware-Workshops/quarkus-workshop/ocp-4.4/docs/_workshop_{{ guide }}.yml"


### PR DESCRIPTION

##### SUMMARY
Minor fix to update URL to keycloak for the user guides.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`ocp4-workload-quarkus-workshop`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Was inadvertently left off of https://github.com/redhat-cop/agnosticd/pull/2159 cc @jkupferer 