### PR TITLE
Introduce ocp4-cluster variable ocp4_network_ovn_install_workaround

### DIFF
--- a/ansible/configs/ocp4-cluster/default_vars.yml
+++ b/ansible/configs/ocp4-cluster/default_vars.yml
@@ -104,6 +104,11 @@ ocp4_base_domain: "example.opentlc.com"
 # OVNKubernetes requires OCP 4.6 and newer
 ocp4_network_type: OpenshiftSDN
 
+# Install the workaround for OVN deployments. Only for 4.6+
+# This is *only* necessary when the cluster will contain
+# Windows nodes. Should be false otherwise.
+ocp4_network_ovn_install_workaround: false
+
 # Run smoketests after installation
 run_smoke_tests: false
 

--- a/ansible/roles/host-ocp4-installer/tasks/main.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/main.yml
@@ -4,11 +4,13 @@
 - name: Generate install_config.yaml
   import_tasks: generate_install_config.yml
 
-# For OVN it is necessary to generate manifests and then change the manifests
+# For Windows Nodes OVN is required.
+# For 4.6 this requires an install workaround to generate
+# manifests and then change the manifests
 # For SDN this is not necessary. Regardless the installation will either generate
 # manifests if there aren't any (default) or use the updated ones (OVN)
 - name: Generate and patch Manifests for OVN
-  when: ocp4_network_type | default("OpenshiftSDN") is match("OVNKubernetes")
+  when: ocp4_network_ovn_install_workaround | bool
   block:
   - name: Run Installer to generate manifests
     become: no
@@ -16,7 +18,7 @@
     - run_installer
     command: openshift-install create manifests --dir=/home/{{ ansible_user }}/{{ cluster_name }}
 
-  - name: Create manifests/cluster-network-03-config.yml for OVN
+  - name: Create install workaround manifests/cluster-network-03-config.yml for OVN
     copy:
       src: ./files/cluster-network-03-config.yml
       dest: "/home/{{ ansible_user }}/{{ cluster_name }}/manifests/cluster-network-03-config.yml"


### PR DESCRIPTION
##### SUMMARY

Introduce a new variable, *ocp4_network_ovn_install_workaround*, for the ocp4-cluster config.
This is necessary to install a workaround during the installation of OCP 4.6+ with OVN Networking. Since this workaround is *only* necessary for Windows nodes set to false by default.

Previous logic would have applied the workaround regardless of need if OVN was selected.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4-cluster
