### PR TITLE
Fix role infra-osp-resources-destroy reset volume error on destroy

### DIFF
--- a/ansible/roles-infra/infra-osp-resources-destroy/tasks/project_resources.yml
+++ b/ansible/roles-infra/infra-osp-resources-destroy/tasks/project_resources.yml
@@ -52,7 +52,8 @@
           command: >-
             openstack volume set --state error {{ item }}
           loop: "{{ _all_volumes }}"
-          
+          failed_when: false
+
         - name: Detach all volumes
           command: >-
             openstack volume set --detached {{ item }}


### PR DESCRIPTION
##### SUMMARY

Destroy of openstack resources fails with message of the sort:

```
        "No volume with a name or ID of 'cd7cd421-de53-4889-97de-0ea4c31bb7f3' exists."
```

This sets a failed_when to ignore this and still attempt to complete the deletion.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Infra role infra-osp-resources-destroy