### PR TITLE
Clean-up role infra-osp-resources-destroy

### DIFF
--- a/ansible/roles-infra/infra-osp-resources-destroy/.yamllint
+++ b/ansible/roles-infra/infra-osp-resources-destroy/.yamllint
@@ -1,0 +1,14 @@
+---
+extends: default
+
+rules:
+  comments:
+    require-starting-space: false
+  comments-indentation: disable
+  indentation:
+    level: warning
+    indent-sequences: consistent
+  line-length:
+    level: warning
+    max: 120
+    allow-non-breakable-inline-mappings: true

--- a/ansible/roles-infra/infra-osp-resources-destroy/tasks/detect_project.yml
+++ b/ansible/roles-infra/infra-osp-resources-destroy/tasks/detect_project.yml
@@ -1,16 +1,10 @@
 ---
-- environment:
-    OS_AUTH_URL: "{{ osp_auth_url }}"
-    OS_USERNAME: "{{ osp_auth_username }}"
-    OS_PASSWORD: "{{ osp_auth_password }}"
-    OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
-    OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"
-  block:
-    - name: Get project information
-    # This changes to os_project_info in Ansible 2.9
-      os_project_facts:
-        name: "{{ osp_project_name }}"
-      register: r_osp_project
+- name: Get project information
+  environment: "{{ __infra_osp_resources_destroy_environment }}"
+  os_project_info:
+    name: "{{ osp_project_name }}"
+  register: r_osp_project
 
-    - set_fact:
-        osp_project_info: "{{ r_osp_project.ansible_facts.openstack_projects }}"
+- name: Set osp_project_info
+  set_fact:
+    osp_project_info: "{{ r_osp_project.openstack_projects }}"

--- a/ansible/roles-infra/infra-osp-resources-destroy/tasks/heat.yml
+++ b/ansible/roles-infra/infra-osp-resources-destroy/tasks/heat.yml
@@ -24,4 +24,3 @@
     until: r_hot_out is succeeded
     register: r_hot_out
     loop: "{{ r_stacks.stdout_lines }}"
-

--- a/ansible/roles-infra/infra-osp-resources-destroy/tasks/heat.yml
+++ b/ansible/roles-infra/infra-osp-resources-destroy/tasks/heat.yml
@@ -1,16 +1,13 @@
 ---
-- environment:
-    OS_AUTH_URL: "{{ osp_auth_url }}"
-    OS_USERNAME: "{{ osp_auth_username }}"
-    OS_PASSWORD: "{{ osp_auth_password }}"
-    OS_PROJECT_NAME: "{{ osp_project_name }}"
-    OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
-    OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"
+- name: Delete HEAT Stacks
+  environment: "{{ __infra_osp_resources_destroy_environment }}"
   block:
   # There is no module that allows retrieving this data.
   - name: Get a list of stacks in the project
     command: >-
-      openstack stack list --property tenant={{ osp_project_info[0].id | default(osp_project_id) }} -f value --column ID
+      openstack stack list
+      --property tenant={{ osp_project_info[0].id | default(osp_project_id) | quote }}
+      -f value --column ID
     register: r_stacks
 
   # The os_stack module doesn't allow deleting by ID and name is not safe to use since there could

--- a/ansible/roles-infra/infra-osp-resources-destroy/tasks/keypairs.yml
+++ b/ansible/roles-infra/infra-osp-resources-destroy/tasks/keypairs.yml
@@ -1,43 +1,40 @@
 ---
-- environment:
-    OS_AUTH_URL: "{{ osp_auth_url }}"
-    OS_USERNAME: "{{ osp_auth_username }}"
-    OS_PASSWORD: "{{ osp_auth_password }}"
-    OS_PROJECT_NAME: "{{ osp_project_name }}"
-    OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
-    OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"
+- name: Make sure this is not changing admin user
+  assert:
+    that:
+    - _keypair_owner != osp_auth_username
+    fail_msg: "The osp_auth_username_member is set to the admin user and would break things. Fix this."
 
+- name: Delete user and user keypairs
+  environment: "{{ __infra_osp_resources_destroy_environment }}"
   block:
-  - name: Make sure this is not changing admin user
-    assert:
-      that:
-      - _keypair_owner != osp_auth_username
-      fail_msg: "The osp_auth_username_member is set to the admin user and would break things. Fix this."
-
   - name: Get user info
-    os_user_facts:
+    os_user_info:
       name: "{{ _keypair_owner }}"
       domain: default
     register: r_osp_user_info
 
-  - when: r_osp_user_info.ansible_facts.openstack_users | length > 0
+  - when: r_osp_user_info.openstack_users | length > 0
     block:
     - name: Get UUID of user
       set_fact:
         osp_user_uuid: "{{ r_osp_user_info | json_query(uuid_query) }}"
       vars:
-        uuid_query: ansible_facts.openstack_users[].id|[0]
+        uuid_query: openstack_users[].id|[0]
 
-    # These can't use the os_ module since impersonating the user is only
-    # available with the nova client here.
-    - name: Get keypairs for user
-      shell: nova keypair-list --user {{ osp_user_uuid }} | grep ssh | awk '{ print $2 }'
-      register: r_user_keypairs
+    - name: List keypairs for user
+      command: nova keypair-list --user {{ osp_user_uuid | quote }}
+      register: r_list_keypairs
 
-    - name: Delete user keypair
-      when: r_user_keypairs.stdout_lines | length > 0
-      shell: nova keypair-delete --user {{ osp_user_uuid }} {{ item }}
-      loop: "{{ r_user_keypairs.stdout_lines }}"
+    - name: Delete user ssh keypairs
+      loop: >-
+        {{ r_list_keypairs.stdout_lines | select('search', '\| ssh ') | list }}
+      vars:
+        __key_name: >-
+          {{ item | regex_replace('^\| ([^|]+) +\| ssh .*', '\1') }}
+      loop_control:
+        label: "{{ __key_name }}"
+      command: nova keypair-delete --user {{ osp_user_uuid | quote }} {{ __key_name | quote }}
 
     - name: Delete user
       os_user:

--- a/ansible/roles-infra/infra-osp-resources-destroy/tasks/keypairs.yml
+++ b/ansible/roles-infra/infra-osp-resources-destroy/tasks/keypairs.yml
@@ -10,7 +10,7 @@
   block:
   - name: Make sure this is not changing admin user
     assert:
-      that: 
+      that:
       - _keypair_owner != osp_auth_username
       fail_msg: "The osp_auth_username_member is set to the admin user and would break things. Fix this."
 

--- a/ansible/roles-infra/infra-osp-resources-destroy/tasks/main.yml
+++ b/ansible/roles-infra/infra-osp-resources-destroy/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
-- import_tasks: detect_project.yml
+- name: Detect project
+  include_tasks: detect_project.yml
   when: osp_project_id is not defined
 
 # If project exists

--- a/ansible/roles-infra/infra-osp-resources-destroy/tasks/main.yml
+++ b/ansible/roles-infra/infra-osp-resources-destroy/tasks/main.yml
@@ -8,6 +8,7 @@
     or osp_project_id is defined
   block:
     - name: Delete all project resources
+      # Delete resources only if the project was created for this environment
       when: >-
         osp_project_create | bool
         or osp_force_delete_all_resources

--- a/ansible/roles-infra/infra-osp-resources-destroy/tasks/main.yml
+++ b/ansible/roles-infra/infra-osp-resources-destroy/tasks/main.yml
@@ -27,7 +27,7 @@
       when: osp_project_create | bool
       include_tasks: keypairs.yml
       loop:
-      - "{{ osp_auth_username_member }}"
+        - "{{ osp_auth_username_member }}"
       loop_control:
         loop_var: _keypair_owner
 

--- a/ansible/roles-infra/infra-osp-resources-destroy/tasks/project.yml
+++ b/ansible/roles-infra/infra-osp-resources-destroy/tasks/project.yml
@@ -1,13 +1,6 @@
 ---
