### PR TITLE
Ocp4 workload windows node

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+become_override: False
+ocp_username: opentlc-mgr
+silent: False
+
+# Defaults values below are for OpenShift Windows Containers - Tech Preview
+ocp4_workload_windows_node_defaults:
+  namespace: "windows-machine-config-operator"
+  cloud_private_key: "/home/ec2-user/.ssh/id_rsa"
+  index_image: "quay.io/redhatworkshops/windows-machine-config-operator-index:v0.0.3"
+  starting_csv: "windows-machine-config-operator.v0.0.3"
+  version: "v0.0.3"

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/defaults/main.yml
@@ -4,9 +4,7 @@ ocp_username: opentlc-mgr
 silent: False
 
 # Defaults values below are for OpenShift Windows Containers - Tech Preview
-ocp4_workload_windows_node_defaults:
-  namespace: "windows-machine-config-operator"
-  cloud_private_key: "/home/ec2-user/.ssh/id_rsa"
-  index_image: "quay.io/redhatworkshops/windows-machine-config-operator-index:v0.0.3"
-  starting_csv: "windows-machine-config-operator.v0.0.3"
-  version: "v0.0.3"
+ocp4_workload_windows_node_namespace: "windows-machine-config-operator"
+ocp4_workload_windows_node_cloud_private_key: "/home/ec2-user/.ssh/id_rsa"
+ocp4_workload_windows_node_index_image: "quay.io/redhatworkshops/windows-machine-config-operator-index:v0.0.3"
+ocp4_workload_windows_node_starting_csv: "windows-machine-config-operator.v0.0.3"

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/defaults/main.yml
@@ -5,6 +5,6 @@ silent: False
 
 # Defaults values below are for OpenShift Windows Containers - Tech Preview
 ocp4_workload_windows_node_namespace: "windows-machine-config-operator"
