### PR TITLE
New bookbag roles.

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_setup/.yamllint
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_setup/.yamllint
@@ -1,0 +1,14 @@
+---
+extends: default
+
+rules:
+  comments:
+    require-starting-space: false
+  comments-indentation: disable
+  indentation:
+    level: warning
+    indent-sequences: consistent
+  line-length:
+    level: warning
+    max: 120
+    allow-non-breakable-inline-mappings: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_setup/README.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_setup/README.adoc
@@ -1,0 +1,66 @@
+= ocp4_workload_bookbag - Build (and optionally deploy) bookbag on OCP4
+
+== Role overview
+
+* This role builds and optionally deploys a bookbag on an OpenShift 4 Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+ environment for the workload deployment.
+*** Debug task will print out: `pre_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to configure authentication
+*** Debug task will print out: `workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+ configure the workload after deployment
+*** This role doesn't do anything here
+*** Debug task will print out: `post_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+ delete the workload
+*** This role removes bookbag from OCP 4. 
+*** Debug task will print out: `remove_workload Tasks completed successfully.`
+
+== Review the defaults variable file
+
+* This file link:./defaults/main.yml[./defaults/main.yml] contains all the variables you need to define to control the deployment of your workload.
+* The variable *ocp_username* is mandatory to assign the workload to the correct OpenShift user.
+* A variable *silent=True* can be passed to suppress debug messages.
+* You can modify any of these default values by adding `-e "variable_name=variable_value"` to the command line
+
+=== Deploy a Workload with the `ocp-workload` playbook [Mostly for testing]
+
+----
+TARGET_HOST="bastion.wk.red.osp.opentlc.com"
+OCP_USERNAME="wkulhane"
+WORKLOAD="ocp4_workload_bookbag_setup"
+GUID=wk
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=cloud-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"silent=False" \
+    -e"guid=${GUID}" \
+    -e"ACTION=create"
+----
+
+=== To Delete an environment
+
+----
+TARGET_HOST="bastion.wk.red.osp.opentlc.com"
+OCP_USERNAME="wkulhane"
+WORKLOAD="ocp4_workload_bookbag_setup"
+GUID=wk
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=ec2-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"guid=${GUID}" \
+    -e"ACTION=remove"
+----
+

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_setup/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_setup/defaults/main.yaml
@@ -1,0 +1,28 @@
+---
+become_override: false
+silent: false
+
+# Repository with the bookbag documentation and terminal code
+# Fork the repo below and implement your bookbag. Then update the variable
+# to point to your repo
+ocp4_workload_bookbag_setup_git_repo: https://github.com/redhat-gpte-devopsautomation/bookbag-template.git
+
+# Branch or tag to use from the repo
+ocp4_workload_bookbag_setup_git_version: master
+
+# Project in which to deploy the bookbag
+ocp4_workload_bookbag_setup_project: "bookbag"
+ocp4_workload_bookbag_setup_project_display: "Bookbag"
+
+# Name of bookbag image
+ocp4_workload_bookbag_setup_image_name: bookbag
+
+# Builder Image to build Bookbag
+ocp4_workload_bookbag_setup_builder_image: quay.io/openshifthomeroom/workshop-dashboard
+ocp4_workload_bookbag_setup_builder_image_tag: "5.0.0"
+
+# WK: Not yet implemented...
+# Deploy a single bookbag pod into the bookbag namespace?
+ocp4_workload_bookbag_setup_deploy_bookbag: false
+# Name of bookbag deployment
+ocp4_workload_bookbag_setup_deploy_name: bookbag

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_setup/meta/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_setup/meta/main.yaml
@@ -1,0 +1,13 @@
+---
+galaxy_info:
+  role_name: ocp4_workload_bookbag_setup
+  author:
+  - Johnathan Kupferer <jkupfere@redhat.com>
+  - Wolfgang Kulhanek <wkulhane@redhat.com>
+  description: OpenShift Homeroom Bookbag Configuration Deployment
+  company: Red Hat
+  license: BSD
+  min_ansible_version: 2.9
+  galaxy_tags: []
+
+dependencies: []

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_setup/tasks/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_setup/tasks/main.yaml
@@ -1,0 +1,29 @@
+---
+- name: Run workload
+  block:
+  - name: Running Pre Workload Tasks
+    include_tasks:
+      file: pre_workload.yaml
+      apply:
+        become: "{{ become_override | bool }}"
+
+  - name: Running Workload Tasks
+    include_tasks:
+      file: workload.yaml
+      apply:
+        become: "{{ become_override | bool }}"
+    when: ACTION == "create" or ACTION == "provision"
+
+  - name: Running Post Workload Tasks
+    include_tasks:
+      file: post_workload.yaml
+      apply:
+        become: "{{ become_override | bool }}"
+    when: ACTION == "create" or ACTION == "provision"
+
+  - name: Running Workload removal Tasks
+    include_tasks:
+      file: remove_workload.yaml
+      apply:
+        become: "{{ become_override | bool }}"
+    when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_setup/tasks/post_workload.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_setup/tasks/post_workload.yaml
@@ -1,0 +1,8 @@
+---
+# Implement your Post Workload deployment tasks here
+
+# Leave this as the last task in the playbook.
+- name: post_workload tasks complete
+  debug:
+    msg: "Post-Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_setup/tasks/pre_workload.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_setup/tasks/pre_workload.yaml
@@ -1,0 +1,17 @@
+---
+# Implement your Pre Workload deployment tasks here
+
+- name: Check for required variables
+  assert:
+    that:
+    - guid is defined
+    - guid != ''
+    - ocp4_workload_bookbag_setup_git_repo is defined
+    - ocp4_workload_bookbag_setup_git_repo != ''
+    fail_msg: Required ocp4_workload_bookbag_setup_* variables are not defined
+
+# Leave this as the last task in the playbook.
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_setup/tasks/remove_workload.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_setup/tasks/remove_workload.yaml
@@ -1,0 +1,13 @@
+---
+# Implement your Workload removal tasks here
+
+- name: Remove Bookbag namespace
+  k8s:
+    state: absent
+    definition: "{{ lookup('template', './templates/bookbag_project.yaml.j2' ) | from_yaml }}"
+
+# Leave this as the last task in the playbook.
+- name: remove_workload tasks complete
+  debug:
+    msg: "Remove Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_setup/tasks/workload.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_setup/tasks/workload.yaml
@@ -1,0 +1,23 @@
+---
+
+- name: Create Bookbag resources
+  k8s:
+    state: present
+    definition: "{{ lookup('template', item ) | from_yaml }}"
+  loop:
+  - ./templates/project.yaml.j2
+  - ./templates/imagestream.yaml.j2
+  - ./templates/buildconfig.yaml.j2
+
+- name: Print bookbag information
+  agnosticd_user_info:
+    msg: "{{ item }}"
+  loop:
+  - "A bookbag image has been created in project {{ ocp4_workload_bookbag_setup_project }}."
+  - "The bookbag imagestream is {{ ocp4_workload_bookbag_setup_image_name }}:latest."
+
+# Leave this as the last task in the playbook.
+- name: workload tasks complete
+  debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_setup/templates/buildconfig.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_setup/templates/buildconfig.yaml.j2
@@ -1,0 +1,23 @@
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: "{{ ocp4_workload_bookbag_setup_image_name }}"
+  namespace: "{{ ocp4_workload_bookbag_setup_project }}"
+spec:
+  source:
+    git:
+      ref: "{{ ocp4_workload_bookbag_setup_git_version }}"
+      uri: "{{ ocp4_workload_bookbag_setup_git_repo }}"
+    type: Git
+  output:
+    to:
+      kind: ImageStreamTag
+      name: "{{ ocp4_workload_bookbag_setup_image_name }}:latest"
+  strategy:
+    type: Source
+    sourceStrategy:
+      from:
+        kind: DockerImage
+        name: "{{ ocp4_workload_bookbag_setup_builder_image }}:{{ ocp4_workload_bookbag_setup_builder_image_tag }}"
+  triggers:
+  - type: ConfigChange

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_setup/templates/buildconfig.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_setup/templates/buildconfig.yaml.j2
@@ -14,8 +14,8 @@ spec:
       kind: ImageStreamTag
       name: "{{ ocp4_workload_bookbag_setup_image_name }}:latest"
   strategy:
-    type: Source
-    sourceStrategy:
+    type: Docker
+    dockerStrategy:
       from:
         kind: DockerImage
         name: "{{ ocp4_workload_bookbag_setup_builder_image }}:{{ ocp4_workload_bookbag_setup_builder_image_tag }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_setup/templates/imagestream.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_setup/templates/imagestream.yaml.j2
@@ -1,0 +1,8 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: "{{ ocp4_workload_bookbag_setup_image_name }}"
+  namespace: "{{ ocp4_workload_bookbag_setup_project }}"
+spec:
+  lookupPolicy:
+    local: false

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_setup/templates/project.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_setup/templates/project.yaml.j2
@@ -1,0 +1,8 @@
+apiVersion: project.openshift.io/v1
+kind: Project
+metadata:
+  name: "{{ ocp4_workload_bookbag_setup_project }}"
+  annotations:
+    openshift.io/description: ""
+    openshift.io/display-name: "{{ ocp4_workload_bookbag_setup_project_display }}"
+    openshift.io/requester: "{{ ocp_username }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/.yamllint
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/.yamllint
@@ -1,0 +1,14 @@
+---
+extends: default
+
+rules:
+  comments:
+    require-starting-space: false
+  comments-indentation: disable
+  indentation:
+    level: warning
+    indent-sequences: consistent
+  line-length:
+    level: warning
+    max: 120
+    allow-non-breakable-inline-mappings: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/README.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/README.adoc
@@ -1,0 +1,66 @@
+= ocp4_workload_bookbag_user - Deploy a bookbag application from an existing image on OCP4
+
+== Role overview
+
+* This role builds and deploys a bookbag on an OpenShift 4 Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+ environment for the workload deployment.
+*** Debug task will print out: `pre_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to configure authentication
+*** Debug task will print out: `workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+ configure the workload after deployment
+*** This role doesn't do anything here
+*** Debug task will print out: `post_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+ delete the workload
+*** This role removes bookbag from OCP 4. 
+*** Debug task will print out: `remove_workload Tasks completed successfully.`
+
+== Review the defaults variable file
+
+* This file link:./defaults/main.yml[./defaults/main.yml] contains all the variables you need to define to control the deployment of your workload.
+* The variable *ocp_username* is mandatory to assign the workload to the correct OpenShift user.
+* A variable *silent=True* can be passed to suppress debug messages.
+* You can modify any of these default values by adding `-e "variable_name=variable_value"` to the command line
+
+=== Deploy a Workload with the `ocp-workload` playbook [Mostly for testing]
+
+----
+TARGET_HOST="bastion.wk.red.osp.opentlc.com"
+OCP_USERNAME="wkulhane"
+WORKLOAD="ocp4_workload_bookbag_user"
+GUID=wk
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=cloud-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"silent=False" \
+    -e"guid=${GUID}" \
+    -e"ACTION=create"
+----
+
+=== To Delete an environment
+
+----
+TARGET_HOST="bastion.wk.red.osp.opentlc.com"
+OCP_USERNAME="wkulhane"
+WORKLOAD="ocp4_workload_bookbag_user"
+GUID=wk
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=ec2-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"guid=${GUID}" \
+    -e"ACTION=remove"
+----
+

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/defaults/main.yaml
@@ -11,6 +11,13 @@ ocp4_workload_bookbag_user_project_display: "Bookbag for user {{ ocp_username }}
 ocp4_workload_bookbag_user_deployment_name: bookbag
 
 # Bookbag Image
