### PR TITLE
Change to quote all values in ocp4 install-config

### DIFF
--- a/ansible/configs/ocp4-ha-lab/files/install-config.yaml.j2
+++ b/ansible/configs/ocp4-ha-lab/files/install-config.yaml.j2
@@ -1,26 +1,26 @@
 ---
 apiVersion: v1
-baseDomain: {{ ocp4_base_domain | default(guid + subdomain_base_suffix) }}
+baseDomain: {{ ocp4_base_domain | default(guid + subdomain_base_suffix) | to_json }}
 compute:
 - hyperthreading: Enabled
   name: worker 
   platform:
     aws:
-      type: {{ worker_instance_type }}
+      type: {{ worker_instance_type | to_json }}
       rootVolume:
-        type: {{ worker_storage_type }}
-  replicas: {{ worker_instance_count }}
+        type: {{ worker_storage_type | to_json }}
+  replicas: {{ worker_instance_count | int }}
 controlPlane:
   hyperthreading: Enabled
   name: master
   platform:
     aws:
-      type: {{ master_instance_type }}
+      type: {{ master_instance_type | to_json }}
       rootVolume:
-        type: {{ master_storage_type }}
-  replicas: {{ master_instance_count }}
+        type: {{ master_storage_type | to_json }}
+  replicas: {{ master_instance_count | int }}
 metadata:
-  name: {{ cluster_name }}
+  name: {{ cluster_name | to_json }}
 networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
@@ -31,8 +31,7 @@ networking:
   networkType: OpenshiftSDN
 platform:
   aws:
-    region: {{ aws_region_final | d(aws_region) }}
-    userTags: {{ hostvars.localhost.cf_tags_final | d({}) | to_json }}
-pullSecret: '{{ ocp4_token }}'
-sshKey: |
-  {{ idrsapub.content | b64decode }}
+    region: {{ aws_region_final | default(aws_region) | to_json }}
+    userTags: {{ hostvars.localhost.cf_tags_final | default({}) | to_json }}
+pullSecret: {{ ocp4_token | to_json }}
+sshKey: {{ idrsapub.content | b64decode | to_json }}

--- a/ansible/configs/ocp4-workshop/files/install-config.yaml.j2
+++ b/ansible/configs/ocp4-workshop/files/install-config.yaml.j2
@@ -1,26 +1,26 @@
 ---
 apiVersion: v1
-baseDomain: {{ ocp4_base_domain | default(guid + subdomain_base_suffix) }}
+baseDomain: {{ ocp4_base_domain | default(guid + subdomain_base_suffix) | to_json }}
 compute:
 - hyperthreading: Enabled
   name: worker 
   platform:
     aws:
-      type: {{ worker_instance_type }}
+      type: {{ worker_instance_type | to_json }}
       rootVolume:
-        type: {{ worker_storage_type }}
-  replicas: {{ worker_instance_count }}
+        type: {{ worker_storage_type | to_json }}
+  replicas: {{ worker_instance_count | int }}
 controlPlane:
   hyperthreading: Enabled
   name: master
   platform:
     aws:
-      type: {{ master_instance_type }}
+      type: {{ master_instance_type | to_json }}
       rootVolume:
-        type: {{ master_storage_type }}
-  replicas: {{ master_instance_count }}
+        type: {{ master_storage_type | to_json }}
+  replicas: {{ master_instance_count | int }}
 metadata:
-  name: {{ cluster_name }}
+  name: {{ cluster_name | to_json }}
 networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
@@ -31,8 +31,8 @@ networking:
   networkType: OpenshiftSDN
 platform:
   aws:
-    region: {{ aws_region_final | d(aws_region) }}
-    userTags: {{ hostvars.localhost.cf_tags_final | d({}) | to_json }}
-pullSecret: '{{ ocp4_token }}'
+    region: {{ aws_region_final | default(aws_region) | to_json }}
+    userTags: {{ hostvars.localhost.cf_tags_final | default({}) | to_json }}
+pullSecret: {{ ocp4_token | to_json }}
 sshKey: |
-  {{ idrsapub.content | b64decode }}
+  {{ idrsapub.content | b64decode | to_json }}

--- a/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
+++ b/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
@@ -1,102 +1,101 @@
 ---
 apiVersion: v1
 metadata:
-  name: "{{ cluster_name }}"
-baseDomain: {{ ocp4_base_domain }}
+  name: {{ cluster_name | to_json }}
+baseDomain: {{ ocp4_base_domain | to_json }}
 controlPlane:
   name: master
   hyperthreading: Enabled
   platform:
 {% if cloud_provider == 'ec2' %}
-{% if custom_image is defined and custom_image.image_id is defined %}
-    ImageId: {{ custom_image.image_id }}
-{% endif %}
+{%   if custom_image is defined and custom_image.image_id is defined %}
+    ImageId: {{ custom_image.image_id | to_json }}
+{%   endif %}
     aws:
-      type: {{ master_instance_type }}
+      type: {{ master_instance_type | to_json }}
       rootVolume:
-        type: {{ master_storage_type }}
+        type: {{ master_storage_type | to_json }}
 {% endif %}
 {% if cloud_provider == 'azure' %}
     azure:
-      type: {{ master_instance_type }}
+      type: {{ master_instance_type | to_json }}
 {% endif %}
 {% if cloud_provider == 'gcp' %}
     gcp:
