### PR TITLE
Fix config test-empty-config when errors without bool filter

### DIFF
--- a/ansible/configs/test-empty-config/destroy_env.yml
+++ b/ansible/configs/test-empty-config/destroy_env.yml
@@ -18,7 +18,7 @@
       vars:
         ACTION: destroy
 
-    - when: pause_destroy | default(false)
+    - when: pause_destroy | default(false) | bool
       pause:
         seconds: 30
 

--- a/ansible/configs/test-empty-config/infra.yml
+++ b/ansible/configs/test-empty-config/infra.yml
@@ -13,7 +13,7 @@
         msg:
           - Entering the test-empty-config infra.yml
 
-    - when: fail_infra | default(false)
+    - when: fail_infra | default(false) | bool
       name: Fail the test-empty-config infra.yml if requested
       fail:
         msg: infra.yml failed as requested

--- a/ansible/configs/test-empty-config/post_infra.yml
+++ b/ansible/configs/test-empty-config/post_infra.yml
@@ -13,7 +13,7 @@
         msg:
           - Entering the test-empty-config post_infra.yml
 
-    - when: fail_post_infra | default(false)
+    - when: fail_post_infra | default(false) | bool
       name: Fail the test-empty-config post_infra.yml if requested
       fail:
         msg: post_infra.yml failed as requested

--- a/ansible/configs/test-empty-config/post_software.yml
+++ b/ansible/configs/test-empty-config/post_software.yml
@@ -14,12 +14,12 @@
         msg:
           - Entering the test-empty-config post_software.yml
 
-    - when: fail_post_software | default(false)
+    - when: fail_post_software | default(false) | bool
       name: Fail the test-empty-config post_software.yml if requested
       fail:
         msg: post_software.yml failed as requested
 
-    - when: pause_post_software | default(false)
+    - when: pause_post_software | default(false) | bool
       pause:
         seconds: 30
 

--- a/ansible/configs/test-empty-config/pre_infra.yml
+++ b/ansible/configs/test-empty-config/pre_infra.yml
@@ -16,7 +16,7 @@
         msg: 
           - Entering the test-empty-config pre_infra.yml
 
-    - when: fail_pre_infra | default(false)
+    - when: fail_pre_infra | default(false) | bool
       name: Fail the test-empty-config pre_infra.yml if requested
       fail:
         msg: pre_infra.yml failed as requested

--- a/ansible/configs/test-empty-config/pre_software.yml
+++ b/ansible/configs/test-empty-config/pre_software.yml
@@ -13,7 +13,7 @@
         msg:
           - Entering the test-empty-config pre_software.yml
 
-    - when: fail_pre_software | default(false)
+    - when: fail_pre_software | default(false) | bool
       name: Fail the test-empty-config pre_software.yml if requested
       fail:
         msg: pre_software.yml failed as requested

--- a/ansible/configs/test-empty-config/software.yml
+++ b/ansible/configs/test-empty-config/software.yml
@@ -13,7 +13,7 @@
         msg:
           - Entering the test-empty-config software.yml
 
-    - when: fail_software | default(false)
+    - when: fail_software | default(false) | bool
       name: Fail the test-empty-config software.yml if requested
       fail:
         msg: software.yml failed as requested


### PR DESCRIPTION
##### SUMMARY

Fix config test-empty-config where there were various `when` condition tests missing `bool` filter. This is a problem because the string "false" ends up evaluating to a true value.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

test-empty-config config