### PR TITLE
Fix role infra-osp-resources-destroy to detect project from admin

### DIFF
--- a/ansible/roles-infra/infra-osp-resources-destroy/tasks/detect_project.yml
+++ b/ansible/roles-infra/infra-osp-resources-destroy/tasks/detect_project.yml
@@ -1,6 +1,7 @@
 ---
 - name: Get project information
-  environment: "{{ __infra_osp_resources_destroy_environment }}"
+  environment: >-
+    {{ __infra_osp_resources_destroy_environment | combine({"OS_PROJECT_NAME": "admin"}) }}
   os_project_info:
     name: "{{ osp_project_name }}"
   register: r_osp_project


### PR DESCRIPTION
##### SUMMARY

Because this role currently sets the environment variable OS_PROJECT_NAME to be the ansible variable `osp_project_name` we are seeing auth failures on the initial project detection.

This PR forces the detect project to use OS_PROJECT_NAME `admin` for this task.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role infra-osp-resources-destroy