### PR TITLE
Change osp-template-generate, Fix dependencies of resources in heat template

### DIFF
--- a/ansible/roles-infra/infra-osp-template-generate/templates/cloud_template_master.j2
+++ b/ansible/roles-infra/infra-osp-template-generate/templates/cloud_template_master.j2
@@ -35,6 +35,8 @@ resources:
       allocation_pools:
         - start: {{ network['allocation_start'] }}
           end: {{ network['allocation_end'] }}
+    depends_on:
+      - {{ network['name'] }}-network
 
 {% if network['create_router'] %}
   {{ network['name'] }}-router:
@@ -118,6 +120,11 @@ resources:
     {% endif %}
     depends_on:
       - {{ instance['network'] | default('default') }}-router_private_interface
+    {% if instance.security_groups is defined %}
+      {% for security_group in instance.security_groups %}
+      - {{ security_group }}
+      {% endfor %}
+    {% endif %}
 
 
     {% if instance.floating_ip | default(false) or instance.public_dns | default(false) %}
@@ -176,6 +183,7 @@ resources:
       - {{ security_group }}
       {% endfor %}
     {% endif %}
+      - port_{{ iname }}
 
     {% if instance.volumes is defined %}
   #### Volumes for {{ iname }} ####


### PR DESCRIPTION
This commit, if applied, adds dependencies between the following
resources in the default HOT template:

- servers require ports
- ports require security groups
- subnet requires network


It tries to fix the network issues we're having on Green.