### PR TITLE
Add workload to customize the OpenShift Web Console

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/.yamllint
+++ b/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/.yamllint
@@ -1,0 +1,13 @@
+---
+extends: default
+
+rules:
+  comments:
+    require-starting-space: false
+    min-spaces-from-content: 1
+  comments-indentation: disable
+  indentation:
+    indent-sequences: consistent
+  line-length:
+    max: 500
+    allow-non-breakable-inline-mappings: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/defaults/main.yml
@@ -1,0 +1,29 @@
+---
+become_override: false
+ocp_username: opentlc-mgr
+silent: false
+
+# Apply customizations for the Web Console login screen
+ocp4_workload_opentlc_webconsole_customize_login: true
+ocp4_workload_opentlc_webconsole_login_background_url: https://gpte-public.s3.amazonaws.com/opentlc_background.png
+ocp4_workload_opentlc_webconsole_login_logo_url: https://gpte-public.s3.amazonaws.com/opentlc_logo.png
+ocp4_workload_opentlc_webconsole_login_logo_text: OpenTLC Training System
+ocp4_workload_opentlc_webconsole_login_logo_title: "Log in to Red Hat OpenShift Container Platform"
+
+# Change the Web Console logo
+ocp4_workload_opentlc_webconsole_customize_logo: true
+ocp4_workload_opentlc_webconsole_console_logo_url: https://gpte-public.s3.amazonaws.com/opentlc_logo.png
+ocp4_workload_opentlc_webconsole_console_logo_product_name: OpenTLC Training System
+
+# Add Help links
+ocp4_workload_opentlc_webconsole_add_console_links: true
+
+ocp4_workload_opentlc_webconsole_links:
+- name: rhpds-help-internal-link
+  text: Training help (Red Hat Employees)
+  location: HelpMenu
+  href: 'https://redhat.service-now.com/help?id=sc_cat_item&sys_id=b92a06471306a600196f7e276144b092&sysparm_category=0062400913b35b00dce03ff18144b0b2&sc_catalog=64bee97813771b00dce03ff18144b092'
+- name: rhpds-help-partners-link
+  text: Training help (Red Hat Partners)
+  location: HelpMenu
+  href: 'https://partnercenter.redhat.com/500/e?retURL=%2F500%2Fo&RecordType=012600000005EVG&cas14=OPEN+LMS+User+Issue&cas15=Enter+your+issue+or+question+here&00N60000001p2aH=OPEN+Program&00N60000001p2aI=LMS+User+Issue&ent=Case'

--- a/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/files/console_operator.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/files/console_operator.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operator.openshift.io/v1
 kind: Console
 metadata:
@@ -8,3 +9,4 @@ spec:
       key: opentlc_logo.png
       name: console-custom-logo
     customProductName: "{{ ocp4_workload_opentlc_webconsole_console_logo_product_name }}"
+

--- a/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/files/console_operator.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/files/console_operator.yaml
@@ -1,0 +1,10 @@
+apiVersion: operator.openshift.io/v1
+kind: Console
+metadata:
+  name: cluster
+spec:
+  customization:
+    customLogoFile:
+      key: opentlc_logo.png
+      name: console-custom-logo
+    customProductName: "{{ ocp4_workload_opentlc_webconsole_console_logo_product_name }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/files/oauth_cluster.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/files/oauth_cluster.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: config.openshift.io/v1
 kind: OAuth
 metadata:

--- a/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/files/oauth_cluster.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/files/oauth_cluster.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: OAuth
+metadata:
+  name: cluster
+spec:
+  templates:
+    login:
+      name: login-template
+    providerSelection:
+      name: providers-template

--- a/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/files/providers.html
+++ b/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/files/providers.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<!--
+
+This template can be modified and used to customize the provider selection page. To replace
+the provider selection page, set master configuration option oauthConfig.templates.providerSelection to
+the path of the template file. Don't remove parameters in curly braces below.
+
+oauthConfig:
+  templates:
+    providerSelection: templates/select-provider-template.html
+
+The Name is unique for each provider and can be used for provider specific customizations like
+the example below.  The Name matches the name of an identity provider in the master configuration.
+-->
+<html>
+  <head>
+    <title>Login</title>
+    <style type="text/css">
+      body {
+        font-family: "Open Sans", Helvetica, Arial, sans-serif;
+        font-size: 14px;
+        margin: 15px;
+      }
+    </style>
+  </head>
+  <body>
+
+    {{ range $provider := .Providers }}
+      <div>
+        <!-- This is an example of customizing display for a particular provider based on its Name -->
+        {{ if eq $provider.Name "ldapidp" }}
+          <a href="{{$provider.URL}}">Log in</a> with your OpenTLC username and password
+        {{ else }}
+          <a href="{{$provider.URL}}">Log in</a> with the username and password from your provisioning e-mail
+        {{ end }}
+      </div>
+    {{ end }}
+
+  </body>
+</html>

