### PR TITLE
Delete RHCos image if it exists on OpenStack

### DIFF
--- a/ansible/configs/ocp4-cluster/destroy_env_osp.yml
+++ b/ansible/configs/ocp4-cluster/destroy_env_osp.yml
@@ -24,5 +24,20 @@
     - openshift_fip_provision
     - use_dynamic_dns
 
+# OpenShift IPI Install creates an RH CoreOS Image in OpenStack (qcow2 format)
+# Delete the image if it exists
+# Image is named something like `cluster-wkrhtr-77jgv-rhcos` where `cluster-wkrhtr-77jgv` is
+# the name of the cluster
+- name: Get Cluster Name
+  k8s_info:
+    api_version: config.openshift.io/v1
+    kind: Infrastructure
+    name: cluster
+  register: r_infrastructure
+- name: Delete CoreOS Image if it exists
+  os_image:
+    state: absent
+    name: "{{ r_infrastructure.resources[0].status.infrastructureName }}-rhcos"
+
 - name: Import default cloud provider destroy playbook
   import_playbook: "../../cloud_providers/{{ cloud_provider }}_destroy_env.yml"


### PR DESCRIPTION
##### SUMMARY

@marcosmamorim noticed that ocp4-cluster configs left qcow2 images in the OpenStack cluster after deletion.
This PR cleans this up.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-cluster
