### PR TITLE
Update Satellite CA package installation mechanism

### DIFF
--- a/ansible/roles/set-repositories/tasks/satellite-repos.yml
+++ b/ansible/roles/set-repositories/tasks/satellite-repos.yml
@@ -57,15 +57,18 @@
     - configure_repos
     - remove_existing_repos
 
-- name: Install satellite CA certificate package
-  package:
+# WK: use `yum` to allow ignore of GPG errors
+#     `package` does not have that options and results in random failures
+- name: Install Satellite CA certificate package
+  yum:
     name: "{{ set_repositories_satellite_ca_rpm_url }}"
     state: present
     disablerepo: "*"
+    disable_gpg_check: true
   register: r_install_satellite_ca_rpm
   until: not r_install_satellite_ca_rpm.failed
   retries: 10
-  delay: 30
+  delay: 10
 
 - name: Run setup if gather_facts hasn't been run
   setup:


### PR DESCRIPTION
##### SUMMARY

Installing the Satellite CA certificate sometimes fails with a GPG error.
Using `yum` instead of `package` with the `disable_gpg_check: true` parameter fixes this.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
set-repositories
