### PR TITLE
updating the role to ocp-client-vm

### DIFF
--- a/ansible/configs/amq-messaging-foundations/software.yml
+++ b/ansible/configs/amq-messaging-foundations/software.yml
@@ -14,7 +14,7 @@
   tasks:
     - name: Set up Client VM for AMQ messaging foundations
       include_role:
-        name: "amq-messaging-foundations"
+        name: "ocp-client-vm"
 
 - name: Software flight-check
   hosts: localhost

--- a/ansible/configs/amq-messaging-foundations/software.yml
+++ b/ansible/configs/amq-messaging-foundations/software.yml
@@ -12,7 +12,7 @@
   gather_facts: false
   become: true
   tasks:
-    - name: Set up Client VM for AMQ messaging foundations
+    - name: Set up a Client VM for AMQ messaging foundations
       include_role:
         name: "ocp-client-vm"
 


### PR DESCRIPTION
SUMMARY
When try to provisioning the environment the agnosticv is expecting an existing role. Since the role it's not matching the environment is not being provisioned.

ISSUE TYPE

Bugfix Pull Request
COMPONENT NAME
amq-messaging-foundations
