### PR TITLE
Updated removal playbook with the proper variables

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/remove_workload.yml
@@ -42,6 +42,30 @@
   set_fact:
     cluster_az: "{{ machineset_list.resources[0].spec.template.spec.providerSpec.value.placement.availabilityZone }}"
 
+# Extract the AWS keys from OpenShift
+- name: Extract the AWS keys from OpenShift
+  k8s_info:
+    api_version: v1
+    kind: Secret
+    name: aws-cloud-credentials
+    namespace: openshift-machine-api
+  register: ocp_aws_keys
+  retries: 25
+  delay: 5
+  until:
+    - ocp_aws_keys.resources[0].data.aws_access_key_id is defined
+    - ocp_aws_keys.resources[0].data.aws_secret_access_key is defined
+
+# Convert extraced AWS access key into a decoded fact for later use
+- name: Convert extraced AWS access key into a decoded fact for later use
+  set_fact:
+    ocp_access_key: "{{ ocp_aws_keys.resources[0].data.aws_access_key_id | b64decode }}"
+
+# Convert extraced AWS secret key into a decoded fact for later use
+- name: Convert extraced AWS secret key into a decoded fact for later use
+  set_fact:
+    ocp_secret_key: "{{ ocp_aws_keys.resources[0].data.aws_secret_access_key | b64decode }}"
+
 # Get the latest Windows Server 2019 with Containers 
 - name: Extract the latest Windows Server 2019 with Containers Image
   ec2_ami_info:


### PR DESCRIPTION
##### SUMMARY

There was a bug in the Windows Node playbook that, due to a missing variable, it didn't remove the workload. This PR fixes that issue.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ocp4_workload_windows_node
