### PR TITLE
Add single user workload for Quarkus Workshop on a shared cluster

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/README.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/README.adoc
@@ -1,0 +1,65 @@
+= ocp4_workload_quarkus_workshop_user - Allow a user access to a shared GPTE cluster
+
+== Role overview
+
+* This role enables the Project Request Template on an OpenShift 4 Cluster. It consists of the following playbooks:
+** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+ environment for the workload deployment.
+*** Debug task will print out: `pre_workload Tasks completed successfully.`
+
+** Playbook: link:./tasks/workload.yml[workload.yml] - Used to enable the workshop items
+*** Debug task will print out: `workload Tasks completed successfully.`
+
+** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+ configure the workload after deployment
+*** This role doesn't do anything here
+*** Debug task will print out: `post_workload Tasks completed successfully.`
+
+** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+ delete the workload
+*** This role removes the service broker from OCP 4
+*** Debug task will print out: `remove_workload Tasks completed successfully.`
+
+== Review the defaults variable file
+
+* This file link:./defaults/main.yml[./defaults/main.yml] contains all the variables you need to define to control the deployment of your workload.
+* The variable *ocp_username* is mandatory to assign the workload to the correct OpenShift user.
+* A variable *silent=True* can be passed to suppress debug messages.
+* You can modify any of these default values by adding `-e "variable_name=variable_value"` to the command line
+
+=== Deploy a Workload with the `ocp-workload` playbook [Mostly for testing]
+
+----
+TARGET_HOST="bastion.na4.openshift.opentlc.com"
+OCP_USERNAME="jfalkner-redhat.com"
+WORKLOAD="ocp4_workload_quarkus_workshop_user"
+GUID=1001
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=ec2-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"silent=False" \
+    -e"guid=${GUID}" \
+    -e"ACTION=create"
+----
+
+=== To Delete an environment
+
+----
+TARGET_HOST="bastion.na4.openshift.opentlc.com"
+OCP_USERNAME="wkulhane-redhat.com"
+WORKLOAD="ocp4_workload_quarkus_workshop_user"
+GUID=1002
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=ec2-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"guid=${GUID}" \
+    -e"ACTION=remove"
+----

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+become_override: False
+ocp_username: jfalkner-redhat.com
+silent: False
+
+workshop_openshift_user_password: 'openshift'
+workshop_che_user_password: 'openshift'
+workshop_openshift_admin_password: 'r3dh4t1!'
+

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/defaults/main.yml
@@ -3,7 +3,5 @@ become_override: False
 ocp_username: jfalkner-redhat.com
 silent: False
 
-workshop_openshift_user_password: 'openshift'
-workshop_che_user_password: 'openshift'
-workshop_openshift_admin_password: 'r3dh4t1!'
+ocp4_workshop_quarkus_workshop_user_che_user_password: 'openshift'
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/meta/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/meta/main.yml
@@ -1,0 +1,18 @@
+---
+galaxy_info:
+  role_name: ocp4-workload-quarkus-workshop-user
+  author:
+    - Application Service BU Runtimes Team, James Falkner (jfalkner@redhat.com)
+    - Application Service BU Runtimes Team, Daniel Oh (doh@redhat.com)
+  description: |
+    Create User for Quarkus Basic and Advanced workshop with CodeReady Workspaces, AMQ Streams, OpenShift 4.
+    This catalog entry is developed and maintained by the Application Services BU.
+  license: MIT
+  min_ansible_version: 2.9
+  platforms: []
+  galaxy_tags:
+  - quarkus
+  - workshop
+  - ocp
+  - openshift
+dependencies: []

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/add-codeready-user.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/add-codeready-user.yaml
@@ -1,0 +1,20 @@
+---
+- name: create codeready user
+  include_tasks: add_che_user.yaml
+  vars:
+    user: "{{ t_user }}"
+
+- name: Pre-create and warm user workspaces
+  include_tasks: create_che_workspace.yaml
+  vars:
+    user: "{{ t_user }}"
+
+- name: wait a minute and let the image download and be registered
+  pause:
+      minutes: 2
+
+- name: Attempt to warm workspaces which failed to start
+  include_tasks: verify_che_workspace.yaml
+  vars:
+    user: "{{ t_user }}"
+

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/add_che_user.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/add_che_user.yaml
@@ -1,0 +1,36 @@
+---
+- name: Get codeready SSO admin token
+  uri:
+    url: https://keycloak-codeready.{{ route_subdomain }}/auth/realms/master/protocol/openid-connect/token
+    validate_certs: false
+    method: POST
+    body:
+      username: "{{ codeready_sso_admin_username }}"
+      password: "{{ codeready_sso_admin_password }}"
+      grant_type: "password"
+      client_id: "admin-cli"
+    body_format: form-urlencoded
+    status_code: 200,201,204
+  register: codeready_sso_admin_token
+
+- name: Add user {{ user }} to Che
+  uri:
+    url: https://keycloak-codeready.{{ route_subdomain }}/auth/admin/realms/codeready/users
+    validate_certs: false
+    method: POST
+    headers:
+      Content-Type: application/json
+      Authorization: "Bearer {{ codeready_sso_admin_token.json.access_token }}"
+    body:
+      username: "{{ user }}"
+      enabled: true
+      emailVerified: true
+      firstName: "{{ user }}"
+      lastName: Developer
+      email: "{{ user }}@no-reply.com"
+      credentials:
+        - type: password
+          value: "{{ workshop_che_user_password }}"
+          temporary: false
+    body_format: json
+    status_code: 201,409

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/add_che_user.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/add_che_user.yaml
@@ -30,7 +30,7 @@
       email: "{{ user }}@no-reply.com"
       credentials:
         - type: password
