### PR TITLE
Update config ocp4-cluster with student_workload list

### DIFF
--- a/ansible/configs/ocp4-cluster/workloads.yml
+++ b/ansible/configs/ocp4-cluster/workloads.yml
@@ -54,6 +54,6 @@
         ocp_username: "user{{ workload_loop_var[0] }}"
         become_override: true
         ACTION: "provision"
-      loop: "{{ users | product(student_workloads) }}"
+      loop: "{{ users | product(student_workloads) | list }}"
       loop_control:
         loop_var: workload_loop_var


### PR DESCRIPTION
##### SUMMARY

This changes the workload.yml in ocp4-config to run the student_workloads through a list filter. This has been tested locally for a deployment using `student_workloads: []`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-cluster