-ocp4_workload_bookbag_image_namespace: "bookbags"
-ocp4_workload_bookbag_image_name: image-registry.openshift-image-registry.svc:5000/bookbag/bookbag
-ocp4_workload_bookbag_image_tag: latest
+ocp4_workload_bookbag_user_image_namespace: "bookbags"
+ocp4_workload_bookbag_user_image_name: image-registry.openshift-image-registry.svc:5000/bookbag/bookbag
+ocp4_workload_bookbag_user_image_tag: latest
+
+# Bookbag configuration
+ocp4_workload_bookbag_user_console_deploy: true
+ocp4_workload_bookbag_user_console_image: quay.io/openshift/origin-console:4.5
+ocp4_workload_bookbag_user_console_branding: openshift
+# Role to grant to the service account
+ocp4_workload_bookbag_user_role: edit

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/defaults/main.yaml
@@ -1,0 +1,16 @@
+---
+become_override: false
+ocp_username: opentlc-mgr
+silent: false
+
+# Project in which to deploy the bookbag deployment
+ocp4_workload_bookbag_user_project: "bookbag-{{ guid }}"
+ocp4_workload_bookbag_user_project_display: "Bookbag for user {{ ocp_username }}"
+
+# Name of bookbag deployment
+ocp4_workload_bookbag_user_deployment_name: bookbag
+
+# Bookbag Image
+ocp4_workload_bookbag_image_namespace: "bookbags"
+ocp4_workload_bookbag_image_name: image-registry.openshift-image-registry.svc:5000/bookbag/bookbag
+ocp4_workload_bookbag_image_tag: latest

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/defaults/main.yaml
@@ -17,7 +17,14 @@ ocp4_workload_bookbag_user_image_tag: latest
 
 # Bookbag configuration
 ocp4_workload_bookbag_user_console_deploy: true
