### PR TITLE
Applying instead of creating RHPAM IS.

### DIFF
--- a/ansible/roles/ocp-workload-pam7-cc-dispute-dmn-pmml/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-pam7-cc-dispute-dmn-pmml/tasks/workload.yml
@@ -24,7 +24,7 @@
   ignore_errors: true
 
 - name: Import the RHPAM ImageStreams into the cluster.
-  shell: "oc create -f {{pam_imagestreams_yml}} -n openshift"
+  shell: "oc apply -f {{pam_imagestreams_yml}} -n openshift"
   when: rhpam_is_exists_result is failed
   ignore_errors: true
 


### PR DESCRIPTION

##### SUMMARY

Fixes an issue of creating an IS when it already exists in the cluster.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp-workload-pam7-cc-dispute-dmn-pmml

##### ADDITIONAL INFORMATION
n.a.