### PR TITLE
Don't create resources directory on bastion by default

### DIFF
--- a/ansible/roles/host-ocp4-provisioner/tasks/osp_prereqs.yml
+++ b/ansible/roles/host-ocp4-provisioner/tasks/osp_prereqs.yml
@@ -69,14 +69,6 @@
     regexp: "^export OS_CLOUD"
     line: "export OS_CLOUD={{ osp_cloud_name }}"
 
-- name: Create resources directory
-  file:
-    path: "/home/{{ ansible_user }}/resources"
-    state: directory
-    owner: "{{ ansible_user }}"
-    group: users
-    mode: 0744
-
 - name: Set OpenStack Object Store Account
   when: osp_use_swift | d(True) | bool
   command: >-


### PR DESCRIPTION
##### SUMMARY

OCP 4 Provisioner would always create a directory /home/{{ ansible_user }}/resources on the bastion. This is not necessary. Remove the creation of this directory (the ocp4_disconnected_lab is the only config that needs this and creates the directory anyway).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
host_ocp4_provisioner