-- environment:
-    OS_AUTH_URL: "{{ osp_auth_url }}"
-    OS_USERNAME: "{{ osp_auth_username }}"
-    OS_PASSWORD: "{{ osp_auth_password }}"
-    OS_PROJECT_NAME: "{{ osp_project_name }}"
-    OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
-    OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"
-
-  name: Delete project
+- name: Delete project
+  environment: "{{ __infra_osp_resources_destroy_environment }}"
   os_project:
     name: "{{ osp_project_name }}"
     state: absent

--- a/ansible/roles-infra/infra-osp-resources-destroy/tasks/project_resources.yml
+++ b/ansible/roles-infra/infra-osp-resources-destroy/tasks/project_resources.yml
@@ -1,98 +1,89 @@
 ---
-- environment:
-    OS_AUTH_URL: "{{ osp_auth_url }}"
-    OS_USERNAME: "{{ osp_auth_username }}"
-    OS_PASSWORD: "{{ osp_auth_password }}"
-    OS_PROJECT_NAME: "{{ osp_project_name }}"
-    OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
-    OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"
-  # Delete resources only if the project was created for this environment
-  when: >-
-    osp_project_create | bool
-    or osp_force_delete_all_resources
+- name: Remove OpenStack resources from project
+  environment: >-
+    {{ __infra_osp_resources_destroy_environment
+     | combine({'OS_PROJECT_ID': osp_project_info[0].id | default(osp_project_id)})
+    }}
   block:
-    - name: Cleanup OpenStack resources
-      environment:
-        OS_PROJECT_ID: "{{ osp_project_info[0].id | default(osp_project_id) }}"
-      block:
-        - name: Do dry-run of compute and storage purge
-          command: |
-            openstack project purge --dry-run --keep-project
-            --project {{ osp_project_id | default(osp_project_name) }}
-          register: project_purge_out
+  - name: Do dry-run of compute and storage purge
+    command: |
+      openstack project purge --dry-run --keep-project
+      --project {{ osp_project_id | default(osp_project_name) | quote }}
+    register: project_purge_out
 
-        - name: Purge compute and storage
-          command: |
-            openstack project purge --keep-project
-            --project {{ osp_project_id | default(osp_project_name) }}
-          when: project_purge_out is succeeded
+  - name: Purge compute and storage
+    command: |
+      openstack project purge --keep-project
+      --project {{ osp_project_id | default(osp_project_name) | quote }}
+    when: project_purge_out is succeeded
 
-        - pause:
-            seconds: 30
+  - pause:
+      seconds: 30
 
-        - name: Get all remaining volumes in project
-          command: >-
-            openstack volume list
-            --project {{ osp_project_id | default(osp_project_name) }}
-            -f json -c ID
-          register: r_volumes
+  - name: Get all remaining volumes in project
+    command: >-
+      openstack volume list
+      --project {{ osp_project_id | default(osp_project_name) | quote }}
+      -f json -c ID
+    register: r_volumes
 
-        - set_fact:
-            _all_volumes: >-
-              {{ r_volumes.stdout
-              | from_json
-              | json_query('[*].ID')
-              | list }}
+  - name: Detach and delete all remaining volumes
+    vars:
+      __all_volumes: >-
+        {{ r_volumes.stdout
+        | from_json
+        | json_query('[*].ID')
+        | list }}
+    block:
+    - name: Show volumes to delete
+      debug:
+        var: __all_volumes
+        verbosity: 2
 
-        - debug:
-            var: _all_volumes
-            verbosity: 2
+    - name: Reset all volumes state to error
+      command: >-
+        openstack volume set --state error {{ item | quote }}
+      loop: "{{ __all_volumes }}"
+      failed_when: false
 
-        - name: Reset all volumes state to error
-          command: >-
-            openstack volume set --state error {{ item }}
-          loop: "{{ _all_volumes }}"
-          failed_when: false
+    - name: Detach all volumes
+      command: >-
+        openstack volume set --detached {{ item | quote }}
+      loop: "{{ __all_volumes }}"
+      failed_when: false
 
