### PR TITLE
Adds admin when gitea operator is deployed

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/defaults/main.yml
@@ -36,3 +36,6 @@ ocp4_workload_gitea_operator_ssl_route: true
 
 # Route name for the Gitea Route. Only set if you know what you are doing!
 # ocp4_workload_gitea_operator_gitea_route: gitea.apps.clusterdomain
+
+ocp4_workload_gitea_operator_admin_user: gitea
+ocp4_workload_gitea_operator_admin_password: gitea

--- a/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/defaults/main.yml
@@ -37,5 +37,7 @@ ocp4_workload_gitea_operator_ssl_route: true
 # Route name for the Gitea Route. Only set if you know what you are doing!
 # ocp4_workload_gitea_operator_gitea_route: gitea.apps.clusterdomain
 
+# for creating an admin user
+ocp4_workload_gitea_operator_create_admin: true
 ocp4_workload_gitea_operator_admin_user: gitea
 ocp4_workload_gitea_operator_admin_password: gitea

--- a/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/tasks/workload.yml
@@ -52,6 +52,42 @@
     - r_gitea_deployment.resources[0].status.availableReplicas is defined
     - r_gitea_deployment.resources[0].status.availableReplicas | int == r_gitea_deployment.resources[0].spec.replicas | int
 
+- name: search for gitea pod
+  k8s_info:
+    kind: Pod
+    namespace: "{{ ocp4_workload_gitea_operator_project }}"
+    label_selectors:
+      - app = gitea
+  register: r_gitea_pod
+
+- name: search for gitea route
+  k8s_info:
+    kind: Route
+    api_version: route.openshift.io/v1
+    namespace: "{{ ocp4_workload_gitea_operator_project }}"
+    label_selectors:
+      - app = gitea
+  register: r_gitea_route
+
+- name: check if gitea admin user already exists
+  uri:
+    url: "https://{{ r_gitea_route.resources[0].spec.host }}/api/v1/users/{{ ocp4_workload_gitea_operator_admin_user }}"
+    method: GET
+    validate_certs: false
+    status_code: 200, 404
+  register: r_giteaadmin_user
+  failed_when: r_giteaadmin_user.status != 200 and r_giteaadmin_user.status != 404
+
+- name: create admin user in gitea
+  command: >
+    oc exec {{ r_gitea_pod.resources[0].metadata.name }}
+    -n {{ ocp4_workload_gitea_operator_project }}
+    -- /home/gitea/gitea admin create-user --username {{ ocp4_workload_gitea_operator_admin_user }}
+    --password {{ ocp4_workload_gitea_operator_admin_password }}
+    --email {{ ocp4_workload_gitea_operator_admin_user }}@workshop.com
+    --must-change-password=false --admin -c /home/gitea/conf/app.ini
+  when: r_giteaadmin_user.status == 404
+
 # Leave this as the last task in the playbook.
 - name: workload tasks complete
   debug:

--- a/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/tasks/workload.yml
@@ -69,24 +69,27 @@
       - app = gitea
   register: r_gitea_route
 
-- name: check if gitea admin user already exists
-  uri:
-    url: "https://{{ r_gitea_route.resources[0].spec.host }}/api/v1/users/{{ ocp4_workload_gitea_operator_admin_user }}"
-    method: GET
-    validate_certs: false
-    status_code: 200, 404
-  register: r_giteaadmin_user
-  failed_when: r_giteaadmin_user.status != 200 and r_giteaadmin_user.status != 404
-
-- name: create admin user in gitea
-  command: >
-    oc exec {{ r_gitea_pod.resources[0].metadata.name }}
-    -n {{ ocp4_workload_gitea_operator_project }}
-    -- /home/gitea/gitea admin create-user --username {{ ocp4_workload_gitea_operator_admin_user }}
-    --password {{ ocp4_workload_gitea_operator_admin_password }}
-    --email {{ ocp4_workload_gitea_operator_admin_user }}@workshop.com
-    --must-change-password=false --admin -c /home/gitea/conf/app.ini
-  when: r_giteaadmin_user.status == 404
+- name: Configure a gitea admin user
+  block:
+    - name: check if gitea admin user already exists
+      uri:
+        url: "https://{{ r_gitea_route.resources[0].spec.host }}/api/v1/users/{{ ocp4_workload_gitea_operator_admin_user }}"
+        method: GET
+        validate_certs: false
+        status_code: 200, 404
+      register: r_giteaadmin_user
+      failed_when: r_giteaadmin_user.status != 200 and r_giteaadmin_user.status != 404
+    
+    - name: create admin user in gitea
+      command: >
+        oc exec {{ r_gitea_pod.resources[0].metadata.name }}
+        -n {{ ocp4_workload_gitea_operator_project }}
+        -- /home/gitea/gitea admin create-user --username {{ ocp4_workload_gitea_operator_admin_user }}
+        --password {{ ocp4_workload_gitea_operator_admin_password }}
+        --email {{ ocp4_workload_gitea_operator_admin_user }}@workshop.com
+        --must-change-password=false --admin -c /home/gitea/conf/app.ini
+      when: r_giteaadmin_user.status == 404
+  when: ocp4_workload_gitea_operator_create_admin | bool
 
 # Leave this as the last task in the playbook.
 - name: workload tasks complete


### PR DESCRIPTION
The operator role didn't create an admin user for gitea, so you couldn't
really do anything. This adds a var for the user and password and makes
sure that the admin is created idempotently (although it won't fix or
change a password if run a second time).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_gitea_operator