### PR TITLE
Fix role ocp4_workload_gitea_operator to convert str -> int when using jinja2 format filter

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/tasks/workload.yml
@@ -115,7 +115,7 @@
   agnosticd_user_info:
     msg: >-
       Gitea users were created, from {{ ocp4_workload_gitea_operator_generate_user_format | format(1) }} to
-      {{ ocp4_workload_gitea_operator_generate_user_format | format(ocp4_workload_gitea_operator_user_number) }} with the password
+      {{ ocp4_workload_gitea_operator_generate_user_format | format(ocp4_workload_gitea_operator_user_number | int) }} with the password
       '{{ ocp4_workload_gitea_operator_user_password }}'
 
 - name: Print the repositories that were migrated if any were migrated


### PR DESCRIPTION
Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>

##### SUMMARY

Fix role `ocp4_workload_gitea_operator` in task `Print the user details if users are created` when attempting to use pass a str when using format `user%d`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_gitea_operator

##### ADDITIONAL INFORMATION
You can test by running the role with variables
```
ocp4_workload_gitea_operator_create_users: true
```
