### PR TITLE
New workload: Image Puller Operator

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_image_puller_operator/.yamllint
+++ b/ansible/roles_ocp_workloads/ocp4_workload_image_puller_operator/.yamllint
@@ -1,0 +1,13 @@
+---
+extends: default
+
+rules:
+  comments:
+    require-starting-space: false
+    min-spaces-from-content: 1
+  comments-indentation: disable
+  indentation:
+    indent-sequences: consistent
+  line-length:
+    max: 120
+    allow-non-breakable-inline-mappings: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_image_puller_operator/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_image_puller_operator/defaults/main.yml
@@ -1,0 +1,52 @@
+---
+become_override: false
+ocp_username: opentlc-mgr
+silent: false
+
+# Defaults values below are for OpenShift CodeReady Workspaces installed
+# via the online catalog
+
+ocp4_workload_image_puller_operator_namespace: image-puller-operator
+
+ocp4_workload_image_puller_operator_namespace_display_name: Image Puller Operator
+# Channel to use for the image puller subscription
+ocp4_workload_image_puller_operator_channel: stable
+
+# Set InstallPlan approvel to Automatic? If no it is also suggested
+# to set the starting_csv to pin a specific version
+# This variable has no effect when using a catalog snapshot (always true)
+ocp4_workload_image_puller_operator_automatic_install_plan_approval: true
+
+# Set a starting ClusterServiceVersion.
+# Recommended to leave empty to get latest in the channel when not using
+# a catalog snapshot.
+# Highly recommended to be set when using a catalog snapshot but can be
+# empty to get the latest available in the channel at the time when
+# the catalog snapshot got created.
+ocp4_workload_image_puller_operator_starting_csv: ""
+# ocp4_workload_image_puller_operator_starting_csv: "kubernetes-imagepuller-operator.v0.0.3"
+
+# Images to be managed by the Image Puller operator
+# The default below is for CodeReady Workspaces
+ocp4_workload_image_puller_operator_images: >-
+  maven=registry.redhat.io/codeready-workspaces/plugin-java11-rhel8@sha256:cc6641ec663307133274080b6af1ea4e4cd01bb34a013cda5c42b3d4213a9c72;stacks-java-rhel8=registry.redhat.io/codeready-workspaces/stacks-java-rhel8:2.1;theia-rhel8=registry.redhat.io/codeready-workspaces/theia-rhel8:2.1;stacks-golang-rhel8=registry.redhat.io/codeready-workspaces/stacks-golang-rhel8:2.1;stacks-node-rhel8=registry.redhat.io/codeready-workspaces/stacks-node-rhel8:2.1;theia-endpoint-rhel8=registry.redhat.io/codeready-workspaces/theia-endpoint-rhel8@sha256:434278f521fceca36f651700a2138f3a6a8565d56651719a658c29481725ce5e;pluginbroker-metadata-rhel8=registry.redhat.io/codeready-workspaces/pluginbroker-metadata-rhel8@sha256:bb64697b628c4702ac6887e75378f7d37d6f01b22c07c427844f521410dc945c;pluginbroker-artifacts-rhel8=registry.redhat.io/codeready-workspaces/pluginbroker-artifacts-rhel8@sha256:19ee9a624f66127f224b8e74f5b8c7a9c70eec5d249346157323a59d2e23595a;centos-quarkus-maven=quay.io/eclipse/che-quarkus:nightly;ubi-minimal=registry.access.redhat.com/ubi8-minimal@sha256:372622021a90893d9e25c298e045c804388c7666f3e756cd48f75d20172d9e55;postgresql=postgres;jwtproxy-rhel8=registry.redhat.io/codeready-workspaces/jwtproxy-rhel8@sha256:4bd319a7069fb10a98545ac927b4b20efa6766b2d1c809447267b6668051a05f;ubi-minimal2=registry.access.redhat.com/ubi8/ubi-minimal
+
+# --------------------------------
+# Operator catalog snapshot settings
+# --------------------------------
+# See https://github.com/redhat-cop/agnosticd/blob/development/docs/Catalogs.adoc for
+# instructions on how to set up a catalog snapshot
+# You MUST have your own catalog snapshot for any demo etc.
+
+# Use a catalog snapshot
+ocp4_workload_image_puller_operator_use_catalog_snapshot: false
+
+# Catalog Source Name when using a catalog snapshot. This should be unique
+# in the cluster to avoid clashes
+ocp4_workload_image_puller_operator_snapshot_name: community-operators-snapshot-image-puller
+
+# Catalog snapshot Image
+ocp4_workload_image_puller_operator_catalog_snapshot_image: quay.io/gpte-devops-automation/olm_snapshot_community_catalog
+
+# Catalog snapshot Image Tag
+ocp4_workload_image_puller_operator_catalog_snapshot_image_tag: "v4.5_2020_10_01"

