### PR TITLE
Remove set PATH for az commands

### DIFF
--- a/ansible/cloud_providers/azure_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/azure_infrastructure_deployment.yml
@@ -15,8 +15,6 @@
     AZURE_CONFIG_DIR: "{{ output_dir }}/.azure-{{project_tag}}"
   tasks:
     - name: Ensure az is installed
-      environment:
-        PATH: '{{ output_dir }}:/usr/bin:/usr/local/bin'
       command: which az
       register: az_result
 
@@ -46,11 +44,9 @@
     - name: Login to Azure
       command: >-
         az login --service-principal
-        -u "{{azure_service_principal}}"
-        -p {{azure_password}}
-        --tenant {{azure_tenant}}
-      environment:
-        PATH: '{{ output_dir }}:/usr/bin:/usr/local/bin'
+        -u {{ azure_service_principal | quote }}
+        -p {{ azure_password | quote }}
+        --tenant {{ azure_tenant | quote }}
       tags:
         - validate_azure_template
         - create_inventory
@@ -122,8 +118,6 @@
         - validate_azure_template
 
     - name: Validate arm template
-      environment:
-        PATH: '{{ output_dir }}:/usr/bin:/usr/local/bin'
       command: >-
         az group deployment validate
         --template-file {{t_dest}}
@@ -135,8 +129,6 @@
         - validate_azure_template
 
     - name: ARM Group deployment create
-      environment:
-        PATH: '{{ output_dir }}:/usr/bin:/usr/local/bin'
       command: >-
         az group deployment create
         --name {{env_type}}.{{guid}}

--- a/ansible/configs/aro/destroy_env.yml
+++ b/ansible/configs/aro/destroy_env.yml
@@ -26,9 +26,9 @@
     - name: Login to Azure
       command: >-
         az login --service-principal
-        -u '{{azure_service_principal}}'
-        -p '{{azure_password}}'
-        --tenant "{{azure_tenant}}"
+        -u {{ azure_service_principal | quote }}
+        -p {{ azure_password | quote }}
+        --tenant {{ azure_tenant | quote }}
 
     - name: Switch Subscriptions
       command: az account set -s "{{azure_subscription_id}}"

--- a/ansible/roles-infra/infra-azure-create-inventory/tasks/main.yml
+++ b/ansible/roles-infra/infra-azure-create-inventory/tasks/main.yml
@@ -10,11 +10,10 @@
 - name: Login to Azure
   command: >-
     az login --service-principal
-    -u "{{azure_service_principal}}"
-    -p {{azure_password}}
-    --tenant {{azure_tenant}}
+    -u {{ azure_service_principal | quote }}
+    -p {{ azure_password | quote }}
+    --tenant {{ azure_tenant | quote }}
   environment:
-    PATH: '{{ output_dir }}:/usr/bin:/usr/local/bin'
     AZURE_CONFIG_DIR: "{{ output_dir }}/.azure-{{project_tag}}"
   tags:
     - validate_azure_template
@@ -27,7 +26,6 @@
   command: az vm list --resource-group "{{az_resource_group}}" --show-details
   # specify path to use azure-cli from system and not from python virtualenv
   environment:
-    PATH: '{{ output_dir }}:/usr/bin:/usr/local/bin'
     AZURE_CONFIG_DIR: "{{ output_dir }}/.azure-{{project_tag}}"
   changed_when: false
   register: result_list

--- a/ansible/roles-infra/infra-azure-create-service-principal/tasks/main.yml
+++ b/ansible/roles-infra/infra-azure-create-service-principal/tasks/main.yml
@@ -15,34 +15,24 @@
     AZURE_CONFIG_DIR: "{{ output_dir }}/.azure-{{project_tag}}"
   block:
   - name: Get the scope for the subscripion
-    environment:
-      PATH: '{{ output_dir }}:/usr/bin:/usr/local/bin'
     command: "az group show --name {{ project_tag }} --query id"
     register: azure_rg_scope
 
   - name: Setting service principal password
-    environment:
-      PATH: '{{ output_dir }}:/usr/bin:/usr/local/bin'
     command: uuidgen
     register: ocp_azure_pwd
 
   - name: Login to Azure
     command: >-
       az login
-      -u '{{azure_ru_username}}'
-      -p '{{azure_ru_password}}'
-      --tenant "{{azure_tenant}}"
-    environment:
-      PATH: '{{ output_dir }}:/usr/bin:/usr/local/bin'
+      -u {{azure_ru_username | quote }}
+      -p {{azure_ru_password | quote }}
+      --tenant {{azure_tenant | quote }}
 
   - name: Switch Subscriptions
     command: az account set -s "{{azure_subscription_id}}"
-    environment:
-      PATH: '{{ output_dir }}:/usr/bin:/usr/local/bin'
 
   - name: Create the Service Principal
-    environment:
-      PATH: '{{ output_dir }}:/usr/bin:/usr/local/bin'
     command: >-
       az ad sp create-for-rbac
       --name "sp-{{ project_tag }}"
@@ -54,15 +44,11 @@
       seconds: 30
 
   - name: Get the ID of the service principal
-    environment:
-      PATH: '{{ output_dir }}:/usr/bin:/usr/local/bin'
     command: az ad sp show --id "http://sp-{{ project_tag }}" --query appId
     register: ocp_azure_sp
 
   - name: Logout of Azure
     command: az logout
-    environment:
-      PATH: '{{ output_dir }}:/usr/bin:/usr/local/bin'
 
   - name: Add Service Principal info to a generic host for later use
     add_host:

