### PR TITLE
Change config ocp4-disconnected-osp-lab to use ocp4_pull_secret

### DIFF
--- a/ansible/configs/ocp4-disconnected-osp-lab/default_vars.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/default_vars.yml
@@ -214,7 +214,7 @@ provider_network: external
 
 test_deploy_enable: false
 test_deploy_results: false
-test_deploy_pull_secret: FROM_SECRET
+test_deploy_pull_secret: "{{ ocp4_pull_secret }}"
 test_deploy_runs: 50
 test_deploy_image: quay.io/nstephan/fio-etcd-osp:v3
 


### PR DESCRIPTION
##### SUMMARY

Change config ocp4-disconnected-osp-lab to use `ocp4_pull_secret` as default value for `test_deploy_pull_secret`. This standardizes the variable name to match `ocp4-cluster` config.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

config ocp4-disconnected-osp-lab