### PR TITLE
Change workload ocp4_workload_rhacm for GA release

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm/defaults/main.yml
@@ -6,6 +6,3 @@ silent: False
 ocp4_workload_rhacm_acm_project: "open-cluster-management"
 ocp4_workload_rhacm_acm_release: "release-2.0"
 ocp4_workload_rhacm_acm_csv: "advanced-cluster-management.v2.0.0"
-# ocp4_workload_rhacm_etcd_csv: "etcdoperator.v0.9.4"
-# ocp4_workload_rhacm_etcd_sub: "etcd-singlenamespace-alpha-community-operators-openshift-marketplace"
-# ocp4_workload_rhacm_docker_registry: "registry.access.redhat.com/rhacm1-tech-preview"

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm/defaults/main.yml
@@ -4,8 +4,8 @@ ocp_username: opentlc-mgr
 silent: False
 
 ocp4_workload_rhacm_acm_project: "open-cluster-management"
-ocp4_workload_rhacm_acm_release: "release-1.0"
-ocp4_workload_rhacm_acm_csv: "advanced-cluster-management.v1.0.1"
-ocp4_workload_rhacm_etcd_csv: "etcdoperator.v0.9.4"
-ocp4_workload_rhacm_etcd_sub: "etcd-singlenamespace-alpha-community-operators-openshift-marketplace"
-ocp4_workload_rhacm_docker_registry: "registry.access.redhat.com/rhacm1-tech-preview"
+ocp4_workload_rhacm_acm_release: "release-2.0"
+ocp4_workload_rhacm_acm_csv: "advanced-cluster-management.v2.0.0"
+# ocp4_workload_rhacm_etcd_csv: "etcdoperator.v0.9.4"
+# ocp4_workload_rhacm_etcd_sub: "etcd-singlenamespace-alpha-community-operators-openshift-marketplace"
+# ocp4_workload_rhacm_docker_registry: "registry.access.redhat.com/rhacm1-tech-preview"

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/remove_workload.yml
@@ -40,22 +40,6 @@
     state: absent
     definition: "{{ lookup('template', './templates/operatorGroup.j2') }}"
 
-- name: Ensure ETCD Subscription is absent
-  k8s:
-    state: absent
-    api_version: operators.coreos.com/v1alpha1
-    kind: Subscription
-    name: "{{ ocp4_workload_rhacm_etcd_sub }}"
-    namespace: "{{ ocp4_workload_rhacm_acm_project }}"
-
-- name: Ensure ETCD Subscription is absent
-  k8s:
-    state: absent
-    api_version: operators.coreos.com/v1alpha1
-    kind: ClusterServiceVersion
-    name: "{{ ocp4_workload_rhacm_etcd_csv }}"
-    namespace: "{{ ocp4_workload_rhacm_acm_project }}"
-
 - name: Ensure ACM CSV is absent
   k8s:
     state: absent

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/workload.yml
@@ -53,39 +53,11 @@
     state: present
     definition: "{{ lookup('template', './templates/multiClusterHub.j2') }}"
 
-# A workaround is needed in order to deploy etcd cluster, issue can be found here: https://bugzilla.redhat.com/show_bug.cgi?id=1839909
-## Workaround starts
-# - name: Wait until the etcdcluster object is created
-#   k8s_info:
-#     api_version: etcd.database.coreos.com/v1beta2
-#     kind: EtcdCluster
-#     name: etcd-cluster
-#     namespace: "{{ ocp4_workload_rhacm_acm_project }}"
-#   register: etcd_cluster
-#   retries: 30
-#   delay: 20
-#   until: etcd_cluster.resources|length > 0
-  
-# - name: Annotate etcd cluster
-#   k8s:
-#     state: present
-#     merge_type: merge
-#     definition:
-#       apiVersion: etcd.database.coreos.com/v1beta2
-#       kind: EtcdCluster
-#       metadata:
-#         name: etcd-cluster
-#         namespace: "{{ ocp4_workload_rhacm_acm_project }}"
-#         annotations:
-#           etcd.database.coreos.com/scope: clusterwide
-#   when: etcd_cluster.resources[0].metadata.name == "etcd-cluster"
-## Workaround ends
-
 # Currently the MultiClusterHub object status reporting sometimes misses the latests state, a fix needs to be implemented to force a new reconcile in order to get the latest status: https://github.com/open-cluster-management/backlog/issues/2374
 # In order to workaround this we will patch the multiclusterhub resource after some time if the status is not correct, that will force a reconcile
 - name: Wait until RHACM MultiClusterHub is Ready (First Try)
   k8s_info:
-    api_version: operators.open-cluster-management.io/v1beta1
+    api_version: operator.open-cluster-management.io/v1
     kind: MultiClusterHub
     name: "multiclusterhub"
     namespace: "{{ ocp4_workload_rhacm_acm_project }}"
@@ -93,34 +65,34 @@
   retries: 30
   delay: 20
   until: rhacm_multiclusterhub.resources[0].status.phase == "Running"
-  ignore_errors: true
+  # ignore_errors: true
 
-#- name: Force a reconcile to force the operator to update the status
-- name: Force a reconcile to force the operator to update the MultiClusterHub object status
-  k8s:
-    state: present
-    merge_type: merge
-    definition:
-      apiVersion: operators.open-cluster-management.io/v1beta1
-      kind: MultiClusterHub
-      metadata:
-        name: multiclusterhub
-        namespace: "{{ ocp4_workload_rhacm_acm_project }}"
-      spec:
-        forcedReconcile: false
-  when: rhacm_multiclusterhub.resources[0].status.phase == "Pending"
+# #- name: Force a reconcile to force the operator to update the status
+# - name: Force a reconcile to force the operator to update the MultiClusterHub object status
+#   k8s:
+#     state: present
+#     merge_type: merge
+#     definition:
+#       apiVersion: operator.open-cluster-management.io/v1
+#       kind: MultiClusterHub
+#       metadata:
+#         name: multiclusterhub
+#         namespace: "{{ ocp4_workload_rhacm_acm_project }}"
+#       spec:
+#         forcedReconcile: false
+#   when: rhacm_multiclusterhub.resources[0].status.phase == "Pending"
 
-- name: Wait until RHACM MultiClusterHub is Ready (Second Try)
-  k8s_info:
-    api_version: operators.open-cluster-management.io/v1beta1
-    kind: MultiClusterHub
-    name: "multiclusterhub"
-    namespace: "{{ ocp4_workload_rhacm_acm_project }}"
-  register: rhacm_multiclusterhub_2
-  retries: 5
-  delay: 20
-  until: rhacm_multiclusterhub_2.resources[0].status.phase == "Running"
-  when: rhacm_multiclusterhub.resources[0].status.phase == "Pending"
+# - name: Wait until RHACM MultiClusterHub is Ready (Second Try)
+#   k8s_info:
+#     api_version: operator.open-cluster-management.io/v1
+#     kind: MultiClusterHub
+#     name: "multiclusterhub"
+#     namespace: "{{ ocp4_workload_rhacm_acm_project }}"
+#   register: rhacm_multiclusterhub_2
+#   retries: 5
+#   delay: 20
+#   until: rhacm_multiclusterhub_2.resources[0].status.phase == "Running"
+#   when: rhacm_multiclusterhub.resources[0].status.phase == "Pending"
 
 # Leave this as the last task in the playbook.
 - name: workload tasks complete

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/workload.yml
@@ -55,30 +55,30 @@
 
 # A workaround is needed in order to deploy etcd cluster, issue can be found here: https://bugzilla.redhat.com/show_bug.cgi?id=1839909
 ## Workaround starts
-- name: Wait until the etcdcluster object is created
-  k8s_info:
-    api_version: etcd.database.coreos.com/v1beta2
-    kind: EtcdCluster
-    name: etcd-cluster
-    namespace: "{{ ocp4_workload_rhacm_acm_project }}"
-  register: etcd_cluster
-  retries: 30
-  delay: 20
-  until: etcd_cluster.resources|length > 0
+# - name: Wait until the etcdcluster object is created
+#   k8s_info:
+#     api_version: etcd.database.coreos.com/v1beta2
+#     kind: EtcdCluster
+#     name: etcd-cluster
+#     namespace: "{{ ocp4_workload_rhacm_acm_project }}"
+#   register: etcd_cluster
+#   retries: 30
+#   delay: 20
+#   until: etcd_cluster.resources|length > 0
   
