### PR TITLE
Add support for Catalog Snapshots to Serverless Operator

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/defaults/main.yml
@@ -3,25 +3,48 @@ become_override: False
 ocp_username: opentlc-mgr
 silent: False
 
-# Defaults values below are for OpenShift Pipelines v1.7.0 (GA)
-
-# Version of kn to be installed on the bastion
-ocp4_workload_serverless_kn_version: "0.13.2"
+# Defaults values below are for OpenShift Pipelines v1.7.2 (GA)
 
 # Channel to use for the OpenShift Serverless subscription
 ocp4_workload_serverless_channel: "4.4"
 
-# Set InstallPlan approvel to Automatic? If no it is also suggested to set the starting_csv
-# to pin a specific version
+# Set InstallPlan approvel to Automatic? If no it is also suggested
+# to set the starting_csv to pin a specific version
+# This variable has no effect when using a catalog mirror (always true)
 ocp4_workload_serverless_automatic_install_plan_approval: true
 
-# Set a starting ClusterServiceVersion. Recommended to leave empty to get latest in the channel.
+# Set a starting ClusterServiceVersion.
+# Recommended to leave empty to get latest in the channel when not using
+# a catalog mirror.
+# Highly recommended to be set when using a catalog mirror but can be
+# empty to get the latest available in the channel at the time when
+# the catalog mirror got created.
 ocp4_workload_serverless_starting_csv: ""
-# ocp4_workload_serverless_starting_csv: v1.7.0
+# ocp4_workload_serverless_starting_csv: v1.7.2
 
 # Wait for the deployment to finish - and check that it finished successfully
 ocp4_workload_serverless_wait_for_deploy: true
 
-# Install KNative Eventing? KNative Eventing is Tech Preview in 4.4.
+# Install KNative Eventing? KNative Eventing is Tech Preview in 4.4 and 4.5.
 # Therefore default to false
 ocp4_workload_serverless_install_eventing: false
+
+# --------------------------------
+# Operator Catalog Mirror Settings
+# --------------------------------
+# See https://github.com/redhat-cop/agnosticd/blob/development/docs/Catalogs.adoc for instructions on how to set up catalog mirrors
+# You MUST have your own catalog mirror for any demo etc.
+
+# Use a catalog mirror snapshot
+ocp4_workload_serverless_use_catalog_mirror: false
+
+# Catalog Source Name when using a catalog mirror. This needs to be unique
+# in the project the operator gets installed (important for operators
+# that to into openshift-operators)
+ocp4_workload_serverless_catalogsource_name: redhat-operators-snapshot-serverless
+
+# Catalog Mirror Image
+ocp4_workload_serverless_catalog_mirror_image: quay.io/gpte-devops-automation/olm_mirror_redhat_catalog
+
+# Catalog Mirror Image Tag
+ocp4_workload_serverless_catalog_mirror_image_tag: "v4.4_2020_07_23"

--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/defaults/main.yml
@@ -10,15 +10,15 @@ ocp4_workload_serverless_channel: "4.4"
 
 # Set automatic InstallPlan approval. If set to false it is also suggested
 # to set the starting_csv to pin a specific version
-# This variable has no effect when using a catalog mirror (always true)
+# This variable has no effect when using a catalog snapshot (always true)
 ocp4_workload_serverless_automatic_install_plan_approval: true
 
 # Set a starting ClusterServiceVersion.
 # Recommended to leave empty to get latest in the channel when not using
-# a catalog mirror.
-# Highly recommended to be set when using a catalog mirror but can be
+# a catalog snapshot.
+# Highly recommended to be set when using a catalog snapshot but can be
 # empty to get the latest available in the channel at the time when
-# the catalog mirror got created.
+# the catalog snapshot got created.
 ocp4_workload_serverless_starting_csv: ""
 # ocp4_workload_serverless_starting_csv: v1.7.2
 
@@ -30,21 +30,21 @@ ocp4_workload_serverless_wait_for_deploy: true
 ocp4_workload_serverless_install_eventing: false
 
 # --------------------------------
-# Operator Catalog Mirror Settings
+# Operator Catalog Snapshot Settings
 # --------------------------------
-# See https://github.com/redhat-cop/agnosticd/blob/development/docs/Catalogs.adoc for instructions on how to set up catalog mirrors
-# You MUST have your own catalog mirror for any demo etc.
+# See https://github.com/redhat-cop/agnosticd/blob/development/docs/Catalogs.adoc for instructions on how to set up catalog snapshot images
+# You MUST have your own catalog snapshot for any demo etc.
 