-      type: {{ master_instance_type }}
+      type: {{ master_instance_type | to_json }}
 {% endif %}
 {% if cloud_provider == 'osp' %}
     openstack:
-      type: {{ master_instance_type }}
+      type: {{ master_instance_type | to_json }}
 {% endif %}
-  replicas: {{ master_instance_count }}
+  replicas: {{ master_instance_count | to_json }}
 compute:
 - name: worker
   hyperthreading: Enabled
   platform:
 {% if cloud_provider == 'ec2' %}
-{% if custom_image is defined and custom_image.image_id is defined %}
-    ImageId: {{ custom_image.image_id }}
-{% endif %}
+{%   if custom_image is defined and custom_image.image_id is defined %}
+    ImageId: {{ custom_image.image_id | to_json }}
+{%   endif %}
     aws:
-      type: {{ worker_instance_type }}
+      type: {{ worker_instance_type | to_json }}
       rootVolume:
-        type: {{ worker_storage_type }}
-{% if openshift_machineset_aws_zones | default( [] ) | length > 0 %}
+        type: {{ worker_storage_type | to_json }}
+{%   if openshift_machineset_aws_zones | default([]) | length > 0 %}
       zones: {{ openshift_machineset_aws_zones | to_json }}
-{% endif %}
+{%   endif %}
 {% endif %}
 {% if cloud_provider == 'azure' %}
     azure:
-      type: {{ worker_instance_type }}
+      type: {{ worker_instance_type | to_json }}
 {% endif %}
 {% if cloud_provider == 'gcp' %}
     gcp:
-      type: {{ worker_instance_type }}
+      type: {{ worker_instance_type | to_json }}
 {% endif %}
 {% if cloud_provider == 'osp' %}
     openstack:
-      type: {{ worker_instance_type }}
+      type: {{ worker_instance_type | to_json }}
 {% endif %}
-  replicas: {{ worker_instance_count }}
+  replicas: {{ worker_instance_count | int }}
 networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
-  machineCIDR: {{ ocp4_machine_cidr | d('10.0.0.0/16') }}
+  machineCIDR: {{ ocp4_machine_cidr | default('10.0.0.0/16') | to_json }}
   serviceNetwork:
   - 172.30.0.0/16
   networkType: OpenshiftSDN
 platform:
 {% if cloud_provider == 'ec2' %}
   aws:
-    region: {{ aws_region_final | d(aws_region) }}
-    userTags: {{ hostvars.localhost.cf_tags_final | d({}) | to_json }}
+    region: {{ aws_region_final | default(aws_region) | to_json }}
+    userTags: {{ hostvars.localhost.cf_tags_final | default({}) | to_json }}
 {% endif %}
 {% if cloud_provider == 'azure' %}
   azure:
-    region: {{ azure_region }}
-    baseDomainResourceGroupName: {{ az_dnszone_resource_group }}
-    userTags: {{ hostvars.localhost.cf_tags_final | d({}) | to_json }}
+    region: {{ azure_region | to_json }}
+    baseDomainResourceGroupName: {{ az_dnszone_resource_group | to_json }}
+    userTags: {{ hostvars.localhost.cf_tags_final | default({}) | to_json }}
 {% endif %}
 {% if cloud_provider == 'gcp' %}
   gcp:
-    region: {{ gcp_region }}
-    ProjectID: {{ gcp_project_id }}
-    userTags: {{ hostvars.localhost.cf_tags_final | d({}) | to_json }}
+    region: {{ gcp_region | to_json }}
+    ProjectID: {{ gcp_project_id | to_json }}
+    userTags: {{ hostvars.localhost.cf_tags_final | default({}) | to_json }}
 {% endif %}
 {% if cloud_provider == 'osp' %}
   openstack:
-    cloud: {{ osp_cloud_name }}
-    computeFlavor: {{ worker_instance_type }}
-    externalNetwork: {{ provider_network | d('external') }}
-    lbFloatingIP: {{ hostvars.localhost.ocp_api_fip }}
-    octaviaSupport: "{{ osp_octavia_support | d('1') }}"
+    cloud: {{ osp_cloud_name | to_json }}
+    computeFlavor: {{ worker_instance_type | to_json }}
+    externalNetwork: {{ provider_network | default('external') | to_json }}
+    lbFloatingIP: {{ hostvars.localhost.ocp_api_fip | to_json }}
+    octaviaSupport: {{ osp_octavia_support | default(true) | bool | to_json }}
     region: ""
-    trunkSupport: "{{ osp_trunk_support | d('0') }}"
-{% if rhcos_image_name is defined %}
-    clusterOSImage: {{ rhcos_image_name }}
+    trunkSupport: {{ osp_trunk_support | default(true) | bool | to_json }}
+{%   if rhcos_image_name is defined %}
+    clusterOSImage: {{ rhcos_image_name | to_json }}
+{%   endif %}
 {% endif %}
-{% endif %}
-pullSecret: '{{ ocp4_pull_secret |  replace("'",'"') }}'
-sshKey: |
-  {{ idrsapub.content | b64decode }}
+pullSecret: {{ ocp4_pull_secret | to_json }}
+sshKey: {{ idrsapub.content | b64decode | to_json }}


### PR DESCRIPTION
##### SUMMARY

Change to safely quote all YAML values in OpenShift install-config.yaml produced by jinja template. This will allow use of strings for cluster_name that would otherwise be interpreted as integers or exponential notation (ex: `1e34`)

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ocp4-ha-lab config
ocp4-workshop config
host-ocp4-installer role