### PR TITLE
Fix role ocp4_workload_bookbag_user yamllint warnings

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/.yamllint
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/.yamllint
@@ -6,9 +6,7 @@ rules:
     require-starting-space: false
   comments-indentation: disable
   indentation:
-    level: warning
     indent-sequences: consistent
   line-length:
-    level: warning
     max: 120
     allow-non-breakable-inline-mappings: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/defaults/main.yaml
@@ -12,7 +12,8 @@ ocp4_workload_bookbag_user_deployment_name: bookbag
 
 # Bookbag Image
 ocp4_workload_bookbag_user_image_namespace: bookbag
-ocp4_workload_bookbag_user_image_name: image-registry.openshift-image-registry.svc:5000/{{ ocp4_workload_bookbag_user_image_namespace }}/bookbag
+ocp4_workload_bookbag_user_image_name: >-
+  image-registry.openshift-image-registry.svc:5000/{{ ocp4_workload_bookbag_user_image_namespace }}/bookbag
 ocp4_workload_bookbag_user_image_tag: latest
 
 # Bookbag configuration

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/tasks/workload.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/tasks/workload.yaml
@@ -45,7 +45,8 @@
     register: r_console_deployment
   - name: Set Console Image variable
     set_fact:
-      ocp4_workload_bookbag_user_console_image: "{{ r_console_deployment.resources[0].spec.template.spec.containers[0].image }}"
+      ocp4_workload_bookbag_user_console_image: >-
+        {{ r_console_deployment.resources[0].spec.template.spec.containers[0].image }}
 - name: Set Console Image to override image
   when: ocp4_workload_bookbag_user_console_image_override | default("") | length > 0
   set_fact:


### PR DESCRIPTION
##### SUMMARY

Fix yamllint warnings on role ocp4_workload_bookbag_user.

- Fixed two long line length warnings
- Tightened yamllint rules to treat line length as error

##### ISSUE TYPE

- Code Clean-Up Pull Request

##### COMPONENT NAME

role ocp4_workload_bookbag_user