### PR TITLE
Added support for catalog snapshots, cleanup all around

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/defaults/main.yml
@@ -5,6 +5,12 @@ silent: False
 
 # Default variables.
 
+# Access Credentials for Quay.io to pull Red Hat Quay
+# Must be overwritten via base64 encoded Global Variables !!!
+# reference https://access.redhat.com/solutions/3533201
+ocp4_workload_quay_operator_quay_dockerconfigjson: 'pull_secret'
+
+# Project Settings
 ocp4_workload_quay_operator_project: quay-enterprise
 ocp4_workload_quay_operator_project_display: Red Hat Quay Registry
 ocp4_workload_quay_operator_name: quay
@@ -12,27 +18,34 @@ ocp4_workload_quay_operator_name: quay
 # Channel to subscribe to
 ocp4_workload_quay_operator_channel: "quay-v3.3"
 
-# Quay starting CSV. Leave empty for current CSV
-# starting_csv: "red-hat-quay.v3.3.0"
+# Set automatic InstallPlan approval. If set to false it is also suggested
+# to set the starting_csv to pin a specific version
+# This variable has no effect when using a catalog snapshot (always true)
+ocp4_workload_quay_operator_automatic_install_plan_approval: true
+
+# Set a starting ClusterServiceVersion.
+# Recommended to leave empty to get latest in the channel when not using
+# a catalog snapshot.
+# Highly recommended to be set when using a catalog snapshot but can be
+# empty to get the latest available in the channel at the time when
+# the catalog snapshot got created.
 ocp4_workload_quay_operator_starting_csv: ""
+#ocp4_workload_quay_operator_starting_csv: "red-hat-quay.v3.3.2-20200903"
 
 # Quay Route. Should be overwritten
+# When empty the route will be quay-{{guid}}.basedomain
 ocp4_workload_quay_operator_route: ""
 
 # Verify successful deployment
 ocp4_workload_quay_operator_verify_deployment: true
 
-# Image tag for Quay and Clair. Usually the same but can be set differently
-ocp4_workload_quay_operator_quay_image_tag:  "v3.3.0"
-ocp4_workload_quay_operator_clair_image_tag: "v3.3.0"
-
 # Enable Clair
-ocp4_workload_quay_operator_clair_enabled: True
+ocp4_workload_quay_operator_clair_enabled: true
 # Clair Update Interval (Default 6h)
 ocp4_workload_quay_operator_clair_update_interval: "10m"
 
 # Enable Repo Mirroring
-ocp4_workload_quay_operator_enabled_repo_mirroring: True
+ocp4_workload_quay_operator_enabled_repo_mirroring: true
 
 # Quay Superuser
 ocp4_workload_quay_operator_superuser_username: quayadmin
@@ -45,11 +58,6 @@ ocp4_workload_quay_operator_superuser_password_length: 16
 
 # Quay Config Password (username is always 'quayconfig'):
 ocp4_workload_quay_operator_config_app_password: quayconfig
-
-# Patch Quay Deployment to workaround bugs
-# https://issues.redhat.com/browse/PROJQUAY-725
-# https://issues.redhat.com/browse/PROJQUAY-713
-ocp4_workload_quay_operator_patch_deployment: true
 
 # Resources for Quay Database
 ocp4_workload_quay_operator_quay_db_volume_size: 10Gi
@@ -96,10 +104,24 @@ ocp4_workload_quay_operator_config_memory_limit: "512Mi"
 ocp4_workload_quay_operator_ssl_certificate: ""
 ocp4_workload_quay_operator_ssl_key: ""
 
-# Access Credentials for Quay.io to pull Red Hat Quay
-# Should be overwritten via base64 encoded Global Variables !!!
-# reference https://access.redhat.com/solutions/3533201
-# ocp4_workload_quay_operator_quay_dockerconfigjson: 'pull_secret'
+# --------------------------------
+# Operator Catalog Snapshot Settings
+# --------------------------------
+# See https://github.com/redhat-cop/agnosticd/blob/development/docs/Operator_Catalog_Snapshots.adoc
+# for instructions on how to set up catalog snapshot images
+
+# Use a catalog snapshot
+ocp4_workload_quay_operator_use_catalog_snapshot: false
+
+# Catalog Source Name when using a catalog snapshot. This should be unique
+# in the cluster to avoid clashes
+ocp4_workload_quay_operator_catalogsource_name: redhat-operators-snapshot-quay-operator
+
+# Catalog snapshot image
+ocp4_workload_quay_operator_catalog_snapshot_image: quay.io/gpte-devops-automation/olm_snapshot_redhat_catalog
+
+# Catalog snapshot image tag
+ocp4_workload_quay_operator_catalog_snapshot_image_tag: "v4.5_2020_09_28"
 
 # Internal variables. Don't set or change
 _ocp4_workload_quay_operator_quay_route: ""

