### PR TITLE
smart-management removing redundant key generation

### DIFF
--- a/ansible/configs/smart-management/pre_infra.yml
+++ b/ansible/configs/smart-management/pre_infra.yml
@@ -11,5 +11,6 @@
     - debug:
         msg: "Step 000 Pre Infrastructure"
 
-    - include_role: 
+    - include_role:
         name: infra-local-create-ssh_key
+      when: set_env_authorized_key | bool

--- a/ansible/configs/smart-management/pre_software.yml
+++ b/ansible/configs/smart-management/pre_software.yml
@@ -6,10 +6,6 @@
     - debug:
         msg: "Step 003 Pre Software"
 
-    - import_role:
-        name: infra-local-create-ssh_key
-      when: set_env_authorized_key | bool
-
 - name: Configure all hosts with Repositories
   hosts: all
   become: true


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

Issue with ssh keys in group testing for the RHTR remediation lab. I believe this is being caused by this role accidentally being called more than once.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
smart-management

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
