### PR TITLE
Fix ocp-workshop cloudformation error on s3bucketpolicy

### DIFF
--- a/ansible/configs/ocp-workshop/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/ocp-workshop/files/cloud_providers/ec2_cloud_template.j2
@@ -360,6 +360,7 @@ Resources:
     Type: AWS::S3::BucketPolicy
     DependsOn:
       - RegistryS3
+      - S3User
     Properties:
       PolicyDocument:
         Id: Give registry access to user


### PR DESCRIPTION
The s3user dependency is missing in the S3BucketPolicy.

This commit if applied, tries to fix this error:

- AWS::S3::BucketPolicy BucketPolicy CREATE_FAILED: Invalid principal in policy

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
