### PR TITLE
Updating playbook to prepull image for student

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/workload.yml
@@ -227,6 +227,43 @@
   until:
     - windocr.resources[0].status.ingress[0].host is defined
 
+# Get the running Windows Node
+- name: Get the running Windows Node
+  k8s_info:
+    api_version: v1
+    kind: Node
+    namespace: default
+    label_selectors:
+      - kubernetes.io/os = windows
+  register: winnode
+  retries: 25
+  delay: 5
+  until:
+    - winnode.resources[0].metadata.name is defined
+
+- name: Set Windows Nodename as a fact for later use
+  set_fact:
+    windows_node: "{{ winnode.resources[0].metadata.name }}"
+
+# Create the job that prepulls the Windows container image
+- name: Create the job that prepulls the Windows container image
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'job-image-pull.j2' ) }}"
+
+# Wait for the job to be created (best effort today)
+- name: Wait for the job to be created (best effort today)
+  k8s_info:
+    api_version: batch/v1
+    kind: Job
+    name: windows-image-pull
+    namespace: "{{ ocp4_workload_windows_node_namespace }}"
+  register: windowsjob
+  retries: 25
+  delay: 5
+  until:
+    - windowsjob.resources[0].status.startTime is defined
+
 # Add the route for user info
 - name: Add userinfo of the route
   agnosticd_user_info:

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/templates/job-image-pull.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/templates/job-image-pull.j2
@@ -1,0 +1,30 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  creationTimestamp: null
+  name: windows-image-pull
+  namespace: "{{ ocp4_workload_windows_node_namespace }}"
+spec:
+  template:
+    metadata:
+      creationTimestamp: null
+    spec:
+      containers:
+      - command:
+        - /bin/bash
+        - -c
+        - |
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /tmp/ssh/private-key.pem administrator@{{ windows_node }} docker pull mcr.microsoft.com/windows/servercore:ltsc2019
+        image: quay.io/redhatworkshops/welcome-php:latest
+        name: windows-image-pull
+        volumeMounts:
+        - name: sshkey
+          mountPath: "/tmp/ssh"
+          readOnly: true
+        resources: {}
+      volumes:
+      - name: sshkey
+        secret:
+          secretName: cloud-private-key
+          defaultMode: 0400
+      restartPolicy: Never


### PR DESCRIPTION
##### SUMMARY

Adding task that "prepulls" the Windows base image. This helps by speeding up application deployment since the image is 5GB in size.

This is done by creating a Job that does an `ssh` connection to the Windows node and runs a `docker pull` of the image. This job is run in the same namespace as the operator, so that it may use the same secret needed to ssh into the Windows node.

Right now this is a "best effort" and I only check if the job gets created. The playbook should still succeed even if the job fails. I've accounted for this in my documentation to the student.

##### ISSUE TYPE

- New config Pull Request

##### COMPONENT NAME

- Adding a `job` task.