-          value: "{{ workshop_che_user_password }}"
+          value: "{{ ocp4_workshop_quarkus_workshop_user_che_user_password }}"
           temporary: false
     body_format: json
     status_code: 201,409

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/confirm_che_workspace.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/confirm_che_workspace.yaml
@@ -1,0 +1,32 @@
+---
+- name: "Get Che {{ user }} token"
+  uri:
+    url: https://keycloak-codeready.{{ route_subdomain }}/auth/realms/codeready/protocol/openid-connect/token
+    validate_certs: false
+    method: POST
+    body:
+      username: "{{ user }}"
+      password: "{{ workshop_che_user_password }}"
+      grant_type: "password"
+      client_id: "admin-cli"
+    body_format: form-urlencoded
+    status_code: 200
+  register: user_token
+
+- name: Confirm running status of workspace for {{ user }}
+  uri:
+    url: "https://codeready-codeready.{{ route_subdomain }}/api/workspace"
+    validate_certs: false
+    method: GET
+    headers:
+      Accept: application/json
+      Authorization: "Bearer {{ user_token.json.access_token }}"
+    status_code: 200
+  register: workspace_def
+
+- name: "Output warning for {{ user }}"
+  agnosticd_user_info:
+    msg: "WARNING: Workspace for {{ user }} failed to initialize - you may need to log in as that user and start it manually!"
+  when: >-
+    workspace_def.json[0].status == "STOPPED" or
+    workspace_def.json[0].status == "STOPPING"

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/confirm_che_workspace.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/confirm_che_workspace.yaml
@@ -6,7 +6,7 @@
     method: POST
     body:
       username: "{{ user }}"
-      password: "{{ workshop_che_user_password }}"
+      password: "{{ ocp4_workshop_quarkus_workshop_user_che_user_password }}"
       grant_type: "password"
       client_id: "admin-cli"
     body_format: form-urlencoded

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/create_che_workspace.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/create_che_workspace.yaml
@@ -1,0 +1,27 @@
+---
+- name: "Get Che {{ user }} token"
+  uri:
+    url: https://keycloak-codeready.{{ route_subdomain }}/auth/realms/codeready/protocol/openid-connect/token
+    validate_certs: false
+    method: POST
+    body:
+      username: "{{ user }}"
+      password: "{{ workshop_che_user_password }}"
+      grant_type: "password"
+      client_id: "admin-cli"
+    body_format: form-urlencoded
+    status_code: 200
+  register: user_token
+
+- name: Create workspace for {{ user }} from devfile
+  uri:
+    url: "https://codeready-codeready.{{ route_subdomain }}/api/workspace/devfile?start-after-create=true&namespace={{ user }}"
+    validate_certs: false
+    method: POST
+    headers:
+      Content-Type: application/json
+      Authorization: "Bearer {{ user_token.json.access_token }}"
+    body: "{{ lookup('template', './templates/devfile.json.j2') }}"
+    body_format: json
+    status_code: 201,409
+  register: workspace_def

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/create_che_workspace.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/create_che_workspace.yaml
@@ -6,7 +6,7 @@
     method: POST
     body:
       username: "{{ user }}"
