### PR TITLE
change config rhel8lab

### DIFF
--- a/ansible/configs/rhel8lab/post_software.yml
+++ b/ansible/configs/rhel8lab/post_software.yml
@@ -45,29 +45,29 @@
     - post_flight_check
   tasks:
 
-- name: Print Console URL
-  agnosticd_user_info:
-    msg: "{{ item }}"
-  loop:
-    - "You can access your bastion (workstation) via SSH:"
-    - "ssh cloud-user@{{ public_ip_address }}"
-    - ""
-    - "Make sure you use the username 'cloud-user' and the password 'r3dh4t1!' when prompted."
-    - ""
-    - "For reference, the data you need to create your clouds.yaml file is:"
-    - ""
-    - "clouds:"
-    - "  {{ osp_project_name }}:"
-    - "    auth:"
-    - "      auth_url: {{ osp_auth_url }}"
-    - "      username: {{ guid }}-user"
-    - "      project_name: {{ osp_project_name }}"
-    - "      project_id: {{ hostvars['localhost']['osp_project_info'][0].id }}"
-    - "      user_domain_name: Default"
-    - "      password: {{ hostvars['localhost']['heat_user_password'] }}"
-    - "    region_name: regionOne"
-    - "    interface: public"
-    - "    identity_api_version: 3"
+    - name: Print Console URL
+      agnosticd_user_info:
+        msg: "{{ item }}"
+      loop:
+        - "You can access your bastion (workstation) via SSH:"
+        - "ssh cloud-user@{{ public_ip_address }}"
+        - ""
+        - "Make sure you use the username 'cloud-user' and the password 'r3dh4t1!' when prompted."
+        - ""
+        - "For reference, the data you need to create your clouds.yaml file is:"
+        - ""
+        - "clouds:"
+        - "  {{ osp_project_name }}:"
+        - "    auth:"
+        - "      auth_url: {{ osp_auth_url }}"
+        - "      username: {{ guid }}-user"
+        - "      project_name: {{ osp_project_name }}"
+        - "      project_id: {{ hostvars['localhost']['osp_project_info'][0].id }}"
+        - "      user_domain_name: Default"
+        - "      password: {{ hostvars['localhost']['heat_user_password'] }}"
+        - "    region_name: regionOne"
+        - "    interface: public"
+        - "    identity_api_version: 3"
   
     - debug:
         msg: "Post-Software checks completed successfully"

--- a/ansible/configs/rhel8lab/post_software.yml
+++ b/ansible/configs/rhel8lab/post_software.yml
@@ -44,5 +44,30 @@
   tags:
     - post_flight_check
   tasks:
+
+- name: Print Console URL
+  agnosticd_user_info:
+    msg: "{{ item }}"
+  loop:
+    - "You can access your bastion (workstation) via SSH:"
+    - "ssh cloud-user@{{ public_ip_address }}"
+    - ""
+    - "Make sure you use the username 'cloud-user' and the password 'r3dh4t1!' when prompted."
+    - ""
+    - "For reference, the data you need to create your clouds.yaml file is:"
+    - ""
+    - "clouds:"
+    - "  {{ osp_project_name }}:"
+    - "    auth:"
+    - "      auth_url: {{ osp_auth_url }}"
+    - "      username: {{ guid }}-user"
+    - "      project_name: {{ osp_project_name }}"
+    - "      project_id: {{ hostvars['localhost']['osp_project_info'][0].id }}"
+    - "      user_domain_name: Default"
+    - "      password: {{ hostvars['localhost']['heat_user_password'] }}"
+    - "    region_name: regionOne"
+    - "    interface: public"
+    - "    identity_api_version: 3"
+  
     - debug:
         msg: "Post-Software checks completed successfully"


### PR DESCRIPTION
closes #NUM

added several lines for the agnosticd_user_info module to print out ssh/user/pass info when RHEL8 Lab is deployed
removed extraneous blank lines (71-74)

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
