### PR TITLE
Add support for OVN Networking for OCP 4.6+

### DIFF
--- a/ansible/configs/ocp4-cluster/default_vars.yml
+++ b/ansible/configs/ocp4-cluster/default_vars.yml
@@ -88,17 +88,21 @@ ocp4_installer_version: "4.4.3"
 # Only works for OCP 4.1 and 4.2. OCP 4.4 should no longer require this.
 ocp4_enable_cluster_shutdown: false
 
-# Install an OpenShift 4 Dev Preview Release
+# Install an OpenShift 4 Developer Preview Release
 # ocp4_installer_use_dev_preview: true
-# ocp4_installer_version: 4.4.0
-# ocp4_installer_url: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp-dev-preview/latest-4.4/openshift-install-linux.tar.gz
-# ocp4_client_url: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp-dev-preview/latest-4.4/openshift-client-linux.tar.gz
+# ocp4_installer_version: 4.6.0
+# ocp4_installer_url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/latest-4.6/openshift-install-linux.tar.gz
+# ocp4_client_url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/latest-4.6/openshift-client-linux.tar.gz
 
 # Pull secret needs to be defined in secrets
 # Get from https://try.openshift.com
 # ocp4_pull_secret: ''
 
 ocp4_base_domain: "example.opentlc.com"
+
+# Network Plugin for OpenShift: OpenshiftSDN (Default) or OVNKubernetes
+# OVNKubernetes requires OCP 4.6 and newer
+ocp4_network_type: OpenshiftSDN
 
 # Run smoketests after installation
 run_smoke_tests: false

--- a/ansible/roles/host-ocp4-installer/files/cluster-network-03-config.yml
+++ b/ansible/roles/host-ocp4-installer/files/cluster-network-03-config.yml
@@ -1,0 +1,21 @@
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  creationTimestamp: null
+  name: cluster
+spec:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  externalIP:
+    policy: {}
+  networkType: OVNKubernetes
+  serviceNetwork:
+  - 172.30.0.0/16
+  defaultNetwork:
+    type: OVNKubernetes
+    ovnKubernetesConfig:
+      hybridOverlayConfig:
+        hybridClusterNetwork:
+        - cidr: 10.132.0.0/14
+          hostPrefix: 23

--- a/ansible/roles/host-ocp4-installer/tasks/generate_install_config.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/generate_install_config.yml
@@ -26,22 +26,26 @@
   become: false
 
 - name: Use version-specific template for install-config-yaml
+  when: rconfig.stat.exists
   set_fact:
     install_config_template_path: templates/install-config.yaml.{{ ocp4_installer_version }}.j2
-  when: rconfig.stat.exists
 
 - name: Use default template for install-config-yaml
+  when: not rconfig.stat.exists
   set_fact:
     install_config_template_path: templates/install-config.yaml.j2
-  when: not rconfig.stat.exists
 
 - name: Generate config install-config.yaml
   template:
     src: "{{ install_config_template_path }}"
     dest: /home/{{ ansible_user }}/{{ cluster_name }}/install-config.yaml
+    owner: "{{ ansible_user }}"
+    mode: 0660
 
 - name: Make a copy of the cluster install config
   copy:
     remote_src: true
     src: /home/{{ ansible_user }}/{{ cluster_name }}/install-config.yaml
     dest: /home/{{ ansible_user }}/{{ cluster_name }}/install-config.yaml.bak
+    owner: "{{ ansible_user }}"
+    mode: 0660

--- a/ansible/roles/host-ocp4-installer/tasks/main.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/main.yml
@@ -4,7 +4,26 @@
 - name: Generate install_config.yaml
   import_tasks: generate_install_config.yml
 
-- name: Installation and getting the logs.
+# For OVN it is necessary to generate manifests and then change the manifests
+# For SDN this is not necessary. Regardless the installation will either generate
+# manifests if there aren't any (default) or use the updated ones (OVN)
+- name: Generate and patch Manifests for OVN
+  when: ocp4_network_type | default("OpenshiftSDN") is match("OVNKubernetes")
+  block:
+  - name: Run Installer to generate manifests
+    become: no
+    tags:
+    - run_installer
+    command: openshift-install create manifests --dir=/home/{{ ansible_user }}/{{ cluster_name }}
+
+  - name: Create manifests/cluster-network-03-config.yml for OVN
+    copy:
+      src: ./files/cluster-network-03-config.yml
+      dest: "/home/{{ ansible_user }}/{{ cluster_name }}/manifests/cluster-network-03-config.yml"
+      owner: "{{ ansible_user }}"
+      mode: 0660
+
+- name: Installation and getting the logs
   block:
   - name: Run the installer
     become: no

--- a/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
+++ b/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
@@ -65,7 +65,11 @@ networking:
   machineCIDR: {{ ocp4_machine_cidr | default('10.0.0.0/16') | to_json }}
   serviceNetwork:
   - 172.30.0.0/16
+{% if ocp4_network_type | default("OpenshiftSDN") is match("OVNKubernetes") %}
+  networkType: OVNKubernetes
+{% else %}
   networkType: OpenshiftSDN
+{% endif %}
 platform:
 {% if cloud_provider == 'ec2' %}
   aws:


### PR DESCRIPTION
##### SUMMARY

Add Support for OVN networking Plugin to ocp4-cluster config (for OCP 4.6+)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Config: ocp4-cluster
Role: host-ocp4-installer

##### ADDITIONAL INFORMATION
This currently requires a nightly release.

To enable:

```
ocp4_installer_use_dev_preview: true
ocp4_installer_version: 4.6.0
ocp4_installer_url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/latest-4.6/openshift-install-linux.tar.gz
ocp4_client_url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/latest-4.6/openshift-client-linux.tar.gz
ocp4_network_type: OVNKubernetes
```