### PR TITLE
Fix sap-hana: don't lookup EC2 snapshots when cloud is osp

### DIFF
--- a/ansible/configs/sap-hana/find_snapshot.yml
+++ b/ansible/configs/sap-hana/find_snapshot.yml
@@ -1,0 +1,19 @@
+---
+- name: Find out SnapShot ID for SAP Software
+  ec2_snapshot_info:
+    region: "{{ aws_region_final | default(aws_region) }}"
+    aws_access_key: "{{ aws_access_key_id }}"
+    aws_secret_key: "{{ aws_secret_access_key }}"
+    filters:
+      description: "{{ sap_software_snapshot_name }}"
+      owner-id: "{{ sap_software_snapshot_owner_id }}"
+  register: sap_snapshot
+
+- name: Stop the deployment if the snapshot is not available
+  fail:
+    msg: "There are not Snapshots available with SAP Software to be used"
+  when: sap_snapshot.snapshots[0].snapshot_id is not defined
+
+- name: Set local fact for sap_software_snapshot_id
+  set_fact:
+    sap_software_snapshot_id: "{{ sap_snapshot.snapshots[0].snapshot_id }}"

--- a/ansible/configs/sap-hana/pre_infra.yml
+++ b/ansible/configs/sap-hana/pre_infra.yml
@@ -29,21 +29,6 @@
         creates: "{{output_dir}}/{{env_authorized_key}}.pub"
       when: set_env_authorized_key | bool
 
-    - name: Find out SnapShot ID for SAP Software
-      ec2_snapshot_info:
-        region: "{{ aws_region_final | default(aws_region) }}"
-        aws_access_key: "{{ aws_access_key_id }}"
-        aws_secret_key: "{{ aws_secret_access_key }}"
-        filters:
-          description: "{{ sap_software_snapshot_name }}"
-          owner-id: "{{ sap_software_snapshot_owner_id }}" 
-      register: sap_snapshot
-
-    - name: Stop the deployment if the snapshot is not available
-      fail:
-        msg: "There are not Snapshots available with SAP Software to be used"
-      when: sap_snapshot.snapshots[0].snapshot_id is not defined
-
-    - name: Set local fact for sap_software_snapshot_id
-      set_fact:
-        sap_software_snapshot_id: "{{ sap_snapshot.snapshots[0].snapshot_id }}"
+    - name: Include tasks to find snapshot in AWS
+      when: cloud_provider == 'ec2'
+      include_tasks: find_snapshot.yml


### PR DESCRIPTION
This commit fixes the following error:

```
TASK [Find out SnapShot ID for SAP Software] ***********************************
Tuesday 06 October 2020  03:02:38 -0400 (0:00:00.178)       0:00:05.462 ******* 
fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'aws_secret_access_key' is undefined\n\nThe error appears to be in '/tmp/openstack-SAP_E2E_AUTOMATION-prod-9dcc-2818/agnosticd/ansible/configs/sap-hana/pre_infra.yml': line 32, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n    - name: Find out SnapShot ID for SAP Software\n      ^ here\n"}
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME

config sap-hana

