### PR TITLE
Fix ocp4-workload-jdg-workshop not to use Keycloak instance environment variables in CRW 2.2.0

### DIFF
--- a/ansible/roles/ocp4-workload-jdg-workshop/files/codeready_cr.yaml
+++ b/ansible/roles/ocp4-workload-jdg-workshop/files/codeready_cr.yaml
@@ -28,6 +28,8 @@ spec:
     identityProviderImage: ''
     externalIdentityProvider: false
     identityProviderURL: ''
+    identityProviderAdminUserName: admin
+    identityProviderPassword: admin
     identityProviderRealm: ''
     identityProviderClientId: ''
   storage:

--- a/ansible/roles/ocp4-workload-jdg-workshop/tasks/install-codeready.yaml
+++ b/ansible/roles/ocp4-workload-jdg-workshop/tasks/install-codeready.yaml
@@ -83,16 +83,6 @@
   debug:
     msg: "codeready keycloak admin password: {{ codeready_sso_admin_password }}"
 
-- name: enable script upload
-  command: oc set env -n codeready deployment/keycloak JAVA_OPTS_APPEND="-Dkeycloak.profile.feature.scripts=enabled -Dkeycloak.profile.feature.upload_scripts=enabled"
-
-- name: wait for keycloak to return
-  command: oc rollout -n codeready status --timeout=1m -w deployment/keycloak
-  register: cmd_res
-  retries: 120
-  delay: 10
-  until: cmd_res.rc == 0
-
 - name: get keycloak pod
   k8s_facts:
     api_version: v1


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix ocp4-workload-jdg-workshop not to use Keycloak instance environment variables in CRW 2.2.0

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
codeready_cr.yaml
install-codeready.yaml

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
