### PR TITLE
Added documentation on how to add a filter to the LDAP configuration.

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_authentication/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_authentication/defaults/main.yml
@@ -28,6 +28,11 @@ ocp4_workload_authentication_htpasswd_add_default_users: true
 # -----------------------------------------------
 # LDAP settings
 # -----------------------------------------------
+# The default settings are for OpenTLC LDAP.
+# Every user with an entry in OpenTLC LDAP will be allowed access.
+# To restrict access change the ldap_url variable to include a filter.
+# For example to restrict to members of "babylon-access" group use the following setting:
+# ocp4_workload_authentication_ldap_url: ldaps://ipa1.opentlc.com:636/cn=users,cn=accounts,dc=opentlc,dc=com?uid?sub?(memberOf=cn=babylon-access,cn=groups,cn=accounts,dc=opentlc,dc=com)
 ocp4_workload_authentication_ldap_url: ldaps://ipa1.opentlc.com:636/cn=users,cn=accounts,dc=opentlc,dc=com?uid
 ocp4_workload_authentication_ldap_ca_url: https://gpte-public.s3.amazonaws.com/opentlc_ipa_ca.crt
 ocp4_workload_authentication_ldap_bind_dn: "uid=ose-mwl-auth,cn=users,cn=accounts,dc=opentlc,dc=com"


### PR DESCRIPTION
##### SUMMARY
Added variable documentation on how to provide a filter for LDAP (e.g. to restrict access to members of a specific group)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ocp4_workload_authentication
