### PR TITLE
fix check to create infra nodes

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_machinesets/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_machinesets/tasks/workload.yml
@@ -49,7 +49,7 @@
 
 - name: Set up Infra Nodes when one MaschineSet group is called 'infra'
   when:
-  - ocp4_workload_machinesets_machineset_groups | selectattr('name', 'contains', 'infra')
+  - ocp4_workload_machinesets_machineset_groups | selectattr('name', 'contains', 'infra') | list | length > 0
   block:
   - name: Configure Ingress Controllers and Image Registry
     k8s:


### PR DESCRIPTION
##### SUMMARY

The check to create infra nodes always evaluated to true. This should fix it.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_machineset
