### PR TITLE
added agnosticd_user_info to post_software.yml

### DIFF
--- a/ansible/configs/rhel8lab/post_software.yml
+++ b/ansible/configs/rhel8lab/post_software.yml
@@ -44,5 +44,31 @@
   tags:
     - post_flight_check
   tasks:
+  
+ 
+    - name: Print Console URL
+      agnosticd_user_info:
+        msg: "{{ item }}"
+      loop:
+        - "You can access your bastion (workstation) via SSH:"
+        - "ssh cloud-user@{{ public_ip_address }}"
+        - ""
+        - "Make sure you use the username 'cloud-user' and the password 'r3dh4t1!' when prompted."
+        - ""
+        - "For reference, the data you need to create your clouds.yaml file is:"
+        - ""
+        - "clouds:"
+        - "  {{ osp_project_name }}:"
+        - "    auth:"
+        - "      auth_url: {{ osp_auth_url }}"
+        - "      username: {{ guid }}-user"
+        - "      project_name: {{ osp_project_name }}"
+        - "      project_id: {{ hostvars['localhost']['osp_project_info'][0].id }}"
+        - "      user_domain_name: Default"
+        - "      password: {{ hostvars['localhost']['heat_user_password'] }}"
+        - "    region_name: regionOne"
+        - "    interface: public"
+        - "    identity_api_version: 3"
+  
     - debug:
         msg: "Post-Software checks completed successfully"


### PR DESCRIPTION
closes #NUM

Added several lines to post_software.yml to print out user access info

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Added several lines to post_software.yml to print out user access info.
Previously, no access info was included in RHPDS email to requestor.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
Added agnosticd_user_info lines at end of post_software.yml

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