--- a/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/meta/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/meta/main.yml
@@ -1,0 +1,13 @@
+---
+galaxy_info:
+  role_name: ocp4_workload_opentlc_webconsole
+  author: Red Hat GPTE, Wolfgang Kulhanek (wkulhane@redhat.com)
+  description: |
+    This role configures an OpenShift 4 cluster with Web Console customizations.
+  license: MIT
+  min_ansible_version: 2.9
+  platforms: []
+  galaxy_tags:
+  - ocp
+  - openshift
+dependencies: []

--- a/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/readme.adoc
@@ -1,0 +1,65 @@
+= ocp4_workload_opentlc_webconsole - Web Console customization for OpenTLC/RHPDS clusters
+
+== Role overview
+
+* This role customizes the OpenShift 4 web console for OpenTLC/RHPDS production use. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+ environment for the workload deployment.
+*** Debug task will print out: `pre_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to configure the cluster
+*** This role creates a route for the image registry, sets up build defaults and removes self-provisioner from all users.
+*** Debug task will print out: `workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+ configure the workload after deployment
+*** This role doesn't do anything here
+*** Debug task will print out: `post_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+ delete the workload
+*** This role removes the production customizations
+*** Debug task will print out: `remove_workload Tasks completed successfully.`
+
+== Review the defaults variable file
+
+* This file link:./defaults/main.yml[./defaults/main.yml] contains all the variables you need to define to control the deployment of your workload.
+* The variable *ocp_username* is mandatory to assign the workload to the correct OpenShift user.
+* A variable *silent=True* can be passed to suppress debug messages.
+
+=== Deploy a Workload with the `ocp-workload` playbook [Mostly for testing]
+
+----
+TARGET_HOST="bastion.na4.openshift.opentlc.com"
+OCP_USERNAME="wkulhane-redhat.com"
+WORKLOAD="ocp4_workload_opentlc_webconsole"
+GUID=1001
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=ec2-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"silent=False" \
+    -e"guid=${GUID}" \
+    -e"ACTION=create"
+----
+
+=== To Delete an environment
+
+----
+TARGET_HOST="bastion.na4.openshift.opentlc.com"
+OCP_USERNAME="wkulhane-redhat.com"
+WORKLOAD="ocp4_workload_opentlc_webconsole"
+GUID=1002
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=ec2-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"guid=${GUID}" \
+    -e"ACTION=remove"
+----

--- a/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+# Do not modify this file
+
+- name: Running Pre Workload Tasks
+  include_tasks:
+    file: ./pre_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload Tasks
+  include_tasks:
+    file: ./workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  include_tasks:
+    file: ./post_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload removal Tasks
+  include_tasks:
+    file: ./remove_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/tasks/post_workload.yml
@@ -1,0 +1,9 @@
+---
+# Implement your Post Workload deployment tasks here
+
+
+# Leave this as the last task in the playbook.
+- name: post_workload tasks complete
+  debug:
+    msg: "Post-Workload Tasks completed successfully."
+  when: not silent | bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/tasks/pre_workload.yml
@@ -1,0 +1,8 @@
+---
+# Implement your Pre Workload deployment tasks here
+
+# Leave this as the last task in the playbook.
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Workload tasks completed successfully."
+  when: not silent | bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/tasks/remove_workload.yml
@@ -1,0 +1,12 @@
+---
+# Implement your Workload removal tasks here
+
+- name: TBD
+  debug:
+    msg: "Removal is not implemented."
+
+# Leave this as the last task in the playbook.
+- name: remove_workload tasks complete
+  debug:
+    msg: "Remove Workload tasks completed successfully."
+  when: not silent | bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/tasks/workload.yml
@@ -1,0 +1,86 @@
+---
+# Implement your Workload deployment tasks here
+
+- name: Setting up workload for user
+  debug:
+    msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
+
+- name: Customize web console login screen
+  when: ocp4_workload_opentlc_webconsole_customize_login | bool
+  block:
+  - name: Copy login page to host
+    template:
+      src: ./templates/login.html.j2
+      dest: /tmp/login.html
+      variable_start_string: "[%"
+      variable_end_string: "%]"
+      mode: 'u=rw,g=rw'
+  - name: Read login page from host
+    slurp:
+      src: /tmp/login.html
+    register: r_login_page
+  - name: Delete login page from host
+    file:
+      state: absent
+      path: /tmp/login.html
+
+  - name: Create login page secrets
+    k8s:
+      state: present
+      definition: "{{ lookup('template', './templates/secret_login_page.yaml.j2' ) | from_yaml }}"
+    loop:
+    - name: login
+      html_data: "{{ r_login_page.content | b64decode }}"
+    - name: providers
+      html_data: "{{ lookup('file', './files/providers.html') }}"
+    loop_control:
+      label: "{{ item.name }}"
+  - name: Update OAuth cluster with new login page
+    k8s:
+      state: present
+      merge_type: merge
+      definition: "{{ lookup('file', './files/oauth_cluster.yaml') | from_yaml }}"
+
+- name: Customize web console logo
+  when: ocp4_workload_opentlc_webconsole_customize_logo | bool
+  block:
+  - name: Download web console logo file
+    get_url:
+      url: "{{ ocp4_workload_opentlc_webconsole_console_logo_url }}"
+      dest: /tmp/logo_file.png
+      mode: 'u=rw,g=rw'
+  - name: Read web console logo file
+    slurp:
+      src: /tmp/logo_file.png
+    register: r_logo_file
+  - name: Remove downloaded file
+    file:
+      state: absent
+      path: /tmp/logo_file.png
+  - name: Create console-custom-logo Config Map
+    k8s:
+      state: present
+      definition: "{{ lookup('template', './templates/config_map_console_custom_logo.yaml.j2' ) | from_yaml }}"
+  - name: Update Console Operator
+    k8s:
+      state: present
+      merge_type: merge
+      definition: "{{ lookup('file', './files/console_operator.yaml') | from_yaml }}"
+
+- name: Customize Help links
+  when:
+  - ocp4_workload_opentlc_webconsole_add_console_links | bool
+  - ocp4_workload_opentlc_webconsole_links is defined
+  - ocp4_workload_opentlc_webconsole_links | length > 0
+  k8s:
+    state: present
+    definition: "{{ lookup('template', './templates/console_link.yaml.j2' ) | from_yaml }}"
+  loop: "{{ ocp4_workload_opentlc_webconsole_links | list }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+# Leave this as the last task in the playbook.
+- name: workload tasks complete
+  debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent | bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/templates/config_map_console_custom_logo.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/templates/config_map_console_custom_logo.yaml.j2
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: console-custom-logo
+  namespace: openshift-config
+binaryData:
+  opentlc_logo.png: "{{ r_logo_file.content }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/templates/console_link.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/templates/console_link.yaml.j2
@@ -1,0 +1,8 @@
+apiVersion: console.openshift.io/v1
+kind: ConsoleLink
+metadata:
+  name: "{{ item.name }}"
+spec:
+  location: "{{ item.location }}"
+  text: "{{ item.text }}"
+  href: "{{ item.href }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/templates/login.html.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/templates/login.html.j2
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<!--
+
+This template can be modified and used to customize the login page. To replace
+the login page, set master configuration option oauthConfig.templates.login to
+the path of the template file. Don't remove parameters in curly braces below.
+
+oauthConfig:
+  templates:
+    login: templates/login-template.html
+-->
+
+<html>
+  <head>
+    <title>Login</title>
+    <style type="text/css">
+      body {
+        font-family: "Open Sans", Helvetica, Arial, sans-serif;
+        font-size: 14px;
+        color: white;
+        background-color: inherit;
+        margin: 15px;
+        background-image: url("[% ocp4_workload_opentlc_webconsole_login_background_url %]");
+        background-repeat: no-repeat;
+        background-attachment: fixed;
+        background-size: 100% 100%;
+      }
+
+      input {
+        margin-bottom: 10px;
+        width: 300px;
+      }
+
+      .error {
+        color: yellow;
+        margin-top: 20px;
+        margin-bottom: 20px;
+      }
+
+      .logo {
+        position: absolute;
+        top: 50px;
+        right: 50px;
+      }
+
+      #bottom {
+        position:absolute;
+        bottom:200px;
+        left:200px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="logo">
+      <img src="[% ocp4_workload_opentlc_webconsole_login_logo_url %]" alt="[% ocp4_workload_opentlc_webconsole_login_logo_text %]">
+    </div>
+    <div id="bottom">
+      <h2>[% ocp4_workload_opentlc_webconsole_login_logo_title %]</h2>
+      <!-- Identity provider name: {{ .ProviderName }} -->
+      <form action="{{ .Action }}" method="POST">
+        <input type="hidden" name="{{ .Names.Then }}" value="{{ .Values.Then }}">
+        <input type="hidden" name="{{ .Names.CSRF }}" value="{{ .Values.CSRF }}">
+
+        <div>
+          <label for="inputUsername">Username</label>
+        </div>
+        <div>
+          <input type="text" id="inputUsername" autofocus="autofocus" type="text" name="{{ .Names.Username }}" value="{{ .Values.Username }}">
+        </div>
+
+        <div>
+          <label for="inputPassword">Password</label>
+        </div>
+        <div>
+          <input type="password" id="inputPassword" type="password" name="{{ .Names.Password }}" value="">
+        </div>
+
+        <button type="submit">Log In</button>
+
+      </form>
+      {{ if .Error }}
+        <div class="error">{{ .Error }}/div>
+        <!-- Error code: {{ .ErrorCode }} -->
+      {{ end }}
+    </div>
+  </body>
+</html>

--- a/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/templates/secret_login_page.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_opentlc_webconsole/templates/secret_login_page.yaml.j2
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: '{{ item.name }}-template'
+  namespace: openshift-config
+type: Opaque
+data:
+  '{{ item.name }}.html': '{{ item.html_data | b64encode }}'

--- a/login.html
+++ b/login.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<!--
+
+This template can be modified and used to customize the login page. To replace
+the login page, set master configuration option oauthConfig.templates.login to
+the path of the template file. Don't remove parameters in curly braces below.
+
+oauthConfig:
+  templates:
+    login: templates/login-template.html
+
+-->
+<html>
+  <head>
+    <title>Login</title>
+    <style type="text/css">
+      body {
+        font-family: "Open Sans", Helvetica, Arial, sans-serif;
+        font-size: 14px;
+        margin: 15px;
+      }
+
+      input {
+        margin-bottom: 10px;
+        width: 300px;
+      }
+
+      .error {
+        color: red;
+        margin-bottom: 10px;
+      }
+    </style>
+  </head>
+  <body>
+
+    {{ if .Error }}
+      <div class="error">{{ .Error }}</div>
+      <!-- Error code: {{ .ErrorCode }} -->
+    {{ end }}
+
+    <!-- Identity provider name: {{ .ProviderName }} -->
+    <form action="{{ .Action }}" method="POST">
+      <input type="hidden" name="{{ .Names.Then }}" value="{{ .Values.Then }}">
+      <input type="hidden" name="{{ .Names.CSRF }}" value="{{ .Values.CSRF }}">
+
+      <div>
+        <label for="inputUsername">Username</label>
+      </div>
+      <div>
+        <input type="text" id="inputUsername" autofocus="autofocus" type="text" name="{{ .Names.Username }}" value="{{ .Values.Username }}">
+      </div>
+
+      <div>
+        <label for="inputPassword">Password</label>
+      </div>
+      <div>
+        <input type="password" id="inputPassword" type="password" name="{{ .Names.Password }}" value="">
+      </div>
+
+      <button type="submit">Log In</button>
+
+    </form>
+
+  </body>
+</html>


### PR DESCRIPTION
##### SUMMARY

As part of the OpenShift Web Console customization contest I wrote this workload to change the login page, logo and any Console Links in the OpenShift Web Console.

Defaults make it look like the labs.opentlc.com provisioning portal, add help links for partners and Red Hatters.
More docs here: https://github.com/wkulhanek/openshift-web-console-customizations

##### ISSUE TYPE
- New role Pull Request

##### COMPONENT NAME
ocp4_workload_opentlc_webconsole