### PR TITLE
Change role infra-ec2-template-generate to add aws_dns_create_public_zone

### DIFF
--- a/ansible/roles-infra/infra-ec2-template-generate/defaults/main.yml
+++ b/ansible/roles-infra/infra-ec2-template-generate/defaults/main.yml
@@ -73,6 +73,7 @@ aws_dns_zone_private_chomped: "{{ aws_dns_zone_private | regex_replace('\\.$', '
 
 # Public DNS Zone dedicated to the environment
 aws_dns_zone_public: "{{ guid }}.{{ aws_dns_zone_root }}"
+aws_dns_create_public_zone: true
 
 aws_dns_ttl_public: 900
 aws_dns_ttl_private: 3600

--- a/ansible/roles-infra/infra-ec2-template-generate/templates/cloud_template.j2
+++ b/ansible/roles-infra/infra-ec2-template-generate/templates/cloud_template.j2
@@ -123,7 +123,9 @@ Resources:
       HostedZoneConfig:
         Comment: "{{ aws_comment }}"
 
-  {% if secondary_stack is not defined %}
+{% if secondary_stack is not defined
+   and aws_dns_create_public_zone | bool
+%}
   DnsZonePublic:
     Type: "AWS::Route53::HostedZone"
     Properties:
@@ -136,11 +138,11 @@ Resources:
     DependsOn:
       - DnsZonePublic
     Properties:
-    {% if HostedZoneId is defined %}
+{%   if HostedZoneId is defined %}
       HostedZoneId: "{{ HostedZoneId }}"
-    {% else %}
+{%   else %}
       HostedZoneName: "{{ aws_dns_zone_root }}"
-    {% endif %}
+{%   endif %}
       RecordSets:
         - Name: "{{ aws_dns_zone_public }}"
           Type: NS
@@ -149,113 +151,115 @@ Resources:
             "Fn::GetAtt":
               - DnsZonePublic
               - NameServers
-    {% endif %}
+{% endif %}
 
 {% for instance in instances %}
-{% if instance['dns_loadbalancer'] | d(false) | bool
-  and not instance['unique'] | d(false) | bool %}
+{%   if instance['dns_loadbalancer'] | default(false) | bool
+     and not instance['unique'] | default(false) | bool %}
   {{instance['name']}}DnsLoadBalancer:
     Type: "AWS::Route53::RecordSetGroup"
     DependsOn:
-    {% for c in range(1, (instance['count']|int)+1) %}
+{%     for c in range(1, (instance['count']|int)+1) %}
       - {{instance['name']}}{{c}}
-      {% if instance['public_dns'] %}
+{%       if instance['public_dns'] %}
       - {{instance['name']}}{{c}}EIP
-      {% endif %}
-    {% endfor %}
+{%       endif %}
+{%     endfor %}
     Properties:
-      {% if secondary_stack is defined %}
+{%     if not aws_dns_create_public_zone | bool %}
+      HostedZoneName: "{{ aws_dns_zone_root }}"
+{%     elif secondary_stack is defined %}
       HostedZoneName: "{{ aws_dns_zone_public }}"
-      {% else %}
+{%     else %}
       HostedZoneId:
         Ref: DnsZonePublic
-      {% endif %}
+{%     endif %}
       RecordSets:
       - Name: "{{instance['name']}}.{{aws_dns_zone_public_prefix|d('')}}{{ aws_dns_zone_public }}"
         Type: A
         TTL: {{ aws_dns_ttl_public }}
         ResourceRecords:
-{% for c in range(1,(instance['count'] |int)+1) %}
+{%     for c in range(1,(instance['count'] |int)+1) %}
           - "Fn::GetAtt":
             - {{instance['name']}}{{c}}
             - PublicIp
-{% endfor %}
-{% endif %}
+{%     endfor %}
+{%   endif %}
 
-{% for c in range(1,(instance['count'] |int)+1) %}
+{%   for c in range(1,(instance['count'] |int)+1) %}
   {{instance['name']}}{{loop.index}}:
     Type: "AWS::EC2::Instance"
     Properties:
-{% if custom_image is defined %}
+{%     if custom_image is defined %}
       ImageId: {{ custom_image.image_id }}
-{% else %}
+{%     else %}
       ImageId:
         Fn::FindInMap:
         - RegionMapping
         - Ref: AWS::Region
         - {{ instance.image | default(aws_default_image) }}
