### PR TITLE
Change workload ocp-workload-migration to save bookbag variables in a file

### DIFF
--- a/ansible/roles/ocp-workload-migration/tasks/pre_workload.yml
+++ b/ansible/roles/ocp-workload-migration/tasks/pre_workload.yml
@@ -69,7 +69,19 @@
       mode: "u+rwx"
     loop:
       - { dest: "/home/{{ student_name }}/cpma", src: "https://cpma.s3.us-east-2.amazonaws.com/cpma" }
-  when: student_name is defined and not status.failed and groups.bastions is defined
+
+  - name: "Saving OCP3 cluster info for bookbag deployment"
+    copy:
+      content: |
+        [OCP3]
+        guid={{ guid }}
+        domain={{ subdomain_base_suffix }}
+        student_name={{ student_name }}
+      dest: /home/{{ student_name }}/cluster.info
+  when:
+  - student_name is defined
+  - not status.failed
+  - groups.bastions is defined
   delegate_to: "{{ groups.bastions | first }}"
   become: yes
 


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Migration workloads require combined OCP3 + OCP4 deployment in order to generate bookbag documentation. Since currently, there are two different catalog items for both the clusters, we cannot leverage `agnosticd_user_info` variable from OCP3 side. This PR creates a file on the OCP3 bastion host with properties for bookbag deployment. Sensitive information is not included in the file. The goal is to make it easier for users to generate bookbag docs using this file as input.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp-workload-migration

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
