### PR TITLE
Fix permissions issues with vscode extensions belonging to root

### DIFF
--- a/ansible/roles/vscode-server/tasks/vscode-server.yml
+++ b/ansible/roles/vscode-server/tasks/vscode-server.yml
@@ -35,6 +35,7 @@
     url: "https://gpte-public.s3.amazonaws.com/vscode-plugins/{{ __default_extension }}"
     dest: /home/{{ vscode_user_name }}/.local/share/code-server/extensions/
     validate_certs: no
+    owner: "{{ vscode_user_name }}"
   loop: "{{ vscode_server_default_extensions }}"
   loop_control:
     loop_var: __default_extension
@@ -45,6 +46,7 @@
     url: "{{ __additional_extension }}"
     dest: /home/{{ vscode_user_name }}/.local/share/code-server/extensions/
     validate_certs: no
+    owner: "{{ vscode_user_name }}"
   loop: "{{ vscode_server_extension_urls }}"
   loop_control:
     loop_var: __additional_extension


### PR DESCRIPTION
##### SUMMARY

vscoder-server role pulls in the extensions into the vscode user homedir as root, extensions are 700 root and this can create issues installing them as another user e.g. devops

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
role vscode-server

##### ADDITIONAL INFORMATION
