### PR TITLE
Replace incorrect hardcoded values

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_dso/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_dso/defaults/main.yml
@@ -6,10 +6,10 @@ silent: False
 ###### OpenShift defaults
 
 # Used for jenkins pipelining, temporary directory, and bastion hostname
-ocp4_dso_guid: raleigh-fb78
+ocp4_dso_guid: "{{ guid }}"
 
 # Needed for jenkins pipelining for oscap-docker
-ocp4_dso_domain: "{{ ocp4_dso_guid }}.openshiftworkshop.com"
+ocp4_dso_domain: "{{ ocp4_dso_guid }}{{ subdomain_base_suffix }}"
 
 # Needed for jenkins pipelining for oscap-docker
 ocp4_dso_bastion: "bastion.{{ ocp4_dso_domain }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_dso/tasks/infrastructure.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_dso/tasks/infrastructure.yml
@@ -69,7 +69,7 @@
 
 - name: create custom jenkins image
   shell: |
-    {{ ocp4_dso_openshift_cli }} new-build -D $'FROM jenkins:latest\nUSER 0\nRUN curl -kL https://updates.jenkins-ci.org/download/plugins/ssh-steps/1.2.1/ssh-steps.hpi -o /usr/lib/jenkins/ssh-steps.hpi && chmod 665 /usr/lib/jenkins/ssh-steps.hpi && sed -i '\''s/{ print $1; }/ {a=$1} END{print a}/'\'' /usr/libexec/s2i/run' --to=custom-jenkins -n openshift
+    {{ ocp4_dso_openshift_cli }} new-build -D $'FROM jenkins:2\nUSER 0\nRUN curl -kL https://updates.jenkins-ci.org/download/plugins/ssh-steps/1.2.1/ssh-steps.hpi -o /usr/lib/jenkins/ssh-steps.hpi && chmod 665 /usr/lib/jenkins/ssh-steps.hpi && sed -i '\''s/{ print $1; }/ {a=$1} END{print a}/'\'' /usr/libexec/s2i/run' --to=custom-jenkins -n openshift
   ignore_errors: true
 
 - name: wait for custom jenkins build to finish


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

Variables related to the bastion were incorrectly hardcoded. Instead use the `guid` and `subdomain_base_suffix`. Also Update jenkins version from `latest` to `2`

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4_workload_dso
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
