### PR TITLE
Use specific EPEL repo when current OS is RHEL8.1.

### DIFF
--- a/ansible/roles/rhel-graphical/tasks/main.yml
+++ b/ansible/roles/rhel-graphical/tasks/main.yml
@@ -85,6 +85,17 @@
         - "xorg-*"
         - coreutils
         - wget
+
+    # xrdp-selinux requires selinux-policy and newer versions of this
+    # package in EPEL require newer selinux-policy which is not available
+    # on RHEL8.1
+    - name: Override EPEL repository with RHEL8.1 one
+      yum_repository:
+        name: epel
+        description: EPEL YUM repo
+        baseurl: https://archives.fedoraproject.org/pub/archive/epel/8.1/Everything/$basearch/
+        enabled: no
+      when: ansible_distribution_version == '8.1'
   
     - name: Install XRDP server and dependencies
       yum:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Use specific EPEL repo when installing packages on RHEL8.1 to avoid any missing dependencies when installing `xrdp` packages.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rhel-graphical
