### PR TITLE
Fix two issues with agnosticd_dynamic role

### DIFF
--- a/ansible/roles/agnosticd_dynamic/tasks/install-git-source.yaml
+++ b/ansible/roles/agnosticd_dynamic/tasks/install-git-source.yaml
@@ -30,7 +30,7 @@
   file:
     state: link
     path: "{{ agnosticd_dynamic_roles_dir }}/{{ _role.key }}"
-    src: "{{ (_install_path ~ '/' ~ _role.value | default('')) | relpath(_install_dir) }}"
+    src: "{{ (_install_path ~ '/' ~ _role.value | default('')) | relpath(agnosticd_dynamic_roles_dir) }}"
   loop: "{{ _source.role_paths | default({}) | dict2items }}"
   loop_control:
     loop_var: _role

--- a/ansible/roles/agnosticd_dynamic/tasks/main.yml
+++ b/ansible/roles/agnosticd_dynamic/tasks/main.yml
@@ -37,7 +37,7 @@
     loop_var: _source
     label: "{{ _source_name }}"
   vars:
-    _source_name: "{{ _source | agnosticd_dynamic_role_git_source_name }}"
+    _source_name: "{{ _source | agnosticd_dynamic_git_source_name }}"
     _install_dir: >-
       {{ agnosticd_dynamic_cache_dir if _source is agnosticd_dynamic_cache_enabled else agnosticd_dynamic_roles_dir }}
     _install_path: >-


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
The `agnosticd_dynamic` role has two bugs, one is a typo which causes the role to fail when using git sources (filter name is incorrect).
The second bug is also related to git sources where the symbolic link was using an incorrect source.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Add the following variable to pull in a dynamic git source
```
agnosticd_dynamic_role_git_sources:
  - repo: https://github.com/redhat-cop/openshift-applier.git
    version: v2.1.2
    role_paths:
      openshift-applier: roles/openshift-applier
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
