### PR TITLE
Add doc for .yamllint

### DIFF
--- a/docs/Contributing.adoc
+++ b/docs/Contributing.adoc
@@ -35,7 +35,21 @@ These are our contribution guidelines for helping out with the project. Any sugg
 
 === Code Quality Rules
 
-. A YAML `.yamllint` file should be added to every role and config when any substantial change is applied to the role or config, all new roles and configs must include a `.yamllint`. You will find a good example link:../ansible/roles-infra/infra-azure-template-destroy/.yamllint[here].  See also link:https://yamllint.readthedocs.io/en/stable/[Official yamllint documentation].
+. A YAML `.yamllint` file should be added to every role and config when any substantial change is applied to the role or config, all new roles and configs must include a `.yamllint`. The AgnosticD standard `.yamllint` configuration is shown below.  See also link:https://yamllint.readthedocs.io/en/stable/[Official yamllint documentation].
++
+----
+extends: default
+rules:
+  comments:
+    require-starting-space: false
+  comments-indentation: disable
+  indentation:
+    indent-sequences: consistent
+  line-length:
+    max: 120
+    allow-non-breakable-inline-mappings: true
+----
+
 . All tasks should be in YAML literal. No `foo=bar` inline notation. See <<yamlliteral,here>>.
 . Indentation is 2 white-spaces.
 . No in-line JSON format in Ansible


### PR DESCRIPTION
##### SUMMARY

Add standard `.yamllint` configuration example to docs.

Rationale: We need a standard `.yamllint` configuration documented so that we can converge our configuration and code standards to this configuration.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

Contributing documentation.