### PR TITLE
Change KNI config, fix osp_project_id in clouds.yml.j2 template

### DIFF
--- a/ansible/configs/kni-osp/files/clouds.yaml.j2
+++ b/ansible/configs/kni-osp/files/clouds.yaml.j2
@@ -4,7 +4,7 @@ clouds:
       auth_url: "{{ osp_auth_url }}"
       username: "{{ osp_auth_username_member | default(hostvars.localhost.osp_auth_username_member) }}"
       project_name: "{{ osp_project_name }}"
-      project_id: "{{ osp_project_id }}"
+      project_id: "{{ osp_project_id | default(hostvars.localhost.osp_project_info[0].id) }}"
       user_domain_name: "Default"
       password: "{{ osp_auth_password_member | default(hostvars.localhost.osp_auth_password_member) }}"
     region_name: "regionOne"

--- a/ansible/configs/kni-osp/files/clouds.yaml.j2
+++ b/ansible/configs/kni-osp/files/clouds.yaml.j2
@@ -3,7 +3,7 @@ clouds:
     auth:
       auth_url: "{{ osp_auth_url }}"
       username: "{{ osp_auth_username_member | default(hostvars.localhost.osp_auth_username_member) }}"
-      project_name: "{{ osp_project_name }}"
+      project_name: "{{ osp_project_name | default(hostvars.localhost.osp_project_info[0].name)}}"
       project_id: "{{ osp_project_id | default(hostvars.localhost.osp_project_info[0].id) }}"
       user_domain_name: "Default"
       password: "{{ osp_auth_password_member | default(hostvars.localhost.osp_auth_password_member) }}"


### PR DESCRIPTION
The variable isn't defined by default, fallback to use the fact osp_project_info.
