### PR TITLE
Update RHACM workload to use catalog source

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm/defaults/main.yml
@@ -6,3 +6,6 @@ silent: False
 ocp4_workload_rhacm_acm_project: "open-cluster-management"
 ocp4_workload_rhacm_acm_release: "release-2.0"
 ocp4_workload_rhacm_acm_csv: "advanced-cluster-management.v2.0.3"
+ocp4_workload_rhacm_catalog_source_image: "quay.io/gpte-devops-automation/olm_snapshot_acm_redhat_catalog"
+ocp4_workload_rhacm_catalog_source_tag: "v4.5_2020_09_25"
+ocp4_workload_rhacm_use_catalog_snapshot: false

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm/meta/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm/meta/main.yml
@@ -1,12 +1,11 @@
-
 ---
 galaxy_info:
   role_name: ocp4_workload_rhacm
-  author: Management Integration Team - pit-hybrid@redhat.com
+  author: Nate Stephany (nate@redhat.com)
   description: |
     Set up ACM on OpenShift 4.
   license: MIT
-  min_ansible_version: 2.8
+  min_ansible_version: 2.9
   platforms: []
   galaxy_tags:
   - ocp

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/workload.yml
@@ -23,10 +23,52 @@
     state: present
     definition: "{{ lookup('template', './templates/operatorGroup.j2') }}"
 
+- name: Create Catalogsource for use with catalog snapshot
+  when: ocp4_workload_rhacm_use_catalog_snapshot | bool
+  k8s:
+    state: present
+    definition: "{{ lookup('template', './templates/catalogsource.j2' ) | from_yaml }}"
+
 - name: Ensure RHACM Subscription is present
   k8s:
     state: present
     definition: "{{ lookup('template', './templates/subscription.j2') }}"
+
+- name: Wait until InstallPlan is created
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: InstallPlan
+    namespace: "{{ ocp4_workload_rhacm_acm_project }}"
+  register: r_install_plans
+  vars:
+    _query: >-
+      [?starts_with(spec.clusterServiceVersionNames[0], 'advanced-cluster-management')]
+  retries: 30
+  delay: 5
+  until:
+  - r_install_plans.resources | length > 0
+  - r_install_plans.resources | to_json | from_json | json_query(_query)
+
+- name: Set InstallPlan Name
+  set_fact:
+    ocp4_workload_rhacm_install_plan_name: "{{ r_install_plans.resources | to_json | from_json | json_query(query) }}"
+  vars:
+    query: >-
+      [?starts_with(spec.clusterServiceVersionNames[0], 'advanced-cluster-management')].metadata.name|[0]
+
+- name: Get InstallPlan
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: InstallPlan
+    name: "{{ ocp4_workload_rhacm_install_plan_name }}"
+    namespace: "{{ ocp4_workload_rhacm_acm_project }}"
+  register: r_install_plan
+
+- name: Approve InstallPlan if necessary
+  when: r_install_plan.resources[0].status.phase is match("RequiresApproval")
+  k8s:
+    state: present
+    definition: "{{ lookup( 'template', './templates/installplan.j2' ) }}"
 
 - name: Wait until some pods are running before checking the sub status
   k8s_info:
@@ -65,7 +107,7 @@
     namespace: "{{ ocp4_workload_rhacm_acm_project }}"
   register: rhacm_multiclusterhub
   retries: 30
-  delay: 20
+  delay: 30
   until: 
   - rhacm_multiclusterhub.resources | length > 0
   - rhacm_multiclusterhub.resources[0].status is defined

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm/templates/catalogSource.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm/templates/catalogSource.j2
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: redhat-operators-snapshot-acm
+  namespace: {{ ocp4_workload_rhacm_acm_project }}
+spec:
+  sourceType: grpc
+  image: {{ ocp4_workload_rhacm_catalog_source_image }}:{{ ocp4_workload_rhacm_catalog_source_tag }}
+  displayName: "Red Hat Operators Snapshot"
+  publisher: "GPTE"

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm/templates/installplan.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm/templates/installplan.j2
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: InstallPlan
+metadata:
+  name: {{ ocp4_workload_rhacm_install_plan_name }}
+  namespace: {{ ocp4_workload_rhacm_acm_project }}
+spec:
+  approved: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm/templates/subscription.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm/templates/subscription.j2
@@ -4,8 +4,9 @@ metadata:
   name: acm-operator-subscription
   namespace: {{ ocp4_workload_rhacm_acm_project }}
 spec:
-  sourceNamespace: openshift-marketplace
-  source: redhat-operators
+  sourceNamespace: {{ ocp4_workload_rhacm_acm_project }}
+  source: redhat-operators-snapshot-acm
   channel: {{ ocp4_workload_rhacm_acm_release }}
-  installPlanApproval: Automatic
+  installPlanApproval: Manual
   name: advanced-cluster-management
+  startingCSV: {{ ocp4_workload_rhacm_acm_csv }}


### PR DESCRIPTION
##### SUMMARY
This will allow the RHACM workload to use a catalog snapshot. To use the snapshot, the `ocp4_workload_rhacm_use_catalog_snapshot` must be set to true. 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_rhacm