### PR TITLE
Serverless: increase timeout for CSV waiting

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/workload.yml
@@ -106,7 +106,7 @@
     name: "{{ r_subscription.resources[0].status.currentCSV }}"
     namespace: openshift-operators
   register: r_csv
-  retries: 15
+  retries: 30
   delay: 5
   until:
   - r_csv.resources[0].status.phase is defined


### PR DESCRIPTION
Several times already my deployment has failed because the Serverless CSV is not ready in a timely manner.
Proposed change is to increase retries from 15 to 30.