### PR TITLE
Remove the automated openshift-installer build and add some checks for deploy success (overlayfs)

### DIFF
--- a/ansible/configs/kni-osp/files/fix-overlay.sh
+++ b/ansible/configs/kni-osp/files/fix-overlay.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+export KUBECONFIG=/home/cloud-user/scripts/ocp/auth/kubeconfig
+
+for i in $(oc get nodes -o wide | awk '/NotReady/ {print $6;}');
+do
+  ssh -o StrictHostKeyChecking=no core@$i "sudo systemctl stop kubelet crio && sudo rm -rf /var/lib/containers/storage/overlay/* && sudo rm -f /var/lib/containers/storage/overlay-layers/layers.json && sudo systemctl restart crio kubelet"
+done

--- a/ansible/configs/kni-osp/files/ocp-install.sh.j2
+++ b/ansible/configs/kni-osp/files/ocp-install.sh.j2
@@ -91,6 +91,12 @@ build_installer() {
   cd $HOME/go/src/github.com/openshift
   git clone --single-branch --branch release-$SUBVER https://github.com/openshift/installer.git
   cd installer/
+  cp -f go.mod go.bak
+  sed -i 's/library-go.*/library-go v0.0.0-20200917093739-70fa806b210a/g' go.mod
+  if [[ $(grep library-go go.mod | wc -l) = 1 ]]
+  then
+    sed -zEi 's|(\n[^\n]*){2}$|\n\tgithub.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20200917093739-70fa806b210a&|' go.mod
+  fi
   cp $HOME/scripts/profile/profile.go vendor/github.com/metal3-io/baremetal-operator/pkg/hardware/profile.go
   sed -i 's|IRONIC_IMAGE=.*|IRONIC_IMAGE=quay.io/roxenham/ironic-image:latest|g' ./data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
   #vi vendor/github.com/metal3-io/baremetal-operator/pkg/hardware/profile.go

--- a/ansible/configs/kni-osp/files/ocp-install.sh.j2
+++ b/ansible/configs/kni-osp/files/ocp-install.sh.j2
@@ -79,6 +79,14 @@ setup_firewalld() {
 }
 
 build_installer() {
+  cd $HOME/scripts
+  # We're not using >=4.5.9 so lets see if we have a prebuilt binary that we can use to speed this up
+  if [[ $(curl -s -o openshift-baremetal-install https://gpte-public.s3.amazonaws.com/openshift-baremetal-install-$VERSION  --write-out '%{http_code}') == 200 ]]
+  then
+    chmod a+x openshift-baremetal-install
+    # skip building the binary if we got a 200 and the file was downloaded
+    return 0
+  fi
   echo "Building $SUBVER openshift-baremetal-install with OpenStack hardware profile..."
   cd $HOME
   sudo dnf -y install libvirt-devel go
@@ -91,12 +99,15 @@ build_installer() {
   cd $HOME/go/src/github.com/openshift
   git clone --single-branch --branch release-$SUBVER https://github.com/openshift/installer.git
   cd installer/
-  cp -f go.mod go.bak
-  sed -i 's/library-go.*/library-go v0.0.0-20200917093739-70fa806b210a/g' go.mod
-  if [[ $(grep library-go go.mod | wc -l) = 1 ]]
-  then
-    sed -zEi 's|(\n[^\n]*){2}$|\n\tgithub.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20200917093739-70fa806b210a&|' go.mod
-  fi
+  # These are now commented as this should land soon - YMMV, you may need to pull these in, depending on the version
+  # https://github.com/openshift/installer/pull/4198/commits/077cc86cafd75bb95023434deb93b110ea2ae106
+  #cp -f go.mod go.bak
+  #sed -i 's/library-go.*/library-go v0.0.0-20200917093739-70fa806b210a/g' go.mod
+  #if [[ $(grep library-go go.mod | wc -l) = 1 ]]
+  #then
+  #  sed -zEi 's|(\n[^\n]*){2}$|\n\tgithub.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20200917093739-70fa806b210a&|' go.mod
+  #fi
+  # Copy the patched OpenStack profile.go into the pre-4.5.9 repo code
   cp $HOME/scripts/profile/profile.go vendor/github.com/metal3-io/baremetal-operator/pkg/hardware/profile.go
   sed -i 's|IRONIC_IMAGE=.*|IRONIC_IMAGE=quay.io/roxenham/ironic-image:latest|g' ./data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
   #vi vendor/github.com/metal3-io/baremetal-operator/pkg/hardware/profile.go
@@ -172,6 +183,7 @@ EOF
 
   oc adm release mirror -a $PULLSECRET --from=$UPSTREAM_REPO --to-release-image=$LOCAL_REG/$LOCAL_REPO:$VERSION --to=$LOCAL_REG/$LOCAL_REPO
 
+  cd $HOME/scripts
   sed -i -e 's/^/  /' $(pwd)/domain.crt
   echo "additionalTrustBundle: |" >> $(pwd)/install-config.yaml
   cat $(pwd)/domain.crt >> $(pwd)/install-config.yaml
@@ -260,9 +272,17 @@ prepare_node() {
     *nightly*) export RELEASE_IMAGE=$(curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/$VERSION/release.txt| grep 'Pull From: quay.io' | awk -F ' ' '{print $3}' | xargs) ;;
     *) export RELEASE_IMAGE=$(curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$VERSION/release.txt| grep 'Pull From: quay.io' | awk -F ' ' '{print $3}' | xargs) ;;
   esac
+  export REVISION=`echo $VERSION | cut -d. -f3`
   case $VERSION in
     4.6*) oc adm release extract --registry-config "${PULLSECRET}" --command=$CMD --to "${EXTRACT_DIR}" ${RELEASE_IMAGE} ;;
-    4.5*) build_installer ;;
+    4.5*)
+      if [[ $REVISION -ge 9 ]]
+      then
+        echo "Release is greater than 4.5.9, we can extract the prebuilt binary"
+        oc adm release extract --registry-config "${PULLSECRET}" --command=$CMD --to "${EXTRACT_DIR}" ${RELEASE_IMAGE}
+      else
+        build_installer
+      fi;;
     *nightly*) build_installer ;;
     *) oc adm release extract --registry-config "${PULLSECRET}" --command=$CMD --to "${EXTRACT_DIR}" ${RELEASE_IMAGE} ;;
   esac

