### PR TITLE
Add role ocp4_workload_bookbag_user AUTH_USERNAME and AUTH_PASSWORD

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/defaults/main.yaml
@@ -27,5 +27,12 @@ ocp4_workload_bookbag_user_role: edit
 ocp4_workload_bookbag_user_console_image_override: ""
 # ocp4_workload_bookbag_user_console_image_override: quay.io/openshift/origin-console:4.5
 
+# Set AUTH_USERNAME to "*" to disable bookbag authentication
+# Set AUTH_USERNAME to "" to authenticate with OpenShift
+# Set AUTH_USERNAME and AUTH_PASSWORD for bookbag user/password check
+# https://github.com/openshift-homeroom/workshop-terminal/blob/develop/terminal/gateway/server.js#L462-L480
+ocp4_workload_bookbag_user_auth_username: '*'
+ocp4_workload_bookbag_user_auth_password: ''
+
 ocp4_workload_bookbag_user_create_pvc: false
 ocp4_workload_bookbag_user_pvc_size: 1Gi

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/templates/deployment.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/templates/deployment.yaml.j2
@@ -42,9 +42,9 @@ spec:
         - name: APPLICATION_NAME
           value: "{{ ocp4_workload_bookbag_user_deployment_name }}"
         - name: AUTH_USERNAME
-          value: '*'
+          value: {{ ocp4_workload_bookbag_user_auth_username | to_json }}
         - name: AUTH_PASSWORD
-          value: ''
+          value: {{ ocp4_workload_bookbag_user_auth_password | to_json }}
         - name: CONSOLE_IMAGE
           value: "{{ ocp4_workload_bookbag_user_console_image }}"
         - name: CONSOLE_BRANDING


### PR DESCRIPTION
##### SUMMARY

The AUTH_USERNAME and AUTH_PASSWORD environment variables for openshift-homeroom (aka bookbag) configure authentication options. This PR adds `ocp4_workload_bookbag_user_auth_username` and 
`ocp4_workload_bookbag_user_auth_password` variables to control these environment variables.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

role ocp4_workload_bookbag_user