### PR TITLE
update serverless subscription channel'

### DIFF
--- a/ansible/roles/ocp4-workload-ml-workflows-infra-summit2020/templates/serverless/subscription.yml.j2
+++ b/ansible/roles/ocp4-workload-ml-workflows-infra-summit2020/templates/serverless/subscription.yml.j2
@@ -4,7 +4,7 @@ metadata:
   name: serverless-operator
   namespace: openshift-operators
 spec:
-  channel: techpreview 
+  channel: '4.3' 
   installPlanApproval: Automatic
   name: serverless-operator
   source: redhat-operators


### PR DESCRIPTION
Updated subscription channel for serverless operator from 'techpreview' to '4.3'. 
