### PR TITLE
Increased retries and delays waiting for IS to become available.

### DIFF
--- a/ansible/roles/ocp-workload-pam7-cc-dispute-dmn-pmml/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-pam7-cc-dispute-dmn-pmml/tasks/workload.yml
@@ -32,8 +32,8 @@
   shell: "oc get is -n openshift | grep -i rhpam | grep -i {{pam_imagestreams_tag}}"
   register: result
   until: result.stdout != ""
-  retries: 5
-  delay: 10
+  retries: 15
+  delay: 15
 
 - name: Import ImageStreams Entando EAP 7.1
   shell: "oc create -f https://raw.githubusercontent.com/entando/entando-ops/credit-card-dispute/Openshift/image-streams/entando-fsi-ccd-demo.json -n {{ OCP_PROJECT }}"


### PR DESCRIPTION
#1875 ### SUMMARY
Increase delay and retries waiting for IS tag to become available on the cluster.  Should fix a problem when the cluster is slow importing the IS.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp-workload-pam7-cc-dispute-dmn-pmml
