### PR TITLE
Clone rhamt-vscode-extension:java11 image from dockerhub to quay.io

### DIFF
--- a/ansible/roles/ocp4-workload-ccnrd/files/cheplugin-meta.yaml
+++ b/ansible/roles/ocp4-workload-ccnrd/files/cheplugin-meta.yaml
@@ -23,7 +23,7 @@ spec:
     attributes:
       protocol: http
   containers:
-    - image: "windup3/rhamt-vscode-extension:java11"
+    - image: "quay.io/openshiftlabs/rhamt-vscode-extension:java11"
       name: rhamt-extension
       mountSources: true
       ports:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
To maintain all images in a single repository, quay.io, I cloned the rhamt-vscode-extension:java11 image to quay.io.
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
