### PR TITLE
Fix ocp4-cluster destroy_env.yml SSH connection (ec2 only)

### DIFF
--- a/ansible/configs/ocp4-cluster/destroy_env.yml
+++ b/ansible/configs/ocp4-cluster/destroy_env.yml
@@ -91,26 +91,6 @@
   connection: local
   become: false
   tasks:
-  - name: Set ssh_key fact (provided)
-    set_fact:
-      ssh_key: "~/.ssh/{{key_name}}.pem"
-    tags:
-    - set_existing_ssh_key
-    - must
-    - create_inventory
-    when:
-    - not set_env_authorized_key | bool
-    - cloud_provider != 'osp'
-  - name: Set ssh_key fact (generated)
-    set_fact:
-      ssh_key: "{{output_dir}}/{{env_authorized_key}}"
-    tags:
-    - set_generated_ssh_key
-    - must
-    - create_inventory
-    when:
-    - set_env_authorized_key | bool
-    - cloud_provider != 'osp'
   - name: Get private SSH key from keyvault (azure)
     include_role:
       name: infra-azure-ssh-key


### PR DESCRIPTION
This commit, if applied, will fix the following error:

```
TASK [Test the bastion host is available, if not skip host-ocp4-destroy] *******
fatal: [bastion.959d.internal]: FAILED! => {"changed": false, "elapsed": 60, "msg": "timed out waiting for ping module test success: Failed to connect to the host via ssh: no such identity: opentlc_admin_backdoor: No such file or directory\r\nno such identity: /tmp/gpte-OCP45_WORKSHOP-dev-959d-28022/output_dir/959dkey: No such file or directory\r\nPermission denied (publickey,gssapi-keyex,gssapi-with-mic,password)."}
```

There is a mismatch between provision and destroy.
The key used when provision is `~/.ssh/..pem` but for destroy it's a generated
key because the varaible `set_env_authorized_key` is true by default in this
config.

The default_ssh_key will be used, like for provision.

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Bugfix Pull Request
##### COMPONENT NAME
config ocp4-cluster, EC2 only.
