### PR TITLE
Update logic for ocp4-cluster ec2 destroy

### DIFF
--- a/ansible/configs/ocp4-cluster/destroy_env_ec2.yml
+++ b/ansible/configs/ocp4-cluster/destroy_env_ec2.yml
@@ -61,13 +61,37 @@
     AWS_SECRET_ACCESS_KEY: "{{aws_secret_access_key}}"
     AWS_DEFAULT_REGION: "{{aws_region_final|d(aws_region)}}"
   tasks:
-  - name: Ensure EC2 instances are running
-    ec2_instance:
-      state: running
-      wait: true
+  - name: Get all EC2 instances
+    ec2_instance_info:
       filters:
         "tag:guid": "{{ guid }}"
         "tag:env_type": "{{ env_type }}"
+        instance-state-name: stopped
+    register: r_stopped_instances
+
+  # Wk: Don't wait for instances to be running. Otherwise this is
+  #     a very sequential task. Just start the instances.
+  #     The next task will wait until all instances are running - but
+  #     this happens now in parallel instead of sequentially.
+  - name: Ensure EC2 instances are running
+    when: r_stopped_instances.instances | length > 0
+    ec2_instance:
+      instance_ids: "{{ item.instance_id }}"
+      state: started
+      wait: false
+    loop: "{{ r_stopped_instances.instances }}"
+
+  - name: Wait until all EC2 instances are running
+    when: r_stopped_instances.instances | length > 0
+    ec2_instance_info:
+      filters:
+        "tag:guid": "{{ guid }}"
+        "tag:env_type": "{{ env_type }}"
+        instance-state-name: running
+    register: r_running_instances
+    until: r_running_instances.instances | length | int >= r_stopped_instances.instances | length | int
+    delay: 10
+    retries: 60
 
 - name: Have the OpenShift installer cleanup what it did
   hosts: bastions


### PR DESCRIPTION
##### SUMMARY

Destroy failed (well, starting instances failed) when there were terminated instances still around. Added filters and better logic to only start stopped instances and leave terminated instances alone.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-cluster

