### PR TITLE
Change role ocp4_workload_authentication to not set bind password

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_authentication/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_authentication/defaults/main.yml
@@ -36,7 +36,7 @@ ocp4_workload_authentication_htpasswd_add_default_users: true
 ocp4_workload_authentication_ldap_url: ldaps://ipa1.opentlc.com:636/cn=users,cn=accounts,dc=opentlc,dc=com?uid
 ocp4_workload_authentication_ldap_ca_url: https://gpte-public.s3.amazonaws.com/opentlc_ipa_ca.crt
 ocp4_workload_authentication_ldap_bind_dn: "uid=ose-mwl-auth,cn=users,cn=accounts,dc=opentlc,dc=com"
-ocp4_workload_authentication_ldap_bind_password: "<FROM SECRET>"
+#ocp4_workload_authentication_ldap_bind_password
 
 # -----------------------------------------------
 # admin user


### PR DESCRIPTION
##### SUMMARY

The ocp4_workload_authentication_ldap_bind_password is currently set to `<FROM SECRET>` in defaults, which prevents the `fail` task in the workload from reporting that this variable has not been set.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ocp4_workload_authentication role