### PR TITLE
Fixing missing prefix in default variables

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhte19_shadowman/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhte19_shadowman/defaults/main.yml
@@ -8,5 +8,5 @@ ocp4_workload_rhte19_shadowman_slack_red_channel: CNSRA1WQM
 ocp4_workload_rhte19_shadowman_slack_white_channel: CNE2Q20G2
 ocp4_workload_rhte19_shadowman_slack_token: xoxp-0000000000-000000000000-000000000000-00000000000000000000000000000000
 
-documentation_link: https://red.ht/shadowman-sprint
+ocp4_workload_rhte19_shadowman_documentation_link: https://red.ht/shadowman-sprint
 silent: false


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #2549

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4_workloads_rhte19_shadowman

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The defaults/main.yml variable "documentation_link" was missing the role prefix.

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
