### PR TITLE
This adds a first extension of 30m to the deployment time without the…

### DIFF
--- a/ansible/roles/host-ocp4-installer/tasks/main.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/main.yml
@@ -12,6 +12,9 @@
       - run_installer
     command: openshift-install create cluster --dir=/home/{{ ansible_user }}/{{ cluster_name }}
     async: "{{ 2 * 60 * 60 }}"
+    ignore_errors: yes
+  - name: Retry OpenShift installation (wait-for install-complete)
+    command: openshift-install --dir=/home/{{ ansible_user }}/{{ cluster_name }} wait-for install-complete
 
   rescue:
     - name: Restarting OpenStack nodes


### PR DESCRIPTION
… automated restart which can sometimes cause the cluster to fail

##### SUMMARY

This further increases the stability of the OpenShift installer when running against OpenStack clusters that may be busy or highly utilised. This provides a very simple extension to the timeout limit by first ignoring the initial failure (almost always due to a timeout) and running a `wait-for install-complete`. Then if this fails it's likely that something more fundamental has failed and to run the rescue commands (reboot nodes if OSP, and attempt to wait for cluster to come up) that were added in an earlier PR.

In our testing this has resulted in a 100% success rate on the OpenStack cluster that we're running against; whereas without this it would occasionally just take the sledgehammer approach in ~50% of cases and reboot all of the nodes. Sometimes this would recover the cluster just fine, but sometimes it would result in a failed deployment. This patch eases that and puts the rescue option in there only as a last resort, instead of just when the cluster has simply timed out but only needed a few more minutes to succeed.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
roles/host-ocp4-installer