-# Use a catalog mirror snapshot
-ocp4_workload_serverless_use_catalog_mirror: false
+# Use a catalog snapshot
+ocp4_workload_serverless_use_catalog_snapshot: false
 
-# Catalog Source Name when using a catalog mirror. This needs to be unique
+# Catalog Source Name when using a catalog snapshot. This needs to be unique
 # in the project the operator gets installed (important for operators
 # that to into openshift-operators)
 ocp4_workload_serverless_catalogsource_name: redhat-operators-snapshot-serverless
 
-# Catalog Mirror Image
-ocp4_workload_serverless_catalog_mirror_image: quay.io/gpte-devops-automation/olm_mirror_redhat_catalog
+# Catalog snapshot image
+ocp4_workload_serverless_catalog_snapshot_image: quay.io/gpte-devops-automation/olm_snapshot_redhat_catalog
 
-# Catalog Mirror Image Tag
-ocp4_workload_serverless_catalog_mirror_image_tag: "v4.4_2020_07_23"
+# Catalog snapshot image tag
+ocp4_workload_serverless_catalog_snapshot_image_tag: "v4.4_2020_07_23"

--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/defaults/main.yml
@@ -8,7 +8,7 @@ silent: False
 # Channel to use for the OpenShift Serverless subscription
 ocp4_workload_serverless_channel: "4.4"
 
-# Set InstallPlan approvel to Automatic? If no it is also suggested
+# Set automatic InstallPlan approval. If set to false it is also suggested
 # to set the starting_csv to pin a specific version
 # This variable has no effect when using a catalog mirror (always true)
 ocp4_workload_serverless_automatic_install_plan_approval: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/defaults/main.yml
@@ -3,7 +3,7 @@ become_override: False
 ocp_username: opentlc-mgr
 silent: False
 
-# Defaults values below are for OpenShift Pipelines v1.7.2 (GA)
+# Defaults values below are for OpenShift Serverless v1.7.2 (GA)
 
 # Channel to use for the OpenShift Serverless subscription
 ocp4_workload_serverless_channel: "4.4"

--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/meta/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   role_name: ocp4_workload_serverless
   author: Red Hat GPTE, Wolfgang Kulhanek (wkulhane@redhat.com)
   description: |
-    Set up OpenShift Serverless (KNative Serving).
+    Set up OpenShift Serverless (KNative Serving, KNative Eventing).
   license: MIT
   min_ansible_version: 2.9
   platforms: []

--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/remove_workload.yml
@@ -114,7 +114,7 @@
     name: "{{ _ocp4_workload_serverless_install_plan_name }}"
     namespace: openshift-operators
 
-- name: Remove CatalogSource for mirrored catalog
+- name: Remove CatalogSource for catalog snapshot
   k8s:
     state: absent
     api_version: operators.coreos.com/v1alpha1

--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/remove_workload.yml
@@ -99,7 +99,7 @@
 - name: Set InstallPlan Name
   when: r_install_plans.resources | length > 0
   set_fact:
-    _ocp4_workload_serverless_install_plan_name: "{{ r_install_plan.resources | to_json | from_json | json_query(query) }}"
+    _ocp4_workload_serverless_install_plan_name: "{{ r_install_plans.resources | to_json | from_json | json_query(query) }}"
   vars:
     query: >-
       [?starts_with(spec.clusterServiceVersionNames[0], 'serverless-operator')].metadata.name|[0]
@@ -114,15 +114,13 @@
     name: "{{ _ocp4_workload_serverless_install_plan_name }}"
     namespace: openshift-operators
 
-- name: Remove remaining knativeservings CRDs
+- name: Remove CatalogSource for mirrored catalog
   k8s:
     state: absent
-    api_version: apiextensions.k8s.io/v1
-    kind: CustomResourceDefinition
-    name: "{{ item }}"
-  loop:
-  - knativeservings.operator.knative.dev
-  - knativeservings.serving.knative.dev
+    api_version: operators.coreos.com/v1alpha1
+    kind: CatalogSource
+    name: "{{ ocp4_workload_codeready_workspaces_catalogsource_name }}"
+    namespace: openshift-operators
 
 # Leave this as the last task in the playbook.
 - name: remove_workload tasks complete

--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/workload.yml
@@ -4,54 +4,51 @@
   debug:
     msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
 
