### PR TITLE
Update config osp-migration to allow create objects as admin for distributed routers

### DIFF
--- a/ansible/configs/osp-migration/infra.yml
+++ b/ansible/configs/osp-migration/infra.yml
@@ -78,7 +78,7 @@
 
     - name: Create objects inside the project (as user)
       register: stack_user_output
-      when: use_openstack_centralized_router | default(False)
+      when: use_openstack_centralized_router | default(False) == False
       environment:
         OS_AUTH_URL: "{{ osp_auth_url }}"
         OS_USERNAME: "{{ guid }}"
@@ -101,7 +101,7 @@
           
     - name: Create objects inside the project (as admin)
       register: stack_user_output
-      when: use_openstack_centralized_router | bool
+      when: use_openstack_centralized_router | default(False)
       environment:
         OS_AUTH_URL: "{{ osp_auth_url }}"
         OS_USERNAME: "{{ osp_auth_username }}"

--- a/ansible/configs/osp-migration/infra.yml
+++ b/ansible/configs/osp-migration/infra.yml
@@ -75,37 +75,25 @@
         OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
         OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"
       command: openstack project set --tag "student={{ student_name }}" "{{ osp_project_name }}"  
-
-    - name: Create objects inside the project (as user)
-      register: stack_user_output
+      
+    - name: Set authentication information to create objects
+      set_fact:
+        create_objects_user: "{{ guid }}"
+        create_objects_password: "{{ osp_migration_api_pass }}"
       when: use_openstack_centralized_router | default(False) == False
-      environment:
-        OS_AUTH_URL: "{{ osp_auth_url }}"
-        OS_USERNAME: "{{ guid }}"
-        OS_PASSWORD: "{{ osp_migration_api_pass }}"
-        OS_PROJECT_NAME: "{{ osp_project_name }}"
-        OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
-        OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"
-      os_stack:
-        name: "create-objects-{{osp_project_name}}"
-        template: "{{ output_dir }}/imported-templates/heat-templates/{{ project }}/stack_user.yaml"
-        timeout: "{{ stack_create_timeout |d('3600') }}"
-        parameters:
-          project_name: "{{ osp_project_name }}"
-          public_net_id: "{{ external_network }}"
-          api_url: "{{ osp_auth_url }}"
-          api_user: "{{ guid }}"
-          api_pass: "{{ osp_migration_api_pass }}"
-          project_guid: "{{ guid }}"
-          dns_domain: "{{ osp_cluster_dns_zone }}"
-          
-    - name: Create objects inside the project (as admin)
-      register: stack_user_output
+
+    - name: Set authentication information to create objects
+      set_fact:
+        create_objects_user: "{{ osp_auth_username }}"
+        create_objects_password: "{{ osp_auth_password }}"
       when: use_openstack_centralized_router | default(False)
+
+    - name: Create objects inside the project
+      register: stack_user_output
       environment:
         OS_AUTH_URL: "{{ osp_auth_url }}"
-        OS_USERNAME: "{{ osp_auth_username }}"
-        OS_PASSWORD: "{{ osp_auth_password }}"
+        OS_USERNAME: "{{ create_objects_user }}"
+        OS_PASSWORD: "{{ create_objects_password }}"
         OS_PROJECT_NAME: "{{ osp_project_name }}"
         OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
         OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"
@@ -121,7 +109,6 @@
           api_pass: "{{ osp_migration_api_pass }}"
           project_guid: "{{ guid }}"
           dns_domain: "{{ osp_cluster_dns_zone }}"
-          
 
     - name: Save services content
       set_fact:

--- a/ansible/configs/osp-migration/infra.yml
+++ b/ansible/configs/osp-migration/infra.yml
@@ -76,8 +76,9 @@
         OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"
       command: openstack project set --tag "student={{ student_name }}" "{{ osp_project_name }}"  
 
-    - name: Create objects inside the project
+    - name: Create objects inside the project (as user)
       register: stack_user_output
+      when: use_openstack_centralized_router | default(False)
       environment:
         OS_AUTH_URL: "{{ osp_auth_url }}"
         OS_USERNAME: "{{ guid }}"
@@ -97,6 +98,30 @@
           api_pass: "{{ osp_migration_api_pass }}"
           project_guid: "{{ guid }}"
           dns_domain: "{{ osp_cluster_dns_zone }}"
+          
+    - name: Create objects inside the project (as admin)
+      register: stack_user_output
+      when: use_openstack_centralized_router | bool
+      environment:
+        OS_AUTH_URL: "{{ osp_auth_url }}"
+        OS_USERNAME: "{{ osp_auth_username }}"
+        OS_PASSWORD: "{{ osp_auth_password }}"
+        OS_PROJECT_NAME: "{{ osp_project_name }}"
+        OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
+        OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"
+      os_stack:
+        name: "create-objects-{{osp_project_name}}"
+        template: "{{ output_dir }}/imported-templates/heat-templates/{{ project }}/stack_user.yaml"
+        timeout: "{{ stack_create_timeout |d('3600') }}"
+        parameters:
+          project_name: "{{ osp_project_name }}"
+          public_net_id: "{{ external_network }}"
+          api_url: "{{ osp_auth_url }}"
+          api_user: "{{ guid }}"
+          api_pass: "{{ osp_migration_api_pass }}"
+          project_guid: "{{ guid }}"
+          dns_domain: "{{ osp_cluster_dns_zone }}"
+          
 
     - name: Save services content
       set_fact:


### PR DESCRIPTION
There is some issues with Distributed Router on OSP Clusters, the idea of this PR is:

Possibility to have in agnosticv the variable: use_openstack_centralized_router (boolean)
If this variable is True, it will use the admin user to create the objects (required for centralized router)
If is false, will continue to use the created user during the lab deployment