### PR TITLE
Fix roles bastion-lite and host-ocp4-provisioner user home dir

### DIFF
--- a/ansible/roles/bastion-lite/tasks/main.yml
+++ b/ansible/roles/bastion-lite/tasks/main.yml
@@ -61,20 +61,20 @@
     owner: root
     group: root
 
-- name: Add GUID to /etc/skel/.bashrc and /home/{{ ansible_user }}/.bashrc
+- name: Add GUID to /etc/skel/.bashrc and ~{{ ansible_user }}/.bashrc
   lineinfile:
     path: "{{ item }}"
     regexp: "^export GUID"
     line: "export GUID={{ guid }}"
   loop:
   - "/etc/skel/.bashrc"
-  - "/home/{{ ansible_user }}/.bashrc"
+  - "~{{ ansible_user }}/.bashrc"
 
-- name: Add CLOUDUSER to /etc/skel/.bashrc and /home/{{ ansible_user }}/.bashrc
+- name: Add CLOUDUSER to /etc/skel/.bashrc and ~{{ ansible_user }}/.bashrc
   lineinfile:
     path: "{{ item }}"
     regexp: "^export CLOUDUSER"
     line: "export CLOUDUSER={{ ansible_user }}"
   loop:
   - "/etc/skel/.bashrc"
-  - "/home/{{ ansible_user }}/.bashrc"
+  - "~{{ ansible_user }}/.bashrc"

--- a/ansible/roles/host-ocp4-provisioner/tasks/osp_prereqs.yml
+++ b/ansible/roles/host-ocp4-provisioner/tasks/osp_prereqs.yml
@@ -44,7 +44,7 @@
 
 - name: Add environment variables for API and Ingress FIPs
   lineinfile:
-    path: "/home/{{ ansible_user }}/.bashrc"
+    path: "~{{ ansible_user }}/.bashrc"
     regexp: "^export {{ item.env_var }}"
     line: "export {{ item.env_var }}={{ item.ip }}"
   loop:
@@ -58,14 +58,14 @@
 
 - name: Add environment variable for DNS domain
   lineinfile:
-    path: "/home/{{ ansible_user }}/.bashrc"
+    path: "~{{ ansible_user }}/.bashrc"
     regexp: "^export OPENSHIFT_DNS_ZONE"
     line: "export OPENSHIFT_DNS_ZONE={{ osp_cluster_dns_zone }}"
   when: openshift_fip_provision
 
 - name: Add environment variable for OpenStack credentials
   lineinfile:
-    path: "/home/{{ ansible_user }}/.bashrc"
+    path: "~{{ ansible_user }}/.bashrc"
     regexp: "^export OS_CLOUD"
     line: "export OS_CLOUD={{ osp_cloud_name }}"
 


### PR DESCRIPTION
##### SUMMARY

Fix bastion-lite and host-ocp4-provisioner to allow `ansible_user` home directory to be in a location other than `/home/{{ ansible_user }}`. Ansible path evaluation honors the standard `~USER/` syntax to lookup a user home directory.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Roles bastion-lite and host-ocp4-provisioner