### PR TITLE
Fix workload dil-streaming user_registration

### DIFF
--- a/ansible/roles/ocp4-workload-dil-streaming/templates/user_registration.yaml.j2
+++ b/ansible/roles/ocp4-workload-dil-streaming/templates/user_registration.yaml.j2
@@ -129,6 +129,8 @@ items:
             value: '{{ num_users | int + 5 }}'
           - name: LAB_USER_PASSWORD
             value: '{{ workshop_openshift_user_password }}'
+          - name: LAB_DURATION_HOURS
+            value: '1week'
           - name: LAB_REDIS_HOST
             value: redis
           - name: LAB_MODULE_URLS


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
Day in the streaming life

##### ADDITIONAL INFORMATION
Add a user assignment duration. Default is 2 hours. This would explain why user assignments are timing out

Closes #2520 