### PR TITLE
Dataloader is now a deployment instead of a deployment config.

### DIFF
--- a/ansible/roles/ocp-workload-pam7-cc-dispute-dmn-pmml/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-pam7-cc-dispute-dmn-pmml/tasks/workload.yml
@@ -201,28 +201,28 @@
   shell: oc new-app gdemo-data-loader --allow-missing-imagestream-tags --name gdemo-data-loader-dmn -e KIE_SERVER_REST_ENDPOINT=http://rhpam7-kieserver:8080/services/rest/server  -e DMN_MODEL_NAME=creditDisputeSimpleInput
 
 - name: Set resource limits for DataLoader DMN
-  shell: oc set resources dc/gdemo-data-loader-dmn --limits=cpu=400m,memory=256Mi --requests=cpu=200m,memory=128Mi
+  shell: oc set resources deployment/gdemo-data-loader-dmn --limits=cpu=400m,memory=256Mi --requests=cpu=200m,memory=128Mi
 
 - name: Deploy DataLoader for PMML-1
   shell: oc new-app gdemo-data-loader --allow-missing-imagestream-tags --name gdemo-data-loader-dmn-pmml1 -e KIE_SERVER_REST_ENDPOINT=http://rhpam7-kieserver:8080/services/rest/server  -e DMN_MODEL_NAME=creditDisputeSimpleInputPmml1
 
 - name: Set resource limits for DataLoader DMN PMML1
-  shell: oc set resources dc/gdemo-data-loader-dmn-pmml1 --limits=cpu=400m,memory=256Mi --requests=cpu=200m,memory=128Mi
+  shell: oc set resources deployment/gdemo-data-loader-dmn-pmml1 --limits=cpu=400m,memory=256Mi --requests=cpu=200m,memory=128Mi
 
 - name: Deploy DataLoader for PMML2
   shell: oc new-app gdemo-data-loader --allow-missing-imagestream-tags --name gdemo-data-loader-dmn-pmml2 -e KIE_SERVER_REST_ENDPOINT=http://rhpam7-kieserver:8080/services/rest/server  -e DMN_MODEL_NAME=creditDisputeSimpleInputPmml2
 
 - name: Set resource limits for DataLoader DMN PMML2
-  shell: oc set resources dc/gdemo-data-loader-dmn-pmml2 --limits=cpu=400m,memory=256Mi --requests=cpu=200m,memory=128Mi
+  shell: oc set resources deployment/gdemo-data-loader-dmn-pmml2 --limits=cpu=400m,memory=256Mi --requests=cpu=200m,memory=128Mi
 
 - name: Set RepController for DMN DC
-  shell: oc scale --replicas=0 dc/gdemo-data-loader-dmn
+  shell: oc scale --replicas=0 deployment/gdemo-data-loader-dmn
 
 - name: Set RepContoller for PMML1 DC
-  shell: oc scale --replicas=0 dc/gdemo-data-loader-dmn-pmml1
+  shell: oc scale --replicas=0 deployment/gdemo-data-loader-dmn-pmml1
 
 - name: Set RepController for PMML2 DC
-  shell: oc scale --replicas=0 dc/gdemo-data-loader-dmn-pmml2
+  shell: oc scale --replicas=0 deployment/gdemo-data-loader-dmn-pmml2
 
 - include_tasks: ./wait_for_build.yml
   vars:


### PR DESCRIPTION

##### SUMMARY

Fix oc commands for dataloader, as the dataloader is now a deployment instead of a deployment config.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp-workload-pam7-cc-dispute-dmn-pmml

##### ADDITIONAL INFORMATION
n.a.