### PR TITLE
Modify check for Grafana operator status

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhtr_xraylab_user/tasks/grafana-operator.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhtr_xraylab_user/tasks/grafana-operator.yaml
@@ -27,7 +27,7 @@
   register: grafana_operator_status
   retries: 30
   delay: 5
-  until: grafana_operator_status.resources[0].status.phase == 'Succeeded'
+  until: grafana_operator_status.resources[0].status.phase | default('') == 'Succeeded'
   ignore_errors: false
 
 - name: Patch Grafana operator


### PR DESCRIPTION
Under load, the Grafana operator may take time to produce a status. The check was failing because the Phase entry was non existent, so could not even be checked if Succeeded.
Patched sets a default value for the check to happen.