### PR TITLE
Change ocp4-workload-workshop-dashboard-cluster-admin-student agnosticd_user_info

### DIFF
--- a/ansible/roles/ocp4-workload-workshop-dashboard-cluster-admin-student/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-workshop-dashboard-cluster-admin-student/tasks/workload.yml
@@ -443,13 +443,14 @@
       var: RoleBinding
     when: not silent|bool
 
-- debug:
-    msg:
-    - "user.info: "
-    - "user.info: Access the workshop at '{{ Route.result.spec.host }}'"
-    - "user.info: Login with '{{ ocp_username }}' and '{{ user_password }}'"
-    - "user.info: "
-    - "user.info: Workshop may not be accessible until rollout finishes shortly."
+- agnosticd_user_info:
+    msg: "{{ item }}"
+  loop:
+    - ""
+    - "Access the workshop at https://{{ Route.result.spec.host }}"
+    - "Login with '{{ ocp_username }}' and '{{ user_password }}'"
+    - ""
+    - "Workshop may not be accessible until rollout finishes shortly."
   when: not silent|bool
 
 # Leave this as the last task in the playbook.


### PR DESCRIPTION
##### SUMMARY

Change workload role ocp4-workload-workshop-dashboard-cluster-admin-student to use `agnosticd_user_info` in order to allow this content to be picked up by the babylon infrastructure.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ocp4-workload-workshop-dashboard-cluster-admin-student 