### PR TITLE
Update config cloud-credentials for template generation

### DIFF
--- a/ansible/configs/cloud-credentials/default_vars.yml
+++ b/ansible/configs/cloud-credentials/default_vars.yml
@@ -1,2 +1,2 @@
 ---
-...
+project_tag: "{{ env_type }}-{{ guid }}"

--- a/ansible/configs/cloud-credentials/default_vars_ec2.yml
+++ b/ansible/configs/cloud-credentials/default_vars_ec2.yml
@@ -1,3 +1,13 @@
 ---
 # mandatory to run ansible/destroy.yml playbook
-aws_region: us-east-1
+aws_region: us-west-2
+
+subdomain_base_suffix: ".example.opentlc.com"
+subdomain_base_short: "{{ guid }}"
+subdomain_base: "{{ guid }}{{ subdomain_base_suffix }}"
+
+aws_dns_zone_root: "{{ subdomain_base_suffix | regex_replace('^\\.', '') }}."
+aws_dns_zone_public: "{{ guid }}.{{ aws_dns_zone_root }}"
+aws_dns_ttl_public: 900
+aws_dns_ttl_private: 3600
+aws_comment: "Created by Ansible Agnostic Deployer"

--- a/ansible/configs/cloud-credentials/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/cloud-credentials/files/cloud_providers/ec2_cloud_template.j2
@@ -1,9 +1,6 @@
 #jinja2: lstrip_blocks: "True"
 ---
 AWSTemplateFormatVersion: "2010-09-09"
-Mappings:
-  RegionMapping: {{ aws_ami_region_mapping | to_json }}
-
 Resources:
   DnsZonePublic:
     Type: "AWS::Route53::HostedZone"

--- a/ansible/configs/cloud-credentials/infra.yml
+++ b/ansible/configs/cloud-credentials/infra.yml
@@ -1,0 +1,80 @@
+---
+- name: Step 001.1 Deploy Infrastructure
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  become: false
+  tags:
+    - step001
+    - step001.1
+    - deploy_infrastructure
+  tasks:
+    - name: Test aws command
+      shell: command -v aws
+      failed_when: false
+      changed_when: false
+      register: raws
+
+    - name: Fail if AWS command CLI if not available
+      fail:
+        msg: AWS command not found in PATH.
+      when: raws.rc != 0
+
+    - name: Set fact for template location
+      set_fact:
+        cloudformation_template: "{{output_dir}}/{{ env_type }}.{{ guid }}.{{cloud_provider}}_cloud_template"
+
+    - name: AWS Generate CloudFormation Template
+      template:
+        src: "./files/cloud_providers/{{ cloud_provider }}_cloud_template.j2"
+        dest: "{{ cloudformation_template }}"
+
+    - name: validation cloudformation template
+      assert:
+        that: >
+          lookup('file', cloudformation_template) | from_yaml is succeeded
+          or lookup('file', cloudformation_template) | from_json is succeeded
+        success_msg: Cloudformation template is syntactically valid
+
+    - name: validate cloudformation template with validate-template (local)
+      environment:
+        AWS_ACCESS_KEY_ID: "{{aws_access_key_id}}"
+        AWS_SECRET_ACCESS_KEY: "{{aws_secret_access_key}}"
+        AWS_DEFAULT_REGION: "{{aws_region_final|d(aws_region)}}"
+      command: >-
+        aws cloudformation validate-template
+        --region {{ aws_region_final | default(aws_region) | default(region) | default('us-east-1') }}
+        --template-body file://{{ cloudformation_template }}
+      changed_when: false
+      register: cloudformation_validation
+      until: cloudformation_validation is succeeded
+      retries: "{{ cloudformation_retries }}"
+      delay: 20
+
+    - name: Stat CloudFormation template
+      stat:
+        path: "{{ cloudformation_template }}"
+      register: stat_template
+
+    - name: Run infra-ec2-template-create Role
+      import_role:
+        name: infra-ec2-template-create
+      vars:
+        aws_region_loop: "{{aws_region}}"
+
+    - name: Run infra-ec2-template-create Role into FallBack region
+      include_role:
+        name: infra-ec2-template-create
+      vars:
+        aws_region_loop: "{{item}}"
+      with_items: "{{ fallback_regions }}"
+      when:
+        - fallback_regions is defined
+        - cloudformation_out is failed
+
+    - name: report Cloudformation error
+      fail:
+        msg: "FAIL {{ project_tag }} Create Cloudformation"
+      when: not cloudformation_out is succeeded
+      tags:
+        - provision_cf_template

--- a/ansible/configs/cloud-credentials/post_infra.yml
+++ b/ansible/configs/cloud-credentials/post_infra.yml
@@ -23,10 +23,10 @@
       - name: Add AWS credentials with agnosticd_user_info
         agnosticd_user_info:
           msg: "{{ item }}"
-          loop:
-            - "aws_access_key_id: {{ student_access_key_id }}"
-            - "aws_secret_access_key: {{ student_secret_access_key }}"
-            - "aws_sandbox_zone: {{ subdomain_base_suffix }}"
+        loop:
+          - "aws_access_key_id: {{ student_access_key_id }}"
+          - "aws_secret_access_key: {{ student_secret_access_key }}"
+          - "aws_sandbox_zone: {{ subdomain_base_suffix }}"
 
       - name: Add AWS credentials with agnosticd_user_info
         agnosticd_user_info:

--- a/ansible/configs/cloud-credentials/pre_infra.yml
+++ b/ansible/configs/cloud-credentials/pre_infra.yml
@@ -9,3 +9,11 @@
   tasks:
     - debug:
         msg: "Step 000 Pre Infrastructure"
+
+    - name: Create students-ocp4-noop IAM group
+      iam_group:
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_access_key }}"
+        aws_region: "{{ aws_region_final | default(aws_region) }}"
+        name: students-ocp4-noop
+        state: present


### PR DESCRIPTION

##### SUMMARY

The first version of cloud-credentials had a few issues generating the cloudformation template for EC2. Rather than use the full template generate role, the necessary minimum tasks have been added to the config in order to avoid changes to a well used cloud provider role.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cloud-credentials