### PR TITLE
Change workload ocp4-workload-ocs-poc to allow using custom operator source

### DIFF
--- a/ansible/roles/ocp4-workload-ocs-poc/README.adoc
+++ b/ansible/roles/ocp4-workload-ocs-poc/README.adoc
@@ -16,6 +16,31 @@ ansible-playbook -i "bastion.${GUID}.${BASE_DOMAIN}", ./ansible/configs/ocp-work
 ----
 <1> This is the same file you used while deploying OCP cluster using agnosticd. Your AWS credentials go in this file
 
+|===
+| Variable | Required? | Default Value | Description
+
+| ocs_operator_source
+| No
+| redhat-operators-snapshot
+| Name of the operator source to use
+
+| ocs_operator_source_namespace
+| No
+| openshift-storage
+| Namespace of the operator source to use
+
+| ocs_channel
+| No
+| stable-4.2
+| OCS Operator OLM release channel
+
+| ocs_cluster_monitoring_enabled
+| No
+| true
+| Enable / disable cluster monitoring on OCS namespace
+
+|===
+
 == Delete the workload
 ----
 ansible-playbook -i "bastion.${GUID}.${BASE_DOMAIN}", ./ansible/configs/ocp-workloads/ocp-workload.yml \

--- a/ansible/roles/ocp4-workload-ocs-poc/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-ocs-poc/defaults/main.yml
@@ -4,6 +4,7 @@ ocs_expected_crds:
 - noobaas.noobaa.io
 - objectbucketclaims.objectbucket.io
 ocs_channel: stable-4.2
+ocs_cluster_monitoring_enabled: true
 ocs_install_mcg: true
 ocs_mcg_core_cpu: 0.5
 ocs_mcg_core_mem: 500Mi

--- a/ansible/roles/ocp4-workload-ocs-poc/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-ocs-poc/tasks/workload.yml
@@ -16,6 +16,7 @@
     definition: "{{ lookup('template', 'operator_group.yml.j2') }}"
 
 - name: create the CatalogSource for the snapshot
+  when: ocs_operator_source is not defined
   k8s:
     state: present
     definition:

--- a/ansible/roles/ocp4-workload-ocs-poc/templates/namespace.yml.j2
+++ b/ansible/roles/ocp4-workload-ocs-poc/templates/namespace.yml.j2
@@ -2,4 +2,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+{% if ocs_cluster_monitoring_enabled %}
+  labels:
+    openshift.io/cluster-monitoring: "true"
+{% endif %}
   name: {{ item }}

--- a/ansible/roles/ocp4-workload-ocs-poc/templates/subscription.yml.j2
+++ b/ansible/roles/ocp4-workload-ocs-poc/templates/subscription.yml.j2
@@ -7,5 +7,5 @@ spec:
   channel: {{ ocs_channel }}
   installPlanApproval: Automatic
   name: ocs-operator
-  source: redhat-operators-snapshot
-  sourceNamespace: openshift-storage
+  source: {{ ocs_operator_source | default('redhat-operators-snapshot') }}
+  sourceNamespace: {{ ocs_operator_source_namespace | default('openshift-storage') }}


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY


This PR adds the ability to use a custom operator source. This is useful when users want to install the latest ocs-operator from `redhat-operators` operator sources. By default, existing catalog source snapshot is used which is pinned to `stable-4.2` channel of OCS operator. 

Fixes #2316 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4-workload-ocs-poc

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
