### PR TITLE
Update role-infra infra-osp-template-generate to use add a parameter to heat template

### DIFF
--- a/ansible/roles-infra/infra-osp-template-generate/templates/cloud_template_master.j2
+++ b/ansible/roles-infra/infra-osp-template-generate/templates/cloud_template_master.j2
@@ -141,7 +141,7 @@ resources:
       name: {{ iname }}
       flavor: {{ instance.flavor.osp }}
       key_name: {get_resource: {{ guid }}-infra_key}
-
+      config_drive: True
       block_device_mapping_v2:
         - image: {{ instance.image_id | default(instance.image) }}
           delete_on_termination: true

--- a/ansible/roles-infra/infra-osp-template-generate/templates/nested_version/cloud_template_nested.j2
+++ b/ansible/roles-infra/infra-osp-template-generate/templates/nested_version/cloud_template_nested.j2
@@ -90,6 +90,7 @@ resources:
       name: { get_param: instance_name }
       flavor: { get_param: instance_flavor }
       key_name: { get_param: key_name }
+      config_drive: True
       block_device_mapping_v2:
         - image: { get_param: instance_image }
           delete_on_termination: true


### PR DESCRIPTION
Creating multiple servers in parallel creates multiple calls to the metadata server. That can cause deployment failure. To avoid this, OSP provides an option to create a virtual disk to access to metadata, to enable that, "config_drive: True" is needed on the Heat template.