### PR TITLE
Change infra-ec2-template-create, Do not allow empty tag

### DIFF
--- a/ansible/roles-infra/infra-ec2-template-create/defaults/main.yml
+++ b/ansible/roles-infra/infra-ec2-template-create/defaults/main.yml
@@ -5,7 +5,7 @@ cf_tags:
   owner: "{{ email | default(user) | default('unknown') }}"
   env_type: "{{ env_type }}"
   guid: "{{ guid }}"
-  uuid: "{{ uuid | default('none') }}"
+  uuid: "{{ uuid | default(omit) }}"
 
 # custom additional tags :
 cloud_tags: {}


### PR DESCRIPTION
This commit, if applied, fixes the following error when uuid is not
defined:

```
TASK [infra-ec2-template-create : debug cloudformation] ************************
Wednesday 19 August 2020  10:56:37 -0400 (0:00:01.018)       0:00:14.114 ******
ok: [localhost] => {
    "cloudformation_out": {
        "attempts": 1,
        "changed": false,
        "exception": "Traceback (most recent call last):\n  File \"/tmp/ansible_cloudformation_payload_MexD1U/__main__.py\", line 369, in create_stack\n    cfn.create_stack(**stack_params)\n  File \"/tmp/ansible_cloudformation_payload_MexD1U/ansible_cloudformation_payload.zip/ansible/module_utils/cloud.py\", line 153, in retry_func\n    raise e\nParamValidationError: Parameter validation failed:\nInvalid length for parameter Tags[4].Value, value: 0, valid range: 1-inf\n",
        "failed": true,
        "msg": "Failed to create stack ocp-workshop-ci-pr-gate-311: Parameter validation failed:\nInvalid length for parameter Tags[4].Value, value: 0, valid range: 1-inf Parameter validation failed:\nInvalid length for parameter Tags[4].Value, value: 0, valid range: 1-inf - <class 'botocore.exceptions.ParamValidationError'>."
    }
}
```

closes #2398

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
