### PR TITLE
Update workload ocp-workload-migration to use latest image SHAs

### DIFF
--- a/ansible/roles/ocp-workload-migration/templates/operator.yml.j2
+++ b/ansible/roles/ocp-workload-migration/templates/operator.yml.j2
@@ -232,7 +232,7 @@ spec:
         - name: MIGRATION_REGISTRY_REPO
           value: {{ mig_migration_namespace }}-registry-rhel8@sha256
         - name: MIGRATION_REGISTRY_TAG
-          value: 0ae610db4f73b6a5353c4821165bd60a8c4e86ac5ba5f1d60cd532f5bcd814bd
+          value: 37536b4487d3668a7105737695a0651e6be64720bc72a69da74153a8443ac9e1
         - name: VELERO_REPO
           value: {{ mig_migration_namespace }}-velero-rhel8@sha256
         - name: VELERO_PLUGIN_REPO
@@ -246,21 +246,21 @@ spec:
         - name: VELERO_AZURE_PLUGIN_REPO
           value: {{ mig_migration_namespace }}-velero-plugin-for-microsoft-azure-rhel8@sha256
         - name: VELERO_TAG
-          value: 1a33e327dd610f0eebaaeae5b3c9b4170ab5db572b01a170be35b9ce946c0281
+          value: 461ea0c165ed525d4276056f6aab879dcf011facb00e94acc88ae6e9f33f1637
         - name: VELERO_RESTIC_RESTORE_HELPER_TAG
-          value: e9459138ec3531eefbefa181dae3fd93fe5cf210b2a0bd3bca7ba38fbec97f60
+          value: 356e8d9dede186325e3e4f8700cbde7121b6c4dc35c0099b8337c6cfb83049d8
         - name: VELERO_PLUGIN_TAG
-          value: d9e2c4a9db9a88c68d3f6b18927c7f00d50a172a9a721ea6add0855e4db1fda0
+          value: 7b6aa42f4428ab744e354c4095afae460b6e5e4e868969a14b4d1aec541a946a
         - name: VELERO_AWS_PLUGIN_TAG
-          value: 22c58f575ce2f54bf995fced82f89ba173329d9b88409cf371122f9ae8cabda1
+          value: bfda4f3c7f95993b5f9dace49856b124505e72bd87d42a50918f4194b7e6d7f0
         - name: VELERO_GCP_PLUGIN_TAG
-          value: 37c0b170d168fcebb104e465621e4ce97515d82549cd37cb42be94e3e55a4271
+          value: fa6c5c8dc38b8965dd9eedb9c2a86dc9a8441cb280392961a1b8b42379648014
         - name: VELERO_AZURE_PLUGIN_TAG
-          value: dd92ad748a84754e5d78287e29576a5b95448e929824e86e80c60857d0c7aff9
+          value: c8b0fb034244ef9598703ec9534ecfb5c97cff42157d2571eab382bdb1aeb5a2
         - name: MIG_UI_TAG
           value: 6abfaea8ac04e3b5bbf9648a3479b420b4baec35201033471020c9cae1fe1e11
         - name: MIG_CONTROLLER_TAG
-          value: f3de5a7b0e6eeee722da155622a9f20425696bd25f833519b7aec320a7b64659
+          value: 35c9a554de83d7dc9c560936c297085bbf05b08202885337addb1e4151b40d40
       volumes:
         - name: runner
           emptyDir: {}


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
This PR updates the operator template in ocp-workload-migration to use the latest image SHAs. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp-workload-migration

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