-      password: "{{ workshop_che_user_password }}"
+      password: "{{ ocp4_workshop_quarkus_workshop_user_che_user_password }}"
       grant_type: "password"
       client_id: "admin-cli"
     body_format: form-urlencoded

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/create_project.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/create_project.yaml
@@ -1,0 +1,30 @@
+---
+- name: create project for {{ t_user }}
+  k8s:
+    state: present
+    kind: Project
+    api_version: project.openshift.io/v1
+    definition:
+      metadata:
+        name: "{{ t_project_name }}"
+        annotations:
+          openshift.io/description: ""
+          openshift.io/display-name: "{{ t_project_desc }}"
+
+- name: assign permissions for user {{ t_user }}
+  k8s:
+    state: present
+    kind: RoleBinding
+    api_version: rbac.authorization.k8s.io/v1
+    definition:
+      metadata:
+        name: admin
+        namespace: "{{ t_project_name }}"
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: admin
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: User
+        name: "{{ t_user }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+
+# Do not modify this file
+
+- name: Running Pre Workload Tasks
+  include_tasks:
+    file: ./pre_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision" or ACTION == "remove"
+
+- name: Running Workload Tasks
+  include_tasks:
+    file: ./workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  include_tasks:
+    file: ./post_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload removal Tasks
+  include_tasks:
+    file: ./remove_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/post_workload.yml
@@ -1,0 +1,34 @@
+---
+- name: Verify everything is deployed correctly
+  include_tasks: verify-workload.yaml
+
+# Implement your Post Workload deployment tasks here
+
+- name: Print user info
+  agnosticd_user_info:
+    msg: "{{ item }}"
+  loop:
+  - "{{ ocp_username }} has been setup on the shared lab environment."
+  - "You have access to the following project: {{ guid }}-project"
+  - ""
+  - "OpenShift Console: {{ console_url }}"
+  - "CodeReady Console: https://codeready-codeready.{{ route_subdomain }}"
+  - ""
+
+- name: Print module info
+  agnosticd_user_info:
+    msg: "Module {{item}}: http://web-{{item}}-guides.{{ route_subdomain }}"
+  loop: "{{ modules }}"
+
+- name: Save user data
+  agnosticd_user_info:
+    data:
+      web_console_url: "{{ console_url }}"
+      api_url: "{{ master_url }}"
+      login_command: "oc login -u {{ ocp_username }} {{ master_url }}"
+
+# Leave this as the last task in the playbook.
+- name: post_workload tasks complete
+  debug:
+    msg: "Post-Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/post_workload.yml
@@ -11,7 +11,7 @@
   - "{{ ocp_username }} has been setup on the shared lab environment."
   - "You have access to the following project: {{ guid }}-project"
   - ""
-  - "OpenShift Console: {{ console_url }}"
+  - "OpenShift Console: https://{{ r_console_route.resources[0].spec.host }}"
   - "CodeReady Console: https://codeready-codeready.{{ route_subdomain }}"
   - ""
 
@@ -23,9 +23,9 @@
 - name: Save user data
   agnosticd_user_info:
     data:
-      web_console_url: "{{ console_url }}"
-      api_url: "{{ master_url }}"
-      login_command: "oc login -u {{ ocp_username }} {{ master_url }}"
+      web_console_url: "https://{{ r_console_route.resources[0].spec.host }}"
+      api_url: "{{ r_console_route.resources[0].spec.host }}"
+      login_command: "oc login -u {{ ocp_username }} {{ r_api_url.resources[0].status.apiServerURL }}"
 
 # Leave this as the last task in the playbook.
 - name: post_workload tasks complete

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/pre_workload.yml
@@ -1,32 +1,27 @@
 ---
 # Implement your Pre Workload deployment tasks here
 
-- name: Ensuring username is defined
-  fail:
-    msg: "This workload requires ocp_username to be defined. Exiting..."
-  when: ocp_username is not defined
+- name: Ensure variables are set
+  assert:
+    that:
+      - ocp_username is defined
+      - guid is defined
+    fail_msg: "Must define ocp_username and guid"
 
-- name: Ensuring guid is defined
-  fail:
-    msg: "This workload requires guid to be defined. Exiting..."
-  when: guid is not defined
+- name: Get Web Console route
+  k8s_facts:
+    api_version: route.openshift.io/v1
+    kind: Route
+    namespace: openshift-console
+    name: console
+  register: r_console_route
 
