### PR TITLE
Add workload MediaWiki sample application for OpenShift migration demos

### DIFF
--- a/ansible/roles/ocp-workload-mediawiki/README.adoc
+++ b/ansible/roles/ocp-workload-mediawiki/README.adoc
@@ -1,0 +1,36 @@
+= MediaWiki Demo Application
+
+== Overview
+
+This workload deploys MediaWiki demo application on OpenShift cluster.
+
+=== Deploy the workload
+[source,'bash']
+----
+ansible-playbook -i "bastion.${GUID}.${BASE_DOMAIN}", ./ansible/configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=${ANSIBLE_USER_KEY_FILE}" \
+    -e"ansible_user=${ANSIBLE_USER}" \
+    -e"ocp_workload=ocp-workload-mediawiki" \
+    -e"silent=False" \
+    -e"ACTION=create" \
+    -e @./secret.yaml <1> \
+    -e @./workload.yaml <2>
+----
+<1> This is the file you used when deploying your cluster with AgnosticD.
+<2> All variables required by the workload go in this file.
+
+
+=== Delete the workload
+
+[source,'bash']
+----
+ansible-playbook -i "bastion.${GUID}.${BASE_DOMAIN}", ./ansible/configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=${ANSIBLE_USER_KEY_FILE}" \
+    -e"ansible_user=${ANSIBLE_USER}" \
+    -e"ocp_workload=ocp-workload-mediawiki" \
+    -e"silent=False" \
+    -e"ACTION=delete" \
+    -e @./secret.yaml \
+    -e @./workload.yaml
+----
+

--- a/ansible/roles/ocp-workload-mediawiki/defaults/main.yml
+++ b/ansible/roles/ocp-workload-mediawiki/defaults/main.yml
@@ -1,0 +1,3 @@
+# workload vars
+silent: false
+

--- a/ansible/roles/ocp-workload-mediawiki/files/mariadb.yml
+++ b/ansible/roles/ocp-workload-mediawiki/files/mariadb.yml
@@ -1,0 +1,87 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mariadb
+  namespace: mediawiki
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mariadb
+  namespace : mediawiki
+  labels:
+    app: mariadb
+    service: mariadb
+spec:
+  selector:
+    app: mariadb
+    service: mariadb
+  ports:
+    - protocol: TCP
+      port: 3306
+      targetPort: 3306
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: mariadb
+  namespace: mediawiki
+  labels:
+    app: mariadb
+    service: mariadb
+spec:
+  replicas: 1
+  selector:
+    app: mariadb
+    service: mariadb
+  strategy:
+    type: Rolling
+    rollingParams:
+      intervalSeconds: 1
+      maxSurge: 25%
+      maxUnavailable: 25%
+      timeoutSeconds: 600
+      updatePeriodSeconds: 1
+  test: false
+  triggers:
+    - type: ConfigChange
+  template:
+    metadata:
+      labels:
+        app: mariadb
+        service: mariadb
+    spec:
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      containers:
+        - image: docker.io/centos/mariadb-102-centos7
+          name: mariadb
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              value: changeme
+            - name: MYSQL_USER
+              value: changeme
+            - name: MYSQL_PASSWORD
+              value: changeme
+            - name: MYSQL_DATABASE
+              value: changeme
+          terminationMessagePath: /dev/termination-log
+          workingDir: /
+          ports:
+            - containerPort: 3306
+              protocol: TCP
+          volumeMounts:
+            - name: mariadb
+              mountPath: /var/lib/mysql/data
+      volumes:
+        - name: mariadb
+          persistentVolumeClaim:
+            claimName: mariadb

--- a/ansible/roles/ocp-workload-mediawiki/files/mediawiki-ns.yml
+++ b/ansible/roles/ocp-workload-mediawiki/files/mediawiki-ns.yml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mediawiki

--- a/ansible/roles/ocp-workload-mediawiki/files/mediawiki-route.yml
+++ b/ansible/roles/ocp-workload-mediawiki/files/mediawiki-route.yml
@@ -1,0 +1,15 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: mediawiki
+  namespace: mediawiki
+  labels:
+    app: mediawiki
+    service: mediawiki
+spec:
+  to:
+    kind: Service
+    name: mediawiki
+  port:
+    targetPort: web

--- a/ansible/roles/ocp-workload-mediawiki/meta/main.yml
+++ b/ansible/roles/ocp-workload-mediawiki/meta/main.yml
@@ -1,0 +1,10 @@
+---
+galaxy_info:
+  author: Pranav Gaikwad <pgaikwad@redhat.com>
+  description: Deploys sample MediaWiki application
+  company: Red Hat
+  license: BSD
+  min_ansible_version: 2.9
+  galaxy_tags: []
+
+dependencies: []

--- a/ansible/roles/ocp-workload-mediawiki/tasks/main.yml
+++ b/ansible/roles/ocp-workload-mediawiki/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- name: Running Pre Workload Tasks
+  import_tasks: ./pre_workload.yml
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload Tasks
+  import_tasks: ./workload.yml
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  import_tasks: ./post_workload.yml
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Remove Workload Tasks
+  import_tasks: ./remove_workload.yml
+  when: ACTION == "remove"

