### PR TITLE
Fix syntax error introduced by reformatting

### DIFF
--- a/ansible/roles_studentvm/studentvm_user/tasks/main.yml
+++ b/ansible/roles_studentvm/studentvm_user/tasks/main.yml
@@ -4,8 +4,7 @@
   - studentvm_user_use_password | bool
   - studentvm_user_password | default("") | length == 0
   set_fact:
-    studentvm_user_student_password: >-
-      {{ lookup('password', '/dev/null length= ' ~ studentvm_user_password_length ~ ' chars=ascii_letters,digits') }}
+    studentvm_user_student_password: "{{ lookup('password', '/dev/null length={{ studentvm_user_password_length }} chars=ascii_letters,digits') }}"
 
 - name: Use provided password
   when:


### PR DESCRIPTION
##### SUMMARY

Reformatting by @ritesh97-rh broke the logic.

TASK [studentvm_user : Generate user password if not defined] ******************
Wednesday 28 October 2020  16:00:59 -0400 (0:00:00.187)       0:07:34.887 *****
fatal: [studentvm.6bc2.internal]: FAILED! => {"msg": "An unhandled exception occurred while running the lookup plugin 'password'. Error was a <class 'ansible.errors.AnsibleError'>, original message: Unrecognized value after key=value parameters given to password lookup"}

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
studentvm_user