-# Figure out paths
-- name: extract api_url
-  command: oc whoami --show-server
-  register: api_url_r
-
-- name: set the master
-  set_fact:
-    master_url: "{{ api_url_r.stdout | trim }}"
-
-- name: extract console_url
-  command: oc whoami --show-console
-  register: console_url_r
-
-- name: set the console
-  set_fact:
-    console_url: "{{ console_url_r.stdout | trim }}"
+- name: Get API server URL
+  k8s_facts:
+    api_version: config.openshift.io/v1
+    kind: Infrastructure
+    name: cluster
+  register: r_api_url
 
 - name: extract route_subdomain
   k8s_facts:
@@ -36,10 +31,6 @@
 - name: set the route
   set_fact:
     route_subdomain: "{{ route_subdomain_r.resources[0].spec.domain | trim }}"
-
-- name: set bastion_fqdn
-  set_fact:
-    bastion_fqdn: "{{ subdomain_base }}"
 
 - name: Get codeready keycloak deployment
   k8s_facts:
@@ -71,11 +62,10 @@
 - name: debug values
   debug:
     msg:
-    - "master URL: {{ master_url }}"
-    - "console URL: {{ console_url }}"
+    - "master URL: {{ r_api_url.resources[0].status.apiServerURL }}"
+    - "console URL: https://{{ r_console_route.resources[0].spec.host }}"
     - "route subdomain: {{ route_subdomain }}"
     - "ocp_username: {{ ocp_username }}"