-ocp4_workload_bookbag_user_console_image: quay.io/openshift/origin-console:4.5
 ocp4_workload_bookbag_user_console_branding: openshift
 # Role to grant to the service account
 ocp4_workload_bookbag_user_role: edit
+# The workload uses the same console image that is used in the
+# deployed cluster. By setting the next variable that can be overridden.
+# Leave empty to use the matching cluster console image.
+ocp4_workload_bookbag_user_console_image_override: ""
+# ocp4_workload_bookbag_user_console_image_override: quay.io/openshift/origin-console:4.5
+
+ocp4_workload_bookbag_user_create_pvc: false
+ocp4_workload_bookbag_user_pvc_size: 1Gi

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/meta/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/meta/main.yaml
@@ -1,0 +1,13 @@
+---
+galaxy_info:
+  role_name: ocp4_workload_bookbag_user
+  author:
+  - Johnathan Kupferer <jkupfere@redhat.com>
+  - Wolfgang Kulhanek <wkulhane@redhat.com>
+  description: OpenShift Homeroom Bookbag Deployment for one User
+  company: Red Hat
+  license: BSD
+  min_ansible_version: 2.9
+  galaxy_tags: []
+
+dependencies: []

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/tasks/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/tasks/main.yaml
@@ -1,0 +1,29 @@
+---
+- name: Run workload
+  block:
+  - name: Running Pre Workload Tasks
+    include_tasks:
+      file: pre_workload.yaml
+      apply:
+        become: "{{ become_override | bool }}"
+
+  - name: Running Workload Tasks
+    include_tasks:
+      file: workload.yaml
+      apply:
+        become: "{{ become_override | bool }}"
+    when: ACTION == "create" or ACTION == "provision"
+
+  - name: Running Post Workload Tasks
+    include_tasks:
+      file: post_workload.yaml
+      apply:
+        become: "{{ become_override | bool }}"
+    when: ACTION == "create" or ACTION == "provision"
+
+  - name: Running Workload removal Tasks
+    include_tasks:
+      file: remove_workload.yaml
+      apply:
+        become: "{{ become_override | bool }}"
+    when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/tasks/post_workload.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/tasks/post_workload.yaml
@@ -1,0 +1,8 @@
+---
+# Implement your Post Workload deployment tasks here
+
+# Leave this as the last task in the playbook.
+- name: post_workload tasks complete
+  debug:
+    msg: "Post-Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/tasks/pre_workload.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/tasks/pre_workload.yaml
@@ -1,0 +1,9 @@
+---
+# Implement your Pre Workload deployment tasks here
+
+
+# Leave this as the last task in the playbook.
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/tasks/remove_workload.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/tasks/remove_workload.yaml
@@ -2,21 +2,19 @@
 # Implement your Workload removal tasks here
 - name: List project namespaces
   k8s_info:
