### PR TITLE
Change KNI lab, Fix typo in variable name

### DIFF
--- a/ansible/configs/kni-osp/default_vars.yml
+++ b/ansible/configs/kni-osp/default_vars.yml
@@ -64,7 +64,7 @@ openshift_fip_provision: true
 
 kni_ocp_domain: "{{ osp_cluster_dns_zone }}"
 
-kni_pull_secret: '{{ ocp4-token }}'
+kni_pull_secret: '{{ ocp4_token }}'
 
 kni_ocp_version: "4.5.7"
 


### PR DESCRIPTION
This commit, if applied, fixes the following error:

```
TASK [Resolving install-config] ************************************************
Tuesday 06 October 2020  13:09:28 +0000 (0:00:03.089)       0:11:16.083 *******
fatal: [provision]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'ocp4' is undefined"}
```

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
