### PR TITLE
Add test to kn download if it doesn't exist.

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/workload.yml
@@ -176,39 +176,44 @@
     namespace: knative-serving
   register: r_kn_download
 
-- name: Download kn cli tool from cluster
-  get_url:
-    url: "http://{{ r_kn_download.resources[0].status.ingress[0].host }}/amd64/linux/kn-linux-amd64.tar.gz"
-    validate_certs: false
-    dest: /tmp/kn-linux-amd64.tar.gz
-    mode: 0660
-  register: r_kn
-  until: r_kn is success
-  retries: 10
-  delay: 10
+- name: Install the kn cli tool if the kn-cli-downloads route exists
+  when:
+  - r_kn_download.resources is defined
+  - r_kn_download.resources | length == 1
+  block:
+  - name: Download kn cli tool from cluster
+    get_url:
+      url: "http://{{ r_kn_download.resources[0].status.ingress[0].host }}/amd64/linux/kn-linux-amd64.tar.gz"
+      validate_certs: false
+      dest: /tmp/kn-linux-amd64.tar.gz
+      mode: 0660
+    register: r_kn
+    until: r_kn is success
+    retries: 10
+    delay: 10
 
-- name: Install kn CLI on bastion
-  become: true
-  unarchive:
-    src: /tmp/kn-linux-amd64.tar.gz
-    remote_src: yes
-    dest: /usr/bin
-    mode: 0775
-    owner: root
-    group: root
-  args:
-    creates: /usr/bin/kn
+  - name: Install kn CLI on bastion
+    become: true
+    unarchive:
+      src: /tmp/kn-linux-amd64.tar.gz
+      remote_src: yes
+      dest: /usr/bin
+      mode: 0775
+      owner: root
+      group: root
+    args:
+      creates: /usr/bin/kn
 
-- name: Remove downloaded file
-  file:
-    state: absent
-    path: /tmp/kn-linux-amd64.tar.gz
+  - name: Remove downloaded file
+    file:
+      state: absent
+      path: /tmp/kn-linux-amd64.tar.gz
 
-- name: Create kn bash completion file
-  become: true
-  command: /usr/bin/kn completion bash >/etc/bash_completion.d/kn
-  args: 
-    creates: /etc/bash_completion.d/kn
+  - name: Create kn bash completion file
+    become: true
+    command: /usr/bin/kn completion bash >/etc/bash_completion.d/kn
+    args: 
+      creates: /etc/bash_completion.d/kn
 
 # Leave this as the last task in the playbook.
 - name: workload tasks complete


### PR DESCRIPTION
##### SUMMARY

In OpenShift Serverless 1.10 the kn-cli-download route does no longer seem to be created.
Therefore add a test  to only try to download the kn cli if the route exists.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_serverless
