### PR TITLE
Enhance user.info for Ansible Workshops to contain workshop name

### DIFF
--- a/ansible/configs/ansible-workshops/pre_infra.yml
+++ b/ansible/configs/ansible-workshops/pre_infra.yml
@@ -64,7 +64,7 @@
     - when: create_login_page  
       name: Output user.info string for email when a workshop, create_login_page set to true, S3 bucket
       debug:
-        msg: "user.info: The list of VMs for this workshop is available at: http://{{ guid }}.{{ workshop_dns_zone }}" 
+        msg: "user.info: {{ (student_workloads | default('Ansible')) | regex_replace('_tower_workshop','') | regex_replace('_', ' ') | title }} Workshop and Student VMs are available at: http://{{ guid }}.{{ workshop_dns_zone }}"
 
     - debug:
         msg: "Post-Software checks completed successfully"


### PR DESCRIPTION
##### SUMMARY

user.info has traditionally lacked context and users have been unable to tell which type of workshop the user.info (email) pertains to.

This is exacerbated by the fact that users may well spin up 2 or more **different** workshops at a time.

Fix puts identifying information into user.info

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Config: ansible_workshops

##### ADDITIONAL INFORMATION

