### PR TITLE
Remove ocp4-workload-jdg-workshop to remove unused importing Realm

### DIFF
--- a/ansible/roles/ocp4-workload-jdg-workshop/tasks/install-codeready.yaml
+++ b/ansible/roles/ocp4-workload-jdg-workshop/tasks/install-codeready.yaml
@@ -96,37 +96,6 @@
   delay: 10
   until: r_keycloak_pod.resources | list | length == 1
 
-- name: Get SSO admin token
-  uri:
-    url: https://keycloak-codeready.{{ route_subdomain }}/auth/realms/master/protocol/openid-connect/token
-    validate_certs: false
-    method: POST
-    body:
-      username: "{{ codeready_sso_admin_username }}"
-      password: "{{ codeready_sso_admin_password }}"
-      grant_type: "password"
-      client_id: "admin-cli"
-    body_format: form-urlencoded
-    status_code: 200,201,204
-  register: sso_admin_token
-
-- name: Import realm
-  uri:
-    url: https://keycloak-codeready.{{ route_subdomain }}/auth/admin/realms
-    validate_certs: false
-    method: POST
-    body_format: json
-    headers:
-      Content-Type: application/json
-      Authorization: "Bearer {{ sso_admin_token.json.access_token }}"
-    body: "{{ lookup('file', './files/quarkus-realm.json') }}"
-    ## accept 409 Conflict in case realm exists
-    status_code: 200,201,204,409
-  register: result
-  retries: 120
-  delay: 10
-  until: result is succeeded
-
 - name: create codeready users
   include_tasks: add_che_user.yaml
   vars:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Remove ocp4-workload-jdg-workshop to remove unused importing Realm

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
