### PR TITLE
Change role infra-osp-create-inventory

### DIFF
--- a/ansible/roles-infra/infra-osp-create-inventory/tasks/main.yml
+++ b/ansible/roles-infra/infra-osp-create-inventory/tasks/main.yml
@@ -35,18 +35,13 @@
       name: "{{ server | json_query(_name_selector) | default(server.name) }}"
       original_name: "{{ server.name }}"
       groups:
-      #TODO: remove thos tag_*
-      # - "tag_Project_{{stack_tag}}"
-      # - "tag_{{ stack_tag}} | default('unknowns') }}"
       - "{{ server.metadata.ostype | default('unknowns') }}"
+      - "{{ server.metadata.AnsibleGroup | default('') }}"
       ansible_user: "{{ ansible_user }}"
       remote_user: "{{ remote_user }}"
-      # ansible_ssh_private_key_file: "{{item['key_name']}}"
-      # key_name: "{{item['key_name']}}"
       state: "{{ server.status }}"
       instance_id: "{{ server.id }}"
       isolated: "{{ server.metadata.isolated | default(false) }}"
-      # private_dns_name: "{{item['private_dns_name']}}"
       private_ip_address: "{{ server.private_v4 }}"
       public_ip_address: "{{ server.public_v4 | default('') }}"
       image_id: "{{ server.image.id | default('') }}"
@@ -61,6 +56,22 @@
     - create_inventory
     - must
 
+  # This should be used if you have VMs with multiple NICs.
+  # Make sure you have multi_network_primary variable set indicating the
+  # name of the network you want to pull the IP from
+  - name: Make sure private IP is set if using multiple networks
+    when: multi_network | default(false)
+    add_host:
+      name: "{{ server | json_query(_name_selector) | default(server.name) }}"
+      private_ip_address: "{{ server.addresses[multi_network_primary] | json_query(private_ip_query) }}"
+    loop: "{{ r_osp_facts.ansible_facts.openstack_servers }}"
+    loop_control:
+      label: "{{ server | json_query(_name_selector) | default(server.name) }}"
+      loop_var: server
+    vars:
+      private_ip_query: >
+        [?"OS-EXT-IPS:type"=='fixed'].addr|[0]
+        
   - add_host:
       name: "{{ server | json_query(_name_selector) | default(server.name) }}"
       groups: "{{ server.metadata.AnsibleGroup }}"

--- a/ansible/roles-infra/infra-osp-create-inventory/tasks/main.yml
+++ b/ansible/roles-infra/infra-osp-create-inventory/tasks/main.yml
@@ -36,7 +36,6 @@
       original_name: "{{ server.name }}"
       groups:
       - "{{ server.metadata.ostype | default('unknowns') }}"
-      - "{{ server.metadata.AnsibleGroup | default('') }}"
       ansible_user: "{{ ansible_user }}"
       remote_user: "{{ remote_user }}"
       state: "{{ server.status }}"

--- a/ansible/roles-infra/infra-osp-create-inventory/tasks/main.yml
+++ b/ansible/roles-infra/infra-osp-create-inventory/tasks/main.yml
@@ -60,7 +60,7 @@
   # Make sure you have multi_network_primary variable set indicating the
   # name of the network you want to pull the IP from
   - name: Make sure private IP is set if using multiple networks
-    when: multi_network | default(false)
+    when: multi_network | default(false) | bool
     add_host:
       name: "{{ server | json_query(_name_selector) | default(server.name) }}"
       private_ip_address: "{{ server.addresses[multi_network_primary] | json_query(private_ip_query) }}"


### PR DESCRIPTION

##### SUMMARY
Ansible seems to randomly select the private IP when there are multiple IPs available to OpenStack instances with multiple NICs. This is specifically affecting the `kni-osp` config where the `private_v4` would sometimes be the pxe network and sometimes the app network - when it always needs to be the app network in this case.

With this change, a config can specify the following two vars to make sure we select the right IP to use. This will default to false, so it will only run if enabled by the config.

`mutli_network` - bool
`multi_network_primary` - full name of the network that you want the IPs selected from

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
infra-osp-create-inventory
