### PR TITLE
added condition to fix only machine config daemon bug in previous 4.5…

### DIFF
--- a/ansible/roles/ocp4-workload-infra-nodes/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-infra-nodes/tasks/workload.yml
@@ -53,14 +53,26 @@
   delay: 30
   retries: 15
 
+- name: Get ClusterVersion
+  k8s_info:
+    api_version: config.openshift.io/v1
+    kind: ClusterVersion
+    name: version
+  register: r_cluster_version
+
+- name: Set ocp4_workload_machinesets_cluster_version fact
+  set_fact:
+    ocp4_workload_machinesets_cluster_version: "{{ r_cluster_version.resources[0].status.history[0].version }}"
+
 # The Machine Config Daemon DaemonSet does not include
 # Universal Tolerations. So by adding taints to Infra
 # (and Elasticsearch) nodes the Machine Config Daemon
 # pods would be removed from those nodes.
 # This adds the necessary tolerations.
-# It may be 4.5 before this is fixed.
+# Fixed in 4.5+ versions
 # See https://bugzilla.redhat.com/show_bug.cgi?id=1780318
 - name: Fix Machine Config and Node CA Daemon Sets (add Tolerations for Infra and Elasticsearch nodes)
+  when: ocp4_workload_machinesets_cluster_version is version_compare('4.5', '<')
   k8s:
     state: present
     merge_type:


### PR DESCRIPTION
SUMMARY

Remove workaround for DaemonSets (DNS, Machine Config) for OpenShift 4.5+. The bug has been fixed.
Also change k8s_facts -> k8s_info.
ISSUE TYPE

    - Feature Pull Request

COMPONENT NAME

ocp4-workload-infra-nodes

Linked to the same fix in https://github.com/redhat-cop/agnosticd/pull/2268