-- name: Install kn CLI
-  become: true
-  unarchive:
-    src: "https://mirror.openshift.com/pub/openshift-v4/clients/serverless/{{ ocp4_workload_serverless_kn_version }}/kn-linux-amd64-{{ ocp4_workload_serverless_kn_version }}.tar.gz"
-    remote_src: yes
-    dest: /usr/bin
-    mode: 0775
-    owner: root
-    group: root
-  args:
-    creates: /usr/bin/kn
-
-- name: Create kn bash completion file
-  become: true
-  command: /usr/bin/kn completion bash >/etc/bash_completion.d/kn
-  args: 
-    creates: /etc/bash_completion.d/kn
+- name: Create Catalogsource for use with catalog mirror
+  when: ocp4_workload_serverless_use_catalog_mirror | bool
+  k8s:
+    state: present
+    definition: "{{ lookup('template', item ) | from_yaml }}"
+  loop:
+  - ./templates/catalogsource.j2
 
 - name: Create OpenShift Serverless subscription
   k8s:
     state: present
     definition: "{{ lookup('template', './templates/subscription.j2' ) }}"
 
-- name: Manually approve InstallPlan
-  when: not ocp4_workload_serverless_automatic_install_plan_approval | bool
-  block:
-  - name: Wait until InstallPlan is created
-    k8s_facts:
-      api_version: operators.coreos.com/v1alpha1
-      kind: InstallPlan
-      namespace: openshift-operators
-    register: r_install_plan
-    retries: 30
-    delay: 5
-    until:
-    - r_install_plan|selectattr('clusterServiceVersionNames', 'contains', 'serverless-operator')
+- name: Wait until InstallPlan is created
+  k8s_facts:
+    api_version: operators.coreos.com/v1alpha1
+    kind: InstallPlan
+    namespace: openshift-operators
+  register: r_install_plans
+  retries: 30
+  delay: 5
+  until:
+  - r_install_plans.resources | length > 0
+  - r_install_plans|selectattr('clusterServiceVersionNames', 'contains', 'serverless-operator')
 
-  - name: Set InstallPlan Name
-    set_fact:
-      _ocp4_workload_serverless_install_plan_name: "{{ r_install_plan.resources | to_json | from_json | json_query(query) }}"
-    vars:
-      query: >-
-        [?starts_with(spec.clusterServiceVersionNames[0], 'serverless-operator')].metadata.name|[0]
+- name: Set InstallPlan Name
+  set_fact:
+    _ocp4_workload_serverless_install_plan_name: "{{ r_install_plans.resources | to_json | from_json | json_query(query) }}"
+  vars:
+    query: >-
+      [?starts_with(spec.clusterServiceVersionNames[0], 'serverless-operator')].metadata.name|[0]
 
-  - name: Approve InstallPlan
-    k8s:
-      state: present
-      definition: "{{ lookup( 'template', './templates/installplan.j2' ) }}"
+- name: Get InstallPlan
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: InstallPlan
+    name: "{{ _ocp4_workload_serverless_install_plan_name }}"
+    namespace: openshift-operators
+  register: r_install_plan
+  
+- name: Approve InstallPlan if necessary
+  when: r_install_plan.resources[0].status.phase is match("RequiresApproval")
+  k8s:
+    state: present
+    definition: "{{ lookup( 'template', './templates/installplan.j2' ) }}"
 
 - name: Get Installed CSV
   k8s_facts:
@@ -134,6 +131,32 @@
     - r_kn_eventing.resources[0].status.conditions[0].status == "True"
     - r_kn_eventing.resources[0].status.conditions[1].status is defined
     - r_kn_eventing.resources[0].status.conditions[1].status == "True"
+
+- name: Get kn download route
+  k8s_info:
+    api_version: route.openshift.io/v1
+    kind: Route
+    name: kn-cli-downloads
+    namespace: knative-serving
+  register: r_kn_download
+
+- name: Install kn CLI on bastion
+  become: true
+  unarchive:
+    src: "http://{{ r_kn_download.resources[0].status.ingress[0].host }}/amd64/linux/kn-linux-amd64.tar.gz"
+    remote_src: yes
+    dest: /usr/bin
+    mode: 0775
+    owner: root
+    group: root
+  args:
+    creates: /usr/bin/kn
+
+- name: Create kn bash completion file
+  become: true
+  command: /usr/bin/kn completion bash >/etc/bash_completion.d/kn
+  args: 
+    creates: /etc/bash_completion.d/kn
 
 # Leave this as the last task in the playbook.
 - name: workload tasks complete

--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/workload.yml
@@ -4,8 +4,8 @@
   debug:
     msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
 
