### PR TITLE
Update MTC (formerly CAM) workloads to MTC 1.3

### DIFF
--- a/ansible/roles/ocp-workload-migration/templates/operator.yml.j2
+++ b/ansible/roles/ocp-workload-migration/templates/operator.yml.j2
@@ -111,6 +111,7 @@ rules:
   - events
   - configmaps
   - secrets
+  - serviceaccounts
   verbs:
   - '*'
 - apiGroups:
@@ -144,6 +145,102 @@ rules:
   verbs:
   - '*'
 ---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: migration-operator
+  namespace: "openshift-migration"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - namespaces
+  - secrets
+  - services
+  verbs:
+  - '*'
+- apiGroups:
+  - noobaa.io
+  resources:
+  - noobaas
+  verbs:
+  - "*"
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - "*"
+- apiGroups:
+  - oauth.openshift.io
+  resources:
+  - oauthclients
+  verbs:
+  - '*'
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - apiservers
+  verbs:
+  - '*'
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - kubeapiservers
+  - authentications
+  verbs:
+  - '*'
+- apiGroups:
+  - migration.openshift.io
+  resources:
+  - migclusters
+  verbs:
+  - '*'
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - infrastructures
+  - clusterversions
+  verbs:
+  - get
+- apiGroups:
+  - rbac.authorization.k8s.io
+  - security.openshift.io
+  - build.openshift.io
+  - migration.openshift.io
+  - velero.io
+  - packages.operators.coreos.com
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+  - patch
+  - create
+  - delete
+  - assign
+  - deletecollection
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  - pods/log
+  verbs:
+  - '*'
+- nonResourceURLs:
+  - '*'
+  verbs:
+  - '*'
+---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -164,7 +261,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: migration-operator
 subjects:
   - kind: ServiceAccount
     name: migration-operator
@@ -189,19 +286,8 @@ spec:
     spec:
       serviceAccountName: migration-operator
       containers:
-      - name: ansible
-        command:
-        - /usr/local/bin/ao-logs
-        - /tmp/ansible-operator/runner
-        - stdout
-        image: registry.redhat.io/rhcam-1-2/{{ mig_migration_namespace }}-rhel7-operator:v1.2
-        imagePullPolicy: Always
-        volumeMounts:
-        - mountPath: /tmp/ansible-operator/runner
-          name: runner
-          readOnly: true
       - name: operator
-        image: registry.redhat.io/rhcam-1-2/{{ mig_migration_namespace }}-rhel7-operator:v1.2
+        image: registry.redhat.io/rhmtc/{{ mig_migration_namespace }}-rhel7-operator:v1.3.0
         imagePullPolicy: Always
         volumeMounts:
         - mountPath: /tmp/ansible-operator/runner
@@ -220,11 +306,11 @@ spec:
         - name: REGISTRY
           value: registry.redhat.io
         - name: PROJECT
-          value: rhcam-1-2
+          value: rhmtc
         - name: HOOK_RUNNER_REPO
           value: {{ mig_migration_namespace }}-hook-runner-rhel7@sha256
         - name: HOOK_RUNNER_TAG
-          value: 86a048f0ee9726b4331d10190dc5851330b66c0326d94652ac07f33a501ae323
+          value: 8a66c13e267050fdcca5612dcbb06ce49f2654ccb17d9e07e3b9eb9f3fca1ea5
         - name: MIG_CONTROLLER_REPO
           value: {{ mig_migration_namespace }}-controller-rhel8@sha256
         - name: MIG_UI_REPO
@@ -232,11 +318,11 @@ spec:
         - name: MIGRATION_REGISTRY_REPO
           value: {{ mig_migration_namespace }}-registry-rhel8@sha256
         - name: MIGRATION_REGISTRY_TAG
-          value: 37536b4487d3668a7105737695a0651e6be64720bc72a69da74153a8443ac9e1
+          value: 9ff723c6dc8371039d20cab26b2c5a6be2fef40c4d5785cd318d8e14fd565faf
         - name: VELERO_REPO
           value: {{ mig_migration_namespace }}-velero-rhel8@sha256
         - name: VELERO_PLUGIN_REPO
-          value: {{ mig_migration_namespace }}-plugin-rhel8@sha256
+          value: openshift-velero-plugin-rhel8@sha256
         - name: VELERO_RESTIC_RESTORE_HELPER_REPO
           value: {{ mig_migration_namespace }}-velero-restic-restore-helper-rhel8@sha256
         - name: VELERO_AWS_PLUGIN_REPO
