### PR TITLE
Lowered initial delay second of livenessprobe. Increased timeout seco…

### DIFF
--- a/ansible/roles/ocp-workload-pam7-cc-dispute-dmn-pmml/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-pam7-cc-dispute-dmn-pmml/tasks/workload.yml
@@ -169,10 +169,16 @@
 
 
 - name: Configure Liveness probe Entando Customer runtime
-  shell: "oc set probe dc/entando-fsi-ccd-customer-runtime --liveness --initial-delay-seconds=480 -n {{ OCP_PROJECT }}"
+  shell: "oc set probe dc/entando-fsi-ccd-customer-runtime --liveness --initial-delay-seconds=360 -n {{ OCP_PROJECT }}"
+
+- name: Configure Liveness probe Entando Customer runtime timeout seconds to cater for hardcoded sleep in EAP 7.1 livenessprobe script
+  shell: "oc set probe dc/entando-fsi-ccd-customer-runtime --liveness --timeout-seconds=8 -n {{ OCP_PROJECT }}"
 
 - name: Configure Liveness probe Entando Admin runtime
-  shell: "oc set probe dc/entando-fsi-ccd-admin-runtime --liveness --initial-delay-seconds=480 -n {{ OCP_PROJECT }}"
+  shell: "oc set probe dc/entando-fsi-ccd-admin-runtime --liveness --initial-delay-seconds=360 -n {{ OCP_PROJECT }}"
+
+- name: Configure Liveness probe Entando Admin runtime timeout seconds to cater for hardcoded sleep in EAP 7.1 livenessprobe script
+  shell: "oc set probe dc/entando-fsi-ccd-admin-runtime --liveness --timeout-seconds=8 -n {{ OCP_PROJECT }}"
 
 ### Prometheus
 


### PR DESCRIPTION
…nds of livebessprobe to 8 seconds. Reason for this is that the EAP 7.1 image of the container has a hardcoded 5 second sleep in its livenessprobe.sh script. So, we need to increase the timeout-seconds for the livenessprobe not to continuously trigger a container termination.

##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
Increased timeoutSeconds to 8 seconds on 2 of the livenessProbes. The reason for this is that the JBoss EAP 7.1 image of these PODs has a hardcoded "sleep 5" in its "/opt/eap/bin/livenessprobe.sh" script. So, with a default "timeoutSeconds: 1" in the livenessprobe, these pods get constantly terminated.

Nasty fix, I know. But this is an external image from a partner, and I can't upgrade it to EAP 7.2. Also I don't want to fiddle with scripts provided by the underlying EAP 7.1 image.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp-workload-pam7-cc-dispute-dmn-pmml

##### ADDITIONAL INFORMATION
n.a.