--- a/ansible/roles/ocp-workload-mediawiki/tasks/post_workload.yml
+++ b/ansible/roles/ocp-workload-mediawiki/tasks/post_workload.yml
@@ -1,0 +1,6 @@
+---
+# Leave this as the last task in the playbook.
+- name: post_workload tasks complete
+  debug:
+    msg: "Post-Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp-workload-mediawiki/tasks/pre_workload.yml
+++ b/ansible/roles/ocp-workload-mediawiki/tasks/pre_workload.yml
@@ -1,0 +1,19 @@
+---
+- name: "Create temp file"
+  tempfile:
+    state: file
+  register: temp_file
+
+- name: "Copy namespace contents"
+  copy:
+    content: "{{ lookup('file', 'mediawiki-ns.yml') }}"
+    dest: "{{ temp_file.path }}"
+
+- name: "Create mediawiki namespace"
+  shell: "oc apply -f {{ temp_file.path }}"
+
+# Leave this as the last task in the playbook.
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp-workload-mediawiki/tasks/remove_workload.yml
+++ b/ansible/roles/ocp-workload-mediawiki/tasks/remove_workload.yml
@@ -1,0 +1,10 @@
+---
+- name: "Delete mediawiki namespace"
+  shell: "oc delete --ignore-not-found=true namespace mediawiki"
+
+# Leave this as the last task in the playbook.
+- name: remove_workload tasks complete
+  debug:
+    msg: "Remove Workload tasks completed successfully."
+  when: not silent|bool
+  

--- a/ansible/roles/ocp-workload-mediawiki/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-mediawiki/tasks/workload.yml
@@ -1,0 +1,39 @@
+---
+- name: "Copying mariadb deployment contents"
+  copy:
+    content: "{{ lookup('file', 'mariadb.yml') }}"
+    dest: "{{ temp_file.path }}"
+
+- name: "Create mariadb deployment"
+  shell: "oc apply -f {{ temp_file.path }}"
+
+- name: "Copy mediawiki route contents"
+  copy:
+    content: "{{ lookup('file', 'mediawiki-route.yml') }}"
+    dest: "{{ temp_file.path }}"
+
+- name: "Create mediawiki route"
+  shell: "oc apply -f {{ temp_file.path }}"
+
+- name: "Read mediawiki route"
+  shell: "oc get route -n mediawiki mediawiki -o go-template='{{ '{{' }} .spec.host {{ '}}' }}{{ '{{' }} println {{ '}}' }}'"
+  register: oc_output
+  until: oc_output.stdout != ""
+  retries: 10
+
+- set_fact:
+    mediawiki_route: "{{ oc_output.stdout }}"
+
+- name: "Create mediawiki deployment file"
+  template:
+    src: mediawiki.yml.j2
+    dest: "{{ temp_file.path }}"
+
+- name: "Create mediawiki deployment"
+  shell: "oc apply -f {{ temp_file.path }}"
+
+# Leave this as the last task in the playbook.
+- name: workload tasks complete
+  debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp-workload-mediawiki/templates/mediawiki.yml.j2
+++ b/ansible/roles/ocp-workload-mediawiki/templates/mediawiki.yml.j2
@@ -1,0 +1,90 @@
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mediawiki
+  namespace: mediawiki
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mediawiki
+  namespace: mediawiki
+  labels:
+    app: mediawiki
+    service: mediawiki
+spec:
+  ports:
+    - name: web
+      port: 8080
+      targetPort: 8080
+  selector:
+    app: mediawiki
+    service: mediawiki
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: mediawiki
+  namespace: mediawiki
+  labels:
+    app: mediawiki
+    service: mediawiki
+spec:
+  replicas: 1
+  selector:
+    app: mediawiki
+    service: mediawiki
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: mediawiki
+        service: mediawiki
+    spec:
+      containers:
+      - image:  docker.io/ansibleplaybookbundle/mediawiki:latest
+        name: mediawiki
+        env:
+          - name: MEDIAWIKI_DB_SCHEMA
+            value: mediawiki
+          - name: MEDIAWIKI_SITE_NAME
+            value: Mediawiki
+          - name: MEDIAWIKI_SITE_LANG
+            value: en
+          - name: MEDIAWIKI_ADMIN_USER
+            value: admin
+          - name: MEDIAWIKI_ADMIN_PASS
+            value: changeme
+          - name: MEDIAWIKI_SITE_SERVER
+            value: {{ mediawiki_route }}
+          - name: DB_TYPE
+            value: mysql
+          - name: DB_HOST
+            value: mariadb
+          - name: DB_PORT
+            value: "3306"
+          - name: DB_USER
+            value: changeme
+          - name: DB_PASSWORD
+            value: changeme
+          - name: DB_NAME
+            value: changeme
+        ports:
+          - containerPort: 8080
+            protocol: TCP
+        volumeMounts:
+          - name: mediawiki
+            mountPath: /persistent
+      volumes:
+        - name: mediawiki
+          persistentVolumeClaim:
+            claimName: mediawiki


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
This PR adds a new workload `ocp-workload-mediawiki`. It is meant to be deployed on 3.x OpenShift clusters. It will be used in CAM labs to demonstrate a use-case of migration as described here: https://github.com/konveyor/mig-operator/blob/master/docs/usage/10.md

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp-workload-mediawiki

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The reason `oc` command is used is that the 3.x lab envs we deploy don't have python-openshift available.
<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
@jwmatthews @tsanders-rh
