### PR TITLE
Fixing the proposed solution in the 2_rhel7_webservers_on_osp training exercise

### DIFF
--- a/training/03_Infrastructure_Deployment/04_Modify_a_base_config_Lab.adoc
+++ b/training/03_Infrastructure_Deployment/04_Modify_a_base_config_Lab.adoc
@@ -90,7 +90,7 @@ instances:
   flavor:
     osp: "{{ webserver_instance_type }}"
   metadata:
-    - AnsibleGroup: "webservers"
+    - AnsibleGroup: "webservers,bastions"
     - function: webserver
     - user: "{{ student_name }}"
     - ostype: linux


### PR DESCRIPTION
Fixing the solution 2_rhel7_webservers_on_osp training exercise. Adding bastions in the AnsibleGroup metadata
ISSUE TYPE
Docs Pull Request
COMPONENT NAME
Training
ADDITIONAL INFORMATION
The proposed solution of the lab was giving the following error: fatal: [localhost]: FAILED! => {"msg": "'dict object' has no attribute 'bastions'"}

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