-    - "bastion host: {{ bastion_fqdn }}"
 
 # Leave this as the last task in the playbook.
 - name: pre_workload tasks complete

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/pre_workload.yml
@@ -1,0 +1,84 @@
+---
+# Implement your Pre Workload deployment tasks here
+
+- name: Ensuring username is defined
+  fail:
+    msg: "This workload requires ocp_username to be defined. Exiting..."
+  when: ocp_username is not defined
+
+- name: Ensuring guid is defined
+  fail:
+    msg: "This workload requires guid to be defined. Exiting..."
+  when: guid is not defined
+
+# Figure out paths
+- name: extract api_url
+  command: oc whoami --show-server
+  register: api_url_r
+
+- name: set the master
+  set_fact:
+    master_url: "{{ api_url_r.stdout | trim }}"
+
+- name: extract console_url
+  command: oc whoami --show-console
+  register: console_url_r
+
+- name: set the console
+  set_fact:
+    console_url: "{{ console_url_r.stdout | trim }}"
+
+- name: extract route_subdomain
+  k8s_facts:
+    kind: Ingress
+  register: route_subdomain_r
+
+- name: set the route
+  set_fact:
+    route_subdomain: "{{ route_subdomain_r.resources[0].spec.domain | trim }}"
+
+- name: set bastion_fqdn
+  set_fact:
+    bastion_fqdn: "{{ subdomain_base }}"
+
+- name: Get codeready keycloak deployment
+  k8s_facts:
+    kind: Deployment
+    namespace: codeready
+    name: keycloak
+  register: r_keycloak_deployment
+
+- name: show cr
+  debug:
+    msg: "existing keycloak deployment: {{ r_keycloak_deployment }}"
+
+- name: set codeready username fact
+  set_fact:
+    codeready_sso_admin_username: "{{ r_keycloak_deployment.resources[0].spec.template.spec.containers[0].env | selectattr('name','equalto','SSO_ADMIN_USERNAME') |map (attribute='value') | list | first }}"
+
+- name: set codeready password fact
+  set_fact:
+    codeready_sso_admin_password: "{{ r_keycloak_deployment.resources[0].spec.template.spec.containers[0].env | selectattr('name','equalto','SSO_ADMIN_PASSWORD') |map (attribute='value') | list | first }}"
+
+- name: show codeready keycloak admin username
+  debug:
+    msg: "codeready keycloak admin username: {{ codeready_sso_admin_username }}"
+
+- name: show codeready keycloak admin password
+  debug:
+    msg: "codeready keycloak admin password: {{ codeready_sso_admin_password }}"
+
+- name: debug values
+  debug:
+    msg:
+    - "master URL: {{ master_url }}"
+    - "console URL: {{ console_url }}"
+    - "route subdomain: {{ route_subdomain }}"
+    - "ocp_username: {{ ocp_username }}"
+    - "bastion host: {{ bastion_fqdn }}"
+
+# Leave this as the last task in the playbook.
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/remove-codeready-user.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/remove-codeready-user.yaml
@@ -1,0 +1,12 @@
+---
+
+- name: Remove user workspace
+  include_tasks: remove_che_workspace.yaml
+  vars:
+    user: "{{ t_user }}"
+
+- name: remove codeready user
+  include_tasks: remove_che_user.yaml
+  vars:
+    user: "{{ t_user }}"
+

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/remove_che_user.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/remove_che_user.yaml
@@ -1,0 +1,35 @@
+---
+- name: Get codeready SSO admin token
+  uri:
+    url: https://keycloak-codeready.{{ route_subdomain }}/auth/realms/master/protocol/openid-connect/token
+    validate_certs: false
+    method: POST
+    body:
+      username: "{{ codeready_sso_admin_username }}"
+      password: "{{ codeready_sso_admin_password }}"
+      grant_type: "password"
+      client_id: "admin-cli"
+    body_format: form-urlencoded
+    status_code: 200,201,204
+  register: codeready_sso_admin_token
+
+- name: get users ID from sso
+  uri:
+    url: https://keycloak-codeready.{{ route_subdomain }}/auth/admin/realms/codeready/users?username={{ user | urlencode }}&exact=true
+    validate_certs: false
+    method: GET
+    headers:
+      Authorization: "Bearer {{ codeready_sso_admin_token.json.access_token }}"
+    status_code: 200,201,204
+  register: user_rep
+
+- name: Remove user {{ user }} from sso
+  uri:
+    url: https://keycloak-codeready.{{ route_subdomain }}/auth/admin/realms/codeready/users/{{ user_rep.json[0].id }}
+    validate_certs: false
+    method: DELETE
+    headers:
+      Content-Type: application/json
+      Authorization: "Bearer {{ codeready_sso_admin_token.json.access_token }}"
+    status_code: 204
+

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/remove_che_workspace.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/remove_che_workspace.yaml
@@ -1,0 +1,68 @@
+---
+- name: "Get Che {{ user }} token"
+  uri:
+    url: https://keycloak-codeready.{{ route_subdomain }}/auth/realms/codeready/protocol/openid-connect/token
+    validate_certs: false
+    method: POST
+    body:
+      username: "{{ user }}"
+      password: "{{ workshop_che_user_password }}"
+      grant_type: "password"
+      client_id: "admin-cli"
+    body_format: form-urlencoded
+    status_code: 200
+  register: user_token
+
+- name: get all workspaces for {{ user }}
+  uri:
+    url: "https://codeready-codeready.{{ route_subdomain }}/api/workspace"
+    validate_certs: false
+    method: GET
+    headers:
+      Accept: application/json
+      Authorization: "Bearer {{ user_token.json.access_token }}"
+    status_code: 200
+  register: all_workspaces
+
+- name: stop workspace for {{ user }}
+  when: >-
+    all_workspaces.json | list | length >= 1 and
+    all_workspaces.json[0].status != "STOPPED" and
+    all_workspaces.json[0].status != "STOPPING"
+  uri:
+    url: "https://codeready-codeready.{{ route_subdomain }}/api/workspace/{{ all_workspaces.json[0].id }}/runtime"
+    validate_certs: false
+    method: DELETE
+    headers:
+      Accept: application/json
+      Authorization: "Bearer {{ user_token.json.access_token }}"
+    status_code: 204
+
+- name: wait for workspace to be stopped
+  when: all_workspaces.json | list | length >= 1
+  uri:
+    url: "https://codeready-codeready.{{ route_subdomain }}/api/workspace"
+    validate_certs: false
+    method: GET
+    headers:
+      Accept: application/json
+      Authorization: "Bearer {{ user_token.json.access_token }}"
+    status_code: 200
+  register: all_stopped_workspaces
+  retries: 200
+  delay: 10
+  until: all_stopped_workspaces.json[0].status == "STOPPED"
+
+- name: delete workspace for {{ user }}
+  when: all_workspaces.json | list | length >= 1
+  uri:
+    url: "https://codeready-codeready.{{ route_subdomain }}/api/workspace/{{ all_workspaces.json[0].id }}"
+    validate_certs: false
+    method: DELETE
+    headers:
+      Accept: application/json
+      Authorization: "Bearer {{ user_token.json.access_token }}"
+    status_code: 204
+  retries: 200
+  delay: 10
+

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/remove_che_workspace.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/remove_che_workspace.yaml
@@ -6,7 +6,7 @@
     method: POST
     body:
       username: "{{ user }}"
