### PR TITLE
Disable lfs check

### DIFF
--- a/.github/workflows/lfs.yml
+++ b/.github/workflows/lfs.yml
@@ -2,8 +2,11 @@ name: LFS check
 
 on:
   pull_request:
-    branches:
-      - development
+    # Disable check...
+    #branches:
+    #  - development
+    branches-ignore:
+      - '**'
 
 jobs:
   lfs-warning:


### PR DESCRIPTION
##### SUMMARY

LFS check jobs are all showing canceled with no other information. Disabling for now.

##### ISSUE TYPE

- Issue workaround

##### COMPONENT NAME

LFS check GitHub action