### PR TITLE
SG fixed for certbot

### DIFF
--- a/ansible/configs/ansible-multitier-infra/default_vars_osp.yml
+++ b/ansible/configs/ansible-multitier-infra/default_vars_osp.yml
@@ -45,9 +45,29 @@ security_groups:
         from_group: FrontendSG
         rule_type: Ingress
 
+  - name: BastionSGCert
+    rules:
+      - name: BastionHTTPPort
+        description: "Allow HTTP from Public"
+        from_port: 80
+        to_port: 80
+        protocol: tcp
+        cidr: "0.0.0.0/0"
+        rule_type: Ingress
+      - name: BastionHTTPSPort
+        description: "Allow HTTPS from Public"
+        from_port: 443
+        to_port: 443
+        protocol: tcp
+        cidr: "0.0.0.0/0"
+        rule_type: Ingress
+
 # Environment Instances
 instances:
-  - name: "bastion"
+
+# Environment Instances
+instances:
+  - name: "control"
     count: 1
     unique: true
     public_dns: true
@@ -58,6 +78,7 @@ instances:
       osp: "{{ bastion_instance_type | default(__instance_type) }}"
     security_groups:
       - BastionSG
+      - BastionSGCert
       - DefaultSG
     tags:
       - key: "AnsibleGroup"


### PR DESCRIPTION

##### SUMMARY

P address. Additionally, please check that", "   your computer has a publicly routable IP address and that no", "   firewalls are preventing the server from communicating with the", "   client. If you're using the webroot plugin, you should also verify", "   that you are serving files from the webroot path you provided.", " - Your account credentials have been saved in your Certbot", "   configuration directory at /etc/letsencrypt. You should make a", "   secure backup of this folder now. This configuration directory will", "   also contain certificates and private keys obtained by Certbot so", "   making regular backups of this folder is ideal."]}

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
default_vars_ops.yml
443 open.


