### PR TITLE
Rollback #2655 and add retries to the command

### DIFF
--- a/ansible/configs/sap-hana/default_vars.yml
+++ b/ansible/configs/sap-hana/default_vars.yml
@@ -8,7 +8,7 @@ rhel_repos:
    - "rhel-8-for-x86_64-sap-solutions-e4s-rpms"
    - "rhel-8-for-x86_64-sap-netweaver-e4s-rpms"
 
-rhel_lock_release: 8.1
+rhel_lock_release: '8.1'
 
 ## Networking
 subdomain_base_short: "{{ guid }}"

--- a/ansible/configs/sap-hana/pre_software.yml
+++ b/ansible/configs/sap-hana/pre_software.yml
@@ -19,12 +19,6 @@
   tasks:
     - name: Lock RHEL release to SAP supported one
       command: subscription-manager release --set={{ rhel_lock_release }}
-      # redhat_subscription:
-      #   state: present
-      #   server_hostname: "{{ set_repositories_satellite_url }}"
-      #   activationkey: "{{ set_repositories_satellite_activationkey }}"
-      #   org_id: "{{ set_repositories_satellite_org | default(satellite_org) }}"
-      #   release: "{{ rhel_lock_release }}"
       register: lock_result
       until: lock_result is succeeded
       retries: 15

--- a/ansible/configs/sap-hana/pre_software.yml
+++ b/ansible/configs/sap-hana/pre_software.yml
@@ -18,12 +18,13 @@
   gather_facts: False
   tasks:
     - name: Lock RHEL release to SAP supported one
-      redhat_subscription:
-        state: present
-        server_hostname: "{{ set_repositories_satellite_url }}"
-        activationkey: "{{ set_repositories_satellite_activationkey }}"
-        org_id: "{{ set_repositories_satellite_org | default(satellite_org) }}"
-        release: "{{ rhel_lock_release }}"
+      command: subscription-manager release --set={{ rhel_lock_release }}
+      # redhat_subscription:
+      #   state: present
+      #   server_hostname: "{{ set_repositories_satellite_url }}"
+      #   activationkey: "{{ set_repositories_satellite_activationkey }}"
+      #   org_id: "{{ set_repositories_satellite_org | default(satellite_org) }}"
+      #   release: "{{ rhel_lock_release }}"
       register: lock_result
       until: lock_result is succeeded
       retries: 15


### PR DESCRIPTION
Trying to fix:

```
TASK [install common packages for RHEL 8] **************************************
Wednesday 07 October 2020  10:24:48 -0400 (0:00:00.066)       0:03:52.774 ***** 
fatal: [hana-testing-2d84]: FAILED! => {"attempts": 1, "changed": false, "msg": "Failed to download metadata for repo 'rhel-8-for-x86_64-appstream-e4s-rpms'", "rc": 1, "results": []}
fatal: [bastion-testing-2d84]: FAILED! => {"attempts": 1, "changed": false, "msg": "Failed to download metadata for repo 'rhel-8-for-x86_64-highavailability-e4s-rpms'", "rc": 1, "results": []}
fatal: [s4hana-testing-2d84]: FAILED! => {"attempts": 1, "changed": false, "msg": "Failed to download metadata for repo 'rhel-8-for-x86_64-appstream-e4s-rpms'", "rc": 1, "results": []}
fatal: [tower-testing-2d84]: FAILED! => {"attempts": 1, "changed": false, "msg": "Failed to download metadata for repo 'rhel-8-for-x86_64-baseos-e4s-rpms'", "rc": 1, "results": []}
```

There is something weird happening on OSP, and we suspect the subscription task.

- Bugfix Pull Request