--- a/ansible/roles_ocp_workloads/ocp4_workload_image_puller_operator/meta/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_image_puller_operator/meta/main.yml
@@ -1,0 +1,13 @@
+---
+galaxy_info:
+  role_name: ocp4_workload_image_puller_operator
+  author: Red Hat GPTE, Wolfgang Kulhanek (wkulhane@redhat.com)
+  description: |
+    Set up the Image Puller Operator
+  license: MIT
+  min_ansible_version: 2.9
+  platforms: []
+  galaxy_tags:
+  - ocp
+  - openshift
+dependencies: []

--- a/ansible/roles_ocp_workloads/ocp4_workload_image_puller_operator/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_image_puller_operator/readme.adoc
@@ -1,0 +1,63 @@
+= ocp4_workload_image_puller_operator - Deploy the Image Puller operator to an OpenShift Cluster
+
+== Role overview
+
+* This role installs the Image Puller operator into an OpenShift Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+ environment for the workload deployment.
+*** Debug task will print out: `pre_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the Image Puller operator
+*** This role creates a namespace (project) and deploys the operator.
+*** Debug task will print out: `workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+ configure the workload after deployment
+*** This role doesn't do anything here
+*** Debug task will print out: `post_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+ delete the workload
+*** This role removes the Image Puller operator
+*** Debug task will print out: `remove_workload Tasks completed successfully.`
+
+== Review the defaults variable file
+
+* This file link:./defaults/main.yml[./defaults/main.yml] contains all the variables you need to define to control the deployment of your workload.
+* The variable *ocp_username* is mandatory to assign the workload to the correct OpenShift user.
+* A variable *silent=True* can be passed to suppress debug messages.
+
+
+=== Deploy a Workload with the `ocp-workload` config [Mostly for testing]
+
+Create a file `workload_vars.yaml` with your variables:
+----
+cloud_provider: none
+env_type: ocp-workloads
+target_host: bastion.dev4.openshift.opentlc.com
+
+ocp_workloads:
+- ocp4_workload_image_puller_operator
+
+#become_override: false
+
+# If the ocp-workload supports it, you should specify the OCP user:
+ocp_username: system:admin
+
+# Usually the ocp-workloads want a GUID also:
+guid: changeme
+----
+
+From the Agnosticd/ansible directory run the playbook:
+
+----
+ansible-playbook main.yml -e @workload_vars.yml -e ACTION="create"
+----
+
+=== To Delete an environment
+
+From the Agnosticd/ansible directory run the playbook:
+
+----
+ansible-playbook main.yml -e @workload_vars.yml -e ACTION="remove"
+----

--- a/ansible/roles_ocp_workloads/ocp4_workload_image_puller_operator/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_image_puller_operator/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+# Do not modify this file
+
+- name: Running Pre Workload Tasks
+  include_tasks:
+    file: ./pre_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload Tasks
+  include_tasks:
+    file: ./workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  include_tasks:
+    file: ./post_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload removal Tasks
+  include_tasks:
+    file: ./remove_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles_ocp_workloads/ocp4_workload_image_puller_operator/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_image_puller_operator/tasks/post_workload.yml
@@ -1,0 +1,9 @@
+---
+# Implement your Post Workload deployment tasks here
+
+
+# Leave this as the last task in the playbook.
+- name: post_workload tasks complete
+  debug:
+    msg: "Post-Workload Tasks completed successfully."
+  when: not silent | bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_image_puller_operator/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_image_puller_operator/tasks/pre_workload.yml
@@ -1,0 +1,8 @@
+---
+# Implement your Pre Workload deployment tasks here
+
+# Leave this as the last task in the playbook.
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Workload tasks completed successfully."
+  when: not silent | bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_image_puller_operator/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_image_puller_operator/tasks/remove_workload.yml
@@ -1,0 +1,68 @@
+---
+# Implement your Workload removal tasks here
+
+- name: Remove Kubernetes Image Puller Installation
+  k8s:
+    state: absent
+    api_version: che.eclipse.org/v1alpha1
+    kind: KubernetesImagePuller
+    name: image-puller
+    namespace: "{{ ocp4_workload_image_puller_operator_namespace }}"
+
+- name: Remove Kubernetes Image Puller DaemonSet
+  k8s:
+    state: absent
+    api_version: apps/v1
+    kind: DaemonSet
+    name: k8s-image-puller
+    namespace: "{{ ocp4_workload_image_puller_operator_namespace }}"
+
+- name: Wait until all Kubernetes Image Puller pods have been removed
+  k8s_info:
+    api_version: v1
+    kind: Pod
+    namespace: "{{ ocp4_workload_image_puller_operator_namespace }}"
+  register: r_kip_pods
+  retries: 20
+  delay: 5
+  until: r_kip_pods.resources | length <= 2
+  # The Operator pod will remain the only running pod
+  # For catalog snapshots there will be the catalog pod as well
+
+- name: Get Installed CSV
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: Subscription
+    name: kubernetes-imagepuller-operator
+    namespace: "{{ ocp4_workload_image_puller_operator_namespace }}"
+  register: r_subscription
+
+- name: Remove CSV
+  when:
+  - r_subscription.resources | length > 0
+  - r_subscription.resources[0].status.currentCSV is defined
+  - r_subscription.resources[0].status.currentCSV | length > 0
+  k8s:
+    state: absent
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    name: "{{ r_subscription.resources[0].status.currentCSV }}"
+    namespace: "{{ ocp4_workload_image_puller_operator_namespace }}"
+
+- name: Remove Subscription
+  k8s:
+    state: absent
+    definition: "{{ lookup('template', './templates/subscription.yaml.j2' ) | from_yaml }}"
+
+- name: Remove Kubernetes Image Puller project
+  k8s:
+    state: absent
+    api_version: project.openshift.io/v1
+    kind: Project
+    name: "{{ ocp4_workload_image_puller_operator_namespace }}"
+
+# Leave this as the last task in the playbook.
+- name: remove_workload tasks complete
+  debug:
+    msg: "Remove Workload tasks completed successfully."
+  when: not silent | bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_image_puller_operator/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_image_puller_operator/tasks/workload.yml
@@ -1,0 +1,100 @@
+---
+# Implement your Workload deployment tasks here
+
+- name: Setting up workload for user
+  debug:
+    msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
+
+- name: Create project for the Kubernates Image Puller operator
+  k8s:
+    state: present
+    definition: "{{ lookup('template', './templates/project.yaml.j2' ) | from_yaml }}"
+
+- name: Create Catalogsource for use with catalog snapshot
+  when: ocp4_workload_image_puller_operator_use_catalog_snapshot | bool
+  k8s:
+    state: present
+    definition: "{{ lookup('template', './templates/catalogsource.yaml.j2' ) | from_yaml }}"
+
+- name: Create OpenShift Objects for the Kubernetes Image Puller operator
+  k8s:
+    state: present
+    definition: "{{ lookup('template', item ) | from_yaml }}"
+  loop:
+  - ./templates/operatorgroup.yaml.j2
+  - ./templates/subscription.yaml.j2
+
+- name: Wait until InstallPlan is created
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: InstallPlan
+    namespace: "{{ ocp4_workload_image_puller_operator_namespace }}"
+  register: r_install_plans
+  vars:
+    _query: >-
+      [?starts_with(spec.clusterServiceVersionNames[0], 'kubernetes-imagepuller-operator')]
+  retries: 30
+  delay: 5
+  until:
+  - r_install_plans.resources | length > 0
+  - r_install_plans.resources | to_json | from_json | json_query(_query)
+
+- name: Set InstallPlan Name
+  set_fact:
+    ocp4_workload_image_puller_operator_install_plan_name: >-
+      {{ r_install_plans.resources | to_json | from_json | json_query(query) }}
+  vars:
+    query: >-
+      [?starts_with(spec.clusterServiceVersionNames[0], 'kubernetes-imagepuller-operator')].metadata.name|[0]
+
+- name: Get InstallPlan
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: InstallPlan
+    name: "{{ ocp4_workload_image_puller_operator_install_plan_name }}"
+    namespace: "{{ ocp4_workload_image_puller_operator_namespace }}"
+  register: r_install_plan
+
+- name: Approve InstallPlan if necessary
+  when: r_install_plan.resources[0].status.phase is match("RequiresApproval")
+  k8s:
+    state: present
+    definition: "{{ lookup( 'template', './templates/installplan.yaml.j2' ) }}"
+
+- name: Get Installed CSV
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: Subscription
+    name: kubernetes-imagepuller-operator
+    namespace: "{{ ocp4_workload_image_puller_operator_namespace }}"
+  register: r_subscription
+  retries: 30
+  delay: 5
+  until:
+  - r_subscription.resources[0].status.currentCSV is defined
+  - r_subscription.resources[0].status.currentCSV | length > 0
+
+- name: Wait until CSV is Installed
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    name: "{{ r_subscription.resources[0].status.currentCSV }}"
+    namespace: "{{ ocp4_workload_image_puller_operator_namespace }}"
+  register: r_csv
+  retries: 15
+  delay: 5
+  until:
+  - r_csv.resources[0].status.phase is defined
+  - r_csv.resources[0].status.phase | length > 0
+  - r_csv.resources[0].status.phase == "Succeeded"
+
+- name: Deploy Kubernetes Image Puller instance
+  k8s:
+    state: present
+    definition: "{{ lookup('template', './templates/kubernetes_image_puller.yaml.j2' ) | from_yaml }}"
+
+# Leave this as the last task in the playbook.
+- name: workload tasks complete
+  debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent | bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_image_puller_operator/templates/catalogsource.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_image_puller_operator/templates/catalogsource.yaml.j2
@@ -1,0 +1,9 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: "{{ ocp4_workload_image_puller_operator_snapshot_name }}"
+  namespace: "{{ ocp4_workload_image_puller_operator_namespace }}"
+spec:
+  sourceType: grpc
+  image: "{{ ocp4_workload_image_puller_operator_catalog_snapshot_image }}:{{ ocp4_workload_image_puller_operator_catalog_snapshot_image_tag }}"
+  displayName: "{{ ocp4_workload_image_puller_operator_snapshot_name }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_image_puller_operator/templates/installplan.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_image_puller_operator/templates/installplan.yaml.j2
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: InstallPlan
+metadata:
+  name: "{{ ocp4_workload_image_puller_operator_install_plan_name }}"
+  namespace: "{{ ocp4_workload_image_puller_operator_namespace }}"
+spec:
+  approved: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_image_puller_operator/templates/kubernetes_image_puller.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_image_puller_operator/templates/kubernetes_image_puller.yaml.j2
@@ -1,0 +1,8 @@
+apiVersion: che.eclipse.org/v1alpha1
+kind: KubernetesImagePuller
+metadata:
+  name: image-puller
+  namespace: "{{ ocp4_workload_image_puller_operator_namespace }}"
+spec:
+  daemonsetName: k8s-image-puller
+  images: "{{ ocp4_workload_image_puller_operator_images }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_image_puller_operator/templates/operatorgroup.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_image_puller_operator/templates/operatorgroup.yaml.j2
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata: 
+  name: "{{ ocp4_workload_image_puller_operator_namespace }}-operatorgroup"
+  namespace: "{{ ocp4_workload_image_puller_operator_namespace }}"
+spec:
+  targetNamespaces:
+  - "{{ ocp4_workload_image_puller_operator_namespace }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_image_puller_operator/templates/project.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_image_puller_operator/templates/project.yaml.j2
@@ -1,0 +1,8 @@
+apiVersion: project.openshift.io/v1
+kind: Project
+metadata:
+  annotations:
+    openshift.io/description: ""
+    openshift.io/display-name: "{{ ocp4_workload_image_puller_operator_namespace_display_name }}"
+    openshift.io/requester: "{{ ocp_username }}"
+  name: "{{ ocp4_workload_image_puller_operator_namespace }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_image_puller_operator/templates/subscription.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_image_puller_operator/templates/subscription.yaml.j2
@@ -1,0 +1,23 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: kubernetes-imagepuller-operator
+  namespace: "{{ ocp4_workload_image_puller_operator_namespace }}"
+spec:
+  channel: "{{ ocp4_workload_image_puller_operator_channel }}"
+{% if ocp4_workload_image_puller_operator_automatic_install_plan_approval | default(True) | bool and not ocp4_workload_image_puller_operator_use_catalog_snapshot | default(False) | bool %}
+  installPlanApproval: Automatic
+{% else %}
+  installPlanApproval: Manual
+{% endif %}
+  name: kubernetes-imagepuller-operator
+{% if ocp4_workload_image_puller_operator_use_catalog_snapshot | default(False) | bool %}
+  source: "{{ ocp4_workload_image_puller_operator_snapshot_name }}"
+  sourceNamespace: "{{ ocp4_workload_image_puller_operator_namespace }}"
+{% else %}
+  source: community-operators
+  sourceNamespace: openshift-marketplace
+{% endif %}
+{% if ocp4_workload_image_puller_operator_starting_csv | d("") | length > 0 %}
+  startingCSV: "{{ ocp4_workload_image_puller_operator_starting_csv }}"
+{% endif %}


### PR DESCRIPTION
##### SUMMARY

New reusable workload to deploy the Kubernetes Image Puller operator. This can be used for CRW for example to speed up start of per user workspaces.

Supports Catalog Snapshots

##### ISSUE TYPE
- New role Pull Request

##### COMPONENT NAME
ocp4_workload_image_puller_operator