### PR TITLE
fixing role name.

### DIFF
--- a/ansible/configs/amq-messaging-foundations/software.yml
+++ b/ansible/configs/amq-messaging-foundations/software.yml
@@ -14,7 +14,7 @@
   tasks:
     - name: Set up Client VM for AMQ messaging foundations
       include_role:
-        name: "amq-client-vm"
+        name: "amq-messaging-foundations"
 
 - name: Software flight-check
   hosts: localhost


### PR DESCRIPTION
SUMMARY
When try to provisioning the environment the agnosticv is expecting amq-messaging-foundations role. Since the role it's not matching the environment is not being provisioned.

ISSUE TYPE
- Bugfix Pull Request

COMPONENT NAME
amq-messaging-foundations
