### PR TITLE
Add config ansible-gitOps-integration var to suppress user info messages

### DIFF
--- a/ansible/configs/ansible-gitOps-integration/default_vars.yml
+++ b/ansible/configs/ansible-gitOps-integration/default_vars.yml
@@ -33,6 +33,10 @@ ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem
 set_env_authorized_key: true
 key_name: "ocpkey"
 
+# Option to suppress user info messages
+# For production we want to include all access information in the lab instructions.
+ansible_gitops_integration_user_info: true
+
 ## Below used variables are set for Role:set-repsitories
 ## for more details refer to README of the role 
 repo_method: file

--- a/ansible/configs/ansible-gitOps-integration/post_software.yml
+++ b/ansible/configs/ansible-gitOps-integration/post_software.yml
@@ -108,6 +108,7 @@
             - "To Access Control node via SSH:"
             - "ssh {{ student_name }}@{{ groups['bastions'][0] | regex_replace('\\..*$') }}.{{ guid }}.{{ osp_cluster_dns_zone }}"
             - "Enter ssh password when prompted: {{ student_password }}"
+          when: ansible_gitops_integration_user_info | bool
 
         - name: Save user data
           agnosticd_user_info:


### PR DESCRIPTION
##### SUMMARY

Add option to suppress user info messages for lab, making it easier for the user to find the link. All access information should be embedded in lab instructions.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Config ansible-gitOps-integration