--- a/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/tasks/remove_workload.yml
@@ -13,22 +13,44 @@
     kind: Pod
     namespace: "{{ ocp4_workload_quay_operator_project }}"
   register: r_running_pods
-  until: r_running_pods.resources | list | length <= 1
+  until: r_running_pods.resources | list | length <= 2
   ignore_errors: true
   retries: 20
   delay: 10
 
-- name: Remove Red Hat Quay Operator
+- name: Get Installed CSV
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: Subscription
+    name: quay-operator
+    namespace: "{{ ocp4_workload_quay_operator_project }}"
+  register: r_subscription
+
+- name: Remove CSV
+  when:
+  - r_subscription.resources | length > 0
+  - r_subscription.resources[0].status.currentCSV is defined
+  - r_subscription.resources[0].status.currentCSV | length > 0
+  k8s:
+    state: absent
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    name: "{{ r_subscription.resources[0].status.currentCSV }}"
+    namespace: "{{ ocp4_workload_quay_operator_project }}"
+
+- name: Remove Subscription
+  k8s:
+    state: absent
+    api_version: operators.coreos.com/v1alpha1
+    kind: Subscription
+    name: quay-operator
+    namespace: "{{ ocp4_workload_quay_operator_project }}"
+
+- name: Remove Red Hat Quay Operator Project
   k8s:
     state: absent
     definition: "{{ lookup('template', item ) | from_yaml }}"
   loop:
-  - ./templates/subscription.j2
-  - ./templates/operatorgroup.j2
-  - ./templates/pull_secret.j2
-  - ./templates/quay_superuser_secret.j2
-  - ./templates/quay_config_secret.j2
-  - ./templates/quay_ssl_certificate_secret.j2
   - ./templates/project.j2
 
 # Leave this as the last task in the playbook.

--- a/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/tasks/workload.yml
@@ -1,5 +1,5 @@
 ---
-- name: Setting up workload for user
+- name: Setting up workload for user {{ ocp_username }}
   debug:
     msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
 
@@ -78,12 +78,25 @@
   set_fact:
     _ocp4_workload_quay_operator_quay_route: "quay-{{ guid }}.{{ r_ingress_config.resources[0].spec.domain }}"
 
-- name: Create Quay Operator Resources
+- name: Create Quay Operator Project
   k8s:
     state: present
     definition:  "{{ lookup('template', item ) | from_yaml }}"
   loop:
   - ./templates/project.j2
+  - ./templates/operatorgroup.j2
+
+- name: Create Catalogsource for use with catalog snapshot
+  when: ocp4_workload_quay_operator_use_catalog_snapshot | bool
+  k8s:
+    state: present
+    definition: "{{ lookup('template', './templates/catalogsource.j2' ) | from_yaml }}"
+
+- name: Create Quay Operator Resources
+  k8s:
+    state: present
+    definition:  "{{ lookup('template', item ) | from_yaml }}"
+  loop:
   - ./templates/operatorgroup.j2
   - ./templates/subscription.j2
   - ./templates/pull_secret.j2
@@ -100,44 +113,68 @@
   loop:
   - ./templates/quay_ssl_certificate_secret.j2
 
