### PR TITLE
update config osp-migration to use new labconsole hosted on OCP4.4 shared cluster

### DIFF
--- a/ansible/configs/osp-migration/post_software.yml
+++ b/ansible/configs/osp-migration/post_software.yml
@@ -10,7 +10,7 @@
       with_items:
         - ""
         - "In case you need to access to the console of the VMs for your lab:"
-        - "URL: https://{{ osp_cluster_dns_zone.split('.')[0] }}-labconsole.apps.shared.na.openshift.opentlc.com/"
+        - "URL: https://{{ osp_cluster_dns_zone.split('.')[0] }}-labconsole.apps.shared-na4.na4.openshift.opentlc.com/"
         - "Username: {{ student_name }}"
         - "Password: *your opentlc password*"
 


### PR DESCRIPTION
Currently labconsole is on OCP 4.1 and it was required to move to a new cluster