### PR TITLE
Make VSCode role more robust

### DIFF
--- a/ansible/roles/vscode-server/tasks/nginx-server.yml
+++ b/ansible/roles/vscode-server/tasks/nginx-server.yml
@@ -16,7 +16,7 @@
 - name: Generate certbot
   command: >-
     certbot certonly --nginx
-    -m {{ email }}
+    -m {{ email | regex_replace('example.com$','opentlc.com') }}
     --agree-tos
     -d {{ vscode_server_hostname  }} -n
 
@@ -45,7 +45,7 @@
 
 - name: Copy custom vscode nginx configuration file
   copy:
-    src: ./files/nginx.conf
+    src: nginx.conf
     dest: /etc/nginx/nginx.conf
 
 - name: Enable selinux boolean to connect with vscode-server


### PR DESCRIPTION
##### SUMMARY

The new vscode-server role uses certbot/letsencrypt which **fails** when used with an email address ending example.com. This occurs throughout many Agnosticd configs.

Rolew made more robust by re-writing any example.com emails to opentlc.com

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
role: vscode-server
##### ADDITIONAL INFORMATION
