### PR TITLE
AWS CloudFormation: auto-select AvailabilityZone

### DIFF
--- a/ansible/roles-infra/infra-ec2-template-generate/defaults/main.yml
+++ b/ansible/roles-infra/infra-ec2-template-generate/defaults/main.yml
@@ -361,3 +361,8 @@ aws_dns_mapping:
       domain: "sa-east-1.compute.internal"
     "ap-south-1":
       domain: "ap-south-1.compute.internal"
+
+# When infra_ec2_template_generate_auto_select_availability_zone is set to true,
+# the role will set aws_availability_zone to an availability that can host
+# all instances types, unless several subnets are used.
+infra_ec2_template_generate_auto_select_availability_zone: true

--- a/ansible/roles-infra/infra-ec2-template-generate/tasks/locate_availability_zones.yml
+++ b/ansible/roles-infra/infra-ec2-template-generate/tasks/locate_availability_zones.yml
@@ -1,0 +1,128 @@
+---
+- name: Get all the instance types
+  set_fact:
+    __all_instance_types: >-
+        {{
+        instances
+        | default([])
+        | json_query('[].flavor')
+        | list
+        | unique
+        }}
+
+# Sometimes the flavor is a map
+# In that case, get the .ec2 value.
+- when:
+    - __all_instance_types | length > 0
+    - __all_instance_types[0] is mapping
+  set_fact:
+    __all_instance_types: >-
+        {{
+        __all_instance_types
+        | json_query('[].ec2')
+        | list
+        | unique
+        }}
+
+- name: Check if the AWS CLI has the 'describe-instance-type-offerings' feature
+  command: aws ec2 describe-instance-type-offerings help
+  failed_when: false
+  changed_when: false
+  register: r_aws_type_offerings
+
+# Some config use instances[].subnet(s) to define in what subnet each instance goes.
+# In case of multiple subnets, we don't want to impose an availability zone, as those
+# can live in different AZs.
+# First get all the subnets:
+- name: Get all subnets or networks in 'instances'
+  set_fact:
+    __all_subnets: >-
+      {{
+      ( instances
+      | default([])
+      | json_query('[].subnet')
+      | list
+      | unique )
+      + ( instances
+      | default([])
+      | json_query('[].subnets')
+      | list
+      | unique )
+      }}
+
+- when:
+    # Run only if some instance types were found
+    - __all_instance_types | length > 0
+    # Run only if the AWS CLI has the cabability to list offerings
+    - r_aws_type_offerings.rc == 0
+    # Do not try to pick the AZ when the config uses several Subnets
+    - __all_subnets | length <= 1
+  block:
+    - name: Get the possible AZs
+      loop: "{{ __all_instance_types }}"
+      loop_control:
+        loop_var: _type
+      environment:
+        AWS_ACCESS_KEY_ID: "{{ aws_access_key_id }}"
+        AWS_SECRET_ACCESS_KEY: "{{ aws_secret_access_key }}"
+        AWS_DEFAULT_REGION: "{{ aws_region_final | default(aws_region) }}"
+      command: >-
+        aws ec2 describe-instance-type-offerings
+        --location-type availability-zone
+        --filters "Name=instance-type,Values={{ _type }}"
+        --query "InstanceTypeOfferings[].Location"
+        --output json
+      register: r_possible_azs
+
+    - debug:
+        var: r_possible_azs
+        verbosity: 3
+
+    - name: Fail if return code is not 0
+      fail:
+        msg: "The command ({{ item.cmd }}) did not have a 0 return code"
+      when: item.rc != 0
+      loop: "{{ r_possible_azs.results }}"
+      loop_control:
+        label: "{{ item.cmd }}"
+
+    - name: Set fact of the possible Availability Zones
+      set_fact:
+        __all_possible_azs: >-
+          {{ r_possible_azs
+          | json_query('results[].stdout')
+          | map('from_json')
+          | list
+          }}
+
+    - name: Calculate intersection of all AZs and set_fact
+      loop: "{{ __all_possible_azs }}"
+      loop_control:
+        loop_var: __azs
+      set_fact:
+        infra_ec2_template_generate_possible_azs: >-
+          {{
+          infra_ec2_template_generate_possible_azs
+          | default(__all_possible_azs[0])
+          | default([])
+          | intersect(__azs)
+          }}
+
+    - name: Abort if no AZ is found
+      assert:
+        that: infra_ec2_template_generate_possible_azs | length > 0
+        msg: >-
+          No availability Zone in region {{ aws_region_final | default(aws_region) }}
+          can host all the specified instance types.
+
+    - name: Print possible availability zones
+      debug:
+        var: infra_ec2_template_generate_possible_azs
+
+    - name: Select the first AZ in the possible AZs and set fact aws_availability_zone
+      set_fact:
+        aws_availability_zone: "{{ infra_ec2_template_generate_possible_azs | first }}"
+
+    - name: Debug
+      debug:
+        var: aws_availability_zone

--- a/ansible/roles-infra/infra-ec2-template-generate/tasks/main.yml
+++ b/ansible/roles-infra/infra-ec2-template-generate/tasks/main.yml
@@ -1,4 +1,13 @@
 ---
+# Cloudformation doesn't guarantee to place the instances into an Availability Zone
+# that can host all instance types. That results in random errors.
+- when:
+    - infra_ec2_template_generate_auto_select_availability_zone | bool
+    - instances | length > 0
+    - aws_availability_zone is undefined
+  name: Detect all possible Availability Zones that can host all the instance types and pick one
+  include_tasks: locate_availability_zones.yml
+
 - import_tasks: locate_template.yml
 - import_tasks: security_groups.yml
 


### PR DESCRIPTION
This commit, if applied, adds a feature to auto detect availbility zones (AZ)
that can host all the instance types defined in the `instances` variable.

If the AZ is omitted in the CloudFormation template, AWS doesn't guarantee to pick the right AZ and that sometimes results in errors of the type:

> "resource_status_reason: Your requested instance type (c3.large) is not supported in your requested Availability Zone (us-east-1a). Please retry your request by not specifying an Availability Zone or choosing us-east-1b, us-east-1d, us-east-1c, us-east-1e."

In order to fix that, this commit adds a set of tasks in the
infra-ec2-template-generate role that do the following:

- Get all the instance types
- For each instance type, get all AZs that support it
- Calculate the intersection of all AZs => all AZs that can host all
  instance types
- Select the first and set `aws_availability_zone`

This feature is enabled by default and can be disabled by setting the following variable:

```yaml
  infra_ec2_template_generate_auto_select_availability_zone: false
```

The tasks are skipped when any of those conditions is met:

- `infra_ec2_template_generate_auto_select_availability_zone` is `false`
- `aws_availability_zone` is defined
- several subnets are found in `instances`: subnets can be created in
  different AZs, in that case we don't want to interfere with the config.
- AWS CLI doesn't support the `describe-instance-type-offerings` feature

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->


##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

`infra-ec2-template-generate` role

FYI @rut31337 