### PR TITLE
disable sap-hana-preconfigure role

### DIFF
--- a/ansible/configs/sap-integration/requirements.yml
+++ b/ansible/configs/sap-integration/requirements.yml
@@ -11,8 +11,8 @@
 - src: https://github.com/linux-system-roles/sap-preconfigure.git
   version: v1.0
 
-- src: https://github.com/linux-system-roles/sap-hana-preconfigure.git
-  version: v1.0
+# - src: https://github.com/linux-system-roles/sap-hana-preconfigure.git
+#   version: v1.0
 
 - src: https://github.com/linux-system-roles/sap-netweaver-preconfigure.git
   version: v1.0


### PR DESCRIPTION
##### SUMMARY
Temporarily disable the use of the `sap-hana-preconfigure` role in the `sap-integration` config. It is causing Travis failures due to it using `include`. 

We will need to decide whether restricting the use of `include` is appropriate since it is not actually deprecated.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
sap-integration

```