-    kubeconfig: "{{ _ocp4_workload_bookbag_user_kubeconfig | default(omit) }}"
     api_version: project.openshift.io/v1
     kind: Project
   register: r_list_projects
 
 - name: Remove bookbag namespace
+  when: ocp4_workload_bookbag_user_namespace in _project_names
   k8s:
-    kubeconfig: "{{ _ocp4_workload_bookbag_user_kubeconfig | default(omit) }}"
     state: absent
     api_version: project.openshift.io/v1
     kind: Project
     name: "{{ ocp4_workload_bookbag_user_namespace }}"
   vars:
     _project_names: "{{ r_list_projects.resources | default([]) | json_query('[].metadata.name') }}"
-  when: ocp4_workload_bookbag_user_namespace in _project_names
 
 # Leave this as the last task in the playbook.
 - name: remove_workload tasks complete

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/tasks/remove_workload.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/tasks/remove_workload.yaml
@@ -1,0 +1,25 @@
+---
+# Implement your Workload removal tasks here
+- name: List project namespaces
+  k8s_info:
+    kubeconfig: "{{ _ocp4_workload_bookbag_user_kubeconfig | default(omit) }}"
+    api_version: project.openshift.io/v1
+    kind: Project
+  register: r_list_projects
+
+- name: Remove bookbag namespace
+  k8s:
+    kubeconfig: "{{ _ocp4_workload_bookbag_user_kubeconfig | default(omit) }}"
+    state: absent
+    api_version: project.openshift.io/v1
+    kind: Project
+    name: "{{ ocp4_workload_bookbag_user_namespace }}"
+  vars:
+    _project_names: "{{ r_list_projects.resources | default([]) | json_query('[].metadata.name') }}"
+  when: ocp4_workload_bookbag_user_namespace in _project_names
+
+# Leave this as the last task in the playbook.
+- name: remove_workload tasks complete
+  debug:
+    msg: "Remove Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/tasks/workload.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/tasks/workload.yaml
@@ -9,7 +9,7 @@
 - name: Fallback for User Data
   when: _user_data | default({}) | length == 0
   set_fact:
-    _user_data: {}
+    _user_data: []
 
 - name: Get User Info
   set_fact:
@@ -20,14 +20,14 @@
 - name: Fallback for User Info
   when: _user_info_messages | default({}) | length == 0
   set_fact:
-    _user_info_messages: {}
+    _user_info_messages: []
 
 - name: Set workshop default vars
   set_fact:
     _workshop_default_vars:
-      GUID: "{{ guid }}"
-      USERNAME: "{{ ocp_username }}"
-      user_info_messages: "{{ _user_info_messages }}"
+      guid: "{{ guid }}"
+      username: "{{ ocp_username }}"
+      user_info_messages: "{{ _user_info_messages | join('\n') }}"
 
 - name: Set Workshop vars
   set_fact:

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/tasks/workload.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/tasks/workload.yaml
@@ -50,7 +50,7 @@
 - name: Set Console Image to override image
   when: ocp4_workload_bookbag_user_console_image_override | default("") | length > 0
   set_fact:
-    ocp4_workload_bookbag_user_console_image: "{{ ocp4_workload_bookbag_user_console_image_override }}" 
+    ocp4_workload_bookbag_user_console_image: "{{ ocp4_workload_bookbag_user_console_image_override }}"
 
 - name: Create Bookbag prerequisite resources
   k8s:

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/tasks/workload.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/tasks/workload.yaml
@@ -1,0 +1,72 @@
+---
+
+- name: Get User Data
+  set_fact:
+    _user_data: >-
+      {{ lookup('file', hostvars.localhost.output_dir ~ '/user-data.yaml', errors='ignore')
+      | from_yaml }}
+
+- name: Fallback for User Data
+  when: _user_data | default({}) | length == 0
+  set_fact:
+    _user_data: {}
+
+- name: Get User Info
+  set_fact:
+    _user_info_messages: >-
+      {{ lookup('file', hostvars.localhost.output_dir ~ '/user-info.yaml', errors='ignore')
+      | from_yaml }}
+
+- name: Fallback for User Info
+  when: _user_info_messages | default({}) | length == 0
+  set_fact:
+    _user_info_messages: {}
+
+- name: Set workshop default vars
+  set_fact:
+    _workshop_default_vars:
+      GUID: "{{ guid }}"
+      USERNAME: "{{ ocp_username }}"
+      user_info_messages: "{{ _user_info_messages }}"
+
+- name: Set Workshop vars
+  set_fact:
+    _workshop_vars: >-
+      {{ _user_data | combine(_workshop_default_vars) }}
+
+- name: Create Bookbag resources
+  k8s:
+    state: present
+    definition: "{{ lookup('template', item ) | from_yaml }}"
+  loop:
+  - ./templates/project.yaml.j2
+  - ./templates/service_account.yaml.j2
+  - ./templates/rolebinding.yaml.j2
+  - ./templates/service.yaml.j2
+  - ./templates/route.yaml.j2
+  - ./templates/deployment.yaml.j2
+
+- name: Get Bookbag route
+  k8s_info:
+    api_version: route.openshift.io/v1
+    kind: Route
+    name: "{{ ocp4_workload_bookbag_user_deployment_name }}"
+    namespace: "{{ ocp4_workload_bookbag_user_project }}"
+  register: r_route
+  failed_when: r_route.resources | length != 1
+
+- name: Set agnosticd_user_info for Bookbag
+  agnosticd_user_info:
+    msg: "Lab instructions: {{ _ocp4_workload_bookbag_user_url }}"
+    data:
+      ocp4_workload_bookbag_user_url: "{{ _ocp4_workload_bookbag_user_url }}"
+  vars:
+    _route: "{{ r_route.resources[0] }}"
+    _ocp4_workload_bookbag_user_url: >-
+      {{ 'https' if 'tls' in _route.spec else 'http' }}://{{ _route.spec.host }}
+
+# Leave this as the last task in the playbook.
+- name: workload tasks complete
+  debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/tasks/workload.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/tasks/workload.yaml
@@ -42,6 +42,7 @@
   - ./templates/project.yaml.j2
   - ./templates/service_account.yaml.j2
   - ./templates/rolebinding.yaml.j2
