### PR TITLE
Updated KNI Lab to use a server affinity group to ensure instances al…

### DIFF
--- a/ansible/configs/kni-osp/files/cloud_providers/osp_cloud_template_master.j2
+++ b/ansible/configs/kni-osp/files/cloud_providers/osp_cloud_template_master.j2
@@ -10,6 +10,13 @@ resources:
       name: {{ guid }}-infra_key
       save_private_key: True
 
+  {{ guid }}-serverGroup:
+    type: OS::Nova::ServerGroup
+    properties:
+      name: {{ guid }}-serverGroup
+      policies:
+        - affinity
+
 {% for network in networks %}
   {{ network['name'] }}-network:
     type: OS::Neutron::Net
@@ -107,6 +114,7 @@ resources:
           network_private: { get_resource: {{ network_private }}-network }
           volume_size: {{ instance['rootfs_size'] | default(osp_default_rootfs_size) }}
           key_name: { get_resource: {{ guid }}-infra_key }
+          affinity_group: {get_resource: {{ guid }}-serverGroup }
           security_groups:
 {% for security_group in instance.security_groups %}
             - {{ guid }}-{{ security_group }}

--- a/ansible/configs/kni-osp/files/cloud_providers/osp_cloud_template_nested.j2
+++ b/ansible/configs/kni-osp/files/cloud_providers/osp_cloud_template_nested.j2
@@ -4,6 +4,10 @@ description: Nested HOT for creating instances, ports, & floating IPs. This temp
 
 parameters:
 
+  affinity_group:
+    type: string
+    description: The name of the serverGroup to pass to the scheduler via hints
+
   network_private:
     type: string
     description: The name of the network created by the top level HOT.
@@ -179,6 +183,8 @@ resources:
       name: { get_param: instance_name }
       flavor: { get_param: instance_flavor }
       key_name: { get_param: key_name }
+      scheduler_hints:
+        group: { get_param: affinity_group }
       image: { get_param: instance_image }
       user_data: |
         #cloud-config


### PR DESCRIPTION
##### SUMMARY
Updated the KNI lab config to take advantage of OSP serverGroups to create affinity hints so that all instances build on the same hypervisor, minimizing inter-node communications.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
kni-osp config heat templates

##### ADDITIONAL INFORMATION
Updated the master and nested template to utilize OSP serverGroups to create an affinity hint that builds all instances on the same hypervisor.