-- name: Get current CSV from Subscription
+- name: Wait until InstallPlan is created
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: InstallPlan
+    namespace: "{{ ocp4_workload_quay_operator_project }}"
+  register: r_install_plans
+  vars:
+    _query: >-
+      [?starts_with(spec.clusterServiceVersionNames[0], 'red-hat-quay')]
+  retries: 30
+  delay: 5
+  until:
+  - r_install_plans.resources | length > 0
+  - r_install_plans.resources | to_json | from_json | json_query(_query)
+
+- name: Set InstallPlan Name
+  set_fact:
+    ocp4_workload_quay_operator_install_plan_name: "{{ r_install_plans.resources | to_json | from_json | json_query(query) }}"
+  vars:
+    query: >-
+      [?starts_with(spec.clusterServiceVersionNames[0], 'red-hat-quay')].metadata.name|[0]
+
+- name: Get InstallPlan
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: InstallPlan
+    name: "{{ ocp4_workload_quay_operator_install_plan_name }}"
+    namespace: "{{ ocp4_workload_quay_operator_project }}"
+  register: r_install_plan
+  
+- name: Approve InstallPlan if necessary
+  when: r_install_plan.resources[0].status.phase is match("RequiresApproval")
+  k8s:
+    state: present
+    definition: "{{ lookup( 'template', './templates/installplan.j2' ) }}"
+
+- name: Get Installed CSV
   k8s_info:
     api_version: operators.coreos.com/v1alpha1
     kind: Subscription
+    name: quay-operator
     namespace: "{{ ocp4_workload_quay_operator_project }}"
-    name: quay
   register: r_subscription
+  retries: 30
+  delay: 5
+  until:
+  - r_subscription.resources[0].status.currentCSV is defined
+  - r_subscription.resources[0].status.currentCSV | length > 0
 
-- name: Wait for ClusterServiceVersion to appear
+- name: Wait until CSV is Installed
   k8s_info:
     api_version: operators.coreos.com/v1alpha1
     kind: ClusterServiceVersion
-    namespace: "{{ ocp4_workload_quay_operator_project }}"
     name: "{{ r_subscription.resources[0].status.currentCSV }}"
-  register: r_csv
-  ignore_errors: true
-  until: r_csv.resources | length > 0
-  retries: 30
-  delay: 10
-
-- name: Wait for Quay operator pod to be ready
-  k8s_info:
-    api_version: v1
-    kind: Deployment
     namespace: "{{ ocp4_workload_quay_operator_project }}"
-    name: "quay-operator"
-  register: r_qo_deployment
-  retries: 30
-  delay: 10
+  register: r_csv
+  retries: 15
+  delay: 5
   until:
-  - r_qo_deployment.resources | length | int > 0
-  - r_qo_deployment.resources[0].status.readyReplicas is defined
-  - r_qo_deployment.resources[0].status.readyReplicas | int == r_qo_deployment.resources[0].spec.replicas | int
-
-- name: Copy Quay Registry Definition
-  template:
-    src: ./templates/quay.j2
-    dest: "/home/{{ ansible_user }}/quay_template.yaml"
+  - r_csv.resources[0].status.phase is defined
+  - r_csv.resources[0].status.phase | length > 0
+  - r_csv.resources[0].status.phase == "Succeeded"
 
 - name: Create Red Hat Quay Registry
   k8s:
@@ -179,18 +216,6 @@
     retries: 25
     delay: 5
 
-# https://issues.redhat.com/browse/PROJQUAY-725
-# https://issues.redhat.com/browse/PROJQUAY-713
-- name: Patch the Quay Deployment to work around permissions issue
-  when: ocp4_workload_quay_operator_patch_deployment | bool
-  block:
-  - name: Wait 5 minutes for Quay Setup to be complete
-    pause:
-      seconds: 300
-
-  - name: Patch Quay Deployment
-    shell: "oc patch deploy {{ ocp4_workload_quay_operator_name }}-quay -p '{\"spec\": {\"template\": {\"spec\":{\"securityContext\":{\"fsGroup\":1001}}}}}' -n {{ ocp4_workload_quay_operator_project }}"
-
 - name: Get Quay Hostname
   k8s_info:
     api_version: redhatcop.redhat.io/v1alpha1
@@ -204,7 +229,7 @@
     msg: "{{ item }}"
   loop:
   - ""
-  - "Red Hat Quay is available at https://{{r_quay.resources[0].status.hostname }}."
+  - "Red Hat Quay is available at https://{{r_quay.resources[0].status.hostname }}"
   - "The Red Hat Quay Super User is {{ ocp4_workload_quay_operator_superuser_username }} with password {{ _ocp4_workload_quay_operator_superuser_password }}"
 
 # Leave this as the last task in the playbook.