+  - ./templates/rolebinding_image_puller.yaml.j2
   - ./templates/service.yaml.j2
   - ./templates/route.yaml.j2
   - ./templates/deployment.yaml.j2

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/tasks/workload.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/tasks/workload.yaml
@@ -34,7 +34,25 @@
     _workshop_vars: >-
       {{ _user_data | combine(_workshop_default_vars) }}
 
-- name: Create Bookbag resources
+- name: Determine OpenShift Console Image
+  when: ocp4_workload_bookbag_user_console_image_override | default("") | length == 0
+  block:
+  - name: Get OpenShift Console Deployment
+    k8s_info:
+      api_version: apps/v1
+      kind: Deployment
+      name: console
+      namespace: openshift-console
+    register: r_console_deployment
+  - name: Set Console Image variable
+    set_fact:
+      ocp4_workload_bookbag_user_console_image: "{{ r_console_deployment.resources[0].spec.template.spec.containers[0].image }}"
+- name: Set Console Image to override image
+  when: ocp4_workload_bookbag_user_console_image_override | default("") | length > 0
+  set_fact:
+    ocp4_workload_bookbag_user_console_image: "{{ ocp4_workload_bookbag_user_console_image_override }}" 
+
+- name: Create Bookbag prerequisite resources
   k8s:
     state: present
     definition: "{{ lookup('template', item ) | from_yaml }}"
@@ -45,7 +63,17 @@
   - ./templates/rolebinding_image_puller.yaml.j2
   - ./templates/service.yaml.j2
   - ./templates/route.yaml.j2
-  - ./templates/deployment.yaml.j2
+
+- name: Create Bookbag PVC
+  when: ocp4_workload_bookbag_user_create_pvc | bool
+  k8s:
+    state: present
+    definition: "{{ lookup('template', './templates/pvc.yaml.j2' ) | from_yaml }}"
+
+- name: Create Bookbag deployment
+  k8s:
+    state: present
+    definition: "{{ lookup('template', './templates/deployment.yaml.j2' ) | from_yaml }}"
 
 - name: Get Bookbag route
   k8s_info:

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/templates/deployment.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/templates/deployment.yaml.j2
@@ -17,9 +17,19 @@ spec:
     spec:
       restartPolicy: Always
       serviceAccountName: "{{ ocp4_workload_bookbag_user_deployment_name }}"
+{% if ocp4_workload_bookbag_user_console_deploy | bool %}
+      initContainers:
+      - name: setup-console
+        image: "{{ ocp4_workload_bookbag_user_image_name }}:{{ ocp4_workload_bookbag_user_image_tag }}"
+        command:
+        - /opt/workshop/bin/setup-console.sh
+        volumeMounts:
+        - name: shared
+          mountPath: /var/run/workshop
+{% endif %}
       containers:
       - name: terminal
-        image: "{{ ocp4_workload_bookbag_image_name }}:{{ ocp4_workload_bookbag_image_tag }}"
+        image: "{{ ocp4_workload_bookbag_user_image_name }}:{{ ocp4_workload_bookbag_user_image_tag }}"
         imagePullPolicy: IfNotPresent
         env:
         - name: APPLICATION_NAME
@@ -28,6 +38,18 @@ spec:
           value: '*'
         - name: AUTH_PASSWORD
           value: ''
+        - name: CONSOLE_IMAGE
+          value: "{{ ocp4_workload_bookbag_user_console_image }}"
+        - name: CONSOLE_BRANDING
+          value: "{{ ocp4_workload_bookbag_user_console_branding }}"
+        - name: ROLE
+          value: "{{ ocp4_workload_bookbag_user_role }}"
+{% if ocp4_workload_bookbag_user_console_deploy | bool %}
+        - name: CONSOLE_URL
+          value: http://0.0.0.0:10083
+{% endif %}
+        - name: OAUTH_SERVICE_ACCOUNT
+          value: "{{ ocp4_workload_bookbag_user_deployment_name }}"
         - name: DOWNLOAD_URL
         - name: WORKSHOP_FILE
         - name: OC_VERSION
