### PR TITLE
Resolve bug for re-registering a previous satellite host

### DIFF
--- a/ansible/roles/set-repositories/tasks/satellite-repos.yml
+++ b/ansible/roles/set-repositories/tasks/satellite-repos.yml
@@ -11,7 +11,7 @@
   package:
     name: rh-amazon-rhui-client
     state: absent
-    disablrepo: "*"
+    disablerepo: "*"    ## This option is undocumented but works, Pulls from yum & dnf
   when: cloud_provider == 'ec2'
 
 - name: Copy satellite CA certificate to /etc/pki/ca-trust/source/anchors/{{ set_repositories_satellite_hostname }}.ca.crt
@@ -30,7 +30,7 @@
   package:
     name: katello-ca-consumer-*.noarch
     state: absent
-    disablrepo: "*"
+    disablerepo: "*"
   ignore_errors: true
 
 - name: Find current repository files
@@ -61,7 +61,7 @@
   package:
     name: "{{ set_repositories_satellite_ca_rpm_url }}"
     state: present
-    disablrepo: "*"
+    disablerepo: "*"
   register: r_install_satellite_ca_rpm
   until: not r_install_satellite_ca_rpm.failed
   retries: 10

--- a/ansible/roles/set-repositories/tasks/satellite-repos.yml
+++ b/ansible/roles/set-repositories/tasks/satellite-repos.yml
@@ -11,6 +11,7 @@
   package:
     name: rh-amazon-rhui-client
     state: absent
+    disablrepo: "*"
   when: cloud_provider == 'ec2'
 
 - name: Copy satellite CA certificate to /etc/pki/ca-trust/source/anchors/{{ set_repositories_satellite_hostname }}.ca.crt
@@ -29,6 +30,7 @@
   package:
     name: katello-ca-consumer-*.noarch
     state: absent
+    disablrepo: "*"
   ignore_errors: true
 
 - name: Find current repository files
@@ -59,6 +61,7 @@
   package:
     name: "{{ set_repositories_satellite_ca_rpm_url }}"
     state: present
+    disablrepo: "*"
   register: r_install_satellite_ca_rpm
   until: not r_install_satellite_ca_rpm.failed
   retries: 10


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

When launching a config multiple times with `repo_method: satellite` the current role breaks. This is due to `/etc/rhsm/rhsm.conf` containing the default values for the Red Hat CDN but pointing to a `/etc/yum.repos.d/redhat.repo` file with satellite repository values. When attempting to use the package module in these conditions (even when removing a pacakge) the repo data is polled failing with a "Unable to find metadata for <repo>". Since no repository info is required to remove the role specified packages we can add `disablerepo: "*"` to these tasks and skip the poll up to the point where we re-install the `katello-ca-consumer-latest` to replace the default values of `rhsm.conf`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

set-repositories/tasks/satellite-repos.yml

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

To reproduce run a config registering to a satellite twice without changing the guid.

TASK [Install satellite CA certificate package] **********************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Failed to download metadata for repo 'rhel-8-for-x86_64-baseos-rpms'", "rc": 1, "results": []}

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
