### PR TITLE
Change role infra-gcp-create-inventory

### DIFF
--- a/ansible/roles-infra/infra-gcp-create-inventory/defaults/main.yml
+++ b/ansible/roles-infra/infra-gcp-create-inventory/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+output_dir: /tmp/output_dir
+key_name: temporary_opentlc
+ssh_key: "{{ output_dir }}/ssh-key-{{ project_tag }}"


### PR DESCRIPTION
##### SUMMARY
PR https://github.com/redhat-cop/agnosticd/pull/2183 removed a set_fact that this role relied on. So setting a default in the role so it won't fail anymore.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
roles-infra/infra-gcp-create-inventory

##### ADDITIONAL INFORMATION
I need to get tags updated in test and prod faster so things like this don't get included by accident