### PR TITLE
Change workload ocp4-workload-migration to use default MCG Route instead of Service endpoint

### DIFF
--- a/ansible/roles/ocp4-workload-migration/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-migration/defaults/main.yml
@@ -17,7 +17,7 @@ migration_workload_destroy: "{{ false if (ACTION=='create' or ACTION=='provision
 migration_workload_title: "{{ 'Creating' if not migration_workload_destroy else 'Removing' }}"
 migration_workload_state: "{{ 'present' if not migration_workload_destroy else 'absent' }}"     # state of k8s resources
 silent: false
-noobaa_s3_endpoint_proto: http
+noobaa_s3_endpoint_proto: https
 ocs_migstorage: false
 ocs_migstorage_bucketname: migstorage
 ocs_migstorage_namespace: openshift-migration

--- a/ansible/roles/ocp4-workload-migration/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-migration/tasks/workload.yml
@@ -76,8 +76,8 @@
   block:
   - name: Discovering NooBaa S3 endpoint
     k8s_info:
-      api_version: v1
-      kind: Service
+      api_version: route.openshift.io/v1
+      kind: Route
       name: s3
       namespace: "{{ ocs_migstorage_namespace }}"
     register: noobaa_s3_endpoint
@@ -85,15 +85,14 @@
     delay: 3
     until: noobaa_s3_endpoint.resources is defined and
            noobaa_s3_endpoint.resources[0] is defined and
-           noobaa_s3_endpoint.resources[0].status.loadBalancer is defined and
-           noobaa_s3_endpoint.resources[0].status.loadBalancer.ingress is defined
+           noobaa_s3_endpoint.resources[0].status.ingress is defined
 
   - set_fact:
-      noobaa_endpoint: "{{ noobaa_s3_endpoint.resources[0].status.loadBalancer.ingress[0].ip }}"
-    when: noobaa_s3_endpoint.resources[0].status.loadBalancer.ingress[0].ip is defined
+      noobaa_endpoint: "{{ noobaa_s3_endpoint.resources[0].status.ingress[0].host }}"
+    when: noobaa_s3_endpoint.resources[0].status.ingress[0].host is defined
 
   - set_fact:
-      noobaa_endpoint: "{{ noobaa_s3_endpoint.resources[0].status.loadBalancer.ingress[0].hostname }}"
+      noobaa_endpoint: "{{ noobaa_s3_endpoint.resources[0].status.ingress[0].hostname }}"
     when: noobaa_s3_endpoint.resources[0].status.loadBalancer.ingress[0].hostname is defined
 
   - name: Get MCG PV Pool secret

--- a/ansible/roles/ocp4-workload-migration/templates/mig_storage.yml.j2
+++ b/ansible/roles/ocp4-workload-migration/templates/mig_storage.yml.j2
@@ -27,7 +27,7 @@ spec:
     credsSecretRef:
       namespace: {{ mig_migration_namespace }}
       name: pvpool-storage-creds
-
+    insecure: true
   volumeSnapshotConfig:
     credsSecretRef:
       namespace: {{ mig_migration_namespace }}


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Recently, we observed in one of our lab environments that the AWS ELB DNS names took longer time to propagate than expected which caused our workload to break since it relied on using load balancer service URL to connect to MCG storage. This PR uses the default Route exported by MCG for the same Service eliminating the need to rely on AWS DNS names to propagate. 

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4-workload-migration

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