-        - name: Detach all volumes
-          command: >-
-            openstack volume set --detached {{ item }}
-          loop: "{{ _all_volumes }}"
-          failed_when: false
+    - name: Delete all volumes
+      command: >-
+        openstack volume delete {{ item | quote }}
+      loop: "{{ __all_volumes }}"
+      retries: 10
+      delay: 10
+      register: r_openstack_volume_delete
+      until: >-
+        r_openstack_volume_delete.rc == 0 or
+        'No volume with a name or ID' in r_openstack_volume_delete.stderr
+      failed_when: >-
+        r_openstack_volume_delete.rc != 0 and
+        'No volume with a name or ID' not in r_openstack_volume_delete.stderr
 
-        - name: Delete all volumes
-          command: >-
-            openstack volume delete {{ item }}
-          loop: "{{ _all_volumes }}"
-          retries: 10
-          delay: 10
-          register: r_openstack_volume_delete
-          until: >-
-            r_openstack_volume_delete.rc == 0 or
-            'No volume with a name or ID' in r_openstack_volume_delete.stderr
-          failed_when: >-
-            r_openstack_volume_delete.rc != 0 and
-            'No volume with a name or ID' not in r_openstack_volume_delete.stderr
+  - name: Get all remaining trunk ports in project
+    command: >-
+      openstack port list
+      --project {{ osp_project_id | default(osp_project_name) | quote }}
+      -f json -c trunk_details
+    register: r_ports
 
-        - name: Get all remaining trunk ports in project
-          command: >-
-            openstack port list
-            --project {{ osp_project_id | default(osp_project_name) }}
-            -f json -c trunk_details
-          register: r_ports
+  - name: Delete any trunk ports in project
+    vars:
+      __all_ports: >-
+        {{ r_ports.stdout
+        | from_json
+        | json_query('[?trunk_details != null].trunk_details.trunk_id')
+        | list }}
+    when: __all_ports | length > 0
+    command: openstack network trunk delete {{ __all_ports | map('quote') | join(' ') }}
 
-        - set_fact:
-            _all_ports: >-
-              {{ r_ports.stdout
-              | from_json
-              | json_query('[?trunk_details != null].trunk_details.trunk_id')
-              | list }}
-
-        - when: _all_ports | length > 0
-          name: Delete any trunk ports in project
-          command: openstack network trunk delete {{ _all_ports | join(' ') }}
-
-        - name: Purge network resources
-          command: |
-            neutron purge
-            --project {{ osp_project_info[0].id | default(osp_project_id) }}
+  - name: Purge network resources
+    command: |
+      neutron purge
+      --project {{ osp_project_info[0].id | default(osp_project_id) | quote }}

--- a/ansible/roles-infra/infra-osp-resources-destroy/tasks/project_resources.yml
+++ b/ansible/roles-infra/infra-osp-resources-destroy/tasks/project_resources.yml
@@ -47,7 +47,7 @@
         - debug:
             var: _all_volumes
             verbosity: 2
-            
+
         - name: Reset all volumes state to error
           command: >-
             openstack volume set --state error {{ item }}
@@ -59,7 +59,7 @@
             openstack volume set --detached {{ item }}
           loop: "{{ _all_volumes }}"
           failed_when: false
-          
+
         - name: Delete all volumes
           command: >-
             openstack volume delete {{ item }}

--- a/ansible/roles-infra/infra-osp-resources-destroy/vars/main.yml
+++ b/ansible/roles-infra/infra-osp-resources-destroy/vars/main.yml
@@ -1,0 +1,8 @@
+---
+__infra_osp_resources_destroy_environment:
+  OS_AUTH_URL: "{{ osp_auth_url }}"
+  OS_USERNAME: "{{ osp_auth_username | default(osp_auth_username_member) }}"
+  OS_PASSWORD: "{{ osp_auth_password | default(osp_auth_password_member) }}"
+  OS_PROJECT_NAME: "{{ osp_project_name }}"
+  OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
+  OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"


### PR DESCRIPTION
#### SUMMARY

Clean-up for infra-osp-resources-destroy role.

* Update to Ansible 2.9, replacing facts modules with info modules
* add `.yamllint`
* move environment settings to the role vars rather than repeating in several places

##### ISSUE TYPE

- Clean-up Pull Request

##### COMPONENT NAME

infra-osp-resources-destroy