### PR TITLE
Add variable in defaults rather than every AgnosticV config

### DIFF
--- a/ansible/configs/ocp4-cluster/default_vars_osp.yml
+++ b/ansible/configs/ocp4-cluster/default_vars_osp.yml
@@ -70,9 +70,9 @@ quota_sg_rules: 100
 # OpenStack SWIFT
 # -------------------------------------------------------------------
 
-# This needs to be true for 4.3 and earlier.
-# For OpenShift 4.4 and later it can be false
-osp_use_swift: true
+# For OpenShift 4.4 and later the default should be false
+# Set to true if you want to use SWIFT for the Registry
+osp_use_swift: false
 
 # -------------------------------------------------------------------
 # OpenStack Networking
@@ -81,6 +81,9 @@ osp_use_swift: true
 # The domain that you want to add DNS entries to
 # Should come from the account settings
 # osp_cluster_dns_zone: FROMSECRET
+
+# Use Dynamic DNS. Always true
+use_dynamic_dns: true
 
 # The dynamic DNS server you will add entries to.
 # NOTE: This is only applicable when {{ use_dynamic_dns}} is true


### PR DESCRIPTION
##### SUMMARY

The use_dynamic_dns variable was set in every AgnosticV config. But it wasn't defined in ocp4-cluster. This fixes that so that the AgnosticV configs can be cleaned up.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-cluster