### PR TITLE
Update ocp4_workload_quarkus_workshop_user workload to fix Print module info

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/post_workload.yml
@@ -10,7 +10,7 @@
       Module {{ocp4_workshop_quarkus_workshop_user_module_titles[item].title}}:
       {{ 'http://web-{}-quarkus-{}-guides.{}{}?userid={}&guid={}'.format(
         item, guid, route_subdomain,
-        ocp4_workshop_quarkus_workshop_user_module_titles[item].path
+        ocp4_workshop_quarkus_workshop_user_module_titles[item].path,
         ocp_username | urlencode, guid | urlencode
       ) }}
   loop: "{{ modules }}"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Add comma(,) to fix Print module info in ocp4_workload_quarkus_workshop_user workload 
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