-{% endif %}
+{%     endif %}
       InstanceType: "{{instance['flavor'][cloud_provider]}}"
       KeyName: "{{instance.key_name | default(key_name)}}"
-    {% if instance['UserData'] is defined %}
+{%     if instance['UserData'] is defined %}
       {{instance['UserData']}}
-    {% endif %}
+{%     endif %}
 
-    {% if instance['security_groups'] is defined %}
+{%     if instance['security_groups'] is defined %}
       SecurityGroupIds:
-      {% for sg in instance.security_groups %}
+{%       for sg in instance.security_groups %}
         - Ref: {{ sg }}
-      {% endfor %}
-    {% else %}
+{%       endfor %}
+{%     else %}
       SecurityGroupIds:
         - Ref: DefaultSG
-    {% endif %}
+{%     endif %}
       SubnetId:
         Ref: PublicSubnet
       Tags:
-    {% if instance['unique'] | d(false) | bool %}
+{%     if instance['unique'] | d(false) | bool %}
         - Key: Name
           Value: {{instance['name']}}
         - Key: internaldns
           Value: {{instance['name']}}.{{aws_dns_zone_private_chomped}}
-    {% else %}
+{%     else %}
         - Key: Name
           Value: {{instance['name']}}{{loop.index}}
         - Key: internaldns
           Value: {{instance['name']}}{{loop.index}}.{{aws_dns_zone_private_chomped}}
-    {% endif %}
+{%     endif %}
         - Key: "owner"
           Value: "{{ email | default('unknownuser') }}"
         - Key: "Project"
           Value: "{{project_tag}}"
         - Key: "{{project_tag}}"
           Value: "{{ instance['name'] }}"
-    {% for tag in instance['tags'] %}
+{%     for tag in instance['tags'] %}
         - Key: {{tag['key']}}
           Value: {{tag['value']}}
-    {% endfor %}
+{%     endfor %}
       BlockDeviceMappings:
-    {% if '/dev/sda1' not in instance.volumes|d([])|json_query('[].device_name')
-      and '/dev/sda1' not in instance.volumes|d([])|json_query('[].name')
+{%     if '/dev/sda1' not in instance.volumes | default([]) | json_query('[].device_name')
+       and '/dev/sda1' not in instance.volumes | default([]) | json_query('[].name')
 %}
         - DeviceName: "/dev/sda1"
           Ebs:
             VolumeSize: "{{ instance['rootfs_size'] | default(aws_default_rootfs_size) }}"
             VolumeType: "{{ aws_default_volume_type }}"
-    {% endif %}
-    {% for vol in instance.volumes|default([]) if vol.enable|d(true) %}
+{%     endif %}
+{%     for vol in instance.volumes|default([]) if vol.enable|d(true) %}
         - DeviceName: "{{ vol.name | default(vol.device_name) }}"
           Ebs:
-          {% if cloud_provider in vol and 'type' in vol.ec2 %}
+{%       if cloud_provider in vol and 'type' in vol.ec2 %}
             VolumeType: "{{ vol[cloud_provider].type }}"
-          {% else %}
+{%       else %}
             VolumeType: "{{ aws_default_volume_type }}"
-          {% endif %}
-          {% if vol.snapshot_id is defined %}
+{%       endif %}
+{%       if vol.snapshot_id is defined %}
             SnapshotId: "{{ vol.snapshot_id}}"
-          {% endif %}
+{%       endif %}
             VolumeSize: "{{ vol.size }}"
-    {% endfor %}
+{%     endfor %}
 
   {{instance['name']}}{{loop.index}}InternalDns:
     Type: "AWS::Route53::RecordSetGroup"
@@ -263,11 +267,11 @@ Resources:
       HostedZoneId:
         Ref: DnsZonePrivate
       RecordSets:
-    {% if instance['unique'] | d(false) | bool %}
+{%     if instance['unique'] | d(false) | bool %}
         - Name: "{{instance['name']}}.{{aws_dns_zone_private}}"
-    {% else %}
+{%     else %}
         - Name: "{{instance['name']}}{{loop.index}}.{{aws_dns_zone_private}}"
-    {% endif %}
+{%     endif %}
           Type: A
           TTL: {{ aws_dns_ttl_private }}
           ResourceRecords:
@@ -275,7 +279,7 @@ Resources:
               - {{instance['name']}}{{loop.index}}
               - PrivateIp
 
-{% if instance['public_dns'] %}
+{%     if instance['public_dns'] %}
   {{instance['name']}}{{loop.index}}EIP:
     Type: "AWS::EC2::EIP"
     DependsOn:
@@ -289,26 +293,28 @@ Resources:
     DependsOn:
       - {{instance['name']}}{{loop.index}}EIP
     Properties:
-      {% if secondary_stack is defined %}
+{%       if not aws_dns_create_public_zone | bool %}
+      HostedZoneName: "{{ aws_dns_zone_root }}"
+{%       elif secondary_stack is defined %}
       HostedZoneName: "{{ aws_dns_zone_public }}"
-      {% else %}
+{%       else %}
       HostedZoneId:
         Ref: DnsZonePublic
-      {% endif %}
+{%       endif %}
       RecordSets:
-      {% if instance['unique'] | d(false) | bool %}
+{%       if instance['unique'] | d(false) | bool %}
         - Name: "{{instance['name']}}.{{aws_dns_zone_public_prefix|d('')}}{{ aws_dns_zone_public }}"
-      {% else %}
+{%       else %}
         - Name: "{{instance['name']}}{{loop.index}}.{{aws_dns_zone_public_prefix|d('')}}{{ aws_dns_zone_public }}"
-      {% endif %}
+{%       endif %}
           Type: A
           TTL: {{ aws_dns_ttl_public }}
           ResourceRecords:
           - "Fn::GetAtt":
             - {{instance['name']}}{{loop.index}}
             - PublicIp
-{% endif %}
-{% endfor %}
+{%     endif %}
+{%   endfor %}
 {% endfor %}
 
   {% if secondary_stack is not defined %}

--- a/ansible/roles-infra/infra-ec2-template-generate/templates/cloud_template.j2
+++ b/ansible/roles-infra/infra-ec2-template-generate/templates/cloud_template.j2
@@ -317,7 +317,9 @@ Resources:
 {%   endfor %}
 {% endfor %}
 
-  {% if secondary_stack is not defined %}
+{% if secondary_stack is not defined
+   and aws_dns_create_public_zone | bool
+%}
   Route53User:
     Type: AWS::IAM::User
     Properties:
@@ -354,14 +356,16 @@ Resources:
       Properties:
         UserName:
           Ref: Route53User
-  {% endif %}
+{% endif %}
 
 Outputs:
   Route53internalzoneOutput:
     Description: The ID of the internal route 53 zone
     Value:
       Ref: DnsZonePrivate
-  {% if secondary_stack is not defined %}
+{% if secondary_stack is not defined
+   and aws_dns_create_public_zone | bool
+%}
   Route53User:
     Value:
       Ref: Route53User
@@ -376,4 +380,4 @@ Outputs:
         - Route53UserAccessKey
         - SecretAccessKey
     Description: IAM User for Route53 (Let's Encrypt)
-  {% endif %}
+{% endif %}

--- a/ansible/roles-infra/infra-ec2-template-generate/templates/cloud_template.j2
+++ b/ansible/roles-infra/infra-ec2-template-generate/templates/cloud_template.j2
@@ -317,9 +317,7 @@ Resources:
 {%   endfor %}
 {% endfor %}
 
-{% if secondary_stack is not defined
-   and aws_dns_create_public_zone | bool
-%}
+{% if secondary_stack is not defined %}
   Route53User:
     Type: AWS::IAM::User
     Properties:
@@ -340,11 +338,16 @@ Resources:
                   - route53:ChangeResourceRecordSets
                   - route53:ListResourceRecordSets
                   - route53:GetHostedZone
+{%   if aws_dns_create_public_zone %}
                 Resource:
                   Fn::Join:
                     - ""
                     - - "arn:aws:route53:::hostedzone/"
                       - Ref: DnsZonePublic
+{%   else %}
+                Resource: "arn:aws:route53:::hostedzone/{{ HostedZoneId }}"
+{%   endif %}
+
 
               - Effect: Allow
                 Action: route53:GetChange
@@ -363,9 +366,7 @@ Outputs:
     Description: The ID of the internal route 53 zone
     Value:
       Ref: DnsZonePrivate
-{% if secondary_stack is not defined
-   and aws_dns_create_public_zone | bool
-%}
+{% if secondary_stack is not defined %}
   Route53User:
     Value:
       Ref: Route53User

--- a/ansible/roles-infra/infra-ec2-template-generate/templates/cloud_template.j2
+++ b/ansible/roles-infra/infra-ec2-template-generate/templates/cloud_template.j2
@@ -166,13 +166,15 @@ Resources:
 {%       endif %}
 {%     endfor %}
     Properties:
-{%     if secondary_stack is defined %}
+{%     if aws_dns_create_public_zone | bool %}
+{%       if secondary_stack is defined %}
       HostedZoneName: "{{ aws_dns_zone_public }}"
-{%     elif not aws_dns_create_public_zone | bool %}
-      HostedZoneName: "{{ aws_dns_zone_root }}"
-{%     else %}
+{%       else %}
       HostedZoneId:
         Ref: DnsZonePublic
+{%       endif %}
+{%     else %}
+      HostedZoneName: "{{ aws_dns_zone_root }}"
 {%     endif %}
       RecordSets:
       - Name: "{{instance['name']}}.{{aws_dns_zone_public_prefix|d('')}}{{ aws_dns_zone_public }}"
@@ -293,14 +295,16 @@ Resources:
     DependsOn:
       - {{instance['name']}}{{loop.index}}EIP
     Properties:
+{%     if aws_dns_create_public_zone | bool %}
 {%       if secondary_stack is defined %}
       HostedZoneName: "{{ aws_dns_zone_public }}"
-{%       elif not aws_dns_create_public_zone | bool %}
-      HostedZoneName: "{{ aws_dns_zone_root }}"
 {%       else %}
       HostedZoneId:
         Ref: DnsZonePublic
 {%       endif %}
+{%     else %}
+      HostedZoneName: "{{ aws_dns_zone_root }}"
+{%     endif %}
       RecordSets:
 {%       if instance['unique'] | d(false) | bool %}
         - Name: "{{instance['name']}}.{{aws_dns_zone_public_prefix|d('')}}{{ aws_dns_zone_public }}"
@@ -347,7 +351,6 @@ Resources:
 {%   else %}
                 Resource: "arn:aws:route53:::hostedzone/{{ HostedZoneId }}"
 {%   endif %}
-
 
               - Effect: Allow
                 Action: route53:GetChange

--- a/ansible/roles-infra/infra-ec2-template-generate/templates/cloud_template.j2
+++ b/ansible/roles-infra/infra-ec2-template-generate/templates/cloud_template.j2
@@ -293,10 +293,10 @@ Resources:
     DependsOn:
       - {{instance['name']}}{{loop.index}}EIP
     Properties:
-{%       if not aws_dns_create_public_zone | bool %}
-      HostedZoneName: "{{ aws_dns_zone_root }}"
-{%       elif secondary_stack is defined %}
+{%       if secondary_stack is defined %}
       HostedZoneName: "{{ aws_dns_zone_public }}"
+{%       elif not aws_dns_create_public_zone | bool %}
+      HostedZoneName: "{{ aws_dns_zone_root }}"
 {%       else %}
       HostedZoneId:
         Ref: DnsZonePublic

--- a/ansible/roles-infra/infra-ec2-template-generate/templates/cloud_template.j2
+++ b/ansible/roles-infra/infra-ec2-template-generate/templates/cloud_template.j2
@@ -166,10 +166,10 @@ Resources:
 {%       endif %}
 {%     endfor %}
     Properties:
-{%     if not aws_dns_create_public_zone | bool %}
-      HostedZoneName: "{{ aws_dns_zone_root }}"
-{%     elif secondary_stack is defined %}
+{%     if secondary_stack is defined %}
       HostedZoneName: "{{ aws_dns_zone_public }}"
+{%     elif not aws_dns_create_public_zone | bool %}
+      HostedZoneName: "{{ aws_dns_zone_root }}"
 {%     else %}
       HostedZoneId:
         Ref: DnsZonePublic


### PR DESCRIPTION
##### SUMMARY

This PR implements functionality for `ocp4-cluster` to match the `ocp4-workshop` flag `use_root_zone`. This is a feature we need for GPTE infrastructure clusters in order to shorten the DNS domain names.

This also makes some whitespace formatting changes to the jinja2 template to make control flow statements easier to see and visually match by moving the opening bracket `{%` to the beginning of the line.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Role infra-ec2-template-generate

##### ADDITIONAL INFORMATION

Test deploys with ocp4-cluster performed both with and without this flag to confirm new functionality and that this feature does not break anything.