### PR TITLE
updating the windows machine operator namespace

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/defaults/main.yml
@@ -4,7 +4,7 @@ ocp_username: opentlc-mgr
 silent: False
 
 # Defaults values below are for OpenShift Windows Containers - Tech Preview
-ocp4_workload_windows_node_namespace: "windows-machine-config-operator"
+ocp4_workload_windows_node_namespace: "openshift-windows-machine-config-operator"
 ocp4_workload_windows_node_cloud_private_key: "/home/{{ ansible_user }}/.ssh/id_rsa"
 ocp4_workload_windows_node_index_image: "quay.io/redhatworkshops/windows-machine-config-operator-index:v0.0.3"
 ocp4_workload_windows_node_starting_csv: "windows-machine-config-operator.v0.0.3"


### PR DESCRIPTION

##### SUMMARY

The Windows Machine Operator [has changed the namespace it deploys to](https://github.com/openshift/windows-machine-config-operator/blob/master/deploy/namespace.yaml#L4) to be in-line with other OpenShift components.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Windows Machine Config Operator
