### PR TITLE
Fix ansible config epel repo url

### DIFF
--- a/ansible/configs/ansible-gitOps-integration/files/repos_template.j2
+++ b/ansible/configs/ansible-gitOps-integration/files/repos_template.j2
@@ -7,7 +7,7 @@ gpgcheck=0
 
 {% endfor %}
 [epel]
-name=Extra Packages for Enterprise Linux 7 
-baseurl={{ own_repo_path }}/epel/
+name=Extra Packages for Enterprise Linux 7
+baseurl={{ own_repo_path | regex_replace("/repos(/.*)?$", "/repos/epel") }}
 enabled=1
 gpgcheck=0

--- a/ansible/configs/ansible-tower-implementation/files/repos_template.j2
+++ b/ansible/configs/ansible-tower-implementation/files/repos_template.j2
@@ -8,7 +8,7 @@ gpgcheck=0
 {% endfor %}
 
 [epel]
-name=Extra Packages for Enterprise Linux 7 
-baseurl={{ own_repo_path | replace( "/tower/", "") }}/epel/
+name=Extra Packages for Enterprise Linux 7
+baseurl={{ own_repo_path | regex_replace("/repos(/.*)?$", "/repos/epel") }}
 enabled=1
 gpgcheck=0

--- a/ansible/configs/three-tier-app/files/repos_template.j2
+++ b/ansible/configs/three-tier-app/files/repos_template.j2
@@ -1,14 +1,14 @@
 {% for rhel_repo in rhel_repos %}
-[{{ rhel_repo }}] 
+[{{ rhel_repo }}]
 name={{ rhel_repo }}
 baseurl={{own_repo_path}}/{{ repo_version }}/{{ rhel_repo }}
-enabled=1  
-gpgcheck=0 
-            
+enabled=1
+gpgcheck=0
+
 {% endfor %}
-            
-[epel]      
-name=Extra Packages for Enterprise Linux 7 
-baseurl={{ own_repo_path | replace( "/tower/", "") }}/epel/
-enabled=1  
+
+[epel]
+name=Extra Packages for Enterprise Linux 7
+baseurl={{ own_repo_path | regex_replace("/repos(/.*)?$", "/repos/epel") }}
+enabled=1
 gpgcheck=0


### PR DESCRIPTION
##### SUMMARY

Fix epel repo base url in ansible configs.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Configs:
- ansible-gitOps-integration
- ansible-tower-intergation
- three-tier-app