### PR TITLE
Fix role ocp4_workload_dso registry route detection

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_dso/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_dso/defaults/main.yml
@@ -52,9 +52,6 @@ ocp4_dso_reponame: SecurityDemos
 # Path of spring boot application build by pipeline
 ocp4_dso_demoapp_location: 2020Labs/OpenShiftSecurity/spring-boot-angular-ecommerce
 
-# Used by docker daemon on bastion for looking up quay images that are pushed by pipeline
-ocp4_dso_ocp_registry_route: unset
-
 # Used for deployment of gogs, sonarqube, and nexus with persistent storage
 ocp4_dso_ephemeral: false
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_dso/tasks/infrastructure.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_dso/tasks/infrastructure.yml
@@ -24,16 +24,20 @@
     state: restarted
   become: true
 
-- name: retrieve registry route
+- name: Retrieve registry route
   k8s_info:
     api_version: route.openshift.io/v1
     kind: route
     name: default-route
     namespace: openshift-image-registry
-  register: image_route
+  register: r_get_registry_route
+  failed_when: >-
+    not r_get_registry_route is success or
+    r_get_registry_route.resources | length != 1
 
-- set_fact:
-    ocp4_dso_ocp_registry_route:  "{{ image_route | json_query('resources[*].spec.host') | first }}"
+- name: Set ocp4_dso_ocp_registry_route
+  set_fact:
+    ocp4_dso_ocp_registry_route:  "{{ r_get_registry_route.resources[0].spec.host }}"
 
 - name: add exposed registry as insecure
   template:
@@ -110,11 +114,6 @@
   ignore_errors: true
   changed_when: false
   tags: always
-
-- name: expose registry
-  command: "{{ ocp4_dso_openshift_cli }} create route passthrough --service=image-registry -n openshift-image-registry"
-  tags: always
-  ignore_errors: true
 
 - name: create project {{ ocp4_admin_project }}
   command: "{{ ocp4_dso_openshift_cli }} new-project {{ ocp4_admin_project }}"


### PR DESCRIPTION
##### SUMMARY

Minor fix-up for ocp4_workload_dso registry route detection. This adds a failure condition to the step when getting the route to make failure more obvious.

Also remove step to expose the registry as this task will have failed here if the registry were not already exposed.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role ocp4_workload_dso