### PR TITLE
Change readiness check, add ignore in case it fails. Update default t…

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_nexus_operator/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_nexus_operator/defaults/main.yml
@@ -26,7 +26,7 @@ ocp4_workload_nexus_operator_name: nexus
 # 3.24.0 is the earliest supported release do to REST API incompatibilities before
 # ocp4_workload_nexus_operator_nexus_image: docker.io/sonatype/nexus3
 ocp4_workload_nexus_operator_nexus_image: registry.connect.redhat.com/sonatype/nexus-repository-manager
-ocp4_workload_nexus_operator_nexus_image_tag: 3.24.0-ubi-1
+ocp4_workload_nexus_operator_nexus_image_tag: 3.26.1-ubi-2
 
 # PVC size for Nexus
 ocp4_workload_nexus_operator_volume_size: 20Gi

--- a/ansible/roles_ocp_workloads/ocp4_workload_nexus_operator/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_nexus_operator/tasks/workload.yml
@@ -41,8 +41,8 @@
   until:
   - r_nexus_operator_deployment.resources is defined
   - r_nexus_operator_deployment.resources | length | int > 0
-  - r_nexus_operator_deployment.resources[0].status.availableReplicas is defined
-  - r_nexus_operator_deployment.resources[0].status.availableReplicas | int == r_nexus_operator_deployment.resources[0].spec.replicas | int
+  - r_nexus_operator_deployment.resources[0].status.readyReplicas is defined
+  - r_nexus_operator_deployment.resources[0].status.readyReplicas | int == r_nexus_operator_deployment.resources[0].spec.replicas | int
 
 - name: Deploy default Nexus instance
   when: ocp4_workload_nexus_operator_deploy_nexus_instance | bool
@@ -59,12 +59,12 @@
       namespace: "{{ ocp4_workload_nexus_operator_project }}"
       name: "{{ ocp4_workload_nexus_operator_name }}"
     register: r_nexus_deployment
-    retries: 20
+    retries: 30
     delay: 10
     until:
     - r_nexus_deployment.resources | length | int > 0
-    - r_nexus_deployment.resources[0].status.availableReplicas is defined
-    - r_nexus_deployment.resources[0].status.availableReplicas | int == r_nexus_deployment.resources[0].spec.replicas | int
+    - r_nexus_deployment.resources[0].status.readyReplicas is defined
+    - r_nexus_deployment.resources[0].status.readyReplicas | int == r_nexus_deployment.resources[0].spec.replicas | int
 
   - name: Get Nexus admin password
     k8s:
@@ -77,8 +77,10 @@
     - r_nexus.result.status.admin_password is defined
     retries: 20
     delay: 5
+    ignore_errors: true
 
   - name: Display Nexus password
+    when: not r_nexus.failed
     agnosticd_user_info:
       msg: "Nexus password is {{ r_nexus.result.status.admin_password }}"
 


### PR DESCRIPTION
##### SUMMARY
Change readiness check, add ignore in case it fails. Update default to Nexus 3.26

Readiness check tested for `availableReplicas` instead of `readyReplicas`. Fixed.
Also added ignore_errors and check to the test for Nexus to ignore an error and continue other workloads.
Updated default Nexus version to 3.26.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_nexus_operator
