### PR TITLE
Add support to limit MachineSet creation to specified AWS zones

### DIFF
--- a/ansible/configs/ocp4-cluster/default_vars_ec2.yml
+++ b/ansible/configs/ocp4-cluster/default_vars_ec2.yml
@@ -29,8 +29,8 @@ aws_region: us-east-1
 # each availability zone).
 # Set to 5 entries or less for deployment in Sandboxes (each MachineSet needs an EIP
 # and Sandboxes only have 5 EIPs available).
-aws_zones: []
-# aws_zones:
+openshift_machineset_aws_zones: []
+# openshift_machineset_aws_zones:
 # - us-east-1a
 # - us-east-1b
 # - us-east-1c

--- a/ansible/configs/ocp4-cluster/default_vars_ec2.yml
+++ b/ansible/configs/ocp4-cluster/default_vars_ec2.yml
@@ -24,8 +24,16 @@ ansible_user: ec2-user
 # The region to be used, if not specified by -e in the command line
 aws_region: us-east-1
 
-az_1_name: "{{ aws_region }}a"
-az_2_name: "{{ aws_region }}b"
+# The availability Zones for which to create worker MachineSets for.
+# Leave empty for the default (set up one MachineSet for
+# each availability zone).
+# Set to 5 entries or less for deployment in Sandboxes (each MachineSet needs an EIP
+# and Sandboxes only have 5 EIPs available).
+aws_zones: []
+# aws_zones:
+# - us-east-1a
+# - us-east-1b
+# - us-east-1c
 
 # -------------------------------------------------------------------
 # Project Tag

--- a/ansible/configs/ocp4-workshop/env_vars.yml
+++ b/ansible/configs/ocp4-workshop/env_vars.yml
@@ -99,8 +99,8 @@ aws_region: us-east-1
 # each availability zone).
 # Set to 5 entries or less for deployment in Sandboxes (each MachineSet needs an EIP
 # and Sandboxes only have 5 EIPs available).
-aws_zones: []
-# aws_zones:
+openshift_machineset_aws_zones: []
+# openshift_machineset_aws_zones:
 # - us-east-1a
 # - us-east-1b
 # - us-east-1c

--- a/ansible/configs/ocp4-workshop/env_vars.yml
+++ b/ansible/configs/ocp4-workshop/env_vars.yml
@@ -93,6 +93,18 @@ set_env_authorized_key: true
 HostedZoneId: Z3IHLWJZOU9SRT
 # The region to be used, if not specified by -e in the command line
 aws_region: us-east-1
+
+# The availability Zones for which to create worker MachineSets for.
+# Leave empty for the default (set up one MachineSet for
+# each availability zone).
+# Set to 5 entries or less for deployment in Sandboxes (each MachineSet needs an EIP
+# and Sandboxes only have 5 EIPs available).
+aws_zones: []
+# aws_zones:
+# - us-east-1a
+# - us-east-1b
+# - us-east-1c
+
 # The key that is used to
 key_name: "default_key_name"
 

--- a/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
+++ b/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
@@ -41,8 +41,8 @@ compute:
       type: {{ worker_instance_type }}
       rootVolume:
         type: {{ worker_storage_type }}
-{% if aws_zones | default( [] ) | length > 0 %}
-      zones: {{ aws_zones | to_json }}
+{% if openshift_machineset_aws_zones | default( [] ) | length > 0 %}
+      zones: {{ openshift_machineset_aws_zones | to_json }}
 {% endif %}
 {% endif %}
 {% if cloud_provider == 'azure' %}

--- a/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
+++ b/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
@@ -41,6 +41,9 @@ compute:
       type: {{ worker_instance_type }}
       rootVolume:
         type: {{ worker_storage_type }}
+{% if aws_zones | default( [] ) | length > 0 %}
+      zones: {{ aws_zones | to_json }}
+{% endif %}
 {% endif %}
 {% if cloud_provider == 'azure' %}
     azure:


### PR DESCRIPTION
##### SUMMARY
This PR adds support to specify which AWS zones in any given region the cluster gets installed.

By specifying a YAML list of availability zones the installer only creates MachineSets for the specified zones instead of one MachineSet for every discovered zone. This should make it possible to install into us-east-1 from a Sandbox (just specify less than the default 6 availability zones). But it also makes setting up clusters easier with multiple workers (say 4) that are spread over less than the default zones (like just 2 - for 2 workers in each of the two zones).

Example:
```
openshift_machineset_aws_region: us-east-2
openshift_machineset_aws_zones:
- us-east-2a
- us-east-2b
```
When openshift_machineset_aws_zones is not specified or empty ( [] ) the default behavior will be all available zones.

This works for both ocp4-cluster and ocp4-workshop.

Minimum OpenShift version: 4.2

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
OpenShift Installer
ocp4-cluster
ocp4-workshop
