### PR TITLE
Fix kni-osp config by commenting default vars from secrets

### DIFF
--- a/ansible/configs/kni-osp/default_vars.yml
+++ b/ansible/configs/kni-osp/default_vars.yml
@@ -8,25 +8,25 @@
 # OpenStack auth vars #
 # #####################
 
-osp_auth_username: FROM_SECRETS
-osp_auth_username_member: FROM_SECRETS
-osp_auth_password: FROM_SECRETS
-osp_auth_password_member: FROM_SECRETS
-osp_project_name: FROM_SECRETS
-osp_project_id: FROM_SECRETS
+#osp_auth_username: FROM_SECRETS
+#osp_auth_username_member: FROM_SECRETS
+#osp_auth_password: FROM_SECRETS
+#osp_auth_password_member: FROM_SECRETS
+#osp_project_name: FROM_SECRETS
+#osp_project_id: FROM_SECRETS
 
-osp_auth_url: FROM_SECRETS
-osp_auth_user_domain: FROM_SECRETS
-osp_auth_project_domain: FROM_SECRETS
+#osp_auth_url: FROM_SECRETS
+#osp_auth_user_domain: FROM_SECRETS
+#osp_auth_project_domain: FROM_SECRETS
 
 ############
 # DNS vars #
 ############
 
-osp_cluster_dns_server: FROM_SECRETS
-osp_cluster_dns_zone: FROM_SECRETS
-ddns_key_name: FROM_SECRETS
-ddns_key_secret: FROM_SECRETS
+#osp_cluster_dns_server: FROM_SECRETS
+#osp_cluster_dns_zone: FROM_SECRETS
+#ddns_key_name: FROM_SECRETS
+#ddns_key_secret: FROM_SECRETS
 
 
 ################
@@ -47,9 +47,9 @@ remote_user: cloud-user
 
 repo_method: satellite
 
-set_repositories_satellite_hostname: FROM_SECRETS
-set_repositories_satellite_activationkey: FROM_SECRETS
-set_repositories_satellite_org: FROM_SECRETS
+#set_repositories_satellite_hostname: FROM_SECRETS
+#set_repositories_satellite_activationkey: FROM_SECRETS
+#set_repositories_satellite_org: FROM_SECRETS
 
 install_student_user: true
 student_password: Redhat01


### PR DESCRIPTION
##### SUMMARY

Fix k8i-osp config by commenting vars that should be set from secrets.

In some cases, such as `osp_project_id`, when a var is not set then AgnosticD will dynamically adjust its behavior. In the case of `osp_project_id`, to create a project for the deployment. Because the defaults set this to `FROM_SECRETS` it broke this behavior.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

config kni-osp