### PR TITLE
XRay Lab - Allow both secure and insecure traffic on the RGW

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhtr_xraylab/templates/storage/rgw_objectstore.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhtr_xraylab/templates/storage/rgw_objectstore.yaml.j2
@@ -105,6 +105,9 @@ items:
       weight: 100
     port:
       targetPort: http
+    tls:
+      termination: edge
+      insecureEdgeTerminationPolicy: Allow
     wildcardPolicy: None
 kind: List
 metadata:


### PR DESCRIPTION
Initially the RGW in OCS is set up to handle http traffic only. This is problematic when the Lab is used with browsers with restrictions in mixed traffic (http/https). This is a small patch on the route to allow both traffics on the same Route.