### PR TITLE
Uses jenkins version 2 instead of latest

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_dso/tasks/infrastructure.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_dso/tasks/infrastructure.yml
@@ -69,7 +69,7 @@
 
 - name: create custom jenkins image
   shell: |
-    {{ ocp4_dso_openshift_cli }} new-build -D $'FROM jenkins:latest\nUSER 0\nRUN curl -kL https://updates.jenkins-ci.org/download/plugins/ssh-steps/1.2.1/ssh-steps.hpi -o /usr/lib/jenkins/ssh-steps.hpi && chmod 665 /usr/lib/jenkins/ssh-steps.hpi && sed -i '\''s/{ print $1; }/ {a=$1} END{print a}/'\'' /usr/libexec/s2i/run' --to=custom-jenkins -n openshift
+    {{ ocp4_dso_openshift_cli }} new-build -D $'FROM jenkins:2\nUSER 0\nRUN curl -kL https://updates.jenkins-ci.org/download/plugins/ssh-steps/1.2.1/ssh-steps.hpi -o /usr/lib/jenkins/ssh-steps.hpi && chmod 665 /usr/lib/jenkins/ssh-steps.hpi && sed -i '\''s/{ print $1; }/ {a=$1} END{print a}/'\'' /usr/libexec/s2i/run' --to=custom-jenkins -n openshift
   ignore_errors: true
 
 - name: wait for custom jenkins build to finish


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

Update jenkins version to 2 instead of latest. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
ocp4_workload_dso

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
