### PR TITLE
Update role ocp4_workload_quarkus_workshop_user to fix destroy issue

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/main.yml
@@ -7,7 +7,7 @@
     file: ./pre_workload.yml
     apply:
       become: "{{ become_override | bool }}"
-  when: ACTION == "create" or ACTION == "provision" or ACTION == "remove"
+  when: ACTION in ("create", "provision", "remove", "destroy")
 
 - name: Running Workload Tasks
   include_tasks:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Append a condition('destroy') to execute the pre_workload task.

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
