### PR TITLE
Update set-repositories role to pass consumer_name for registration

### DIFF
--- a/ansible/roles/set-repositories/tasks/satellite-repos.yml
+++ b/ansible/roles/set-repositories/tasks/satellite-repos.yml
@@ -75,22 +75,28 @@
     gather_subset: min
   when: ansible_date_time is not defined
 
-- name: Randomize hostname for Satellite
+- name: Set set_repositories_subscription_hostname with randomization
+  set_fact:
+    set_repositories_subscription_hostname: >-
+      {%- if guid in inventory_hostname -%}
+      {{ inventory_hostname }}-{{ ansible_date_time.iso8601_basic | lower }}
+      {%- else -%}
+      {{ inventory_hostname }}.{{ guid }}.internal-{{ ansible_date_time.iso8601_basic | lower }}
+      {%- endif -%}
+
+- name: Set network.fqdn in /etc/rhsm/facts/katello.facts
   copy:
     dest: /etc/rhsm/facts/katello.facts
-    content: >-
-        {
-          "network.fqdn": {% if guid in inventory_hostname %}
-          "{{ inventory_hostname }}-{{ ansible_date_time.iso8601_basic | lower }}"
-          {% else %}
-          "{{ inventory_hostname }}.{{guid}}.internal-{{ ansible_date_time.iso8601_basic | lower }}" 
-          {% endif %}
-        } 
+    content: "{{ __content | to_json }}"
+  vars:
+    __content:
+      network.fqdn: "{{ set_repositories_subscription_hostname }}"
 
 - name: Register with activation-key
   when: set_repositories_satellite_activationkey != ''
   redhat_subscription:
     state: present
+    consumer_name: "{{ set_repositories_subscription_hostname }}"
     server_hostname: "{{ set_repositories_satellite_hostname }}"
     activationkey: "{{ set_repositories_satellite_activationkey }}"
     org_id: "{{ set_repositories_satellite_org | default(satellite_org) }}"


### PR DESCRIPTION
##### SUMMARY

Update set-repositories role to pass consumer_name for satellite registration. For some reason, setting `network.fqdn` in `/etc/rhsm/facts/katello.facts` was not sufficient.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role set-repositories