### PR TITLE
Fix intermittent failure of oc import

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_dso/tasks/install-codeready.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_dso/tasks/install-codeready.yaml
@@ -141,5 +141,9 @@
   until: r_stack_is.resources | list | length == 1
 
 - name: import stack image
-  shell: |
-    oc import-image --all quarkus-stack -n openshift
+  command: >-
+    {{ ocp4_dso_openshift_cli }} import-image --all quarkus-stack -n openshift
+  register: r_import_image
+  until: r_import_image is success
+  retries: 5
+  delay: 10


### PR DESCRIPTION
##### SUMMARY

The import of the quarkus-stack image in the `ocp_workload_dso` role can result in an intermittent failure. Error log output included at the end of this description. This appears to be a timing issue between the creation of the image stream and import of the images. The import has been updated with retries and a ten second delay to mitigate potential concurrency issues.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp_workload_dso role

##### ADDITIONAL INFORMATION

Error log output
```
TASK [ocp4_workload_dso : import stack image] **********************************
Wednesday 21 October 2020  15:06:29 -0400 (0:00:01.163)       1:27:51.867 *****
fatal: [bastion.7e01.internal]: FAILED! => {"changed": true, "cmd": "oc import-image --all quarkus-stack -n openshift\n", "delta":
"0:00:00.142603", "end": "2020-10-21 19:06:29.498440", "msg": "non-zero return code", "rc": 1, "start": "2020-10-21
19:06:29.355837", "stderr": "Error from server (Conflict): Operation cannot be fulfilled on imagestream.image.openshift.io 
\"quarkus-stack\": the image stream was updated from \"45804\" to \"45815\"", "stderr_lines": ["Error from server (Conflict): 
Operation cannot be fulfilled on imagestream.image.openshift.io \"quarkus-stack\": the image stream was updated from \"45804\" 
to \"45815\""], "stdout": "", "stdout_lines": []}
```