-      password: "{{ workshop_che_user_password }}"
+      password: "{{ ocp4_workshop_quarkus_workshop_user_che_user_password }}"
       grant_type: "password"
       client_id: "admin-cli"
     body_format: form-urlencoded

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/remove_workload.yml
@@ -1,0 +1,22 @@
+# vim: set ft=ansible
+---
+# Implement your Workload removal tasks here
+
+- name: remove codeready user
+  include_tasks: remove-codeready-user.yaml
+  vars:
+    t_user: "{{ ocp_username }}"
+
+- name: remove the user Project
+  k8s:
+    state: absent
+    name: "{{ guid }}-project"
+    kind: Project
+    api_version: project.openshift.io/v1
+
+
+# Leave this as the last task in the playbook.
+- name: remove_workload tasks complete
+  debug:
+    msg: "Remove Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/verify-workload.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/verify-workload.yaml
@@ -1,0 +1,21 @@
+---
+- name: verify user project exists
+  k8s_facts:
+    api_version: v1
+    kind: Namespace
+    name: "{{ guid }}-project"
+    field_selectors:
+      - status.phase=Active
+  register: r_user_namespace
+  failed_when: r_user_namespace.resources | list | length != 1
+
+- name: verify user workspaces are started
+  include_tasks: confirm_che_workspace.yaml
+  vars:
+    user: "{{ ocp_username }}"
+
+# Leave this as the last task in the playbook.
+- name: workload verification tasks complete
+  debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/verify_che_workspace.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/verify_che_workspace.yaml
@@ -1,0 +1,38 @@
+---
+- name: "Get Che {{ user }} token"
+  uri:
+    url: https://keycloak-codeready.{{ route_subdomain }}/auth/realms/codeready/protocol/openid-connect/token
+    validate_certs: false
+    method: POST
+    body:
+      username: "{{ user }}"
+      password: "{{ workshop_che_user_password }}"
+      grant_type: "password"
+      client_id: "admin-cli"
+    body_format: form-urlencoded
+    status_code: 200
+  register: user_token
+
+- name: Get workspace for {{ user }}
+  uri:
+    url: "https://codeready-codeready.{{ route_subdomain }}/api/workspace"
+    validate_certs: false
+    method: GET
+    headers:
+      Accept: application/json
+      Authorization: "Bearer {{ user_token.json.access_token }}"
+    status_code: 200
+  register: workspace_def
+
+- name: Verify and start workspace for {{ user }} again if stopped
+  when: workspace_def.json[0].status == "STOPPED"
+  uri:
+    url: "https://codeready-codeready.{{ route_subdomain }}/api/workspace/{{ workspace_def.json[0].id }}/runtime"
+    validate_certs: false
+    method: POST
+    headers:
+      Accept: application/json
+      Authorization: "Bearer {{ user_token.json.access_token }}"
+    status_code: 200
+
+

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/verify_che_workspace.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/verify_che_workspace.yaml
@@ -6,7 +6,7 @@
     method: POST
     body:
       username: "{{ user }}"
