### PR TITLE
Remove xrdp package from the verification workload.

### DIFF
--- a/ansible/roles/rhel-custom-security-content-verification/tasks/main.yml
+++ b/ansible/roles/rhel-custom-security-content-verification/tasks/main.yml
@@ -4,7 +4,6 @@
     - name: Check if required packages are installed
       package:
         name:
-          - xrdp
           - firewalld
           - git
           - make


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Remove xrdp package from the verification workload since it's not being installed anymore.
Align with changes from: https://github.com/redhat-cop/agnosticd/pull/2248
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
rhel-custom-security-content