### PR TITLE
Change to use ocp4_pull_secret rather than ocp4_token

### DIFF
--- a/ansible/configs/ocp4-ha-lab/files/install-config.yaml.j2
+++ b/ansible/configs/ocp4-ha-lab/files/install-config.yaml.j2
@@ -33,5 +33,5 @@ platform:
   aws:
     region: {{ aws_region_final | default(aws_region) | to_json }}
     userTags: {{ hostvars.localhost.cf_tags_final | default({}) | to_json }}
-pullSecret: {{ ocp4_token | to_json }}
+pullSecret: {{ ocp4_pull_secret | to_json | to_json if ocp4_pull_secret is mapping else ocp4_pull_secret | to_json }}
 sshKey: {{ idrsapub.content | b64decode | to_json }}

--- a/ansible/configs/ocp4-workshop/README.adoc
+++ b/ansible/configs/ocp4-workshop/README.adoc
@@ -54,6 +54,6 @@ subdomain_base_suffix: .openshift.opentlc.com
 HostedZoneId: Z186MFNM7DX4NF
 worker_instance_type: m4.xlarge
 worker_instance_count: 1
-ocp4_token: >-
-  Your OCP token from try.openshift.com
+ocp4_pull_secret: >-
+  Your OCP pull secret from try.openshift.com
 ----

--- a/ansible/configs/ocp4-workshop/files/install-config.yaml.j2
+++ b/ansible/configs/ocp4-workshop/files/install-config.yaml.j2
@@ -33,6 +33,6 @@ platform:
   aws:
     region: {{ aws_region_final | default(aws_region) | to_json }}
     userTags: {{ hostvars.localhost.cf_tags_final | default({}) | to_json }}
-pullSecret: {{ ocp4_token | to_json }}
+pullSecret: {{ ocp4_pull_secret | to_json | to_json if ocp4_pull_secret is mapping else ocp4_pull_secret | to_json }}
 sshKey: |
   {{ idrsapub.content | b64decode | to_json }}

--- a/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
+++ b/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
@@ -97,5 +97,5 @@ platform:
     clusterOSImage: {{ rhcos_image_name | to_json }}
 {%   endif %}
 {% endif %}
-pullSecret: {{ ocp4_pull_secret | to_json }}
+pullSecret: {{ ocp4_pull_secret | to_json | to_json if ocp4_pull_secret is mapping else ocp4_pull_secret | to_json }}
 sshKey: {{ idrsapub.content | b64decode | to_json }}


### PR DESCRIPTION
##### SUMMARY

Change to use variable `ocp4_pull_secret` rather than `ocp4_token` and to guard against structured data value in `ocp4_pull_secret`.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ocp4-ha-lab config
ocp4-workshop config
host-ocp4-installer role