@@ -39,3 +61,35 @@ spec:
         - containerPort: 10080
           protocol: TCP
         resources: {}
+{% if ocp4_workload_bookbag_user_console_deploy | bool %}
+        volumeMounts:
+        - name: shared
+          mountPath: /var/run/workshop
+{% endif %}
+{% if ocp4_workload_bookbag_user_console_deploy | bool %}
+      - name: console
+        image: "{{ ocp4_workload_bookbag_user_console_image }}"
+        command:
+        - /var/run/workshop/start-console.sh
+        env:
+        - name: BRIDGE_K8S_MODE
+          value: in-cluster
+        - name: BRIDGE_LISTEN
+          value: http://0.0.0.0:10083
+        - name: BRIDGE_BASE_PATH
+          value: /console/
+        - name: BRIDGE_PUBLIC_DIR
+          value: /opt/bridge/static
+        - name: BRIDGE_USER_AUTH
+          value: disabled
+        - name: BRIDGE_BRANDING
+          value: "{{ ocp4_workload_bookbag_user_console_branding }}"
+        volumeMounts:
+        - name: shared
+          mountPath: /var/run/workshop
+{% endif %}
+{% if ocp4_workload_bookbag_user_console_deploy | bool %}
+      volumes:
+      - name: shared
+        emptyDir: {}
+{% endif %}

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/templates/deployment.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/templates/deployment.yaml.j2
@@ -61,10 +61,16 @@ spec:
         - containerPort: 10080
           protocol: TCP
         resources: {}
-{% if ocp4_workload_bookbag_user_console_deploy | bool %}
+{% if ocp4_workload_bookbag_user_console_deploy | bool or ocp4_workload_bookbag_user_create_pvc | bool %}
         volumeMounts:
+{%   if ocp4_workload_bookbag_user_console_deploy | bool %}
         - name: shared
           mountPath: /var/run/workshop
+{%   endif %}
+{%   if ocp4_workload_bookbag_user_create_pvc | bool %}
+        - name: home
+          mountPath: /opt/app-root/src
+{%   endif %}
 {% endif %}
 {% if ocp4_workload_bookbag_user_console_deploy | bool %}
       - name: console
@@ -88,8 +94,15 @@ spec:
         - name: shared
           mountPath: /var/run/workshop
 {% endif %}
-{% if ocp4_workload_bookbag_user_console_deploy | bool %}
+{% if ocp4_workload_bookbag_user_console_deploy | bool or ocp4_workload_bookbag_user_create_pvc | bool %}
       volumes:
+{%   if ocp4_workload_bookbag_user_console_deploy | bool %}
       - name: shared
         emptyDir: {}
+{%   endif %}
+{%   if ocp4_workload_bookbag_user_create_pvc | bool %}
+      - name: home
+        persistentVolumeClaim:
+          claimName: "{{ ocp4_workload_bookbag_user_deployment_name }}"
+{%   endif %}
 {% endif %}

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/templates/deployment.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/templates/deployment.yaml.j2
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ ocp4_workload_bookbag_user_deployment_name }}"
+  namespace: "{{ ocp4_workload_bookbag_user_project }}"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      deployment: "{{ ocp4_workload_bookbag_user_deployment_name }}"
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        deployment: "{{ ocp4_workload_bookbag_user_deployment_name }}"
+    spec:
+      restartPolicy: Always
+      serviceAccountName: "{{ ocp4_workload_bookbag_user_deployment_name }}"
+      containers:
+      - name: terminal
+        image: "{{ ocp4_workload_bookbag_image_name }}:{{ ocp4_workload_bookbag_image_tag }}"
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: APPLICATION_NAME
+          value: "{{ ocp4_workload_bookbag_user_deployment_name }}"
+        - name: AUTH_USERNAME
+          value: '*'
+        - name: AUTH_PASSWORD
+          value: ''
+        - name: DOWNLOAD_URL
+        - name: WORKSHOP_FILE
+        - name: OC_VERSION
+        - name: ODO_VERSION
+        - name: KUBECTL_VERSION
+        - name: WORKSHOP_VARS
+          value: '{{ _workshop_vars  | to_json }}'
+        ports:
+        - containerPort: 10080
+          protocol: TCP
+        resources: {}

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/templates/project.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/templates/project.yaml.j2
@@ -1,0 +1,8 @@
+apiVersion: project.openshift.io/v1
+kind: Project
+metadata:
+  name: "{{ ocp4_workload_bookbag_user_project }}"
+  annotations:
+    openshift.io/description: ""
+    openshift.io/display-name: "{{ ocp4_workload_bookbag_user_project_display }}"
+    openshift.io/requester: "{{ ocp_username }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/templates/pvc.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/templates/pvc.yaml.j2
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "{{ ocp4_workload_bookbag_user_deployment_name }}"
+  namespace: "{{ ocp4_workload_bookbag_user_project }}"
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: "{{ ocp4_workload_bookbag_user_pvc_size }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/templates/rolebinding.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/templates/rolebinding.yaml.j2
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "bookbag-{{ ocp4_workload_bookbag_user_project }}"
+  namespace: "{{ ocp4_workload_bookbag_image_namespace }}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:image-puller
+subjects:
+- kind: ServiceAccount
+  name: "{{ ocp4_workload_bookbag_user_deployment_name }}"
+  namespace: "{{ ocp4_workload_bookbag_user_project }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/templates/rolebinding_image_puller.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/templates/rolebinding_image_puller.yaml.j2
@@ -1,12 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: "{{ ocp4_workload_bookbag_user_deployment_name }}-{{ ocp4_workload_bookbag_user_role }}"
+  name: "bookbag-{{ ocp4_workload_bookbag_user_project }}"
   namespace: "{{ ocp4_workload_bookbag_user_image_namespace }}"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: "{{ ocp4_workload_bookbag_user_role }}"
