### PR TITLE
Fix ocp4-workshop install retry on throttling rate exceeded

### DIFF
--- a/ansible/configs/ocp4-workshop/software.yml
+++ b/ansible/configs/ocp4-workshop/software.yml
@@ -128,7 +128,7 @@
           register: r_openshift_install
           until: >-
             r_openshift_install.rc == 0 or
-            'validate AWS credentials: mint credentials check: error simulating policy: Throttling: Rate exceeded' not in r_openshift_install.stderr
+            'error simulating policy: Throttling: Rate exceeded' not in r_openshift_install.stderr
           delay: 300
           retries: 10
 


### PR DESCRIPTION
##### SUMMARY

Previously we checked for the string:

'validate AWS credentials: mint credentials check: error simulating policy: Throttling: Rate exceeded'

But "mint" was not present. This shortens the check to look for:

'error simulating policy: Throttling: Rate exceeded'
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ocp4-workshop config