### PR TITLE
Added a retry mechanism for OpenShift IPI installations

### DIFF
--- a/ansible/roles-infra/infra-osp-resources-destroy/tasks/heat.yml
+++ b/ansible/roles-infra/infra-osp-resources-destroy/tasks/heat.yml
@@ -10,7 +10,7 @@
   # There is no module that allows retrieving this data.
   - name: Get a list of stacks in the project
     command: >-
-      openstack stack list --property tenant={{ osp_project_info[0].id }} -f value --column ID
+      openstack stack list --property tenant={{ osp_project_info[0].id | default(osp_project_id) }} -f value --column ID
     register: r_stacks
 
   # The os_stack module doesn't allow deleting by ID and name is not safe to use since there could
@@ -24,4 +24,4 @@
     until: r_hot_out is succeeded
     register: r_hot_out
     loop: "{{ r_stacks.stdout_lines }}"
-  
+

--- a/ansible/roles/host-ocp4-installer/tasks/main.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/main.yml
@@ -13,6 +13,21 @@
     command: openshift-install create cluster --dir=/home/{{ ansible_user }}/{{ cluster_name }}
     async: "{{ 2 * 60 * 60 }}"
 
+  rescue:
+    - name: Restarting OpenStack nodes
+      when: cloud_provider == "osp"
+      shell: openstack server reboot --hard {{ item }}
+      with_lines: openstack server list | awk '/{{ cluster_name }}/ { print $2 };'
+      ignore_errors: yes
+    - pause:
+        minutes: 10
+        prompt: "Pausing whilst OpenStack nodes recover..."
+      when: cloud_provider == "osp"
+    - name: Retry OpenShift installation (wait-for bootstrap-complete)
+      command: openshift-install --dir=/home/{{ ansible_user }}/{{ cluster_name }} wait-for bootstrap-complete
+    - name: Retry OpenShift installation (wait-for install-complete)
+      command: openshift-install --dir=/home/{{ ansible_user }}/{{ cluster_name }} wait-for install-complete
+
   always:
   - name: Gzip Install log
     archive:


### PR DESCRIPTION
…that fail due to slow OpenStack environments, and where timeouts are common

##### SUMMARY
This adds an additional rescue step for scenarios where the openshift-installer may fail due to hitting a timeout, where instead of the playbook exiting, it will attempt to wait for the cluster to stabilise (with `wait-for bootstrap-complete` and `wait-for install-complete`). In addition, if the cluster is running on OpenStack it will forcefully reboot the nodes as it's common for the hosts to get stuck in a `NotReady` state, and it's been proven that forcing a reboot can recover things. This patch, if executed against a non-OSP environment, will only attempt the additional wait, so it's not invasive.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
roles/host-ocp4-installer