### PR TITLE
kno-osp: Fix facts in clouds.yaml.j2 template

### DIFF
--- a/ansible/configs/kni-osp/files/clouds.yaml.j2
+++ b/ansible/configs/kni-osp/files/clouds.yaml.j2
@@ -2,11 +2,11 @@ clouds:
   {{ osp_project_name }}:
     auth:
       auth_url: "{{ osp_auth_url }}"
-      username: "{{ osp_auth_username_member }}"
+      username: "{{ osp_auth_username_member | default(hostvars.localhost.osp_auth_username_member) }}"
       project_name: "{{ osp_project_name }}"
       project_id: "{{ osp_project_id }}"
       user_domain_name: "Default"
-      password: "{{ osp_auth_password_member }}"
+      password: "{{ osp_auth_password_member | default(hostvars.localhost.osp_auth_password_member) }}"
     region_name: "regionOne"
     interface: "public"
     identity_api_version: 3


### PR DESCRIPTION
This commit, if applied, fixes the following error:

```
TASK [Create clouds.yaml file] *************************************************
Tuesday 06 October 2020  03:59:03 +0000 (0:00:01.900)       0:10:58.291 *******
fatal: [provision]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'osp_auth_username_member' is undefined"}
```

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