+  name: system:image-puller
 subjects:
 - kind: ServiceAccount
   name: "{{ ocp4_workload_bookbag_user_deployment_name }}"
+  namespace: "{{ ocp4_workload_bookbag_user_project }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/templates/route.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/templates/route.yaml.j2
@@ -1,0 +1,14 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: "{{ ocp4_workload_bookbag_user_deployment_name }}"
+  namespace: "{{ ocp4_workload_bookbag_user_project }}"
+spec:
+  port:
+    targetPort: 10080-tcp
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  to:
+    kind: Service
+    name: "{{ ocp4_workload_bookbag_user_deployment_name }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/templates/service.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/templates/service.yaml.j2
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ ocp4_workload_bookbag_user_deployment_name }}"
+  namespace: "{{ ocp4_workload_bookbag_user_project }}"
+spec:
+  ports:
+  - name: 10080-tcp
+    port: 10080
+    protocol: TCP
+    targetPort: 10080
+  selector:
+    deployment: "{{ ocp4_workload_bookbag_user_deployment_name }}"
+  type: ClusterIP

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/templates/service_account.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/templates/service_account.yaml.j2
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "{{ ocp4_workload_bookbag_user_deployment_name }}"
+  namespace: "{{ ocp4_workload_bookbag_user_project }}"


### PR DESCRIPTION
##### SUMMARY

This PR introduces two new bookbag workloads:

*ocp4_workload_bookbag_setup*: this workload builds a bookbag image from a git repository.
*ocp4_workload_bookbag_user*: this workload deploys a bookbag for a user in a new project from the image that the other role created.

Use case:
On a shared cluster use *ocp4_workload_bookbag_setup* as an `infra_workload` to create the image.
Then use *ocp4_workload_bookbag_setup* as a `student_workload` to deploy x number of bookbags

Second use case:
Create the image when setting up a shared cluster.
On demand when provisioning an environment deploy the workloads that make up the environment and the ocp4_workload_bookbag_user role to deploy the matching bookbag.

##### ISSUE TYPE
- New role Pull Request

##### COMPONENT NAME
ocp4_workload_bookbag_setup
ocp4_workload_bookbag_user

Example variables:

\# Bookbag Setup
ocp4_workload_bookbag_setup_project: "bookbag"
ocp4_workload_bookbag_setup_project_display: "Bookbag RHTR2020 OCP4 Pipelines"
ocp4_workload_bookbag_setup_git_repo: https://github.com/redhat-gpte-devopsautomation/rhtr2020_pipelines
ocp4_workload_bookbag_setup_git_version: master
ocp4_workload_bookbag_setup_image_name: rhtr2020pipelines

\# Bookbag User
ocp4_workload_bookbag_user_project: "bookbag-wkrhtr"
ocp4_workload_bookbag_user_project_display: "Bookbag for user {{ ocp_username }}"
ocp4_workload_bookbag_user_deployment_name: bookbag
ocp4_workload_bookbag_image_name: image-registry.openshift-image-registry.svc:5000/bookbag/rhtr2020pipelines
ocp4_workload_bookbag_image_tag: latest
ocp4_workload_bookbag_image_namespace: "bookbag"