-- name: Create Catalogsource for use with catalog mirror
-  when: ocp4_workload_serverless_use_catalog_mirror | bool
+- name: Create Catalogsource for use with catalog snapshot
+  when: ocp4_workload_serverless_use_catalog_snapshot | bool
   k8s:
     state: present
     definition: "{{ lookup('template', './templates/catalogsource.j2' ) | from_yaml }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/workload.yml
@@ -8,14 +8,12 @@
   when: ocp4_workload_serverless_use_catalog_mirror | bool
   k8s:
     state: present
-    definition: "{{ lookup('template', item ) | from_yaml }}"
-  loop:
-  - ./templates/catalogsource.j2
+    definition: "{{ lookup('template', './templates/catalogsource.j2' ) | from_yaml }}"
 
 - name: Create OpenShift Serverless subscription
   k8s:
     state: present
-    definition: "{{ lookup('template', './templates/subscription.j2' ) }}"
+    definition: "{{ lookup('template', './templates/subscription.j2' ) | from_yaml }}"
 
 - name: Wait until InstallPlan is created
   k8s_facts:

--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/templates/catalogsource.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/templates/catalogsource.j2
@@ -5,5 +5,5 @@ metadata:
   namespace: openshift-operators
 spec:
   sourceType: grpc
-  image: "{{ ocp4_workload_serverless_catalog_mirror_image }}:{{ ocp4_workload_serverless_catalog_mirror_image_tag }}"
+  image: "{{ ocp4_workload_serverless_catalog_snapshot_image }}:{{ ocp4_workload_serverless_catalog_snapshot_image_tag }}"
   displayName: "{{ ocp4_workload_serverless_catalogsource_name }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/templates/catalogsource.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/templates/catalogsource.j2
@@ -1,0 +1,9 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: "{{ ocp4_workload_serverless_catalogsource_name }}"
+  namespace: openshift-operators
+spec:
+  sourceType: grpc
+  image: "{{ ocp4_workload_serverless_catalog_mirror_image }}:{{ ocp4_workload_serverless_catalog_mirror_image_tag }}"
+  displayName: "{{ ocp4_workload_serverless_catalogsource_name }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/templates/subscription.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/templates/subscription.j2
@@ -5,14 +5,19 @@ metadata:
   namespace: openshift-operators
 spec:
   channel: "{{ ocp4_workload_serverless_channel }}"
-{% if ocp4_workload_serverless_automatic_install_plan_approval | default(True) | bool %}
+{% if ocp4_workload_serverless_automatic_install_plan_approval | default(True) | bool and not ocp4_workload_serverless_use_catalog_mirror | default(False) | bool %}
   installPlanApproval: Automatic
 {% else %}
   installPlanApproval: Manual
 {% endif %}
   name: serverless-operator
+{% if ocp4_workload_serverless_use_catalog_mirror | default(False) | bool %}
+  source: "{{ ocp4_workload_serverless_catalogsource_name }}"
+  sourceNamespace: openshift-operators
+{% else %}
   source: redhat-operators
   sourceNamespace: openshift-marketplace
+{% endif %}
 {% if ocp4_workload_serverless_starting_csv | default("") | length > 0 %}
-  startingCSV: "serverless-operator.{{ ocp4_workload_serverless_starting_csv }}"
+  startingCSV: "{{ ocp4_workload_serverless_starting_csv }}"
 {% endif %}

--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/templates/subscription.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/templates/subscription.j2
@@ -5,13 +5,13 @@ metadata:
   namespace: openshift-operators
 spec:
   channel: "{{ ocp4_workload_serverless_channel }}"
-{% if ocp4_workload_serverless_automatic_install_plan_approval | default(True) | bool and not ocp4_workload_serverless_use_catalog_mirror | default(False) | bool %}
+{% if ocp4_workload_serverless_automatic_install_plan_approval | default(True) | bool and not ocp4_workload_serverless_use_catalog_snapshot | default(False) | bool %}
   installPlanApproval: Automatic
 {% else %}
   installPlanApproval: Manual
 {% endif %}
   name: serverless-operator
-{% if ocp4_workload_serverless_use_catalog_mirror | default(False) | bool %}
+{% if ocp4_workload_serverless_use_catalog_snapshot | default(False) | bool %}
   source: "{{ ocp4_workload_serverless_catalogsource_name }}"
   sourceNamespace: openshift-operators
 {% else %}


### PR DESCRIPTION
##### SUMMARY
Add support for Operator Catalog Mirrors to the Serverless Operator. Also download tkn from the installed version of Serverless which always matches the installed version.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_serverless
