### PR TITLE
Update ocp4-workload-quarkus-workshop to add prebuild .m2

### DIFF
--- a/ansible/roles/ocp4-workload-quarkus-workshop/files/stack.Dockerfile
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/files/stack.Dockerfile
@@ -4,6 +4,7 @@
 
 FROM registry.redhat.io/codeready-workspaces/plugin-java11-rhel8:latest
 
+ENV OC_VERSION=4.4
 ENV GRAALVM_VERSION=19.3.1
 ENV QUARKUS_VERSION=1.3.4.Final-redhat-00001
 ENV GRAALVM_HOME="/usr/local/graalvm-ce-java11-${GRAALVM_VERSION}"
@@ -11,7 +12,7 @@ ENV PATH="/usr/local/maven/apache-maven-${MVN_VERSION}/bin:${PATH}"
 
 USER root
 
-RUN wget -O /tmp/oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.3/linux/oc.tar.gz && cd /usr/bin && tar -xvzf /tmp/oc.tar.gz && chmod a+x /usr/bin/oc && rm -f /tmp/oc.tar.gz
+RUN wget -O /tmp/oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/oc/${OC_VERSION}/linux/oc.tar.gz && cd /usr/bin && tar -xvzf /tmp/oc.tar.gz && chmod a+x /usr/bin/oc && rm -f /tmp/oc.tar.gz
 
 RUN wget -O /tmp/kn.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/serverless/0.11.0/kn-linux-amd64-0.11.0.tar.gz && cd /usr/bin && tar -xvzf /tmp/kn.tar.gz ./kn && chmod a+x kn && rm -f /tmp/kn.tar.gz
 
@@ -27,9 +28,9 @@ RUN mkdir /home/jboss/.m2
 
 COPY settings.xml /home/jboss/.m2
 
-RUN cd /tmp && mkdir project && cd project && mvn io.quarkus:quarkus-maven-plugin:${QUARKUS_VERSION}:create -DprojectGroupId=org.acme -DprojectArtifactId=footest -Dextensions="quarkus-agroal,quarkus-arc,quarkus-hibernate-orm,quarkus-hibernate-orm-panache,quarkus-jdbc-h2,quarkus-jdbc-postgresql,quarkus-kubernetes,quarkus-scheduler,quarkus-smallrye-fault-tolerance,quarkus-smallrye-health,quarkus-smallrye-opentracing" && mvn -f footest clean compile package && cd / && rm -rf /tmp/project
+RUN cd /tmp && mkdir project && cd project && mvn io.quarkus:quarkus-maven-plugin:${QUARKUS_VERSION}:create -DprojectGroupId=org.acme -DprojectArtifactId=footest -DplatformVersion=${QUARKUS_VERSION} -Dextensions="quarkus-agroal,quarkus-arc,quarkus-hibernate-orm,quarkus-hibernate-orm-panache,quarkus-jdbc-h2,quarkus-jdbc-postgresql,quarkus-kubernetes,quarkus-scheduler,quarkus-smallrye-fault-tolerance,quarkus-smallrye-health,quarkus-smallrye-opentracing" && mvn -f footest clean compile package && cd / && rm -rf /tmp/project
 
-RUN cd /tmp && mkdir project && cd project && mvn io.quarkus:quarkus-maven-plugin:${QUARKUS_VERSION}:create -DprojectGroupId=org.acme -DprojectArtifactId=footest -Dextensions="quarkus-smallrye-reactive-streams-operators,quarkus-smallrye-reactive-messaging,quarkus-smallrye-reactive-messaging-kafka,quarkus-swagger-ui,quarkus-vertx,quarkus-kafka-client, quarkus-smallrye-metrics,quarkus-smallrye-openapi" && mvn -f footest clean compile package -Pnative && cd / && rm -rf /tmp/project
+RUN cd /tmp && mkdir project && cd project && mvn io.quarkus:quarkus-maven-plugin:${QUARKUS_VERSION}:create -DprojectGroupId=org.acme -DprojectArtifactId=footest -DplatformVersion=${QUARKUS_VERSION} -Dextensions="quarkus-smallrye-reactive-streams-operators,quarkus-smallrye-reactive-messaging,quarkus-smallrye-reactive-messaging-kafka,quarkus-swagger-ui,quarkus-vertx,quarkus-kafka-client, quarkus-smallrye-metrics,quarkus-smallrye-openapi" && mvn -f footest clean compile package -Pnative && cd / && rm -rf /tmp/project
 
 RUN siege && sed -i 's/^connection = close/connection = keep-alive/' $HOME/.siege/siege.conf && sed -i 's/^benchmark = false/benchmark = true/' $HOME/.siege/siege.conf
 

--- a/ansible/roles/ocp4-workload-quarkus-workshop/files/stack_imagestream.yaml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/files/stack_imagestream.yaml
@@ -11,48 +11,18 @@ spec:
       iconClass: icon-java
       supports: java
       tags: builder,java
-      version: "1.0"
-    from:
-      kind: DockerImage
-      name: quay.io/openshiftlabs/quarkus-workshop-stack:1.0
-    name: "1.0"
-  - annotations:
-      description: Quarkus stack for Java and CodeReady Workspaces
-      iconClass: icon-java
-      supports: java
-      tags: builder,java
-      version: "1.1"
-    from:
-      kind: DockerImage
-      name: quay.io/openshiftlabs/quarkus-workshop-stack:1.1
-    name: "1.1"
-  - annotations:
-      description: Quarkus stack for Java and CodeReady Workspaces
-      iconClass: icon-java
-      supports: java
-      tags: builder,java
-      version: "1.2"
-    from:
-      kind: DockerImage
-      name: quay.io/openshiftlabs/quarkus-workshop-stack:1.2
-    name: "1.2"
-  - annotations:
-      description: Quarkus stack for Java and CodeReady Workspaces
-      iconClass: icon-java
-      supports: java
-      tags: builder,java
-      version: "1.3"
-    from:
-      kind: DockerImage
-      name: quay.io/openshiftlabs/quarkus-workshop-stack:1.3
-    name: "1.3"
-  - annotations:
-      description: Quarkus stack for Java and CodeReady Workspaces
-      iconClass: icon-java
-      supports: java
-      tags: builder,java
       version: "2.1"
     from:
       kind: DockerImage
       name: quay.io/openshiftlabs/quarkus-workshop-stack:2.1
+    name: "2.1"
+  - annotations:
+      description: Quarkus stack for Java and CodeReady Workspaces
+      iconClass: icon-java
+      supports: java
+      tags: builder,java
+      version: "2.2"
+    from:
+      kind: DockerImage
+      name: quay.io/openshiftlabs/quarkus-workshop-stack:2.2
     name: "2.1"

--- a/ansible/roles/ocp4-workload-quarkus-workshop/files/stack_imagestream.yaml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/files/stack_imagestream.yaml
@@ -25,4 +25,4 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshiftlabs/quarkus-workshop-stack:2.2
-    name: "2.1"
+    name: "2.2"

--- a/ansible/roles/ocp4-workload-quarkus-workshop/templates/devfile.json.j2
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/templates/devfile.json.j2
@@ -13,7 +13,7 @@
       "memoryLimit": "4Gi",
       "type": "dockerimage",
       "alias": "quarkus-tools",
-      "image": "image-registry.openshift-image-registry.svc:5000/openshift/quarkus-stack:2.1",
+      "image": "image-registry.openshift-image-registry.svc:5000/openshift/quarkus-stack:2.2",
       "env": [
         {
           "value": "/home/jboss/.m2",


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Update ocp4-workload-quarkus-workshop to add prebuild .m2 in CRW 2.2 base image

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
