### PR TITLE
Remove role ocp4_workload_rhtr_xraylab_user extra user info

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhtr_xraylab_user/tasks/workload.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhtr_xraylab_user/tasks/workload.yaml
@@ -124,23 +124,12 @@
     name: cluster
   register: r_api_url
 
-- name: Print user info
-  agnosticd_user_info:
-    msg: "{{ item }}"
-  loop:
-  - "{{ ocp_username }}, which is your OpenTLC User ID, has been setup on the shared lab environment."
-  - "Use this OpenTLC User ID and password to log into your environment."
-  - "You have access to the following projects: {{ ocp4_workload_rhtr_xraylab_user_projects }}"
-  - "Your Object Store access key is: {{ S3_access_key }}"
-  - "Your Object Store secret key is: {{ S3_secret_key }}"
-
 - name: Save user data
   agnosticd_user_info:
     data:
       web_console_url: "https://{{ r_console_route.resources[0].spec.host }}"
       api_url: "{{ r_api_url.resources[0].status.apiServerURL }}"
       login_command: "oc login -u {{ ocp_username }} {{ r_api_url.resources[0].status.apiServerURL }}"
-      project_name: "{{ ocp4_workload_rhtr_xraylab_user_projects }}"
       S3_access_key: "{{ S3_access_key }}"
       S3_secret_key: "{{ S3_secret_key }}"
 


### PR DESCRIPTION
##### SUMMARY

Remove agnosticd_user_info for ocp4_workload_rhtr_xraylab_user to remove redundant information from user info that will be available in the lab instructions.

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME

Role ocp4_workload_rhtr_xraylab_user