### PR TITLE
Fix check for ready pods (availableReplicas -> readyReplicas)

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_example_shared_cluster/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_example_shared_cluster/tasks/workload.yml
@@ -32,8 +32,8 @@
   delay: 10
   until:
     - r_hello_openshift_deployment.resources | length | int > 0
-    - r_hello_openshift_deployment.resources[0].status.availableReplicas is defined
-    - r_hello_openshift_deployment.resources[0].status.availableReplicas | int == r_hello_openshift_deployment.resources[0].spec.readyReplicas | int
+    - r_hello_openshift_deployment.resources[0].status.readyReplicas is defined
+    - r_hello_openshift_deployment.resources[0].status.readyReplicas | int == r_hello_openshift_deployment.resources[0].spec.readyReplicas | int
 
 - name: get route by querying the OpenShift API
   k8s_info:

--- a/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/tasks/workload.yml
@@ -28,8 +28,8 @@
   until:
   - r_gitea_operator_deployment.resources is defined
   - r_gitea_operator_deployment.resources | length | int > 0
-  - r_gitea_operator_deployment.resources[0].status.availableReplicas is defined
-  - r_gitea_operator_deployment.resources[0].status.availableReplicas | int == r_gitea_operator_deployment.resources[0].spec.replicas | int
+  - r_gitea_operator_deployment.resources[0].status.readyReplicas is defined
+  - r_gitea_operator_deployment.resources[0].status.readyReplicas | int == r_gitea_operator_deployment.resources[0].spec.replicas | int
 
 - name: Deploy default Gitea instance
   when: ocp4_workload_gitea_operator_deploy_gitea_instance | bool
@@ -50,8 +50,8 @@
     delay: 10
     until:
     - r_gitea_deployment.resources | length | int > 0
-    - r_gitea_deployment.resources[0].status.availableReplicas is defined
-    - r_gitea_deployment.resources[0].status.availableReplicas | int == r_gitea_deployment.resources[0].spec.replicas | int
+    - r_gitea_deployment.resources[0].status.readyReplicas is defined
+    - r_gitea_deployment.resources[0].status.readyReplicas | int == r_gitea_deployment.resources[0].spec.replicas | int
 
 - name: search for gitea pod
   k8s_info:

--- a/ansible/roles_ocp_workloads/ocp4_workload_pipelines/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_pipelines/tasks/workload.yml
@@ -108,8 +108,8 @@
   delay: 10
   until:
   - r_pipeline_controller_deployment.resources | length | int > 0
-  - r_pipeline_controller_deployment.resources[0].status.availableReplicas is defined
-  - r_pipeline_controller_deployment.resources[0].status.availableReplicas | int == r_pipeline_controller_deployment.resources[0].spec.replicas | int
+  - r_pipeline_controller_deployment.resources[0].status.readyReplicas is defined
+  - r_pipeline_controller_deployment.resources[0].status.readyReplicas | int == r_pipeline_controller_deployment.resources[0].spec.replicas | int
 
 # Leave this as the last task in the playbook.
 - name: workload tasks complete

--- a/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/tasks/workload.yml
@@ -131,8 +131,8 @@
   delay: 10
   until:
   - r_qo_deployment.resources | length | int > 0
-  - r_qo_deployment.resources[0].status.availableReplicas is defined
-  - r_qo_deployment.resources[0].status.availableReplicas | int == r_qo_deployment.resources[0].spec.replicas | int
+  - r_qo_deployment.resources[0].status.readyReplicas is defined
+  - r_qo_deployment.resources[0].status.readyReplicas | int == r_qo_deployment.resources[0].spec.replicas | int
 
 - name: Copy Quay Registry Definition
   template:


### PR DESCRIPTION
##### SUMMARY

Some workloads used the wrong check (availableReplicas) to check for ready pods. Replaced with the proper check (readyReplicas).

##### ISSUE TYPE
- Bugfix Pull Request

