### PR TITLE
yamllint formatting cleanup for role ocp4-workload-ausgeben-infra

### DIFF
--- a/ansible/roles/ocp4-workload-ausgeben-infra/.yamllint
+++ b/ansible/roles/ocp4-workload-ausgeben-infra/.yamllint
@@ -1,0 +1,13 @@
+---
+extends: default
+
+rules:
+  comments:
+    require-starting-space: false
+    min-spaces-from-content: 1
+  comments-indentation: disable
+  indentation:
+    indent-sequences: consistent
+  line-length:
+    max: 120
+    allow-non-breakable-inline-mappings: true

--- a/ansible/roles/ocp4-workload-ausgeben-infra/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-ausgeben-infra/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-become_override: False
+become_override: false
 ocp_username: opentlc-mgr
-silent: False
+silent: false

--- a/ansible/roles/ocp4-workload-ausgeben-infra/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-ausgeben-infra/tasks/workload.yml
@@ -60,7 +60,7 @@
 
 - debug:
     msg:
-    - "user.info: Ausgeben URL for students: http://{{ route_out.resources[0].spec.host }}"
+      - "user.info: Ausgeben URL for students: http://{{ route_out.resources[0].spec.host }}"
 
 # Leave this as the last task in the playbook.
 - name: workload tasks complete


### PR DESCRIPTION
##### SUMMARY
For the specified roles:
- Create a yamllint file to enforce formatting rules
- Make changes to existing code base to adhere to formatting requirements
- yamllint errors will be displayed during formatting checks in future development

##### ISSUE TYPE
- Code Cleanup Request

##### COMPONENT NAME
ocp4-workload-ausgeben-infra