@@ -246,21 +332,21 @@ spec:
         - name: VELERO_AZURE_PLUGIN_REPO
           value: {{ mig_migration_namespace }}-velero-plugin-for-microsoft-azure-rhel8@sha256
         - name: VELERO_TAG
-          value: 461ea0c165ed525d4276056f6aab879dcf011facb00e94acc88ae6e9f33f1637
+          value: 6ced7586aab260f68b2241faeb25eaaab9b1b8b204360d84dba429259cc8976a
         - name: VELERO_RESTIC_RESTORE_HELPER_TAG
-          value: 356e8d9dede186325e3e4f8700cbde7121b6c4dc35c0099b8337c6cfb83049d8
+          value: 82842581bc1f659c5cf1fbd6828ed5a6e74d7a6fce8437a50db5ace54ccc7f90
         - name: VELERO_PLUGIN_TAG
-          value: 7b6aa42f4428ab744e354c4095afae460b6e5e4e868969a14b4d1aec541a946a
+          value: 77d7aaf48a2fe364165eb50bc10dbbea6a45abfa7565d3c16a1a8d4e5b5386d1
         - name: VELERO_AWS_PLUGIN_TAG
-          value: bfda4f3c7f95993b5f9dace49856b124505e72bd87d42a50918f4194b7e6d7f0
+          value: 0ff4483b225cfad0b71b21a7ea2b8bb3f8e8d9d27de1a42053eb190b22f3a11a
         - name: VELERO_GCP_PLUGIN_TAG
-          value: fa6c5c8dc38b8965dd9eedb9c2a86dc9a8441cb280392961a1b8b42379648014
+          value: b0d20aab3b59907b60b5f97161df87e1d2e55687817fb4d97dbf408432271e2d
         - name: VELERO_AZURE_PLUGIN_TAG
-          value: c8b0fb034244ef9598703ec9534ecfb5c97cff42157d2571eab382bdb1aeb5a2
+          value: 938a2a0bbee15e26c915d94ebd5330ba1ca3be1eeb590d655afeb8ec77d63619
         - name: MIG_UI_TAG
-          value: 6abfaea8ac04e3b5bbf9648a3479b420b4baec35201033471020c9cae1fe1e11
+          value: 12f1de55d7ad30d8ce7b6a62d0f25df0c7357f637bcd14793f2bc36df3341a97
         - name: MIG_CONTROLLER_TAG
-          value: 35c9a554de83d7dc9c560936c297085bbf05b08202885337addb1e4151b40d40
+          value: 7011bc6882205114be8ed20c19f0beb33310aaca726287189744109a29ecee09
       volumes:
         - name: runner
           emptyDir: {}

--- a/ansible/roles/ocp4-workload-migration/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-migration/tasks/workload.yml
@@ -20,6 +20,26 @@
     state: "{{ mig_state }}"
     definition: "{{ lookup('template', 'mig-operator-subscription-downstream.yml.j2' ) }}"
 
+- when: mig_state == 'present'
+  block:
+  - name: "Waiting for install plan to be created"
+    k8s_info:
+      api_version: operators.coreos.com/v1alpha1
+      kind: InstallPlan
+      namespace: openshift-migration
+    register: mtc_install_plans
+    retries: 10
+    until: mtc_install_plans.get('resources', []) | length > 0
+
+  - set_fact:
+      mtc_approved_install_plan: "{{ mtc_install_plans.get('resources', [])[0]
+        | combine({'spec': {'approved': true}}, recursive=true) }}"
+
+  - name: "Approve install plan"
+    k8s:
+      state: present
+      definition: "{{ mtc_approved_install_plan }}"
+
 - name: "Wait for Migration CRDs to exist"
   k8s_info:
     api_version: "apiextensions.k8s.io/v1beta1"

--- a/ansible/roles/ocp4-workload-migration/templates/mig-operator-subscription-downstream.yml.j2
+++ b/ansible/roles/ocp4-workload-migration/templates/mig-operator-subscription-downstream.yml.j2
@@ -1,11 +1,12 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: cam-operator
+  name: mtc-operator
   namespace: {{ mig_migration_namespace }}
 spec:
-  channel: release-v1.2
-  installPlanApproval: Automatic
-  name: cam-operator
+  channel: release-v1.3
+  installPlanApproval: Manual
+  startingCSV: mtc-operator.v1.3.0
+  name: mtc-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

This PR:
- Updates OCP3 migration workload to use latest MTC 1.3.0 release
- Pins down version of OCP4 migration workloads to MTC 1.3.0 using Manual install plan

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp-workload-migration
ocp4-workload-migration

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
