### PR TITLE
initialize empty array so it ends up as an empty array when num_users…

### DIFF
--- a/ansible/roles/ocp4-workload-quarkus-workshop/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/tasks/pre_workload.yml
@@ -10,9 +10,13 @@
   debug:
     msg: "Debugging num_users {{ num_users }}"
 
+- name: initialize username array
+  set_fact:
+    users: []
+
 - name: create usernames
   set_fact:
-    users: "{{ users | default([]) + ['user'+item | string] }}"
+    users: "{{ users + ['user'+item | string] }}"
   loop: "{{ range(1,((num_users | int) + 1)) | list }}"
 
 # Figure out paths


### PR DESCRIPTION
…=0 instead of undefined

##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

To support the use case where `num_user=0` (initializing a shared cluster for the workshop, but not creating users), this change ensures that the `users` array is empty (`[]`) instead of _undefined_ (which causes references to fail later on in the script).

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
`ocp4-workload-quarkus-workshop`

##### ADDITIONAL INFORMATION

cc @jkupferer @danieloh30 