--- a/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/templates/catalogsource.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/templates/catalogsource.j2
@@ -1,0 +1,9 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: "{{ ocp4_workload_quay_operator_catalogsource_name }}"
+  namespace: "{{ ocp4_workload_quay_operator_project }}"
+spec:
+  sourceType: grpc
+  image: "{{ ocp4_workload_quay_operator_catalog_snapshot_image }}:{{ ocp4_workload_quay_operator_catalog_snapshot_image_tag }}"
+  displayName: "{{ ocp4_workload_quay_operator_catalogsource_name }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/templates/installplan.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/templates/installplan.j2
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: InstallPlan
+metadata:
+  name: "{{ ocp4_workload_quay_operator_install_plan_name }}"
+  namespace: "{{ ocp4_workload_quay_operator_project }}"
+spec:
+  approved: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/templates/operatorgroup.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/templates/operatorgroup.j2
@@ -1,8 +1,6 @@
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  annotations:
-    olm.providedAPIs: "QuayEcosystem.v1alpha1.redhatcop.redhat.io"
   name: "{{ ocp4_workload_quay_operator_project }}-operatorgroup"
   namespace: "{{ ocp4_workload_quay_operator_project }}"
 spec:

--- a/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/templates/quay.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/templates/quay.j2
@@ -5,9 +5,7 @@ metadata:
   namespace: "{{ ocp4_workload_quay_operator_project }}"
 spec:
   quay:
-{% if ocp4_workload_quay_operator_quay_image_tag is version_compare('v3.2.0', '>=') %}
     enableRepoMirroring: {{ ocp4_workload_quay_operator_enabled_repo_mirroring | bool }}
-{% endif %}
     imagePullSecretName: quay-pull-secret
     superuserCredentialsSecretName: quay-superuser-secret
     configSecretName: quay-config-secret
@@ -30,7 +28,6 @@ spec:
           memory: "{{ ocp4_workload_quay_operator_quay_db_memory_limit }}"
           cpu: "{{ ocp4_workload_quay_operator_quay_db_cpu_limit}}"
     deploymentStrategy: Recreate
-    image: "quay.io/redhat/quay:{{ ocp4_workload_quay_operator_quay_image_tag }}"
     registryStorage:
       persistentVolumeAccessModes:
       - ReadWriteOnce
@@ -64,7 +61,6 @@ spec:
   clair:
     enabled: true
     deploymentStrategy: Recreate
-    image: "quay.io/redhat/clair-jwt:{{ ocp4_workload_quay_operator_clair_image_tag }}"
     imagePullSecretName: quay-pull-secret
     updateInterval: "{{ ocp4_workload_quay_operator_clair_update_interval }}"
     resources:

--- a/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/templates/subscription.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/templates/subscription.j2
@@ -1,14 +1,23 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: quay
+  name: quay-operator
   namespace: "{{ ocp4_workload_quay_operator_project }}"
 spec:
   channel: "{{ ocp4_workload_quay_operator_channel }}"
+{% if ocp4_workload_quay_operator_automatic_install_plan_approval | default(True) | bool and not ocp4_workload_quay_operator_use_catalog_snapshot | default(False) | bool %}
   installPlanApproval: Automatic
+{% else %}
+  installPlanApproval: Manual
+{% endif %}
   name: quay-operator
+{% if ocp4_workload_quay_operator_use_catalog_snapshot | default(False) | bool %}
+  source: "{{ ocp4_workload_quay_operator_catalogsource_name }}"
+  sourceNamespace: "{{ ocp4_workload_quay_operator_project }}"
+{% else %}
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-{% if ocp4_workload_quay_operator_starting_csv | length > 0 %}
+{% endif %}
+{% if ocp4_workload_quay_operator_starting_csv | default("") | length > 0 %}
   startingCSV: "{{ ocp4_workload_quay_operator_starting_csv }}"
 {% endif %}


### PR DESCRIPTION
##### SUMMARY

Quay Operator
- Add Support for Catalog Snapshots
- Cleanup all around
  - Remove workarounds for previous bugs
  - Remove settings to set images for Quay and Clair, those should come from the operator based on CSV
- Test that latest operator works (and cleans up after itself)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_quay_operator
