### PR TITLE
Fix role infra-osp-resources-destroy to set default osp_project_create

### DIFF
--- a/ansible/roles-infra/infra-osp-resources-destroy/defaults/main.yaml
+++ b/ansible/roles-infra/infra-osp-resources-destroy/defaults/main.yaml
@@ -3,6 +3,8 @@ osp_stack_delete_retries: 3
 
 osp_auth_username_member: "{{ guid }}-user"
 
+# Defaults to match infra-osp-project-create
+osp_project_create: true
 osp_create_sandbox: false
 
 # This is useful if you're working with osp_project_create = false but


### PR DESCRIPTION
#### SUMMARY

The infra-osp-resources-destroy role does not define a default for `osp_project_create`, while the role infra-osp-project-create defines this as true. The result is that a config provisions without this set but fails on destroy.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role infra-osp-rsources-destroy