### PR TITLE
Change role infra-ec2-template-create to add uuid to cloud tags

### DIFF
--- a/ansible/roles-infra/infra-ec2-template-create/defaults/main.yml
+++ b/ansible/roles-infra/infra-ec2-template-create/defaults/main.yml
@@ -5,6 +5,7 @@ cf_tags:
   owner: "{{ email | default(user) | default('unknown') }}"
   env_type: "{{ env_type }}"
   guid: "{{ guid }}"
+  uuid: "{{ uuid | default('') }}"
 
 # custom additional tags :
 cloud_tags: {}


### PR DESCRIPTION
##### SUMMARY

Add uuid tag with default empty string to standard ec2 instance tags.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Infrastructure role infra-ec2-template-create