### PR TITLE
create per-user guides; skip some infra steps when num_users <= 0

### DIFF
--- a/ansible/roles/ocp4-workload-quarkus-workshop/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/defaults/main.yml
@@ -20,3 +20,4 @@ module_type: m1
 module_titles:
   - { name: m1, title: "Basic Quarkus Development", path: /workshop/quarkus-lab/lab/intro }
   - { name: m2, title: "Advanced Quarkus Development", path: /workshop/quarkus-lab/lab/extensions }
+  - { name: m3, title: "Spring to Quarkus Modernization", path: /workshop/quarkus-lab/lab/springweb }

--- a/ansible/roles/ocp4-workload-quarkus-workshop/tasks/install-codeready.yaml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/tasks/install-codeready.yaml
@@ -151,6 +151,7 @@
   with_list: "{{ users }}"
 
 - name: wait a minute and let the image download and be registered
+  when: num_users | int > 0
   pause:
       minutes: 2
 

--- a/ansible/roles/ocp4-workload-quarkus-workshop/tasks/verify-workload.yaml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/tasks/verify-workload.yaml
@@ -11,6 +11,7 @@
   loop: "{{ users }}"
 
 - name: verify guides pod is running
+  when: num_users | int > 0
   k8s_facts:
     api_version: v1
     kind: Pod
@@ -26,6 +27,7 @@
   loop: "{{ modules }}"
 
 - name: verify guides are accessible
+  when: num_users | int > 0
   uri:
     url: http://web-{{ item }}-guides.{{ route_subdomain }}
     method: GET

--- a/ansible/roles/ocp4-workload-quarkus-workshop/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/tasks/workload.yml
@@ -25,6 +25,7 @@
     loop_var: t_user
 
 - name: create guides project
+  when: num_users | int > 0
   k8s:
     state: present
     kind: Project
@@ -37,12 +38,14 @@
           openshift.io/display-name: "Quarkus Workshop Guides"
 
 - name: install guides
+  when: num_users | int > 0
   include_tasks: install-guides.yaml
   vars:
     guide: "{{ item }}"
   loop: "{{ modules }}"
 
 - name: install username distribution
+  when: num_users | int > 0
   include_tasks: install-username-distribution.yaml
 
 - name: search for rhsso

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/defaults/main.yml
@@ -4,4 +4,15 @@ ocp_username: jfalkner-redhat.com
 silent: False
 
 ocp4_workshop_quarkus_workshop_user_che_user_password: 'openshift'
+ocp4_workshop_quarkus_workshop_user_openshift_user_password: 'openshift'
 
+ocp4_workshop_quarkus_workshop_user_module_titles:
+  m1:
+    title: "Basic Quarkus Development"
+    path: "/workshop/quarkus-lab/lab/intro"
+  m2:
+    title: "Advanced Quarkus Development"
+    path: "/workshop/quarkus-lab/lab/extensions"
+  m3:
+    title: "Spring to Quarkus Modernization"
+    path: "/workshop/quarkus-lab/lab/springweb"

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/defaults/main.yml
@@ -3,8 +3,8 @@ become_override: False
 ocp_username: jfalkner-redhat.com
 silent: False
 
-ocp4_workshop_quarkus_workshop_user_che_user_password: 'openshift'
-ocp4_workshop_quarkus_workshop_user_openshift_user_password: 'openshift'
+ocp4_workshop_quarkus_workshop_user_che_user_password: "{{ lookup('password', '/dev/null length=12 chars=ascii_letters,digits') }}"
+ocp4_workshop_quarkus_workshop_user_openshift_user_password: "{{ lookup('password', '/dev/null length=12 chars=ascii_letters,digits') }}"
 
 ocp4_workshop_quarkus_workshop_user_module_titles:
   m1:

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/install-guides.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/install-guides.yaml
@@ -1,0 +1,44 @@
+---
+- name: search for guide {{ guide }}
+  k8s_facts:
+    kind: DeploymentConfig
+    name: web-{{ guide }}
+    namespace: "{{project}}"
+  register: r_guide_dc
+
+- name: deploy guide {{ guide }} to {{project}}
+  when: r_guide_dc.resources | list | length == 0
+  shell: >
+    oc -n {{project}} new-app --as-deployment-config quay.io/openshiftlabs/workshopper:rhtr2020 --name=web-{{ guide }}
+    -e CHE_USER_PASSWORD='{{ ocp4_workshop_quarkus_workshop_user_che_user_password }}'
+    -e OPENSHIFT_USER_PASSWORD='{{ ocp4_workshop_quarkus_workshop_user_openshift_user_password }}'
+    -e MASTER_URL={{ r_console_route.resources[0].spec.host }}
+    -e CONSOLE_URL=https://{{ r_console_route.resources[0].spec.host }}
+    -e CHE_URL=https://codeready-codeready.{{ route_subdomain }}
+    -e KEYCLOAK_URL=https://secure-rhsso-rhsso.{{ route_subdomain }}
+    -e ROUTE_SUBDOMAIN={{ route_subdomain }}
+    -e CONTENT_URL_PREFIX='https://raw.githubusercontent.com/RedHat-Middleware-Workshops/quarkus-workshop/rhtr2020/docs/'
+    -e WORKSHOPS_URLS="https://raw.githubusercontent.com/RedHat-Middleware-Workshops/quarkus-workshop/rhtr2020/docs/_workshop_{{ guide }}.yml"
+    -e LOG_TO_STDOUT=true
+
+- name: create the Route for {{ guide }}
+  when: r_guide_dc.resources | list | length == 0
+  k8s:
+    api_version: route.openshift.io/v1
+    namespace: "{{project}}"
+    state: present
+    kind: Route
+    definition:
+      metadata:
+        name: web-{{ guide }}
+        labels:
+          app: web-{{ guide }}
+      spec:
+        host: ''
+        to:
+          kind: Service
+          name: web-{{ guide }}
+          weight: 100
+        port:
+          targetPort: 8080-tcp
+  register: Route

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/post_workload.yml
@@ -9,7 +9,7 @@
     msg: "{{ item }}"
   loop:
   - "{{ ocp_username }} has been setup on the shared lab environment."
