### PR TITLE
Open Banking Sandbox CI DEV - use 'template' module as a mid step to process downloaded J2 file

### DIFF
--- a/ansible/roles/ocp4-workload-openbanking-sandbox/tasks/3amp-deploy-full-api.yml
+++ b/ansible/roles/ocp4-workload-openbanking-sandbox/tasks/3amp-deploy-full-api.yml
@@ -11,6 +11,11 @@
 - name: Retrieve the Backend CRD content from Open Banking Sandbox repo into tempfile
   get_url:
     url: "{{ obsandbox_api_crds_base_url + '/backend-' + _api_resource_id + '.yml.j2' }}"
+    dest: "{{ _crd_template.path + '.j2' }}"
+
+- name: Processing tempfile with the CRD template on local filesystem
+  template:
+    src: "{{ _crd_template.path + '.j2' }}"
     dest: "{{ _crd_template.path }}"
 
 - name: Creating the "{{ _api_resource_id }}" Backend CRD provided by 3scale
@@ -19,13 +24,16 @@
     merge_type:
     - strategic-merge
     - merge
-    definition: "{{ lookup('template', _crd_template.path ) | from_yaml }}"
+    definition: "{{ lookup('file', _crd_template.path ) | from_yaml }}"
 
-- name: Remove tempfile created for Backend CRD
+- name: Remove the two tempfiles created for Backend CRD
   file:
-    path: "{{ _crd_template.path }}"
+    path: "{{ item }}"
     state: absent
   when: _crd_template.path is defined
+  loop:
+    - "{{ _crd_template.path }}"
+    - "{{ _crd_template.path + '.j2' }}"
 
 - name: Wait to synchronize the "{{ _api_resource_id }}" Backend CRDs with 3scale
   k8s_info:


### PR DESCRIPTION
##### SUMMARY

Fixes #3033 in order to pass the provisioning test in the DEV SHARED environment.
The resolution is about using the `template` module instead of defining a property with `lookup('template',  <absolute-path>)`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ROLE: ocp4-workload-openbanking-sandbox

##### ADDITIONAL INFORMATION
See #3033 