### PR TITLE
Using ec2_ami_info module instead of using shell with the aws cli

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/post_workload.yml
@@ -1,16 +1,6 @@
 ---
 # Implement your Post Workload deployment tasks here
 
-# Copy original AWS Credentials file back over
-- name: Copy original AWS Credentials file back over
-  copy:
-    src: /tmp/windows_node_workload_backups/aws_credentials
-    dest: "/home/{{ ansible_user }}/.aws/credentials"
-    owner: "{{ ansible_user }}"
-    group: "{{ ansible_user }}"
-    mode: '0664'
-    remote_src: yes 
-
 # Leave this as the last task in the playbook.
 - name: post_workload tasks complete
   debug:

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/pre_workload.yml
@@ -10,76 +10,31 @@
     group: "{{ ansible_user }}"
     mode: '0775'
   loop:
-    - /tmp/windows_node_workload_backups
     - "/home/{{ ansible_user }}/windows_node_scripts"
 
-# Make backup copy of AWS Credentials file
-- name: Make backup copy of AWS Credentials file
-  copy:
-    src: "/home/{{ ansible_user }}/.aws/credentials"
-    dest: /tmp/windows_node_workload_backups/aws_credentials
-    owner: "{{ ansible_user }}"
-    group: "{{ ansible_user }}"
-    mode: '0664'
-    remote_src: yes
-
-# Extract the AWS access key from OpenShift
-- name: Extract the AWS access key from OpenShift
+# Extract the AWS keys from OpenShift
+- name: Extract the AWS keys from OpenShift
   k8s_info:
     api_version: v1
     kind: Secret
     name: aws-cloud-credentials
     namespace: openshift-machine-api
-  register: ocp_access_key_fact
+  register: ocp_aws_keys
   retries: 25
   delay: 5
   until:
-    - ocp_access_key_fact.resources[0].data.aws_access_key_id is defined
+    - ocp_aws_keys.resources[0].data.aws_access_key_id is defined
+    - ocp_aws_keys.resources[0].data.aws_secret_access_key is defined
 
 # Convert extraced AWS access key into a decoded fact for later use
 - name: Convert extraced AWS access key into a decoded fact for later use
   set_fact:
-    ocp_access_key: "{{ ocp_access_key_fact.resources[0].data.aws_access_key_id | b64decode }}"
-
-# Extract the AWS secret key from OpenShift
-- name: Extract the AWS secret key from OpenShift
-  k8s_info:
-    api_version: v1
-    kind: Secret
-    name: aws-cloud-credentials
-    namespace: openshift-machine-api
-  register: ocp_secret_key_fact
-  retries: 25
-  delay: 5
-  until:
-    - ocp_secret_key_fact.resources[0].data.aws_secret_access_key is defined
+    ocp_access_key: "{{ ocp_aws_keys.resources[0].data.aws_access_key_id | b64decode }}"
 
 # Convert extraced AWS secret key into a decoded fact for later use
 - name: Convert extraced AWS secret key into a decoded fact for later use
   set_fact:
-    ocp_secret_key: "{{ ocp_secret_key_fact.resources[0].data.aws_secret_access_key | b64decode }}"
-
-# Remove existing AWS credentials file
-- name: Remove existing AWS credentials file
-  file:
-    path: "/home/{{ ansible_user }}/.aws/credentials"
-    state: absent
-
-# Configure the AWS credentials file with the access key and secret key from OpenShift
-- name: Configure the AWS credentials file with the access key and secret key from OpenShift
-  when:
-  - ocp_access_key | default("") | length > 0
-  - ocp_secret_key | default("") | length > 0
-  blockinfile:
-    state: present
-    path: "/home/{{ ansible_user }}/.aws/credentials"
-    create: true
-    insertbefore: BOF
-    marker: "# {mark} ANSIBLE MANAGED BLOCK AMI Search Credentials"
-    block: |-
-      [default]
-      aws_access_key_id = {{ ocp_access_key }}
-      aws_secret_access_key = {{ ocp_secret_key }}
+    ocp_secret_key: "{{ ocp_aws_keys.resources[0].data.aws_secret_access_key | b64decode }}"
 
 # Leave this as the last task in the playbook.
 - name: pre_workload tasks complete

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/remove_workload.yml
@@ -42,11 +42,20 @@
   set_fact:
     cluster_az: "{{ machineset_list.resources[0].spec.template.spec.providerSpec.value.placement.availabilityZone }}"
 
