### PR TITLE
poll_email.py: Deal with Socket errors

### DIFF
--- a/tests/jenkins/downstream/poll_email.py
+++ b/tests/jenkins/downstream/poll_email.py
@@ -6,6 +6,7 @@ import re
 import os
 import sys
 import argparse
+from socket import error as SocketError
 from time import sleep
 
 credentials = os.environ['credentials']
@@ -103,6 +104,12 @@ def wait_email(pattern, time_window):
 
         except imaplib.IMAP4.error as err:
             print("IMAP4 error: {0}".format(err))
+            print("reconnecting")
+            # reconnect
+            disconnect(M)
+            M = connect()
+        except SocketError as err:
+            print("SOCKET error: {0}".format(err))
             print("reconnecting")
             # reconnect
             disconnect(M)


### PR DESCRIPTION
This change fixes the following error in jenkins:

```+ ./tests/jenkins/downstream/poll_email.py --server imap.gmail.com --guid 18f2 --timeout 40 --filter 'has completed'
Traceback (most recent call last):
  File "./tests/jenkins/downstream/poll_email.py", line 120, in <module>
    args.timeout))
  File "./tests/jenkins/downstream/poll_email.py", line 78, in wait_email
    M.select('INBOX')
  File "/usr/lib64/python2.7/imaplib.py", line 662, in select
    typ, dat = self._simple_command(name, mailbox)
  File "/usr/lib64/python2.7/imaplib.py", line 1083, in _simple_command
    return self._command_complete(name, self._command(name, *args))
  File "/usr/lib64/python2.7/imaplib.py", line 910, in _command_complete
    typ, data = self._get_tagged_response(tag)
  File "/usr/lib64/python2.7/imaplib.py", line 1012, in _get_tagged_response
    self._get_response()
  File "/usr/lib64/python2.7/imaplib.py", line 929, in _get_response
    resp = self._get_line()
  File "/usr/lib64/python2.7/imaplib.py", line 1022, in _get_line
    line = self.readline()
  File "/usr/lib64/python2.7/imaplib.py", line 1184, in readline
    return self.file.readline()
  File "/usr/lib64/python2.7/socket.py", line 447, in readline
    data = self._sock.recv(self._rbufsize)
  File "/usr/lib64/python2.7/ssl.py", line 757, in recv
    return self.read(buflen)
  File "/usr/lib64/python2.7/ssl.py", line 651, in read
    v = self._sslobj.read(len or 1024)```


- Test Pull Request
