### PR TITLE
assign static ips from outside dhcp range for customer ports for ocp4…

### DIFF
--- a/ansible/roles/ocp4-workload-cnvlab/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-cnvlab/tasks/pre_workload.yml
@@ -165,6 +165,8 @@
     mac_address: de:ad:be:ef:00:01
     port_security_enabled: no
     network: "{{ guid }}-ocp-network"
+    fixed_ips:
+      - ip_address: 192.168.47.5
 
 - name: Create OpenStack port02 for CNV VM's that need DHCP
   os_port:
@@ -173,6 +175,8 @@
     mac_address: de:ad:be:ef:00:02
     port_security_enabled: no
     network: "{{ guid }}-ocp-network"
+    fixed_ips:
+      - ip_address: 192.168.47.6
 
 - name: Create OpenStack port03 for CNV VM's that need DHCP
   os_port:
@@ -181,6 +185,8 @@
     mac_address: de:ad:be:ef:00:03
     port_security_enabled: no
     network: "{{ guid }}-ocp-network"
+    fixed_ips:
+      - ip_address: 192.168.47.7
 
 - name: Create OpenStack port04 for CNV VM's that need DHCP
   os_port:
@@ -189,6 +195,8 @@
     mac_address: de:ad:be:ef:00:04
     port_security_enabled: no
     network: "{{ guid }}-ocp-network"
+    fixed_ips:
+      - ip_address: 192.168.47.8
 
 - name: Get list of OpenShift workers
   k8s_info:


### PR DESCRIPTION
…-cnvlab workloads

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

To manage the fact that OVN is blocking DHCP even on ports without port security we need to ensure an IP is set. This allows us to set the IP using cloud-init and ensure the CNV VMs get an IP from the "public network" in the lab.

Normally we'd like to have neutron managing this (or standalone DHCP in a non-OSP env) but in Orange with OVN it has not been wokring (BZ coming soon).

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New config Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
CNV Hands on Lab.

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
