### PR TITLE
Add OS_CACERT environment variable migration host

### DIFF
--- a/ansible/configs/osp-migration/pre_infra.yml
+++ b/ansible/configs/osp-migration/pre_infra.yml
@@ -41,6 +41,7 @@
     - name: Download images from project
       become: true
       environment:
+        OS_CACERT: "/etc/ipa/ipa.crt"
         OS_AUTH_URL: "{{ osp_auth_url }}"
         OS_USERNAME: "{{ osp_auth_username }}"
         OS_PASSWORD: "{{ osp_auth_password }}"


### PR DESCRIPTION
##### SUMMARY
This PR add the environment variable OS_CACERT to the migration host used to download images from IBM cloud 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
osp-migration 

