### PR TITLE
Change workload ocp4-workload-migration to use the latest available release

### DIFF
--- a/ansible/roles/ocp4-workload-migration/README.adoc
+++ b/ansible/roles/ocp4-workload-migration/README.adoc
@@ -4,13 +4,7 @@
 
 The workload includes migration operator which deploys migration controller, migration ui and Velero.
 
-== Supported Versions
-
-This workload supports following versions of Cluster Application Migration Tool
-
-- release-1.0.1
-
-Older version are no longer supported
+Current workload deploys CAM 1.2.4
 
 === Deploy the workload
 [source,'bash']
@@ -34,16 +28,15 @@ This workload does not require any variables. Following variables can be overrid
 |===
 | Variable | Default Value | Description
 
-| mig_operator_release
-| v1.0.1
-| Migration operator release
+| ocs_migstorage
+| false
+| Request to create a default replication repository after installing CAM
 
 | mig_migration_namespace
 | openshift-migration
 | Migration operator namespace
 
 |===
-
 
 === Delete the workload
 
@@ -58,4 +51,3 @@ ansible-playbook -i "bastion.${GUID}.${BASE_DOMAIN}", ./ansible/configs/ocp-work
     -e @./secret.yaml \
     -e @./workload.yaml
 ----
-

--- a/ansible/roles/ocp4-workload-migration/meta/main.yml
+++ b/ansible/roles/ocp4-workload-migration/meta/main.yml
@@ -1,0 +1,10 @@
+---
+galaxy_info:
+  author: Pranav Gaikwad <pgaikwad@redhat.com>
+  description: Deploys Cluster Application Migration Tool on OCP4 clusters through OLM
+  company: Red Hat
+  license: BSD
+  min_ansible_version: 2.9
+  galaxy_tags: []
+
+dependencies: []

--- a/ansible/roles/ocp4-workload-migration/tasks/post_workload.yml
+++ b/ansible/roles/ocp4-workload-migration/tasks/post_workload.yml
@@ -8,6 +8,9 @@
       ocp4_domain: "{{ guid }}{{ subdomain_base_suffix }}"
       ocp4_ssh_user: "{{ student_name }}"
       ocp4_password: "{{ student_password }}"
+  when:
+  - student_name is defined
+  - student_password is defined
 
 # For deployment onto a dedicated cluster (as part of the
 # cluster deployment) set workload_shared_deployment to False

--- a/ansible/roles/ocp4-workload-migration/templates/mig-operator-subscription-downstream.yml.j2
+++ b/ansible/roles/ocp4-workload-migration/templates/mig-operator-subscription-downstream.yml.j2
@@ -4,7 +4,7 @@ metadata:
   name: cam-operator
   namespace: {{ mig_migration_namespace }}
 spec:
-  channel: release-v1.1
+  channel: release-v1.2
   installPlanApproval: Automatic
   name: cam-operator
   source: redhat-operators


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

This PR updates ocp4-workload-migration to use the latest available release 1.2.4. It also adds minor safe guarding code around usage of agnosticd_user_info module.

Previously, the workload used release 1.1

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4-workload-migration

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
