### PR TITLE
fix ocp4-workload-ccnrd to create deploymentconfig for oc new-app

### DIFF
--- a/ansible/roles/ocp4-workload-ccnrd/tasks/install-guides.yaml
+++ b/ansible/roles/ocp4-workload-ccnrd/tasks/install-guides.yaml
@@ -9,7 +9,7 @@
 - name: deploy guide {{ guide }}
   when: r_guide_dc.resources | list | length == 0
   shell: >
-    oc -n labs-infra new-app quay.io/openshiftlabs/workshopper:1.0 --name=guides-{{ guide }}
+    oc -n labs-infra new-app --as-deployment-config quay.io/openshiftlabs/workshopper:1.0 --name=guides-{{ guide }}
     -e MASTER_URL={{ master_url }}
     -e CONSOLE_URL={{ console_url }}
     -e ECLIPSE_CHE_URL=https://codeready-labs-infra.{{ route_subdomain }}

--- a/ansible/roles/ocp4-workload-ccnrd/tasks/install-username-distribution.yaml
+++ b/ansible/roles/ocp4-workload-ccnrd/tasks/install-username-distribution.yaml
@@ -48,7 +48,7 @@
 - name: deploy username distribution tool
   when: r_gau_dc.resources | list | length == 0
   shell: >
-    oc -n labs-infra new-app quay.io/openshiftlabs/username-distribution:1.3 --name=get-a-username
+    oc -n labs-infra new-app --as-deployment-config quay.io/openshiftlabs/username-distribution:1.3 --name=get-a-username
     -e LAB_REDIS_HOST=redis
     -e LAB_REDIS_PASS=redis
     -e LAB_TITLE={{ 'Containers & Cloud Native Roadshow' | quote }}


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
This PR aims to use "--as-deployment-config" option to use deploymentconfig than deployment in OCP 4.5

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
