### PR TITLE
Fix role ocp4-workload-homeroomlab-starter-guides update git repo url

### DIFF
--- a/ansible/roles/ocp4-workload-homeroomlab-starter-guides/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-homeroomlab-starter-guides/defaults/main.yml
@@ -9,7 +9,7 @@ tmp_git_location: "{{ tmp_dir }}/git"
 
 project_name: labs
 project_display: "OpenShift Workshop Labs"
-lab_repo: https://github.com/openshiftlabs/starter-guides
+lab_repo: https://github.com/openshift-labs/starter-guides
 lab_branch: ocp-4.5
 
 homeroom_template_path: "https://raw.githubusercontent.com/openshift-homeroom/workshop-homeroom/2.1.0/templates/production.json"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Fix typo for repo git url: https://github.com/openshift-labs/starter-guides
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
`defaults/main.yml`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
RHPDS fails at **checkSoftwareDeploy**

Logs:
```
TASK [ocp4-workload-homeroomlab-starter-guides : Create homeroom resources] ****
Friday 02 October 2020  05:54:28 -0400 (0:00:00.051)       1:19:42.907 ********
changed: [bastion.723f.internal]

TASK [ocp4-workload-homeroomlab-starter-guides : Wait for the homeroom to deploy] ***
Friday 02 October 2020  05:54:32 -0400 (0:00:04.569)       1:19:47.476 ********
changed: [bastion.723f.internal]

TASK [ocp4-workload-homeroomlab-starter-guides : Git clone the repo if it doesn't exist] ***
Friday 02 October 2020  05:55:05 -0400 (0:00:32.285)       1:20:19.762 ********

=================================================================================
Fri Oct  2 10:41:34 UTC 2020 | destroy
=================================================================================
```