### PR TITLE
Fix role ocp4_workload_dso to set ocp4_dso_ocp_registry_route in pre_workload

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_dso/tasks/infrastructure.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_dso/tasks/infrastructure.yml
@@ -24,21 +24,6 @@
     state: restarted
   become: true
 
-- name: Retrieve registry route
-  k8s_info:
-    api_version: route.openshift.io/v1
-    kind: route
-    name: default-route
-    namespace: openshift-image-registry
-  register: r_get_registry_route
-  failed_when: >-
-    not r_get_registry_route is success or
-    r_get_registry_route.resources | length != 1
-
-- name: Set ocp4_dso_ocp_registry_route
-  set_fact:
-    ocp4_dso_ocp_registry_route:  "{{ r_get_registry_route.resources[0].spec.host }}"
-
 - name: add exposed registry as insecure
   template:
     src: daemon.json.j2

--- a/ansible/roles_ocp_workloads/ocp4_workload_dso/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_dso/tasks/pre_workload.yml
@@ -28,6 +28,21 @@
   set_fact:
     ocp4_dso_gogs_generate_user_count: "{{ user_count_end }}"
 
+- name: Retrieve registry route
+  k8s_info:
+    api_version: route.openshift.io/v1
+    kind: route
+    name: default-route
+    namespace: openshift-image-registry
+  register: r_get_registry_route
+  failed_when: >-
+    not r_get_registry_route is success or
+    r_get_registry_route.resources | length != 1
+
+- name: Set ocp4_dso_ocp_registry_route
+  set_fact:
+    ocp4_dso_ocp_registry_route:  "{{ r_get_registry_route.resources[0].spec.host }}"
+
 - name: extract route_subdomain
   k8s_info:
     kind: Ingress


### PR DESCRIPTION
##### SUMMARY

The  variable ocp4_dso_ocp_registry_route is referenced in the pre_workload.yml and so needs to be set before use there.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role ocp4_workload_dso