### PR TITLE
[WIP] Update osp-migration with new tasks to find the external network ID of the cluster

### DIFF
--- a/ansible/configs/osp-migration/env_vars.yml
+++ b/ansible/configs/osp-migration/env_vars.yml
@@ -46,6 +46,8 @@ osp_project_name: >-
   | replace('-bp','')
   }}-{{ guid }}
 
+# Default name of the external network for FIP
+osp_external_network: external
 
 # Why is this config being deployed?
 # Some valid: development, ilt, production, event

--- a/ansible/configs/osp-migration/infra.yml
+++ b/ansible/configs/osp-migration/infra.yml
@@ -81,6 +81,23 @@
         create_objects_user: "{{ guid }}"
         create_objects_password: "{{ osp_migration_api_pass }}"
       when: use_openstack_centralized_router | default(False) == False
+      
+    - name: Gather OSP network external network
+      os_networks_facts:
+        name: "{{ osp_external_network | default('external') }}"
+        filters:
+          router:external: true
+      register: r_osp_n_facts
+
+    - name: Fail is there is not an external network found
+      assert:
+        that:
+          - (r_osp_n_facts.ansible_facts.openstack_networks | count) > 0
+        msg: "No OSP external network found"
+
+    - set_fact:
+        external_network:
+          "{{ (r_osp_n_facts.ansible_facts.openstack_networks | first).id }}"
 
     - name: Set authentication information to create objects
       set_fact:

--- a/ansible/configs/osp-migration/infra.yml
+++ b/ansible/configs/osp-migration/infra.yml
@@ -46,7 +46,7 @@
         parameters:
           project_name: "{{ osp_project_name }}"
           project_guid: "{{ guid }}"
-          project_description: "created:{{ ansible_date_time.epoch }}"
+          project_description: "created:{{ ansible_date_time.epoch | default('') }}"
           project_api_user: "{{ guid }}"
           project_api_pass: "{{ osp_migration_api_pass }}"
           blueprint: "{{ project }}"


### PR DESCRIPTION
Currently, external network ID are defined on the secret for each cluster. With this PR it will find automatically this ID