-- name: Annotate etcd cluster
-  k8s:
-    state: present
-    merge_type: merge
-    definition:
-      apiVersion: etcd.database.coreos.com/v1beta2
-      kind: EtcdCluster
-      metadata:
-        name: etcd-cluster
-        namespace: "{{ ocp4_workload_rhacm_acm_project }}"
-        annotations:
-          etcd.database.coreos.com/scope: clusterwide
-  when: etcd_cluster.resources[0].metadata.name == "etcd-cluster"
+# - name: Annotate etcd cluster
+#   k8s:
+#     state: present
+#     merge_type: merge
+#     definition:
+#       apiVersion: etcd.database.coreos.com/v1beta2
+#       kind: EtcdCluster
+#       metadata:
+#         name: etcd-cluster
+#         namespace: "{{ ocp4_workload_rhacm_acm_project }}"
+#         annotations:
+#           etcd.database.coreos.com/scope: clusterwide
+#   when: etcd_cluster.resources[0].metadata.name == "etcd-cluster"
 ## Workaround ends
 
 # Currently the MultiClusterHub object status reporting sometimes misses the latests state, a fix needs to be implemented to force a new reconcile in order to get the latest status: https://github.com/open-cluster-management/backlog/issues/2374

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/workload.yml
@@ -53,9 +53,7 @@
     state: present
     definition: "{{ lookup('template', './templates/multiClusterHub.j2') }}"
 
-# Currently the MultiClusterHub object status reporting sometimes misses the latests state, a fix needs to be implemented to force a new reconcile in order to get the latest status: https://github.com/open-cluster-management/backlog/issues/2374
-# In order to workaround this we will patch the multiclusterhub resource after some time if the status is not correct, that will force a reconcile
-- name: Wait until RHACM MultiClusterHub is Ready (First Try)
+- name: Wait until RHACM MultiClusterHub is Ready
   k8s_info:
     api_version: operator.open-cluster-management.io/v1
     kind: MultiClusterHub
@@ -65,34 +63,7 @@
   retries: 30
   delay: 20
   until: rhacm_multiclusterhub.resources[0].status.phase == "Running"
-  # ignore_errors: true
 
-# #- name: Force a reconcile to force the operator to update the status
-# - name: Force a reconcile to force the operator to update the MultiClusterHub object status
-#   k8s:
-#     state: present
-#     merge_type: merge
-#     definition:
-#       apiVersion: operator.open-cluster-management.io/v1
-#       kind: MultiClusterHub
-#       metadata:
-#         name: multiclusterhub
-#         namespace: "{{ ocp4_workload_rhacm_acm_project }}"
-#       spec:
-#         forcedReconcile: false
-#   when: rhacm_multiclusterhub.resources[0].status.phase == "Pending"
-
-# - name: Wait until RHACM MultiClusterHub is Ready (Second Try)
-#   k8s_info:
-#     api_version: operator.open-cluster-management.io/v1
-#     kind: MultiClusterHub
-#     name: "multiclusterhub"
-#     namespace: "{{ ocp4_workload_rhacm_acm_project }}"
-#   register: rhacm_multiclusterhub_2
-#   retries: 5
-#   delay: 20
-#   until: rhacm_multiclusterhub_2.resources[0].status.phase == "Running"
-#   when: rhacm_multiclusterhub.resources[0].status.phase == "Pending"
 
 # Leave this as the last task in the playbook.
 - name: workload tasks complete

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm/templates/multiClusterHub.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm/templates/multiClusterHub.j2
@@ -1,4 +1,4 @@
-apiVersion: operators.open-cluster-management.io/v1beta1
+apiVersion: operator.open-cluster-management.io/v1
 kind: MultiClusterHub
 metadata:
   name: multiclusterhub


### PR DESCRIPTION
##### SUMMARY
With the release of RHACM 2.0, this PR will update the version of RHACM being deployed and remove unnecessary tasks and vars for the etcd workaround needed in previous version.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_rhacm

@mvazquezc FYI