-  - "You have access to the following project: {{ guid }}-project"
+  - "You have access to the following project: quarkus-{{ guid }}-project"
   - ""
   - "OpenShift Console: https://{{ r_console_route.resources[0].spec.host }}"
   - "CodeReady Console: https://codeready-codeready.{{ route_subdomain }}"
@@ -17,7 +17,7 @@
 
 - name: Print module info
   agnosticd_user_info:
-    msg: "Module {{item}}: http://web-{{item}}-guides.{{ route_subdomain }}"
+    msg: "Module {{ocp4_workshop_quarkus_workshop_user_module_titles[item].title}} for {{ocp_username}}: http://web-{{item}}-quarkus-{{guid}}-guides.{{ route_subdomain }}{{ocp4_workshop_quarkus_workshop_user_module_titles[item].path}}?userid={{ocp_username | urlencode }}&guid={{guid | urlencode }}"
   loop: "{{ modules }}"
 
 - name: Save user data

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/pre_workload.yml
@@ -66,6 +66,7 @@
     - "console URL: https://{{ r_console_route.resources[0].spec.host }}"
     - "route subdomain: {{ route_subdomain }}"
     - "ocp_username: {{ ocp_username }}"
+    - "guid: {{ guid }}"
 
 # Leave this as the last task in the playbook.
 - name: pre_workload tasks complete

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/remove_workload.yml
@@ -10,10 +10,12 @@
 - name: remove the user Project
   k8s:
     state: absent
-    name: "{{ guid }}-project"
+    name: "{{item}}"
     kind: Project
     api_version: project.openshift.io/v1
-
+  loop:
+    - "quarkus-{{ guid }}-project"
+    - "quarkus-{{ guid }}-guides"
 
 # Leave this as the last task in the playbook.
 - name: remove_workload tasks complete

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/verify-workload.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/verify-workload.yaml
@@ -3,7 +3,7 @@
   k8s_facts:
     api_version: v1
     kind: Namespace
-    name: "{{ guid }}-project"
+    name: "quarkus-{{ guid }}-project"
     field_selectors:
       - status.phase=Active
   register: r_user_namespace

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/workload.yml
@@ -14,9 +14,28 @@
 - name: create project user project
   include_tasks: create_project.yaml
   vars:
-    t_project_name: "{{ guid }}-project"
+    t_project_name: "quarkus-{{ guid }}-project"
     t_project_desc: "User project for {{ ocp_username }}"
     t_user: "{{ ocp_username }}"
+
+- name: create guides project
+  k8s:
+    state: present
+    kind: Project
+    api_version: project.openshift.io/v1
+    definition:
+      metadata:
+        name: "quarkus-{{guid}}-guides"
+        annotations:
+          openshift.io/description: ""
+          openshift.io/display-name: "Quarkus Workshop Guides for {{ocp_username}}"
+
+- name: Install guides with per-user support
+  include_tasks: install-guides.yaml
+  vars:
+    guide: "{{ item }}"
+    project: "quarkus-{{guid}}-guides"
+  loop: "{{ modules }}"
 
 - name: add codeready user
   include_tasks: add-codeready-user.yaml


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

When using the `ocp4-workload-quarkus-workshop` workload to lay down infra when `num_users` is 0, we don't need to install the username-distribution or guides, so skip them with a `when:` clause.

For the per-user workload `ocp4-workload-quarkus-workshop-user`, deploy per-user guides that provide support for using the per-user unique `guid` variable for creating OCP project/namespaces, and then output the proper URL in the resulting `user.info` for the final email which gives a direct link to the per-user guide.

Also, add the definition for module 3 (`m3`).

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
`ocp4-quarkus-workshop` and `ocp4-quarkus-workshop-user`

cc @danieloh30 @jkupferer 