### PR TITLE
Fixes #3147 processing content read on remote host fails - OCP4 Open Banking role 

### DIFF
--- a/ansible/roles/ocp4-workload-openbanking-sandbox/tasks/3amp-deploy-full-api.yml
+++ b/ansible/roles/ocp4-workload-openbanking-sandbox/tasks/3amp-deploy-full-api.yml
@@ -1,38 +1,16 @@
 ---
 ###
 # Backend CRD deployment
-- name: Create a tempfile for Backend CRD
-  tempfile:
-    state: file
-    suffix: temp
-  register: _crd_template
-  until: _crd_template.path is defined
-
-- name: Retrieve the Backend CRD content from Open Banking Sandbox repo into tempfile
-  get_url:
-    url: "{{ obsandbox_api_crds_base_url + '/backend-' + _api_resource_id + '.yml' }}"
-    dest: "{{ _crd_template.path }}"
-
-- name: Read Backend CRD tempfile '{{ _crd_template.path }}' into '_crd_content' variable
-  slurp:
-    src: "{{ _crd_template.path }}"
-  register: _crd_content
-
 - name: Creating the "{{ _api_resource_id }}" Backend CRD provided by 3scale
   k8s:
     state: present
     merge_type:
     - strategic-merge
     - merge
-    definition: "{{ _crd_content['content'] | replace('%NAMESPACE%', obsandbox_3scale_namespace) |
+    definition: "{{ lookup('url', obsandbox_api_crds_base_url + '/backend-' + _api_resource_id + '.yml', split_lines=False) |
+      replace('%NAMESPACE%', obsandbox_3scale_namespace) |
       replace('%PROVIDER_ACCOUNT_REF%', obsandbox_3scale_tenant_provider_account_ref) |
       replace('%PRIVATE_BASE_URL%', _mock_base_url) | from_yaml }}"
-
-- name: Remove the tempfile created for Backend CRD
-  file:
-    path: "{{ _crd_template.path }}"
-    state: absent
-  when: _crd_template.path is defined
 
 - name: Wait to synchronize the "{{ _api_resource_id }}" Backend CRDs with 3scale
   k8s_info:
@@ -53,15 +31,6 @@
 
 ###
 # Product CRD deployment
-- name: Retrieve the Product CRD content from Open Banking Sandbox repo into tempfile
-  get_url:
-    url: "{{ obsandbox_api_crds_base_url + '/product-' + _api_resource_id + '.yml' }}"
-    dest: "{{ _crd_template.path }}"
-
-- name: Read Product CRD tempfile '{{ _crd_template.path }}' into '_crd_content' variable
-  slurp:
-    src: "{{ _crd_template.path }}"
-  register: _crd_content
 
 - name: Create the "{{ _api_resource_id }}" Product CRD provided by 3scale
   k8s:
@@ -69,14 +38,9 @@
     merge_type:
     - strategic-merge
     - merge
-    definition: "{{ _crd_content['content'] | replace('%NAMESPACE%', obsandbox_3scale_namespace) |
+    definition: "{{ lookup('url', obsandbox_api_crds_base_url + '/product-' + _api_resource_id + '.yml', split_lines=False) |
+      replace('%NAMESPACE%', obsandbox_3scale_namespace) |
       replace('%PROVIDER_ACCOUNT_REF%', obsandbox_3scale_tenant_provider_account_ref) | from_yaml }}"
-
-- name: Remove tempfile created for Product CRD
-  file:
-    path: "{{ _crd_template.path }}"
-    state: absent
-  when: _crd_template.path is defined
 
 - name: Wait to synchronize the "{{ _api_resource_id }}" Product CRDs with 3scale
   k8s_info:


### PR DESCRIPTION
##### SUMMARY

Fixes #3147.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Role: ocp4-workload-openbanking-sandbox

##### ADDITIONAL INFORMATION
After some search I found this issue #3147 might be related to a characteristic behaviour of some builtin modules when Split_Lines=True by default. In this case, found no option to disable this mode on `slurp` ansible module.

I've tested this update on full role execution against a regular OCP 4.5 workshop (small) cluster from RHPDS.

