### PR TITLE
Change workload ocp-workload-migration to use the latest available release 

### DIFF
--- a/ansible/roles/ocp-workload-migration/README.adoc
+++ b/ansible/roles/ocp-workload-migration/README.adoc
@@ -4,13 +4,7 @@
 
 The workload includes migration operator which deploys migration controller, migration ui and Velero.
 
-== Supported Versions
-
-This workload supports following versions of Cluster Application Migration Tool
-
-- release-1.0.1
-
-Older version are no longer supported
+Current workload deploys CAM 1.2.4
 
 === Deploy the workload
 [source,'bash']

--- a/ansible/roles/ocp-workload-migration/meta/main.yml
+++ b/ansible/roles/ocp-workload-migration/meta/main.yml
@@ -1,0 +1,10 @@
+---
+galaxy_info:
+  author: Pranav Gaikwad <pgaikwad@redhat.com>
+  description: Deploys Cluster Application Migration Tool on OCP3 clusters using Migration Operator
+  company: Red Hat
+  license: BSD
+  min_ansible_version: 2.9
+  galaxy_tags: []
+
+dependencies: []

--- a/ansible/roles/ocp-workload-migration/tasks/post_workload.yml
+++ b/ansible/roles/ocp-workload-migration/tasks/post_workload.yml
@@ -5,6 +5,9 @@
       ocp3_domain: "{{ guid }}{{ subdomain_base_suffix }}"
       ocp3_ssh_user: "{{ student_name }}"
       ocp3_password: "{{ student_password }}"
+  when:
+  - student_name is defined
+  - student_password is defined
 
 # Leave this as the last task in the playbook.
 - name: post_workload tasks complete

--- a/ansible/roles/ocp-workload-migration/templates/operator.yml.j2
+++ b/ansible/roles/ocp-workload-migration/templates/operator.yml.j2
@@ -7,6 +7,7 @@ metadata:
   labels:
     control-plane: controller-manager
     controller-tools.k8s.io: "1.0"
+    openshift.io/cluster-monitoring: "true"
   name: "{{ mig_migration_namespace }}"
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -193,14 +194,14 @@ spec:
         - /usr/local/bin/ao-logs
         - /tmp/ansible-operator/runner
         - stdout
-        image: registry.redhat.io/rhcam-1-1/{{ mig_migration_namespace }}-rhel7-operator:v1.1
+        image: registry.redhat.io/rhcam-1-2/{{ mig_migration_namespace }}-rhel7-operator:v1.2
         imagePullPolicy: Always
         volumeMounts:
         - mountPath: /tmp/ansible-operator/runner
           name: runner
           readOnly: true
       - name: operator
-        image: registry.redhat.io/rhcam-1-1/{{ mig_migration_namespace }}-rhel7-operator:v1.1
+        image: registry.redhat.io/rhcam-1-2/{{ mig_migration_namespace }}-rhel7-operator:v1.2
         imagePullPolicy: Always
         volumeMounts:
         - mountPath: /tmp/ansible-operator/runner
@@ -219,7 +220,11 @@ spec:
         - name: REGISTRY
           value: registry.redhat.io
         - name: PROJECT
-          value: rhcam-1-1
+          value: rhcam-1-2
+        - name: HOOK_RUNNER_REPO
+          value: {{ mig_migration_namespace }}-hook-runner-rhel7@sha256
+        - name: HOOK_RUNNER_TAG
+          value: 86a048f0ee9726b4331d10190dc5851330b66c0326d94652ac07f33a501ae323
         - name: MIG_CONTROLLER_REPO
           value: {{ mig_migration_namespace }}-controller-rhel8@sha256
         - name: MIG_UI_REPO
@@ -241,21 +246,21 @@ spec:
         - name: VELERO_AZURE_PLUGIN_REPO
           value: {{ mig_migration_namespace }}-velero-plugin-for-microsoft-azure-rhel8@sha256
         - name: VELERO_TAG
-          value: db2997115d8a0767d61038e14f48170dc53d3c54b977184e7ecb37ead2f131da
+          value: 1a33e327dd610f0eebaaeae5b3c9b4170ab5db572b01a170be35b9ce946c0281
         - name: VELERO_RESTIC_RESTORE_HELPER_TAG
-          value: 44f0362c8570d707582bd428aaf18f390ce915ef72cdeb60cf2699171dbda3c8
+          value: e9459138ec3531eefbefa181dae3fd93fe5cf210b2a0bd3bca7ba38fbec97f60
         - name: VELERO_PLUGIN_TAG
-          value: 4009d8488a9aa382d7799e8d25617048f57b273c298a9c89a4f233d7a12af628
+          value: d9e2c4a9db9a88c68d3f6b18927c7f00d50a172a9a721ea6add0855e4db1fda0
         - name: VELERO_AWS_PLUGIN_TAG
-          value: 2623e239a43208390680fb1da81f547248773d48da546b9cc6c516b2e60daee4
+          value: 22c58f575ce2f54bf995fced82f89ba173329d9b88409cf371122f9ae8cabda1
         - name: VELERO_GCP_PLUGIN_TAG
-          value: 44f40ff5a3c8ad9b76105e2b8fc5bd04692464cc4aa683da2cf83b3336200863
+          value: 37c0b170d168fcebb104e465621e4ce97515d82549cd37cb42be94e3e55a4271
         - name: VELERO_AZURE_PLUGIN_TAG
-          value: 9e69f2af712452218cde0c3325c60f9e1eb4624bcaff67770822b60f2e19ac60
+          value: dd92ad748a84754e5d78287e29576a5b95448e929824e86e80c60857d0c7aff9
         - name: MIG_UI_TAG
-          value: 11c8c729bd4871c33b52f0405a0c5ec0438aefd2ed0ffc712034ba89160ed133
+          value: 6abfaea8ac04e3b5bbf9648a3479b420b4baec35201033471020c9cae1fe1e11
         - name: MIG_CONTROLLER_TAG
-          value: 52e3bb16a6fb0852aec7676bba5e5a5af01580f4997bac7747f158239b839ece
+          value: f3de5a7b0e6eeee722da155622a9f20425696bd25f833519b7aec320a7b64659
       volumes:
         - name: runner
           emptyDir: {}


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

This PR updates ocp-workload-migration to use the latest available release 1.2.4. It also adds minor safe guarding code around usage of agnosticd_user_info module.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp-workload-migration
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