-ocp4_workload_windows_node_cloud_private_key: "/home/ec2-user/.ssh/id_rsa"
+ocp4_workload_windows_node_cloud_private_key: "/home/{{ ansible_user }}/.ssh/id_rsa"
 ocp4_workload_windows_node_index_image: "quay.io/redhatworkshops/windows-machine-config-operator-index:v0.0.3"
 ocp4_workload_windows_node_starting_csv: "windows-machine-config-operator.v0.0.3"

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/files/sshcmd.sh
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/files/sshcmd.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+ssh_key_param=''
+if [ ! -z "$SSH_KEY_PATH" ]; then
+    ssh_key_param="-i $SSH_KEY_PATH"
+fi
+
+ingress_host="$(oc get service --all-namespaces -l run=ssh-bastion -o go-template='{{ with (index (index .items 0).status.loadBalancer.ingress 0) }}{{ or .hostname .ip }}{{end}}')"
+ssh $ssh_key_param -t -o StrictHostKeyChecking=no -o ProxyCommand="ssh $ssh_key_param -A -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -W %h:%p core@${ingress_host}" administrator@$1 "powershell"

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/meta/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/meta/main.yml
@@ -1,0 +1,14 @@
+---
+galaxy_info:
+  role_name: ocp4_workload_windows_node
+  author: Red Hat Cloud Platfroms Business Unit, Christian Hernandez (christian@redhat.com)
+  description: |
+    Set up a Windows Node on OpenShift
+  license: MIT
+  min_ansible_version: 2.9
+  platforms: []
+  galaxy_tags:
+  - ocp
+  - openshift
+dependencies: []
+

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/readme.adoc
@@ -1,0 +1,65 @@
+= ocp4_workload_windows_node - Deploy a Windows Node to OpenShift
+
+== Role overview
+
+* This role installs a Windows node (backed by OVNKubernetes) into an OpenShift Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+ environment for the workload deployment.
+*** Debug task will print out: `pre_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy a Windows node
+*** This role creates a namespace (project) and deploys the operator. It will then create the Windows Node via a MachineSet
+*** Debug task will print out: `workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+ configure the workload after deployment
+*** This will undo some of the pre_workload tasks
+*** Debug task will print out: `post_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+ delete the workload
+*** This role removes the Windows node
+*** Debug task will print out: `remove_workload Tasks completed successfully.`
+
+== Review the defaults variable file
+
+* This file link:./defaults/main.yml[./defaults/main.yml] contains all the variables you need to define to control the deployment of your workload.
+* The variable *ocp_username* is mandatory to assign the workload to the correct OpenShift user.
+* A variable *silent=True* can be passed to suppress debug messages.
+
+=== Deploy a Workload with the `ocp-workload` playbook [Mostly for testing]
+
+----
+TARGET_HOST="bastion.ocp43.openshift.opentlc.com"
+OCP_USERNAME="chernand-redhat.com"
+WORKLOAD="ocp4_workload_windows_node"
+GUID=1001
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=ec2-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"silent=False" \
+    -e"guid=${GUID}" \
+    -e"ACTION=create"
+----
+
+=== To Delete an environment
+
+----
+TARGET_HOST="bastion.ocp43.openshift.opentlc.com"
+OCP_USERNAME="chernand-redhat.com"
+WORKLOAD="ocp4_workload_windows_node"
+GUID=1002
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=ec2-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"guid=${GUID}" \
+    -e"ACTION=remove"
+----

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+# Do not modify this file
+
+- name: Running Pre Workload Tasks
+  include_tasks:
+    file: ./pre_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload Tasks
+  include_tasks:
+    file: ./workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  include_tasks:
+    file: ./post_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload removal Tasks
+  include_tasks:
+    file: ./remove_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/post_workload.yml
@@ -1,0 +1,18 @@
+---
+# Implement your Post Workload deployment tasks here
+
+# Copy original AWS Credentials file back over
+- name: Copy original AWS Credentials file back over
+  copy:
+    src: /tmp/windows_node_workload_backups/aws_credentials
+    dest: /home/ec2-user/.aws/credentials
+    owner: ec2-user
+    group: ec2-user
+    mode: '0664'
+    remote_src: yes 
+
+# Leave this as the last task in the playbook.
+- name: post_workload tasks complete
+  debug:
+    msg: "Post-Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/post_workload.yml
@@ -5,9 +5,9 @@
 - name: Copy original AWS Credentials file back over
   copy:
     src: /tmp/windows_node_workload_backups/aws_credentials
-    dest: /home/ec2-user/.aws/credentials
-    owner: ec2-user
-    group: ec2-user
+    dest: "/home/{{ ansible_user }}/.aws/credentials"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
     mode: '0664'
     remote_src: yes 
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/pre_workload.yml
@@ -1,0 +1,50 @@
+---
+# Implement your Pre Workload deployment tasks here
+
+# Create various needed directories
+- name: Create various needed directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: ec2-user
+    group: ec2-user
+    mode: '0775'
+  loop:
+    - /tmp/windows_node_workload_backups
+
+# Make backup copy of AWS Credentials file
+- name: Make backup copy of AWS Credentials file
+  copy:
+    src: /home/ec2-user/.aws/credentials
+    dest: /tmp/windows_node_workload_backups/aws_credentials
+    owner: ec2-user
+    group: ec2-user
+    mode: '0664'
+    remote_src: yes
+
+# Extract the AWS access key from OpenShift
+- name: Extract the AWS access key from OpenShift
+  shell: oc get secret -n openshift-machine-api aws-cloud-credentials -o jsonpath='{.data.aws_access_key_id}' | base64 -d
+  register: ocp_access_key
+
+# Extract the AWS secret key from OpenShift
+- name: Extract the AWS secret key from OpenShift
+  shell: oc get secret -n openshift-machine-api aws-cloud-credentials -o jsonpath='{.data.aws_secret_access_key}' | base64 -d
+  register: ocp_secret_key
+
+# Configure the AWS access key from OpenShift into the credentials file
+- name: Configure the AWS access key from OpenShift into the credentials file
+  shell: aws configure set aws_access_key_id "{{ ocp_access_key.stdout }}"
+
+# Configure the AWS secret key from OpenShift into the credentials file
+- name: Configure the AWS secret key from OpenShift into the credentials file
+  shell: aws configure set aws_secret_access_key "{{ ocp_secret_key.stdout }}"
+
+# Leave this as the last task in the playbook.
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Workload tasks completed successfully."
+  when: not silent|bool
+
+##
+##

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/pre_workload.yml
@@ -11,6 +11,7 @@
     mode: '0775'
   loop:
     - /tmp/windows_node_workload_backups
+    - /home/ec2-user/windows_node_scripts
 
 # Make backup copy of AWS Credentials file
 - name: Make backup copy of AWS Credentials file

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/pre_workload.yml
@@ -6,40 +6,80 @@
   file:
     path: "{{ item }}"
     state: directory
-    owner: ec2-user
-    group: ec2-user
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
     mode: '0775'
   loop:
     - /tmp/windows_node_workload_backups
-    - /home/ec2-user/windows_node_scripts
+    - "/home/{{ ansible_user }}/windows_node_scripts"
 
 # Make backup copy of AWS Credentials file
 - name: Make backup copy of AWS Credentials file
   copy:
-    src: /home/ec2-user/.aws/credentials
+    src: "/home/{{ ansible_user }}/.aws/credentials"
     dest: /tmp/windows_node_workload_backups/aws_credentials
-    owner: ec2-user
-    group: ec2-user
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
     mode: '0664'
     remote_src: yes
 
 # Extract the AWS access key from OpenShift
 - name: Extract the AWS access key from OpenShift
-  shell: oc get secret -n openshift-machine-api aws-cloud-credentials -o jsonpath='{.data.aws_access_key_id}' | base64 -d
-  register: ocp_access_key
+  k8s_info:
+    api_version: v1
+    kind: Secret
+    name: aws-cloud-credentials
+    namespace: openshift-machine-api
+  register: ocp_access_key_fact
+  retries: 25
+  delay: 5
+  until:
+    - ocp_access_key_fact.resources[0].data.aws_access_key_id is defined
+
+# Convert extraced AWS access key into a decoded fact for later use
+- name: Convert extraced AWS access key into a decoded fact for later use
+  set_fact:
+    ocp_access_key: "{{ ocp_access_key_fact.resources[0].data.aws_access_key_id | b64decode }}"
 
 # Extract the AWS secret key from OpenShift
 - name: Extract the AWS secret key from OpenShift
-  shell: oc get secret -n openshift-machine-api aws-cloud-credentials -o jsonpath='{.data.aws_secret_access_key}' | base64 -d
-  register: ocp_secret_key
+  k8s_info:
+    api_version: v1
+    kind: Secret
+    name: aws-cloud-credentials
+    namespace: openshift-machine-api
+  register: ocp_secret_key_fact
+  retries: 25
+  delay: 5
+  until:
+    - ocp_secret_key_fact.resources[0].data.aws_secret_access_key is defined
 
-# Configure the AWS access key from OpenShift into the credentials file
-- name: Configure the AWS access key from OpenShift into the credentials file
-  shell: aws configure set aws_access_key_id "{{ ocp_access_key.stdout }}"
+# Convert extraced AWS secret key into a decoded fact for later use
+- name: Convert extraced AWS secret key into a decoded fact for later use
+  set_fact:
+    ocp_secret_key: "{{ ocp_secret_key_fact.resources[0].data.aws_secret_access_key | b64decode }}"
 
-# Configure the AWS secret key from OpenShift into the credentials file
-- name: Configure the AWS secret key from OpenShift into the credentials file
-  shell: aws configure set aws_secret_access_key "{{ ocp_secret_key.stdout }}"
+# Remove existing AWS credentials file
+- name: Remove existing AWS credentials file
+  file:
+    path: "/home/{{ ansible_user }}/.aws/credentials"
+    state: absent
+
+# Configure the AWS credentials file with the access key and secret key from OpenShift
+- name: Configure the AWS credentials file with the access key and secret key from OpenShift
+  when:
+  - ocp_access_key | default("") | length > 0
+  - ocp_secret_key | default("") | length > 0
+  blockinfile:
+    state: present
+    path: "/home/{{ ansible_user }}/.aws/credentials"
+    create: true
+    insertbefore: BOF
+    marker: "# {mark} ANSIBLE MANAGED BLOCK AMI Search Credentials"
+    block: |-
+      [default]
+      aws_access_key_id = {{ ocp_access_key }}
+      aws_secret_access_key = {{ ocp_secret_key }}
 
 # Leave this as the last task in the playbook.
 - name: pre_workload tasks complete

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/remove_workload.yml
@@ -1,25 +1,51 @@
 ---
 # Implement your Workload removal tasks here
 
-# Get the OpenShift cluster ID
+# Extract the AWS secret key from OpenShift
 - name: Get the OpenShift cluster ID
-  shell: oc get -o jsonpath='{.status.infrastructureName}' infrastructure cluster
-  register: cluster_id
+  k8s_info:
+    api_version: config.openshift.io/v1
+    kind: Infrastructure
+    name: cluster
+    namespace: default
+  register: cluster_id_fact
+  retries: 25
+  delay: 5
+  until:
+    - cluster_id_fact.resources[0].status.infrastructureName is defined
+
+# Set the Openshift ID as a fact for later use
+- name: Set the Openshift ID as a fact for later use
+  set_fact:
+    cluster_id: "{{ cluster_id_fact.resources[0].status.infrastructureName }}"
+
+# Extract OpenShift machineSet region and first availablity zone
+- name: Extract OpenShift machineSet region and first availablity zone
+  k8s_info:
+    api_version: machine.openshift.io/v1beta1
+    kind: MachineSet
+    namespace: openshift-machine-api
+  register: machineset_list
+  retries: 25
+  delay: 5
+  until:
+    - machineset_list.resources[0].spec.template.spec.providerSpec.value.placement.region is defined
+    - machineset_list.resources[0].spec.template.spec.providerSpec.value.placement.availabilityZone is defined
 
 # Get the region for the cluster
-- name: Get the region for the cluster
-  shell: oc get machineset -n openshift-machine-api -o jsonpath='{.items[0].spec.template.spec.providerSpec.value.placement.region}'
-  register: cluster_region
+- name: Get the region for the cluster and set it as a fact for later use
+  set_fact:
+    cluster_region: "{{ machineset_list.resources[0].spec.template.spec.providerSpec.value.placement.region }}"
 
 # Get the first availability zone for the cluster
-- name: Get the first availability zone for the cluster
-  shell: oc get machineset -n openshift-machine-api -o jsonpath='{.items[0].spec.template.spec.providerSpec.value.placement.availabilityZone}'
-  register: cluster_az
+- name: Get the first availability zone for the cluster and set it as a fact for later use
+  set_fact:
+    cluster_az: "{{ machineset_list.resources[0].spec.template.spec.providerSpec.value.placement.availabilityZone }}"
 
 # Get the latest Windows Server 2019 with Containers AMI
 - name: Get the latest Windows Server 2019 with Containers AMI
   shell: >
-    aws ec2 describe-images --region={{ cluster_region.stdout }} --filters 'Name=name,Values=Windows_Server-2019*English*Full*Containers*' 'Name=is-public,Values=true' --query 'reverse(sort_by(Images, &CreationDate))[*].{name: Name, id: ImageId}' | jq -r '.[0].id'
+    aws ec2 describe-images --region={{ cluster_region }} --filters 'Name=name,Values=Windows_Server-2019*English*Full*Containers*' 'Name=is-public,Values=true' --query 'reverse(sort_by(Images, &CreationDate))[*].{name: Name, id: ImageId}' | jq -r '.[0].id'
   register: windows_ami
 
 # Remove the Windows Node MachineSet

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/remove_workload.yml
@@ -1,0 +1,59 @@
+---
+# Implement your Workload removal tasks here
+
+# Get the OpenShift cluster ID
+- name: Get the OpenShift cluster ID
+  shell: oc get -o jsonpath='{.status.infrastructureName}' infrastructure cluster
+  register: cluster_id
+
+# Get the region for the cluster
+- name: Get the region for the cluster
+  shell: oc get machineset -n openshift-machine-api -o jsonpath='{.items[0].spec.template.spec.providerSpec.value.placement.region}'
+  register: cluster_region
+
+# Get the first availability zone for the cluster
+- name: Get the first availability zone for the cluster
+  shell: oc get machineset -n openshift-machine-api -o jsonpath='{.items[0].spec.template.spec.providerSpec.value.placement.availabilityZone}'
+  register: cluster_az
+
+# Get the latest Windows Server 2019 with Containers AMI
+- name: Get the latest Windows Server 2019 with Containers AMI
+  shell: >
+    aws ec2 describe-images --region={{ cluster_region.stdout }} --filters 'Name=name,Values=Windows_Server-2019*English*Full*Containers*' 'Name=is-public,Values=true' --query 'reverse(sort_by(Images, &CreationDate))[*].{name: Name, id: ImageId}' | jq -r '.[0].id'
+  register: windows_ami
+
+# Remove the Windows Node MachineSet
+- name: Remove the Windows Node MachineSet
+  k8s:
+    state: absent 
+    definition: "{{ lookup('template', 'windows-ms.j2' ) }}"
+
+# Delete the Namespace for the Operator
+- name: Delete the Namespace for the Operator
+  k8s:
+    state: absent
+    definition: "{{ lookup('template', 'namespace.j2' ) }}"
+
+# Remove catalog source
+- name: Remove catalog source
+  k8s:
+    state: absent
+    definition: "{{ lookup('template', 'catalogsource.j2' ) }}"
+
+# Remove the Operator group
+- name: Remove the Operator group
+  k8s:
+    state: absent
+    definition: "{{ lookup('template', 'operatorgroup.j2' ) }}"
+
+# Remove the Subscription
+- name: Remove the Subscription
+  k8s:
+    state: absent
+    definition: "{{ lookup('template', 'subscription.j2' ) }}"
+
+# Leave this as the last task in the playbook.
+- name: remove_workload tasks complete
+  debug:
+    msg: "Remove Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/workload.yml
@@ -59,7 +59,9 @@
   register: wmcocs
   retries: 25
   delay: 5
-  until: wmcocs.resources[0].status.connectionState.lastObservedState == "READY"
+  until:
+    - wmcocs.resources[0].status.connectionState.lastObservedState is defined
+    - wmcocs.resources[0].status.connectionState.lastObservedState == "READY"
 
 # Create the Operator group
 - name: Create the Operator group
@@ -92,7 +94,9 @@
   register: wcoperator
   retries: 25
   delay: 5
-  until: wcoperator.resources[0].status.readyReplicas == 1
+  until:
+    - wcoperator.resources[0].status.readyReplicas is defined
+    - wcoperator.resources[0].status.readyReplicas == 1
 
 # Create the Windows Node MachineSet
 - name: Create the Windows Node MachineSet
@@ -111,7 +115,9 @@
   register: wnmstatus
   retries: 25
   delay: 30
-  until: wnmstatus.resources[0].status.phase == "Running"
+  until:
+    - wnmstatus.resources[0].status.phase is defined
+    - wnmstatus.resources[0].status.phase == "Running"
 
 # Leave this as the last task in the playbook.
 - name: workload tasks complete

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/workload.yml
@@ -101,7 +101,7 @@
     definition: "{{ lookup('template', 'windows-ms.j2' ) }}"
 
 # Wait for the Window machine to come up
-- name: Wait for the Window machine to come up
+- name: Wait for the Window machine to come up (this may take some time)
   k8s_info:
     api_version: machine.openshift.io/v1beta1
     kind: Machine
@@ -110,7 +110,7 @@
     namespace: openshift-machine-api
   register: wnmstatus
   retries: 25
-  delay: 5
+  delay: 30
   until: wnmstatus.resources[0].status.phase == "Running"
 
 # Leave this as the last task in the playbook.

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/workload.yml
@@ -1,0 +1,123 @@
+---
+# Implement your Workload deployment tasks here
+- name: Setting up workload for user
+  debug:
+    msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
+
+# Get the OpenShift cluster ID
+- name: Get the OpenShift cluster ID
+  shell: oc get -o jsonpath='{.status.infrastructureName}' infrastructure cluster
+  register: cluster_id
+
+# Get the region for the cluster
+- name: Get the region for the cluster
+  shell: oc get machineset -n openshift-machine-api -o jsonpath='{.items[0].spec.template.spec.providerSpec.value.placement.region}'
+  register: cluster_region
+
+# Get the first availability zone for the cluster
+- name: Get the first availability zone for the cluster
+  shell: oc get machineset -n openshift-machine-api -o jsonpath='{.items[0].spec.template.spec.providerSpec.value.placement.availabilityZone}'
+  register: cluster_az
+
+# Get the latest Windows Server 2019 with Containers AMI
+- name: Get the latest Windows Server 2019 with Containers AMI
+  shell: >
+    aws ec2 describe-images --region={{ cluster_region.stdout }} --filters 'Name=name,Values=Windows_Server-2019*English*Full*Containers*' 'Name=is-public,Values=true' --query 'reverse(sort_by(Images, &CreationDate))[*].{name: Name, id: ImageId}' | jq -r '.[0].id'
+  register: windows_ami
+
+# Slurp SSH key to use for secret
+- name: Slurp SSH key to use for secret
+  slurp:
+    src: "{{ ocp4_workload_windows_node_defaults.cloud_private_key }}"
+  register: ssh_key
+
+# Create the Namespace for the Operator
+- name: Create the Namespace for the Operator
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'namespace.j2' ) }}"
+
+# Create Secret with the contents of the ssh key
+- name: Create Secret with the contents of the ssh key
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'sshsecrets.j2' ) }}"
+
+# Create catalog source
+- name: Create catalog source
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'catalogsource.j2' ) }}"
+
+# Wait for the catalog item to be ready
+- name: Wait for the catalog item to be ready
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: CatalogSource
+    name: wmco
+    namespace: openshift-marketplace
+  register: wmcocs
+  retries: 25
+  delay: 5
+  until: wmcocs.resources[0].status.connectionState.lastObservedState == "READY"
+
+# Create the Operator group
+- name: Create the Operator group
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'operatorgroup.j2' ) }}"
+
+# Create the Subscription
+- name: Create the Subscription
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'subscription.j2' ) }}"
+
+# Wait for the deployment to appear
+- name: Wait for the deployment to appear
+  shell: >
+    oc get deployment -n windows-machine-config-operator windows-machine-config-operator  -o name | wc -l
+  register: wcodeployment
+  retries: 25
+  delay: 5
+  until: wcodeployment.stdout | int == 1
+
+# Wait for the operator to come up
+- name: Wait for the operator to come up
+  k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: windows-machine-config-operator
+    namespace: "{{ ocp4_workload_windows_node_defaults.namespace }}"
+  register: wcoperator
+  retries: 25
+  delay: 5
+  until: wcoperator.resources[0].status.readyReplicas == 1
+
+# Create the Windows Node MachineSet
+- name: Create the Windows Node MachineSet
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'windows-ms.j2' ) }}"
+
+# Wait for the Window machine to come up
+- name: Wait for the Window machine to come up
+  k8s_info:
+    api_version: machine.openshift.io/v1beta1
+    kind: Machine
+    label_selectors:
+      - machine.openshift.io/os-id = Windows
+    namespace: openshift-machine-api
+  register: wnmstatus
+  retries: 25
+  delay: 5
+  until: wnmstatus.resources[0].status.phase == "Running"
+
+# Leave this as the last task in the playbook.
+- name: workload tasks complete
+  debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent|bool
+
+##
+##

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/workload.yml
@@ -4,6 +4,24 @@
   debug:
     msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
 
+# Download SSH proxy container creator script
+- name: Download SSH proxy container creator script
+  get_url:
+    url: https://raw.githubusercontent.com/eparis/ssh-bastion/master/deploy/deploy.sh
+    dest: /home/ec2-user/windows_node_scripts/deploy-sshproxy.sh
+    owner: ec2-user
+    group: ec2-user
+    mode: '0555'
+
+# Copy over ssh command script
+- name: Download SSH proxy container creator script
+  copy:
+    src: sshcmd.sh
+    dest: /home/ec2-user/windows_node_scripts/sshcmd.sh
+    owner: ec2-user
+    group: ec2-user
+    mode: '0555'
+
 # Get the OpenShift cluster ID
 - name: Get the OpenShift cluster ID
   shell: oc get -o jsonpath='{.status.infrastructureName}' infrastructure cluster

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/workload.yml
@@ -7,40 +7,66 @@
 # Download SSH proxy container creator script
 - name: Download SSH proxy container creator script
   get_url:
-    url: https://raw.githubusercontent.com/eparis/ssh-bastion/master/deploy/deploy.sh
-    dest: /home/ec2-user/windows_node_scripts/deploy-sshproxy.sh
-    owner: ec2-user
-    group: ec2-user
-    mode: '0555'
+    url: https://raw.githubusercontent.com/eparis/ssh-bastion/3b0e2565534424e216f995254b0b048c632c4edc/deploy/deploy.sh
+    dest: "/home/{{ ansible_user }}/windows_node_scripts/deploy-sshproxy.sh"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: '0755'
 
 # Copy over ssh command script
 - name: Download SSH proxy container creator script
   copy:
     src: sshcmd.sh
-    dest: /home/ec2-user/windows_node_scripts/sshcmd.sh
-    owner: ec2-user
-    group: ec2-user
-    mode: '0555'
+    dest: "/home/{{ ansible_user }}/windows_node_scripts/sshcmd.sh"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: '0755'
 
-# Get the OpenShift cluster ID
+# Extract the AWS secret key from OpenShift
 - name: Get the OpenShift cluster ID
-  shell: oc get -o jsonpath='{.status.infrastructureName}' infrastructure cluster
-  register: cluster_id
+  k8s_info:
+    api_version: config.openshift.io/v1
+    kind: Infrastructure
+    name: cluster
+    namespace: default
+  register: cluster_id_fact
+  retries: 25
+  delay: 5
+  until:
+    - cluster_id_fact.resources[0].status.infrastructureName is defined
+
+# Set the Openshift ID as a fact for later use
+- name: Set the Openshift ID as a fact for later use
+  set_fact:
+    cluster_id: "{{ cluster_id_fact.resources[0].status.infrastructureName }}"
+
+# Extract OpenShift machineSet region and first availablity zone
+- name: Extract OpenShift machineSet region and first availablity zone
+  k8s_info:
+    api_version: machine.openshift.io/v1beta1
+    kind: MachineSet
+    namespace: openshift-machine-api
+  register: machineset_list
+  retries: 25
+  delay: 5
+  until:
+    - machineset_list.resources[0].spec.template.spec.providerSpec.value.placement.region is defined
+    - machineset_list.resources[0].spec.template.spec.providerSpec.value.placement.availabilityZone is defined
 
 # Get the region for the cluster
-- name: Get the region for the cluster
-  shell: oc get machineset -n openshift-machine-api -o jsonpath='{.items[0].spec.template.spec.providerSpec.value.placement.region}'
-  register: cluster_region
+- name: Get the region for the cluster and set it as a fact for later use
+  set_fact:
+    cluster_region: "{{ machineset_list.resources[0].spec.template.spec.providerSpec.value.placement.region }}"
 
 # Get the first availability zone for the cluster
-- name: Get the first availability zone for the cluster
-  shell: oc get machineset -n openshift-machine-api -o jsonpath='{.items[0].spec.template.spec.providerSpec.value.placement.availabilityZone}'
-  register: cluster_az
+- name: Get the first availability zone for the cluster and set it as a fact for later use
+  set_fact:
+    cluster_az: "{{ machineset_list.resources[0].spec.template.spec.providerSpec.value.placement.availabilityZone }}"
 
 # Get the latest Windows Server 2019 with Containers AMI
 - name: Get the latest Windows Server 2019 with Containers AMI
   shell: >
-    aws ec2 describe-images --region={{ cluster_region.stdout }} --filters 'Name=name,Values=Windows_Server-2019*English*Full*Containers*' 'Name=is-public,Values=true' --query 'reverse(sort_by(Images, &CreationDate))[*].{name: Name, id: ImageId}' | jq -r '.[0].id'
+    aws ec2 describe-images --region={{ cluster_region }} --filters 'Name=name,Values=Windows_Server-2019*English*Full*Containers*' 'Name=is-public,Values=true' --query 'reverse(sort_by(Images, &CreationDate))[*].{name: Name, id: ImageId}' | jq -r '.[0].id'
   register: windows_ami
 
 # Slurp SSH key to use for secret
@@ -92,15 +118,6 @@
   k8s:
     state: present
     definition: "{{ lookup('template', 'subscription.j2' ) }}"
-
-# Wait for the deployment to appear
-- name: Wait for the deployment to appear
-  shell: >
-    oc get deployment -n windows-machine-config-operator windows-machine-config-operator  -o name | wc -l
-  register: wcodeployment
-  retries: 25
-  delay: 5
-  until: wcodeployment.stdout | int == 1
 
 # Wait for the operator to come up
 - name: Wait for the operator to come up

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/workload.yml
@@ -46,7 +46,7 @@
 # Slurp SSH key to use for secret
 - name: Slurp SSH key to use for secret
   slurp:
-    src: "{{ ocp4_workload_windows_node_defaults.cloud_private_key }}"
+    src: "{{ ocp4_workload_windows_node_cloud_private_key }}"
   register: ssh_key
 
 # Create the Namespace for the Operator
@@ -108,7 +108,7 @@
     api_version: apps/v1
     kind: Deployment
     name: windows-machine-config-operator
-    namespace: "{{ ocp4_workload_windows_node_defaults.namespace }}"
+    namespace: "{{ ocp4_workload_windows_node_namespace }}"
   register: wcoperator
   retries: 25
   delay: 5

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/templates/catalogsource.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/templates/catalogsource.j2
@@ -1,0 +1,12 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: wmco
+  namespace: openshift-marketplace
+spec:
+  displayName: Windows Machine Config operators
+  sourceType: grpc
+  image: "{{ ocp4_workload_windows_node_defaults.index_image }}"
+  updateStrategy:
+    registryPoll:
+      interval: 5m

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/templates/catalogsource.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/templates/catalogsource.j2
@@ -6,7 +6,7 @@ metadata:
 spec:
   displayName: Windows Machine Config operators
   sourceType: grpc
-  image: "{{ ocp4_workload_windows_node_defaults.index_image }}"
+  image: "{{ ocp4_workload_windows_node_index_image }}"
   updateStrategy:
     registryPoll:
       interval: 5m

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/templates/namespace.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/templates/namespace.j2
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "{{ ocp4_workload_windows_node_defaults.namespace }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/templates/namespace.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/templates/namespace.j2
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: "{{ ocp4_workload_windows_node_defaults.namespace }}"
+  name: "{{ ocp4_workload_windows_node_namespace }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/templates/operatorgroup.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/templates/operatorgroup.j2
@@ -4,7 +4,7 @@ metadata:
   annotations:
     olm.providedAPIs: WindowsMachineConfig.v1alpha1.wmc.openshift.io
   name: windows-machine-config-operator
-  namespace: "{{ ocp4_workload_windows_node_defaults.namespace }}"
+  namespace: "{{ ocp4_workload_windows_node_namespace }}"
 spec:
   targetNamespaces:
-  - "{{ ocp4_workload_windows_node_defaults.namespace }}"
+  - "{{ ocp4_workload_windows_node_namespace }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/templates/operatorgroup.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/templates/operatorgroup.j2
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  annotations:
+    olm.providedAPIs: WindowsMachineConfig.v1alpha1.wmc.openshift.io
+  name: windows-machine-config-operator
+  namespace: "{{ ocp4_workload_windows_node_defaults.namespace }}"
+spec:
+  targetNamespaces:
+  - "{{ ocp4_workload_windows_node_defaults.namespace }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/templates/sshsecrets.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/templates/sshsecrets.j2
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  private-key.pem: "{{ ssh_key.content }}"
+kind: Secret
+metadata:
+  creationTimestamp: null
+  name: cloud-private-key
+  namespace: "{{ ocp4_workload_windows_node_defaults.namespace }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/templates/sshsecrets.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/templates/sshsecrets.j2
@@ -5,4 +5,4 @@ kind: Secret
 metadata:
   creationTimestamp: null
   name: cloud-private-key
-  namespace: "{{ ocp4_workload_windows_node_defaults.namespace }}"
+  namespace: "{{ ocp4_workload_windows_node_namespace }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/templates/subscription.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/templates/subscription.j2
@@ -1,0 +1,12 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: windows-machine-config-operator
+  namespace: "{{ ocp4_workload_windows_node_defaults.namespace }}"
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: windows-machine-config-operator
+  source: wmco
+  sourceNamespace: openshift-marketplace
+  startingCSV: "{{ ocp4_workload_windows_node_defaults.starting_csv }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/templates/subscription.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/templates/subscription.j2
@@ -2,11 +2,11 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: windows-machine-config-operator
-  namespace: "{{ ocp4_workload_windows_node_defaults.namespace }}"
+  namespace: "{{ ocp4_workload_windows_node_namespace }}"
 spec:
   channel: alpha
   installPlanApproval: Automatic
   name: windows-machine-config-operator
   source: wmco
   sourceNamespace: openshift-marketplace
-  startingCSV: "{{ ocp4_workload_windows_node_defaults.starting_csv }}"
+  startingCSV: "{{ ocp4_workload_windows_node_starting_csv }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/templates/windows-ms.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/templates/windows-ms.j2
@@ -1,0 +1,60 @@
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  labels:
+    machine.openshift.io/cluster-api-cluster: "{{ cluster_id.stdout }}"
+  name: "{{ cluster_id.stdout }}-windows-{{ cluster_az.stdout }}"
+  namespace: openshift-machine-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: "{{ cluster_id.stdout }}"
+      machine.openshift.io/cluster-api-machineset: "{{ cluster_id.stdout }}-worker-{{ cluster_az.stdout }}"
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster: "{{ cluster_id.stdout }}"
+        machine.openshift.io/cluster-api-machine-role: worker
+        machine.openshift.io/cluster-api-machine-type: worker
+        machine.openshift.io/cluster-api-machineset: "{{ cluster_id.stdout }}-worker-{{ cluster_az.stdout }}"
+        machine.openshift.io/os-id: Windows
+    spec:
+      metadata:
+        labels:
+          node-role.kubernetes.io/worker: ""
+      providerSpec:
+        value:
+          ami:
+            id: "{{ windows_ami.stdout }}"
+          apiVersion: awsproviderconfig.openshift.io/v1beta1
+          blockDevices:
+            - ebs:
+                iops: 0
+                volumeSize: 120
+                volumeType: gp2
+          credentialsSecret:
+            name: aws-cloud-credentials
+          deviceIndex: 0
+          iamInstanceProfile:
+            id: "{{ cluster_id.stdout }}-worker-profile"
+          instanceType: m5a.large
+          kind: AWSMachineProviderConfig
+          placement:
+            availabilityZone: "{{ cluster_az.stdout }}"
+            region: "{{ cluster_region.stdout }}"
+          securityGroups:
+            - filters:
+                - name: tag:Name
+                  values:
+                    - "{{ cluster_id.stdout }}-worker-sg"
+          subnet:
+            filters:
+              - name: tag:Name
+                values:
+                  - "{{ cluster_id.stdout }}-private-{{ cluster_az.stdout }}"
+          tags:
+            - name: "kubernetes.io/cluster/{{ cluster_id.stdout }}"
+              value: owned
+          userDataSecret:
+            name: windows-user-data

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/templates/windows-ms.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/templates/windows-ms.j2
@@ -2,22 +2,22 @@ apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
   labels:
-    machine.openshift.io/cluster-api-cluster: "{{ cluster_id.stdout }}"
-  name: "{{ cluster_id.stdout }}-windows-{{ cluster_az.stdout }}"
+    machine.openshift.io/cluster-api-cluster: "{{ cluster_id }}"
+  name: "{{ cluster_id }}-windows-{{ cluster_az }}"
   namespace: openshift-machine-api
 spec:
   replicas: 1
   selector:
     matchLabels:
-      machine.openshift.io/cluster-api-cluster: "{{ cluster_id.stdout }}"
-      machine.openshift.io/cluster-api-machineset: "{{ cluster_id.stdout }}-worker-{{ cluster_az.stdout }}"
+      machine.openshift.io/cluster-api-cluster: "{{ cluster_id }}"
+      machine.openshift.io/cluster-api-machineset: "{{ cluster_id }}-worker-{{ cluster_az }}"
   template:
     metadata:
       labels:
-        machine.openshift.io/cluster-api-cluster: "{{ cluster_id.stdout }}"
+        machine.openshift.io/cluster-api-cluster: "{{ cluster_id }}"
         machine.openshift.io/cluster-api-machine-role: worker
         machine.openshift.io/cluster-api-machine-type: worker
-        machine.openshift.io/cluster-api-machineset: "{{ cluster_id.stdout }}-worker-{{ cluster_az.stdout }}"
+        machine.openshift.io/cluster-api-machineset: "{{ cluster_id }}-worker-{{ cluster_az }}"
         machine.openshift.io/os-id: Windows
     spec:
       metadata:
@@ -37,24 +37,24 @@ spec:
             name: aws-cloud-credentials
           deviceIndex: 0
           iamInstanceProfile:
-            id: "{{ cluster_id.stdout }}-worker-profile"
+            id: "{{ cluster_id }}-worker-profile"
           instanceType: m5a.large
           kind: AWSMachineProviderConfig
           placement:
-            availabilityZone: "{{ cluster_az.stdout }}"
-            region: "{{ cluster_region.stdout }}"
+            availabilityZone: "{{ cluster_az }}"
+            region: "{{ cluster_region }}"
           securityGroups:
             - filters:
                 - name: tag:Name
                   values:
-                    - "{{ cluster_id.stdout }}-worker-sg"
+                    - "{{ cluster_id }}-worker-sg"
           subnet:
             filters:
               - name: tag:Name
                 values:
-                  - "{{ cluster_id.stdout }}-private-{{ cluster_az.stdout }}"
+                  - "{{ cluster_id }}-private-{{ cluster_az }}"
           tags:
-            - name: "kubernetes.io/cluster/{{ cluster_id.stdout }}"
+            - name: "kubernetes.io/cluster/{{ cluster_id }}"
               value: owned
           userDataSecret:
             name: windows-user-data


### PR DESCRIPTION
##### SUMMARY

This workload deploys a windows node on a 4.6 cluster. It also deploys ssh helper scripts in order to get a powershell connection into the windows node.

##### ADDITIONAL INFORMATION

This playbook deploys a Windows Server 2019 with Containers instance and adds it as a OpenShift node. A few things to note.

* This playbook requires 4.6
* OCP 4.6 needs to be installed using OVNKubernetes network plugin
* I temporarily extract the install keys in order to list the ami to get the right Windows ami dynamically.
* I backup the aws config for the ec2-user and restore it once I get the right ami.