### PR TITLE
Grafana is now a deployment instead of a deployment config.

### DIFF
--- a/ansible/roles/ocp-workload-pam7-cc-dispute-dmn-pmml/tasks/grafana_workload.yml
+++ b/ansible/roles/ocp-workload-pam7-cc-dispute-dmn-pmml/tasks/grafana_workload.yml
@@ -6,7 +6,7 @@
   shell: oc new-app grafana/grafana -n {{ OCP_PROJECT }}
 
 - name: Set Grafana resources
-  shell: oc set resources dc/grafana --limits=cpu=800m,memory=512Mi --requests=cpu=400m,memory=256Mi
+  shell: oc set resources deployment/grafana --limits=cpu=800m,memory=512Mi --requests=cpu=400m,memory=256Mi
 
 # Expose Grafana via router
 - name: Create route to Grafana


### PR DESCRIPTION
##### SUMMARY

Sets Grafana limits on Deployment instead of DeploymentConfig (seems to have changed in a recent RHPDS upgrade).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp-workload-pam7-cc-dispute-dmn-pmml
