### PR TITLE
Change role infra-ec2-template-create to use "none" as default uuid

### DIFF
--- a/ansible/roles-infra/infra-ec2-template-create/.yamllint
+++ b/ansible/roles-infra/infra-ec2-template-create/.yamllint
@@ -1,0 +1,14 @@
+---
+extends: default
+
+rules:
+  comments:
+    require-starting-space: false
+  comments-indentation: disable
+  indentation:
+    level: warning
+    indent-sequences: consistent
+  line-length:
+    level: warning
+    max: 120
+    allow-non-breakable-inline-mappings: true

--- a/ansible/roles-infra/infra-ec2-template-create/defaults/main.yml
+++ b/ansible/roles-infra/infra-ec2-template-create/defaults/main.yml
@@ -5,7 +5,7 @@ cf_tags:
   owner: "{{ email | default(user) | default('unknown') }}"
   env_type: "{{ env_type }}"
   guid: "{{ guid }}"
-  uuid: "{{ uuid | default('') }}"
+  uuid: "{{ uuid | default('none') }}"
 
 # custom additional tags :
 cloud_tags: {}

--- a/ansible/roles-infra/infra-ec2-template-create/tasks/main.yml
+++ b/ansible/roles-infra/infra-ec2-template-create/tasks/main.yml
@@ -76,7 +76,7 @@
         )
       retries: "{{ cloudformation_retries | default(3) }}"
       delay: "{{ cloudformation_retry_delay | default(30) }}"
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: debug cloudformation
       debug:
@@ -104,7 +104,7 @@
           s3_bucket:
             name: "{{ env_type }}-{{ guid }}"
             state: absent
-            force: yes
+            force: true
             region: "{{ aws_region_loop|d(aws_region) }}"
           tags:
             - remove_s3
@@ -112,7 +112,7 @@
           until: s3_result is succeeded
           retries: 5
           delay: "{{ cloudformation_retry_delay | default(60) }}"
-          ignore_errors: yes
+          ignore_errors: true
 
         - name: report s3 error
           fail:


### PR DESCRIPTION
##### SUMMARY

Use default `uuid` tag value `none` rather than empty string for ec2 templates.
This resolves an issue reported by @prakhar1985 when `uuid` variable is not set.

The need for this change is a bit of a mystery because according to AWS documentation an empty string is a valid tag value.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

role infra-ec2-template-create