--- a/ansible/configs/kni-osp/software.yml
+++ b/ansible/configs/kni-osp/software.yml
@@ -139,6 +139,14 @@
         src: ./files/metal3-config.yaml
         dest: /home/cloud-user/scripts/metal3-config.yaml
 
+    - name: sending fix-overlay.sh script if CoreOS breaks
+      copy:
+        src: ./files/fix-overlay.sh
+        dest: /home/cloud-user/scripts/fix-overlay.sh
+        owner: "cloud-user"
+        group: "cloud-user"
+        mode: 0777
+
     - name: Resolving install-config
       template:
         src: "./files/install-config.yaml.j2"
@@ -201,7 +209,7 @@
         owner: "cloud-user"
         mode: 0744
 
-- name: Step 002 Time to get Shifty in here !
+- name: Step 003 Prepare the node for OpenShift KNI installation
   hosts: utility
   gather_facts: false
   become: False
@@ -214,6 +222,11 @@
       async: 900
       poll: 5
 
+- name: Step 004 Time to get Schwifty in here !
+  hosts: utility
+  gather_facts: false
+  become: False
+  tasks:
     - name: Installing KNI if kni_auto_install enabled, this may take a while ...
       when: kni_auto_install
       shell: /home/cloud-user/scripts/ocp-install.sh 2>&1 | tee -a /tmp/ocp-install.log
@@ -221,3 +234,35 @@
         chdir: /home/cloud-user/scripts/
       async: 9000
       poll: 10
+      ignore_errors: yes
+
+    - name: Ensuring all of the nodes came up successfully and verifying overlayfs success
+      when: kni_auto_install
+      shell: /home/cloud-user/scripts/fix-overlay.sh 2>&1 | tee -a /tmp/ocp-install.log
+      args:
+        chdir: /home/cloud-user/scripts/
+      ignore_errors: yes
+
+    - name: Checking OpenShift installation (wait-for bootstrap-complete)
+      shell: /home/cloud-user/scripts/openshift-baremetal-install --dir=/home/cloud-user/scripts/ocp --log-level debug wait-for bootstrap-complete 2>&1 | tee -a /tmp/ocp-install.log
+      when: kni_auto_install
+
+    - name: Checking OpenShift installation (wait-for install-complete)
+      when: kni_auto_install
+      shell: /home/cloud-user/scripts/openshift-baremetal-install --dir=/home/cloud-user/scripts/ocp --log-level debug wait-for install-complete 2>&1 | tee -a /tmp/ocp-install.log
+
+- name: Step 005 Make sure workers are up and running
+  hosts: utility
+  gather_facts: false
+  become: False
+  tasks:
+    - name: Ensuring all of the nodes came up successfully and verifying overlayfs success
+      when: kni_auto_install
+      shell: /home/cloud-user/scripts/fix-overlay.sh 2>&1 | tee -a /tmp/ocp-install.log
+      args:
+        chdir: /home/cloud-user/scripts/
+      ignore_errors: yes
+
+    - name: Checking OpenShift installation (wait-for install-complete)
+      when: kni_auto_install
+      shell: /home/cloud-user/scripts/openshift-baremetal-install --dir=/home/cloud-user/scripts/ocp --log-level debug wait-for install-complete 2>&1 | tee -a /tmp/ocp-install.log


### PR DESCRIPTION
##### SUMMARY

The baremetal installer relies on library-go to build the
openshift-install binary. Unfortunately this relies on an
unstable URL. This bumps the version to something a lot newer
and is referenced in commit 077cc86cafd75bb95023434deb93b110ea2ae106

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
kni-osp

