### PR TITLE
Add additional attempts to deploy the CNV Lab Workbook

### DIFF
--- a/ansible/roles/ocp4-workload-cnvlab/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-cnvlab/tasks/workload.yml
@@ -10,6 +10,10 @@
   k8s:
     state: present
     definition: "{{ lookup('file', 'project.yaml') }}"
+  register: project_success
+  retries: 3
+  delay: 30
+  until: project_success is not failed
 
 - name: Clone OpenShift virt repositories
   git:
@@ -21,6 +25,10 @@
   block:
   - name: Configure and apply build template
     shell: oc -n workbook process -f ~/openshift-virt-labs/docs/build-template.yaml -p NAME=cnv | oc -n workbook apply -f -
+    register: buildt_success
+    retries: 3
+    delay: 30
+    until: buildt_success is not failed
 
   - name: Start the build
     shell: oc -n workbook start-build cnv --from-dir=openshift-virt-labs/docs/
@@ -31,11 +39,20 @@
 
   - name: Configure and deploy the deploy template
     shell: oc -n workbook process -f ~/openshift-virt-labs/docs/deploy-template.yaml -p NAME=cnv -p IMAGE_STREAM_NAME=cnv | oc -n workbook apply -f -
+    register: deploy_success
+    retries: 3
+    delay: 30
+    until: deploy_success is not failed
 
 - name: Give cluster-admin privileges to CNV user
   k8s:
     state: present
     definition: "{{ lookup('file', 'cnv-admin.yaml') }}"
+  register: clusteradmin_success
+  retries: 3
+  delay: 30
+  until: clusteradmin_success is not failed
+
 
 # Leave this as the last task in the playbook.
 # --------------------------------------------


### PR DESCRIPTION
##### SUMMARY

We've seen some issues with busy clusters and commands that only
have a single attempt cause entire deployment failures. This is
largely happening post-deployment when the OpenShift cluster is
already up and running. This patch attempts to provide some
more attempts where we've seen these failures

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
ocp4-workload-cnvlab
