### PR TITLE
Add insecure tolerance to kn download

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/workload.yml
@@ -176,10 +176,23 @@
     namespace: knative-serving
   register: r_kn_download
 
+- name: Download kn cli tool from cluster
+  get_url:
+    url: "http://{{ r_kn_download.resources[0].status.ingress[0].host }}/amd64/linux/kn-linux-amd64.tar.gz"
+    validate_certs: false
+    dest: /tmp/kn-linux-amd64.tar.gz
+    owner: root
+    group: root
+    mode: 0666
+  register: r_kn
+  until: r_kn is success
+  retries: 10
+  delay: 10
+
 - name: Install kn CLI on bastion
   become: true
   unarchive:
-    src: "http://{{ r_kn_download.resources[0].status.ingress[0].host }}/amd64/linux/kn-linux-amd64.tar.gz"
+    src: /tmp/kn-linux-amd64.tar.gz
     remote_src: yes
     dest: /usr/bin
     mode: 0775
@@ -187,8 +200,6 @@
     group: root
   args:
     creates: /usr/bin/kn
-  retries: 10
-  delay: 10
 
 - name: Create kn bash completion file
   become: true


### PR DESCRIPTION
Bugfix. Ignore insecure connection when downloading kn binary from the cluster if run before certificates have been added.
Workload: ocp4_serverless