### PR TITLE
Add support to install matching serverless channel for cluster version

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/defaults/main.yml
@@ -6,7 +6,11 @@ silent: False
 # Defaults values below are for OpenShift Serverless v1.7.2 (GA)
 
 # Channel to use for the OpenShift Serverless subscription
-ocp4_workload_serverless_channel: "4.4"
+# When not set (or set to "") use the default channel for the
+# OpenShift version this operator is installed on. If there is no matchin
+# version use the `defaultChannel`
+ocp4_workload_serverless_channel: ""
+# ocp4_workload_serverless_channel: "4.5"
 
 # Set automatic InstallPlan approval. If set to false it is also suggested
 # to set the starting_csv to pin a specific version

--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/remove_workload.yml
@@ -22,6 +22,8 @@
     api_version: v1
     kind: Pod
     namespace: knative-serving
+    field_selectors:
+    - status.phase=Running
   register: r_knative_pods
   retries: 20
   delay: 5
@@ -33,6 +35,8 @@
     api_version: v1
     kind: Pod
     namespace: knative-eventing
+    field_selectors:
+    - status.phase=Running
   register: r_knative_eventing_pods
   retries: 20
   delay: 5
@@ -61,9 +65,10 @@
 - name: Remove Subscription
   k8s:
     state: absent
-    definition: "{{ lookup('template', item ) | from_yaml }}"
-  loop:
-  - ./templates/subscription.j2
+    api_version: operators.coreos.com/v1alpha1
+    kind: Subscription
+    name: serverless-operator
+    namespace: openshift-operators
 
 - name: Remove knative-serving project
   k8s:

--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/workload.yml
@@ -10,6 +10,41 @@
     state: present
     definition: "{{ lookup('template', './templates/catalogsource.j2' ) | from_yaml }}"
 
+- name: Determine channel for Serverless operator is no channel specified
+  when: ocp4_workload_serverless_channel | default("") | length == 0
+  block:
+  - name: Get cluster version
+    k8s_info:
+      api_version: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+    register: r_cluster_version
+
+  - name: Get current stable channel for Serverless operator
+    k8s_info:
+      api_version: packages.operators.coreos.com/v1
+      kind: PackageManifest
+      name: serverless-operator
+      namespace: openshift-marketplace
+    register: r_so_channel
+
+  # Set Serverless channel to the one matching the deployed cluster version.
+  # If no matching channel available set to defaultChannel from the subscription.
+  - name: Set Serverless operator channel
+    set_fact:
+      ocp4_workload_serverless_channel: >-
+        {{ t_version_match_channel | default(r_so_channel.resources[0].status.defaultChannel, true) }}
+    vars:
+      t_cluster_version: >-
+        {{ r_cluster_version.resources[0].spec.channel | regex_replace('.*-(\d+\.\d+)', '\1') }}
+      t_version_match_query: "[?name=='{{ t_cluster_version }}']|[0].name"
+      t_version_match_channel: >-
+        {{ r_so_channel.resources[0].status.channels | json_query(t_version_match_query) }}
+
+- name: Print Serverless operator channel to be installed
+  debug:
+    msg: "Serverless operator channel to be installed: {{ ocp4_workload_serverless_channel }}"
+
 - name: Create OpenShift Serverless subscription
   k8s:
     state: present
@@ -152,6 +187,8 @@
     group: root
   args:
     creates: /usr/bin/kn
+  retries: 10
+  delay: 10
 
 - name: Create kn bash completion file
   become: true


### PR DESCRIPTION
##### SUMMARY

Added support to Serverless workload to install the matching serverless version for the cluster version.
Bugfix to not wait for Completed pods on Remove.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_serverless
