### PR TITLE
Change infra-aws-sandbox, Fix aws-nuke failing because of AWSBackup default

### DIFF
--- a/ansible/roles-infra/infra-aws-sandbox/defaults/main.yml
+++ b/ansible/roles-infra/infra-aws-sandbox/defaults/main.yml
@@ -118,6 +118,18 @@ aws_nuke_filters_default:
   MediaConvertQueue:
     - Default
 
+  # Default Plan and Vault cannot be deleted
+  AWSBackupSelection:
+    - property: Name
+      value: aws/efs/automatic-backup-selection
+  AWSBackupPlan:
+    - property: Name
+      value: aws/efs/automatic-backup-plan
+  AWSBackupVault:
+    - property: Name
+      value: aws/efs/automatic-backup-vault
+
+
 ##############################
 # POOL management
 ##############################


### PR DESCRIPTION
Once a Backup plan and vault is created in the account, it cannot be
deleted and aws-nuke fails.

This commit, if applied, fixes that by ignoring those default resources.

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
