### PR TITLE
Add health probes for SSO

### DIFF
--- a/ansible/roles/ocp4-workload-quarkus-workshop/files/rhsso-template.yaml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/files/rhsso-template.yaml
@@ -183,6 +183,20 @@ objects:
           image: ${APPLICATION_NAME}
           imagePullPolicy: Always
           name: ${APPLICATION_NAME}
+          readinessProbe:
+            httpGet:
+              path: /auth/realms/master
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            failureThreshold: 10
+          livenessProbe:
+            httpGet:
+              path: /auth/realms/master
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            failureThreshold: 10
           ports:
           - containerPort: 8778
             name: jolokia


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

Occasionally, depending on timing, RH-SSO will come up ahead of its dependent database (postgres). When this happens, SSO will fail to initialize but continue to run and never be able to work properly. This adds health probes to the app so that OpenShift will kill and restart the pod in this case, so that it can come back up and connect properly.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`ocp4-workload-quarkus-workshop`