```paste below
$ ansible --version
ansible 2.9.14
  config file = /home/rmarins/Workspaces/agnosticd/ansible.cfg
  configured module search path = ['/home/rmarins/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.8/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.8.6 (default, Sep 25 2020, 00:00:00) [GCC 10.2.1 20200723 (Red Hat 10.2.1-1)]

$ pip freeze
ansible==2.9.14
appdirs==1.4.3
argcomplete==1.10.0
attrs==19.3.0
awscli==1.17.17
Babel==2.8.0
bcrypt==3.1.7
Beaker==1.10.0
beautifulsoup4==4.9.3
blivet==3.2.2
blivet-gui==2.1.15
boto3==1.14.38
botocore==1.17.38
Brlapi==0.7.0
cachetools==3.1.1
certifi==2018.10.15
cffi==1.14.0
chardet==3.0.4
chrome-gnome-shell==0.0.0
cliff==2.16.0
cmd2==0.9.16
colorama==0.4.1
configobj==5.0.6
cryptography==2.8
cupshelpers==1.0
dasbus==0.2
dbus-python==1.2.16
debtcollector==1.22.0
decorator==4.4.0
defusedxml==0.6.0
distlib==0.3.1
distro==1.4.0
dnspython==2.0.0
docutils==0.15.2
dogpile.cache==0.9.0
filelock==3.0.12
fluidity-sm==0.2.0
fros==1.1
funcsigs==1.0.2
google-auth==1.21.3
gpg==1.14.0
humanize==0.5.1
idna==2.8
invoke==1.4.1
iso8601==0.1.12
jeepney==0.4.3
Jinja2==2.11.2
jmespath==0.9.4
jsonpatch==1.21
jsonpointer==1.10
jsonschema==3.2.0
k8s==0.16.0
keyring==21.3.1
keystoneauth1==3.17.1
kubernetes==11.0.0
langtable==0.0.53
lexicon==1.0.0
libcomps==0.1.15
lxml==4.4.1
Mako==1.1.1.dev0
MarkupSafe==1.1.1
msgpack==0.6.2
munch==2.3.2
netaddr==0.7.19
netifaces==0.10.6
nftables==0.1
ntlm-auth==1.1.0
ntplib==0.3.3
oauthlib==3.0.2
olefile==0.46
openshift==0.11.2
openstacksdk==0.36.0
ordered-set==3.1
os-client-config==1.33.0
os-service-types==1.7.0
osc-lib==1.14.1
oslo.config==6.11.1
oslo.context==2.23.0
oslo.i18n==3.24.0
oslo.log==3.44.1
oslo.serialization==2.29.2
oslo.utils==3.41.1
paramiko==2.7.1
Paste==3.2.4
pbr==5.4.3
pid==2.2.3
Pillow==7.0.0
ply==3.11
prettytable==0.7.2
productmd==1.28
psutil==5.6.7
pwquality==1.4.2
pyasn1==0.4.8
pyasn1-modules==0.2.8
pycairo==1.18.2
pycparser==2.19
pycrypto==2.6.1
pycups==2.0.1
pycurl==7.43.0.5
pyenchant==2.0.0
PyGObject==3.36.1
pyinotify==0.9.6
PyJWT==1.7.1
pykickstart==3.24
PyNaCl==1.3.0
pyOpenSSL==19.0.0
pyparsing==2.4.7
pyparted==3.11.4
pyperclip==1.6.4
pyRFC3339==1.1
pyrsistent==0.16.0
PySocks==1.7.1
python-augeas==0.5.0
python-cinderclient==5.0.0
python-dateutil==2.8.0
python-glanceclient==2.17.0
python-keystoneclient==3.21.0
python-meh==0.48
python-neutronclient==6.14.0
python-novaclient==15.1.0
python-openstackclient==4.0.0
python-string-utils==1.0.0
python3-openid==3.1.0
pytz==2020.1
pyudev==0.22.0
pywinrm==0.3.0
pyxdg==0.26
PyYAML==5.3.1
requests==2.22.0
requests-file==1.4.3
requests-ftp==0.3.1
requests-ntlm==1.1.0
requests-oauthlib==1.2.0
requestsexceptions==1.4.0
rfc3986==1.2.0
rpm==4.15.1
rsa==3.4.2
ruamel.yaml==0.16.10
ruamel.yaml.clib==0.2.0
s3transfer==0.3.3
SecretStorage==3.1.1
selinux==3.0
sepolicy==3.0
setools==4.3.0
simplejson==3.17.0
simpleline==1.6
six==1.12.0
slip==0.6.4
slip.dbus==0.6.4
sos==3.9
soupsieve==1.9.2
stevedore==1.31.0
systemd-python==234
Tempita==0.5.1
terminator==2.0.1
udica==0.2.3
urllib3==1.25.7
virtualenv==20.0.30
warlock==1.3.3
wcwidth==0.2.4
websocket-client==0.56.0
wrapt==1.11.2
xmltodict==0.12.0
```
