### PR TITLE
Adding output for kubeadmin password for agnosticd user info

### DIFF
--- a/ansible/roles/ocp4-workload-cnvlab/tasks/post_workload.yml
+++ b/ansible/roles/ocp4-workload-cnvlab/tasks/post_workload.yml
@@ -21,6 +21,14 @@
   agnosticd_user_info:
     msg: "CNV Lab Workbook: https://{{ getroute.resources[0].spec.host }}"
 
+- name: Get kubeadmin password
+  command: cat ~/cluster-{{ guid }}/auth/kubeadmin-password
+  register: kubeadmin_password
+
+- name: Report KubeAdmin Login Details
+  agnosticd_user_info:
+    msg: "Login Credentials for OpenShift: kubeadmin / {{ kubeadmin_password.stdout }}"
+
 # Leave these as the last tasks in the playbook
 # ---------------------------------------------
 


### PR DESCRIPTION

##### SUMMARY

Adding agnosticd user info output for the kubeadmin password that was missed in the first PR.

##### ISSUE TYPE
- Bugfix Pull Request

