### PR TITLE
Change lifecycle OSP: Dont' print facts (huge debug)

### DIFF
--- a/ansible/lifecycle_osp.yml
+++ b/ansible/lifecycle_osp.yml
@@ -70,6 +70,7 @@
 
         - debug:
             var: r_instances
+            verbosity: 3
 
         - name: Print status information to a file
           copy:


### PR DESCRIPTION
The debug statement is not necessary and is polluting the logs, remove it by adding verbosity.