### PR TITLE
Fix occurences of variable 'update_all_packages', rename it to 'update_packages'

### DIFF
--- a/ansible/configs/just-a-bunch-of-nodes/sample_vars_osp.yml
+++ b/ansible/configs/just-a-bunch-of-nodes/sample_vars_osp.yml
@@ -39,4 +39,4 @@ bastion_instance_image: "{{ ___image }}"
 node_instance_image: "{{ ___image }}"
 node_instance_count: 1
 
-update_all_packages: false
+update_packages: false

--- a/ansible/configs/multi-cloud-capsule/default_vars.yml
+++ b/ansible/configs/multi-cloud-capsule/default_vars.yml
@@ -18,7 +18,6 @@ install_common: true
 install_ipa_client: false
 tower_run: false
 update_packages: false
-update_all_packages: false
 install_satellite: True
 configure_satellite: false
 

--- a/ansible/configs/rhel-container-security/sample_vars_osp.yml
+++ b/ansible/configs/rhel-container-security/sample_vars_osp.yml
@@ -49,6 +49,6 @@ student_name: gucore
 #CHANGEME
 admin_user: gucore
 
-update_all_packages: false
+update_packages: false
 
 osp_project_create: true

--- a/ansible/configs/rhel8lab/my_vars_osp_rhel8lab.yml
+++ b/ansible/configs/rhel8lab/my_vars_osp_rhel8lab.yml
@@ -65,7 +65,7 @@ student_name: 3257-user #change to your GUID
 #admin_user: opentlc-mgr
 admin_user: 3257-user #change to your GUID
 
-update_all_packages: false
+update_packages: false
 
 #osp_project_create: true
 

--- a/ansible/configs/rhel8lab/sample_vars/private-dns-osp.yml
+++ b/ansible/configs/rhel8lab/sample_vars/private-dns-osp.yml
@@ -57,7 +57,7 @@ student_name: 3257-user #change to your GUID
 #admin_user: opentlc-mgr
 admin_user: 3257-user #change to your GUID
 
-update_all_packages: false
+update_packages: false
 
 #osp_project_create: true
 

--- a/ansible/configs/rhel8lab/sample_vars_osp.yml
+++ b/ansible/configs/rhel8lab/sample_vars_osp.yml
@@ -51,7 +51,7 @@ node3_instance_image: "{{ ___image }}"
 student_name: student
 admin_user: opentlc-mgr
 
-update_all_packages: false
+update_packages: false
 
 instances:
   - name: workstation

--- a/ansible/configs/rhel8lab/sample_vars_osp.yml.ORIG
+++ b/ansible/configs/rhel8lab/sample_vars_osp.yml.ORIG
@@ -54,6 +54,6 @@ student_name: gucore
 #admin_user: opentlc-mgr
 admin_user: gucore
 
-update_all_packages: false
+update_packages: false
 
 osp_project_create: true

--- a/ansible/configs/satellite-infrastructure/default_vars.yml
+++ b/ansible/configs/satellite-infrastructure/default_vars.yml
@@ -29,7 +29,6 @@ install_common: true
 install_ipa_client: false
 tower_run: false
 update_packages: false
-update_all_packages: false
 install_satellite: true
 configure_satellite: false
 

--- a/ansible/configs/satellite-vm/default_vars.yml
+++ b/ansible/configs/satellite-vm/default_vars.yml
@@ -28,7 +28,6 @@ install_common: true
 install_ipa_client: false
 tower_run: false
 update_packages: false
-update_all_packages: false
 install_satellite: True
 configure_satellite: false
 

--- a/ansible/configs/smart-management/default_vars.yml
+++ b/ansible/configs/smart-management/default_vars.yml
@@ -24,7 +24,6 @@ install_common: true
 install_ipa_client: false
 tower_run: false
 update_packages: false
-update_all_packages: false
 install_satellite: true
 configure_satellite: false
 software_to_deploy: tower              # tower install playbook from software directory

--- a/ansible/configs/three-tier-app/sample_vars/private-dns-osp.yml
+++ b/ansible/configs/three-tier-app/sample_vars/private-dns-osp.yml
@@ -57,7 +57,7 @@ student_name: 3257-user #change to your GUID
 #admin_user: opentlc-mgr
 admin_user: 3257-user #change to your GUID
 
-update_all_packages: false
+update_packages: false
 
 #osp_project_create: true
 


### PR DESCRIPTION
The variable `update_all_packages` doesn't exist. In the role 'common' it is
simply called `update_packages`.

This commit if applied, will rename the variables, or just remove it in case the
other variable is already in the file.

sample_vars are usually safe to change, default_vars need a little more extra
precautions.

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
