### PR TITLE
Update migration workloads to MTC 1.3.1

### DIFF
--- a/ansible/roles/ocp-workload-migration/templates/operator.yml.j2
+++ b/ansible/roles/ocp-workload-migration/templates/operator.yml.j2
@@ -287,7 +287,7 @@ spec:
       serviceAccountName: migration-operator
       containers:
       - name: operator
-        image: registry.redhat.io/rhmtc/{{ mig_migration_namespace }}-rhel7-operator:v1.3.0
+        image: registry.redhat.io/rhmtc/{{ mig_migration_namespace }}-rhel7-operator:v1.3.1
         imagePullPolicy: Always
         volumeMounts:
         - mountPath: /tmp/ansible-operator/runner
@@ -310,7 +310,7 @@ spec:
         - name: HOOK_RUNNER_REPO
           value: {{ mig_migration_namespace }}-hook-runner-rhel7@sha256
         - name: HOOK_RUNNER_TAG
-          value: 8a66c13e267050fdcca5612dcbb06ce49f2654ccb17d9e07e3b9eb9f3fca1ea5
+          value: 779af420a02683fc8288b56d70e1d026fdc790f7248d4aa68a256b811c20608e
         - name: MIG_CONTROLLER_REPO
           value: {{ mig_migration_namespace }}-controller-rhel8@sha256
         - name: MIG_UI_REPO
@@ -318,7 +318,7 @@ spec:
         - name: MIGRATION_REGISTRY_REPO
           value: {{ mig_migration_namespace }}-registry-rhel8@sha256
         - name: MIGRATION_REGISTRY_TAG
-          value: 9ff723c6dc8371039d20cab26b2c5a6be2fef40c4d5785cd318d8e14fd565faf
+          value: 68d1d072d485ed79e16a4808f39dd62745b1a308b7278ba50268bce0915f492b
         - name: VELERO_REPO
           value: {{ mig_migration_namespace }}-velero-rhel8@sha256
         - name: VELERO_PLUGIN_REPO
@@ -332,21 +332,21 @@ spec:
         - name: VELERO_AZURE_PLUGIN_REPO
           value: {{ mig_migration_namespace }}-velero-plugin-for-microsoft-azure-rhel8@sha256
         - name: VELERO_TAG
-          value: 6ced7586aab260f68b2241faeb25eaaab9b1b8b204360d84dba429259cc8976a
+          value: b9297b801115abe344cf85f78fa895d5eb8f05b56993d73cf84984c0ef106bd3
         - name: VELERO_RESTIC_RESTORE_HELPER_TAG
-          value: 82842581bc1f659c5cf1fbd6828ed5a6e74d7a6fce8437a50db5ace54ccc7f90
+          value: c2a30aed87caddfa95d15fd1363c4ed3e02803e84a627b64f9d31a5206ddc51d
         - name: VELERO_PLUGIN_TAG
-          value: 77d7aaf48a2fe364165eb50bc10dbbea6a45abfa7565d3c16a1a8d4e5b5386d1
+          value: f82430cceadd4a45696bb4ea84ee5f72365b0a92c3b6880fac724cae086e37fb
         - name: VELERO_AWS_PLUGIN_TAG
-          value: 0ff4483b225cfad0b71b21a7ea2b8bb3f8e8d9d27de1a42053eb190b22f3a11a
+          value: cae3f43d754c0b8d334c22fe50c8dbbda78953813819674ee66dc99d8e9ca259
         - name: VELERO_GCP_PLUGIN_TAG
-          value: b0d20aab3b59907b60b5f97161df87e1d2e55687817fb4d97dbf408432271e2d
+          value: 510953b3c2c930f436f70e8ffbc717e5c33bf3164668c3953b3d820b417ad048
         - name: VELERO_AZURE_PLUGIN_TAG
-          value: 938a2a0bbee15e26c915d94ebd5330ba1ca3be1eeb590d655afeb8ec77d63619
+          value: df27eabda39e07c18e995ff528a31540999088039b1fe8766a66247b9f718813
         - name: MIG_UI_TAG
-          value: 12f1de55d7ad30d8ce7b6a62d0f25df0c7357f637bcd14793f2bc36df3341a97
+          value: 029b0cc4ae4855a290241b240c8360c0fac831f3d5a2d554450c38133a220811
         - name: MIG_CONTROLLER_TAG
-          value: 7011bc6882205114be8ed20c19f0beb33310aaca726287189744109a29ecee09
+          value: 6141fd9a8670ba59245d3429d88ace528851974042ab7261b443bc6899ca44b1
       volumes:
         - name: runner
           emptyDir: {}

--- a/ansible/roles/ocp4-workload-migration/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-migration/tasks/workload.yml
@@ -28,7 +28,7 @@
       kind: InstallPlan
       namespace: openshift-migration
     register: mtc_install_plans
-    retries: 10
+    retries: 20
     until: mtc_install_plans.get('resources', []) | length > 0
 
   - set_fact:

--- a/ansible/roles/ocp4-workload-migration/templates/mig-operator-subscription-downstream.yml.j2
+++ b/ansible/roles/ocp4-workload-migration/templates/mig-operator-subscription-downstream.yml.j2
@@ -6,7 +6,7 @@ metadata:
 spec:
   channel: release-v1.3
   installPlanApproval: Manual
-  startingCSV: mtc-operator.v1.3.0
+  startingCSV: mtc-operator.v1.3.1
   name: mtc-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

Updates migration workloads from MTC 1.3.0 to 1.3.1
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp-workload-migration
ocp4-workload-migration

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
