### PR TITLE
Add ocp4-workload-quarkus-workshop to check RH-SSO running

### DIFF
--- a/ansible/roles/ocp4-workload-quarkus-workshop/tasks/install-rhsso.yaml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/tasks/install-rhsso.yaml
@@ -56,6 +56,9 @@
     body_format: form-urlencoded
     status_code: 200,201,204
   register: rhsso_admin_token
+  retries: 120
+  delay: 10
+  until: rhsso_admin_token.status == 200 | rhsso_admin_token.status == 201 | rhsso_admin_token.status == 204
 
 - name: Import realm
   uri:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To avoid timing issues in terms of it tries to get a token before RH-SSO is ready to serve.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
