### PR TITLE
Update workload ocp4_workload_rhacm

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/workload.yml
@@ -53,6 +53,10 @@
     state: present
     definition: "{{ lookup('template', './templates/multiClusterHub.j2') }}"
 
+- name: Pause to let the status field show up in CR
+  pause:
+    seconds: 20
+
 - name: Wait until RHACM MultiClusterHub is Ready
   k8s_info:
     api_version: operator.open-cluster-management.io/v1


### PR DESCRIPTION

##### SUMMARY
After the `multiclusterhub` CR was created, Ansible checks for the status too quickly and that field is not present. This adds a short pause before it starts the retry loop.

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
ocp4_workload_rhacm