### PR TITLE
Fix missing default on ovn_workaround

### DIFF
--- a/ansible/roles/host-ocp4-installer/tasks/main.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/main.yml
@@ -10,7 +10,7 @@
 # For SDN this is not necessary. Regardless the installation will either generate
 # manifests if there aren't any (default) or use the updated ones (OVN)
 - name: Generate and patch Manifests for OVN
-  when: ocp4_network_ovn_install_workaround | bool
+  when: ocp4_network_ovn_install_workaround | default(false) | bool
   block:
   - name: Run Installer to generate manifests
     become: no


### PR DESCRIPTION
##### SUMMARY

Bug fix: ocp4_network_ovn_install_workaround didn't have a default where checked to prevent configs other than ocp4-cluster from failing.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
host_ocp4_installer
