### PR TITLE
Fix the command used to retrieve the image registry url

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_dso/tasks/infrastructure.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_dso/tasks/infrastructure.yml
@@ -25,11 +25,15 @@
   become: true
 
 - name: retrieve registry route
-  shell: "{{ ocp4_dso_openshift_cli }} get routes --all-namespaces | grep registry | grep default | grep -v console | awk '{print $3}'"
+  k8s_info:
+    api_version: route.openshift.io/v1
+    kind: route
+    name: default-route
+    namespace: openshift-image-registry
   register: image_route
 
 - set_fact:
-    ocp4_dso_ocp_registry_route: "{{ image_route.stdout }}"
+    ocp4_dso_ocp_registry_route:  "{{ image_route | json_query('resources[*].spec.host') }}"
 
 - name: add exposed registry as insecure
   template:


### PR DESCRIPTION
##### SUMMARY

The shell command used to retrieve the OCP internal registry route is incorrect, resulting in a failure of the lab. Fixed the grep.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_dso