-      password: "{{ workshop_che_user_password }}"
+      password: "{{ ocp4_workshop_quarkus_workshop_user_che_user_password }}"
       grant_type: "password"
       client_id: "admin-cli"
     body_format: form-urlencoded

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/workload.yml
@@ -1,0 +1,31 @@
+# vim: set ft=ansible
+---
+# Implement your Workload deployment tasks here
+
+- name: create module list
+  set_fact:
+    modules: "{{ module_type.split(';') | map('trim') | list }}"
+
+- name: Selected Modules
+  debug:
+    msg: "selected modules list: {{ modules }}"
+
+# Create projects for user
+- name: create project user project
+  include_tasks: create_project.yaml
+  vars:
+    t_project_name: "{{ guid }}-project"
+    t_project_desc: "User project for {{ ocp_username }}"
+    t_user: "{{ ocp_username }}"
+
+- name: add codeready user
+  include_tasks: add-codeready-user.yaml
+  vars:
+    t_user: "{{ ocp_username }}"
+
+
+# Leave this as the last task in the playbook.
+- name: workload tasks complete
+  debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/templates/devfile.json.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/templates/devfile.json.j2
@@ -1,0 +1,115 @@
+{
+  "apiVersion": "1.0.0",
+  "metadata": {
+    "name": "{{ user }}-workspace"
+  },
+  "components": [
+    {
+      "id": "redhat/quarkus-java11/latest",
+      "type": "chePlugin"
+    },
+    {
+      "mountSources": true,
+      "memoryLimit": "4Gi",
+      "type": "dockerimage",
+      "alias": "quarkus-tools",
+      "image": "image-registry.openshift-image-registry.svc:5000/openshift/quarkus-stack:2.2.45",
+      "env": [
+        {
+          "value": "/home/jboss/.m2",
+          "name": "MAVEN_CONFIG"
+        },
+        {
+          "value": "-Xmx4G -Xss128M -XX:MetaspaceSize=1G -XX:MaxMetaspaceSize=2G -XX:+CMSClassUnloadingEnabled",
+          "name": "MAVEN_OPTS"
+        }
+      ],
+      "endpoints": [
+        {
+          "name": "web-{{ guid }}",
+          "port": 8080,
+          "attributes": {
+            "discoverable": "true",
+            "public": "true",
+            "protocol": "http"
+          }
+        },
+        {
+          "name": "debug-{{ guid }}",
+          "port": 5005,
+          "attributes": {
+            "discoverable": "false",
+            "public": "false",
+            "protocol": "jdwp"
+          }
+        }
+      ]
+    }
+  ],
+  "commands": [
+    {
+      "name": "Login to OpenShift",
+      "actions": [
+        {
+          "type": "exec",
+          "component": "quarkus-tools",
+          "command": "oc login https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT --insecure-skip-tls-verify=true",
+          "workdir": "${CHE_PROJECTS_ROOT}"
+        }
+      ]
+    },
+    {
+      "name": "Run Tests",
+      "actions": [
+        {
+          "type": "exec",
+          "component": "quarkus-tools",
+          "command": "mvn verify -f ${CHE_PROJECTS_ROOT}/quarkus-workshop-labs",
+          "workdir": "${CHE_PROJECTS_ROOT}"
+        }
+      ]
+    },
+    {
+      "name": "Start Live Coding",
+      "actions": [
+        {
+          "type": "exec",
+          "component": "quarkus-tools",
+          "command": "mvn clean compile quarkus:dev -f ${CHE_PROJECTS_ROOT}/quarkus-workshop-labs",
+          "workdir": "${CHE_PROJECTS_ROOT}"
+        }
+      ]
+    },
+    {
+      "name": "Package App for OpenShift",
+      "actions": [
+        {
+          "type": "exec",
+          "component": "quarkus-tools",
+          "command": "mvn package -DuberJar=true -DskipTests -f ${CHE_PROJECTS_ROOT}/quarkus-workshop-labs",
+          "workdir": "${CHE_PROJECTS_ROOT}"
+        }
+      ]
+    },
+    {
+      "name": "Build Native App",
+      "actions": [
+        {
+          "type": "exec",
+          "component": "quarkus-tools",
+          "command": "mvn package -Pnative -DskipTests -f ${CHE_PROJECTS_ROOT}/quarkus-workshop-labs",
+          "workdir": "${CHE_PROJECTS_ROOT}"
+        }
+      ]
+    },
+    {
+      "name": "Start Debugger on 5005",
+      "actions": [
+        {
+          "type": "vscode-launch",
+          "referenceContent": "{\n  \"version\": \"0.2.0\",\n  \"configurations\": [\n    {\n      \"type\": \"java\",\n      \"request\": \"attach\",\n      \"name\": \"Attach to App\",\n      \"hostName\": \"localhost\",\n      \"port\": 5005\n    }\n  ]\n}\n"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

Adds a new workload to deploy (and remove) the per-user quarkus workshop components for a single user, after the cluster is prepared with the shared cluster workload (`ocp4-workload-quarkus-workshop`). 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`ocp4_workload_quarkus_workshop_user`


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
cc @jkupferer @danieloh30 @wkulhanek for RHTR. @danieloh30  later we will need to separately add the guides/code to the workshop repos, then modify the agnosticV variables to only install the spring->quarkus stuff (`m3`) for RHTR.