+# Get the latest Windows Server 2019 with Containers 
+- name: Extract the latest Windows Server 2019 with Containers Image
+  ec2_ami_info:
+    region: "{{ cluster_region }}"
+    aws_access_key: "{{ ocp_access_key }}"
+    aws_secret_key: "{{ ocp_secret_key }}"
+    filters:
+      name: 'Windows_Server-2019*English*Full*Containers*'
+  register: wami_fact
+
 # Get the latest Windows Server 2019 with Containers AMI
-- name: Get the latest Windows Server 2019 with Containers AMI
-  shell: >
-    aws ec2 describe-images --region={{ cluster_region }} --filters 'Name=name,Values=Windows_Server-2019*English*Full*Containers*' 'Name=is-public,Values=true' --query 'reverse(sort_by(Images, &CreationDate))[*].{name: Name, id: ImageId}' | jq -r '.[0].id'
-  register: windows_ami
+- name: Set the latest Windows Server 2019 with Containers AMI as a fact for later use
+  set_fact:
+    windows_ami: "{{ (wami_fact.images | sort(attribute='creation_date') | last).image_id }}"
 
 # Remove the Windows Node MachineSet
 - name: Remove the Windows Node MachineSet

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/workload.yml
@@ -63,11 +63,20 @@
   set_fact:
     cluster_az: "{{ machineset_list.resources[0].spec.template.spec.providerSpec.value.placement.availabilityZone }}"
 
+# Get the latest Windows Server 2019 with Containers 
+- name: Extract the latest Windows Server 2019 with Containers Image
+  ec2_ami_info:
+    region: "{{ cluster_region }}"
+    aws_access_key: "{{ ocp_access_key }}"
+    aws_secret_key: "{{ ocp_secret_key }}"
+    filters:
+      name: 'Windows_Server-2019*English*Full*Containers*'
+  register: wami_fact
+
 # Get the latest Windows Server 2019 with Containers AMI
-- name: Get the latest Windows Server 2019 with Containers AMI
-  shell: >
-    aws ec2 describe-images --region={{ cluster_region }} --filters 'Name=name,Values=Windows_Server-2019*English*Full*Containers*' 'Name=is-public,Values=true' --query 'reverse(sort_by(Images, &CreationDate))[*].{name: Name, id: ImageId}' | jq -r '.[0].id'
-  register: windows_ami
+- name: Set the latest Windows Server 2019 with Containers AMI as a fact for later use 
+  set_fact:
+    windows_ami: "{{ (wami_fact.images | sort(attribute='creation_date') | last).image_id }}"
 
 # Slurp SSH key to use for secret
 - name: Slurp SSH key to use for secret

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/templates/windows-ms.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/templates/windows-ms.j2
@@ -26,7 +26,7 @@ spec:
       providerSpec:
         value:
           ami:
-            id: "{{ windows_ami.stdout }}"
+            id: "{{ windows_ami }}"
           apiVersion: awsproviderconfig.openshift.io/v1beta1
           blockDevices:
             - ebs:


### PR DESCRIPTION
##### SUMMARY

This PR improves the playbook by using `ec2_ami_info` instead of calling the `shell` module and running the `aws` cli. A byproduct of this, is that I no longer need to touch the `~ec2-user/.aws/credentials` file at all. Therefore I've removed that part of the playbook, which simplifies the playbook.

##### ISSUE TYPE

Enhancement.

##### COMPONENT NAME

`ec2_ami_info` added to this playbook.

##### ADDITIONAL INFORMATION

N/A
