### PR TITLE
Change role infra-gcp-ssh-key

### DIFF
--- a/ansible/roles-infra/infra-gcp-ssh-key/defaults/main.yml
+++ b/ansible/roles-infra/infra-gcp-ssh-key/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 output_dir: /tmp/output_dir
 key_name: temporary_opentlc
-ssh_key: "~/.ssh/{{key_name}}.pem"
+ssh_key: "{{ output_dir }}/ssh-key-{{ project_tag }}"

--- a/ansible/roles-infra/infra-gcp-ssh-key/defaults/main.yml
+++ b/ansible/roles-infra/infra-gcp-ssh-key/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 output_dir: /tmp/output_dir
 key_name: temporary_opentlc
+ssh_key: "~/.ssh/{{key_name}}.pem"


### PR DESCRIPTION
##### SUMMARY
PR https://github.com/redhat-cop/agnosticd/pull/2183 removed a set_fact that this role relied on. So setting a default in the role so it won't fail anymore.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
roles-infra/infra-gcp-ssh-key

##### ADDITIONAL INFORMATION
I need to get tags updated in test and prod faster so things like this don't get included by accident