### PR TITLE
Updates for Serverless 1.10+ (and ConsoleCLIDownload CRs)

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/defaults/main.yml
@@ -10,7 +10,7 @@ silent: False
 # OpenShift version this operator is installed on. If there is no matchin
 # version use the `defaultChannel`
 ocp4_workload_serverless_channel: ""
-# ocp4_workload_serverless_channel: "4.5"
+# ocp4_workload_serverless_channel: "4.6"
 
 # Set automatic InstallPlan approval. If set to false it is also suggested
 # to set the starting_csv to pin a specific version
@@ -24,7 +24,7 @@ ocp4_workload_serverless_automatic_install_plan_approval: true
 # empty to get the latest available in the channel at the time when
 # the catalog snapshot got created.
 ocp4_workload_serverless_starting_csv: ""
-# ocp4_workload_serverless_starting_csv: "serverless-operator.v1.7.2"
+# ocp4_workload_serverless_starting_csv: "serverless-operator.v1.10.0"
 
 # Wait for the deployment to finish - and check that it finished successfully
 ocp4_workload_serverless_wait_for_deploy: true
@@ -50,4 +50,4 @@ ocp4_workload_serverless_catalogsource_name: redhat-operators-snapshot-serverles
 ocp4_workload_serverless_catalog_snapshot_image: quay.io/gpte-devops-automation/olm_snapshot_redhat_catalog
 
 # Catalog snapshot image tag
-ocp4_workload_serverless_catalog_snapshot_image_tag: "v4.4_2020_07_23"
+ocp4_workload_serverless_catalog_snapshot_image_tag: "v4.6_2020_10_26"

--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/defaults/main.yml
@@ -50,4 +50,4 @@ ocp4_workload_serverless_catalogsource_name: redhat-operators-snapshot-serverles
 ocp4_workload_serverless_catalog_snapshot_image: quay.io/gpte-devops-automation/olm_snapshot_redhat_catalog
 
 # Catalog snapshot image tag
-ocp4_workload_serverless_catalog_snapshot_image_tag: "v4.6_2020_10_26"
+ocp4_workload_serverless_catalog_snapshot_image_tag: "v4.6_2020_10_28"

--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/workload.yml
@@ -168,22 +168,41 @@
     - r_kn_eventing.resources[0].status.conditions[1].status is defined
     - r_kn_eventing.resources[0].status.conditions[1].status == "True"
 
-- name: Get kn download route
+- name: Get kn ConsoleCLIDownload
   k8s_info:
-    api_version: route.openshift.io/v1
-    kind: Route
-    name: kn-cli-downloads
-    namespace: knative-serving
-  register: r_kn_download
+    api_version: console.openshift.io/v1
+    kind: ConsoleCLIDownload
+    name: kn
+  register: r_kn_cli_download
 
-- name: Install the kn cli tool if the kn-cli-downloads route exists
-  when:
-  - r_kn_download.resources is defined
-  - r_kn_download.resources | length == 1
+- name: Get kn download URL
+  when: r_kn_cli_download.resources | length > 0
+  set_fact:
+    __ocp4_workload_serverless_kn_url: >-
+      {{ r_kn_cli_download.resources[0] | to_json | from_json
+       | json_query("spec.links[?contains(href,'-linux-amd64')].href") | first }}
+
+- name: No ConsoleCLIDownload for kn - try Route instead
+  when: r_kn_cli_download.resources | length == 0
   block:
-  - name: Download kn cli tool from cluster
+  - name: Get kn download route
+    k8s_info:
+      api_version: route.openshift.io/v1
+      kind: Route
+      name: kn-cli-downloads
+      namespace: knative-serving
+    register: r_kn_download
+
+  - name: get kn download URL
+    set_fact:
+      __ocp4_workload_serverless_kn_url: "{{ r_kn_download.resources[0].status.ingress[0].host }}/amd64/linux/kn-linux-amd64.tar.gz"
+
+- name: Install kn cli tool if a download URL was found
+  when: __ocp4_workload_serverless_kn_url is defined
+  block:
+  - name: Download kn cli tool
     get_url:
-      url: "http://{{ r_kn_download.resources[0].status.ingress[0].host }}/amd64/linux/kn-linux-amd64.tar.gz"
+      url: "{{ __ocp4_workload_serverless_kn_url }}"
       validate_certs: false
       dest: /tmp/kn-linux-amd64.tar.gz
       mode: 0660
@@ -211,7 +230,7 @@
 
   - name: Create kn bash completion file
     become: true
-    command: /usr/bin/kn completion bash >/etc/bash_completion.d/kn
+    shell: /usr/bin/kn completion bash >/etc/bash_completion.d/kn
     args: 
       creates: /etc/bash_completion.d/kn
 


### PR DESCRIPTION
##### SUMMARY

OpenShift Serverless 1.10+ does no longer create a Route to download the kn CLI tool. It uses the "ConsoleCLIDownload" custom resource instead. This PR checks if this CR exists and if so uses it. Otherwise it looks for the route. And if that doesn't exist either the kn tool is not installed.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_serverless
