### PR TITLE
Print out user info only when bookbag is not defined.

### DIFF
--- a/ansible/configs/rhel-custom-security-content/post_software.yml
+++ b/ansible/configs/rhel-custom-security-content/post_software.yml
@@ -22,6 +22,8 @@
         - ""
         - "Whenever you see instructions on the guide like &lt;PASSWORD&gt; or &lt;IP_ADDRESS&gt; you replace with credentials provided here."
         - ""
+      when:
+      - bookbag_git_repo is not defined
 
     - name: print out user.data
       agnosticd_user_info:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Do not print out user info when deployment uses bookbag documentation interface.
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
rhel-custom-security-content