--- a/ansible/roles-infra/infra-azure-delete-service-principal/tasks/main.yml
+++ b/ansible/roles-infra/infra-azure-delete-service-principal/tasks/main.yml
@@ -15,34 +15,24 @@
   - name: Login to Azure
     command: >-
       az login
-      -u '{{azure_ru_username}}'
-      -p '{{azure_ru_password}}'
-      --tenant "{{azure_tenant}}"
-    environment:
-      PATH: '{{ output_dir }}:/usr/bin:/usr/local/bin'
+      -u {{ azure_ru_username | quote }}
+      -p {{ azure_ru_password | quote }}
+      --tenant {{ azure_tenant | quote }}
 
   - name: Switch Subscriptions
     command: az account set -s "{{azure_subscription_id}}"
-    environment:
-      PATH: '{{ output_dir }}:/usr/bin:/usr/local/bin'
 
   - name: Get the ID of the service principal
-    environment:
-      PATH: '{{ output_dir }}:/usr/bin:/usr/local/bin'
     command: "az ad sp show --id http://sp-{{ project_tag }} --query appId"
     register: ocp_azure_sp_id
     ignore_errors: true
 
   - name: Delete the Service Principal
-    environment:
-      PATH: '{{ output_dir }}:/usr/bin:/usr/local/bin'
     command: "az ad sp delete --id {{ ocp_azure_sp_id.stdout }}"
     ignore_errors: true
 
   - name: Logout of Azure
     command: az logout
-    environment:
-      PATH: '{{ output_dir }}:/usr/bin:/usr/local/bin'
 
   when:
   - azure_ru_username is defined

--- a/ansible/roles-infra/infra-azure-ssh-key/tasks/main.yml
+++ b/ansible/roles-infra/infra-azure-ssh-key/tasks/main.yml
@@ -10,11 +10,10 @@
 - name: Login to Azure
   command: >-
     az login --service-principal
-    -u "{{azure_service_principal}}"
-    -p {{azure_password}}
-    --tenant {{azure_tenant}}
+    -u {{ azure_service_principal | quote }}
+    -p {{ azure_password | quote }}
+    --tenant {{ azure_tenant | quote }}
   environment:
-    PATH: '{{ output_dir }}:/usr/bin:/usr/local/bin'
     AZURE_CONFIG_DIR: "{{ output_dir }}/.azure-{{project_tag}}"
 
 - name: Set infra_ssh_key
@@ -36,7 +35,6 @@
     - name: Retrieve SSH Key from keyvault
       environment:
         AZURE_CONFIG_DIR: "{{ output_dir }}/.azure-{{project_tag}}"
-        PATH: '{{ output_dir }}:/usr/bin:/usr/local/bin'
       command: >
         az keyvault secret show
         --vault-name 'rhpds-{{guid[:12]}}-kv'
@@ -72,7 +70,6 @@
     - name: Create project specific keyvault
       environment:
         AZURE_CONFIG_DIR: "{{ output_dir }}/.azure-{{project_tag}}"
-        PATH: '{{ output_dir }}:/usr/bin:/usr/local/bin'
       command: >
           az keyvault create
           --name 'rhpds-{{guid[:12]}}-kv'
@@ -82,7 +79,6 @@
     - name: Store SSH Key in keyvault
       environment:
         AZURE_CONFIG_DIR: "{{ output_dir }}/.azure-{{project_tag}}"
-        PATH: '{{ output_dir }}:/usr/bin:/usr/local/bin'
       command: >
           az keyvault secret set
           --vault-name 'rhpds-{{guid[:12]}}-kv'

--- a/ansible/roles-infra/infra-azure-template-destroy/tasks/main.yml
+++ b/ansible/roles-infra/infra-azure-template-destroy/tasks/main.yml
@@ -74,8 +74,6 @@
           register: az_dep
           until: az_dep is succeeded
           retries: 5
-          environment:
-            PATH: '{{ output_dir }}:/usr/bin:/usr/local/bin'
 
         - debug:
             var: az_dep
@@ -87,8 +85,6 @@
           retries: 5
           until: az_tag is succeeded
           changed_when: false
-          environment:
-            PATH: '{{ output_dir }}:/usr/bin:/usr/local/bin'
 
         - name: delete all resources
           vars:
@@ -100,5 +96,3 @@
           until: az_delete is succeeded
           retries: 5
           when: ids|length > 0
-          environment:
-            PATH: '{{ output_dir }}:/usr/bin:/usr/local/bin'

--- a/ansible/roles/host-ocp4-provisioner/tasks/azure_prereqs.yml
+++ b/ansible/roles/host-ocp4-provisioner/tasks/azure_prereqs.yml
@@ -29,10 +29,12 @@
     name: azure-cli
 
 - name: Logging into Azure
-  shell: az login --service-principal -u '{{azure_service_principal}}' -t '{{azure_tenant}}' -p '{{azure_password}}'
+  command: >-
+    az login --service-principal
+    -u {{ azure_service_principal | quote }}
+    -t {{ azure_tenant | quote }}
+    -p {{ azure_password | quote }}
   become: no
-  environment:
-    PATH: '{{ output_dir }}:/usr/bin:/usr/local/bin'
 
 - name: Add osServicePrincipal.json file for OpenShift Installer
   template:


### PR DESCRIPTION
##### SUMMARY

Remove PATH environment variable for az commands to enable execution when
az is installed within a python virtualenv.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

azure cloud_provider
aro config

Roles:
- infra-azure-create-inventory
- infra-azure-create-service-principal
- infra-azure-delete-service-principal
- infra-azure-ssh-key
- infra-azure-template-destroy
- host-ocp4-provisioner
