### PR TITLE
Change workload ocp4-workload-migration to save bookbag variables in a file

### DIFF
--- a/ansible/roles/ocp4-workload-migration/tasks/post_workload.yml
+++ b/ansible/roles/ocp4-workload-migration/tasks/post_workload.yml
@@ -12,6 +12,17 @@
   - student_name is defined
   - student_password is defined
 
+- when: student_name is defined
+  name: "Saving OCP4 cluster info for bookbag deployment"
+  copy:
+    content: |
+      [OCP4]
+      guid={{ guid }}
+      domain={{ subdomain_base_suffix }}
+      student_name={{ student_name }}
+    dest: "/home/{{ student_name }}/cluster.info"
+  become: true
+
 # For deployment onto a dedicated cluster (as part of the
 # cluster deployment) set workload_shared_deployment to False
 # This is the default so it does not have to be set explicitely


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

Migration workloads require combined OCP3 + OCP4 deployment in order to generate bookbag documentation. Since currently, there are two different catalog items for both the clusters, we cannot leverage `agnosticd_user_info` variable from OCP3 side. This PR creates a file on the OCP3 bastion host with properties for bookbag deployment. Sensitive information is not included in the file. The goal is to make it easier for users to generate bookbag docs using this file as input.

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4-workload-migration

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
