### PR TITLE
Update: Accumulated Azure bugs

### DIFF
--- a/ansible/cloud_providers/azure_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/azure_infrastructure_deployment.yml
@@ -119,7 +119,7 @@
 
     - name: Validate arm template
       command: >-
-        az group deployment validate
+        az deployment group validate
         --template-file {{t_dest}}
         --resource-group {{az_resource_group}}
         --parameters @{{params_dest}}
@@ -130,7 +130,7 @@
 
     - name: ARM Group deployment create
       command: >-
-        az group deployment create
+        az deployment group create
         --name {{env_type}}.{{guid}}
         --template-file {{t_dest}}
         --resource-group {{az_resource_group}}

--- a/ansible/cloud_providers/azure_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/azure_infrastructure_deployment.yml
@@ -149,7 +149,7 @@
         - azure_infrastructure_deployment
 
     - name: Fetch DNS zone NS entries
-      azure_rm_dnsrecordset_facts:
+      azure_rm_dnsrecordset_info:
         zone_name: "{{guid}}.{{HostedZoneId}}"
         resource_group: "{{az_resource_group}}"
         record_type: NS

--- a/ansible/cloud_providers/azure_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/azure_infrastructure_deployment.yml
@@ -128,7 +128,7 @@
         - azure_infrastructure_deployment
         - validate_azure_template
 
-    - name: ARM Group deployment create
+    - name: ARM deployment group create
       command: >-
         az deployment group create
         --name {{env_type}}.{{guid}}

--- a/ansible/cloud_providers/gcp_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/gcp_infrastructure_deployment.yml
@@ -92,7 +92,7 @@
         name: infra-gcp-create-inventory
 
     - name: Fetch DNS zone Info
-      gcp_dns_managed_zone_facts:
+      gcp_dns_managed_zone_info:
         dns_name: '{{ cluster_dns_zone + "."}}'
         project: "{{ gcp_project_id }}"
         auth_kind: "{{ gcp_auth_type }}"

--- a/ansible/configs/aro/pre_software.yml
+++ b/ansible/configs/aro/pre_software.yml
@@ -75,9 +75,6 @@
     - name: Register 'Microsoft.RedHatOpenShift' resource provider if deploying ARO4
       command: az provider register -n Microsoft.RedHatOpenShift --wait
       when: aro_version == "4"
-    - name: Install 'az aro' extension if deploying ARO4
-      command: az extension add -n aro --index https://az.aroapp.io/preview
-      when: aro_version == "4"
 
 - name: Software flight-check
   hosts: localhost

--- a/ansible/configs/ocp4-cluster/default_vars_azure.yml
+++ b/ansible/configs/ocp4-cluster/default_vars_azure.yml
@@ -11,6 +11,10 @@ cloud_provider: azure
 
 # The resource group for the DNS name
 #az_dnszone_resource_group: FROM_SECRET
+#
+# The name of the shared keyvault for ssh keys located in the
+# ame resource group as the dns zone
+#az_ssh_keyvault: rhpds-guid-kv
 
 # If we dhould create DNS delegation or a bastion entry
 dns_delegation: false
@@ -37,8 +41,10 @@ HostedZoneId: "{{ cluster_dns_zone }}"
 # Duplicating this in the Azure file to allow an unique default
 master_instance_count: 3
 
-# Number of Windows VMs to create
-windows_vm_count: 1
+# Number of Windows VMs to create -- multipla uses
+# from having a machine to RDP to for a console to windows container
+# The max value is 4, I mean this is for demo purposes
+windows_vm_count: 0
 
 # sku sets version of OS
 rhel_sku: 8-LVM

--- a/ansible/configs/ocp4-cluster/files/cloud_providers/azure_cloud_template.j2
+++ b/ansible/configs/ocp4-cluster/files/cloud_providers/azure_cloud_template.j2
@@ -5,11 +5,8 @@
 {% set temp1_guid = temp_guid.replace("-","") %}
 {% set temp2_guid = temp1_guid.replace("_","") %}
 {% set storage_guid = temp2_guid[:8]+temp2_guid[-8:] %}
-{% if windows_vm_count is not defined %}
-{% set windows_vm_count = 1 %}
-{% endif %}
-{% if windows_vm_count < 1 %}
-{% set windows_vm_count = 1 %}
+{% if windows_vm_count > 4 %}
+{% set windows_vm_count = 4 %}
 {% endif %}
 {% if windows_password is not defined %}
 {% set windows_password = "AwfulP@ssw0rd" %}
@@ -207,7 +204,7 @@
         }
       }
     },
-    {
+{% if windows_vm_count > 0 %}    {
       "apiVersion": "2018-11-01",
       "name": "[concat(variables('publicIPWindowsAddressName'), copyIndex())]",
       "type": "Microsoft.Network/publicIPAddresses",
@@ -226,7 +223,7 @@
         "name": "winipcopy",
         "count": "[parameters('windowsVmCount')]"
       }
-    },
+    },{% endif %}
     {
       "comments":  "Default Network Security Group",
       "type":  "Microsoft.Network/networkSecurityGroups",
@@ -322,7 +319,7 @@
         ]
       }
     },
-    {
+{% if windows_vm_count > 0 %}    {
       "apiVersion": "2018-11-01",
       "name": "[concat(variables('nicWindowsName'), copyIndex())]",
       "type": "Microsoft.Network/networkInterfaces",
@@ -356,7 +353,7 @@
         "name": "winniccopy",
         "count": "[parameters('windowsVmCount')]"
       }
-    },
+    },{% endif %}
     {
       "type": "Microsoft.Network/networkInterfaces",
       "apiVersion": "2018-11-01",
@@ -388,7 +385,7 @@
         ]
       }
     },
-    {
+{% if windows_vm_count > 0 %}    {
       "apiVersion": "2019-07-01",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('vmNameWindows'), copyIndex())]",
@@ -447,7 +444,7 @@
         "name": "winvmcopy",
         "count": "[parameters('windowsVmCount')]"
       }
-    },
+    },{% endif %}
     {
       "apiVersion": "2019-07-01",
       "type": "Microsoft.Compute/virtualMachines",

--- a/ansible/configs/ocp4-cluster/post_infra.yml
+++ b/ansible/configs/ocp4-cluster/post_infra.yml
@@ -24,7 +24,7 @@
   - name: GCP Post Infrastructure
     when: cloud_provider is match("gcp")
     block:
-    - name: Create keyvault for SSH Key
+    - name: Create secret for SSH Key
       include_role:
         name: infra-gcp-ssh-key
 
@@ -44,7 +44,7 @@
   - name: Azure Post Infrastructure
     when: cloud_provider is match("azure")
     block:
-    - name: Create keyvault for SSH Key
+    - name: Store SSH Key in shared keyvault
       include_role:
         name: infra-azure-ssh-key
 

--- a/ansible/roles-infra/infra-azure-ssh-key/a
+++ b/ansible/roles-infra/infra-azure-ssh-key/a
@@ -1,0 +1,5 @@
+        az keyvault secret show
+        --vault-name "rhpds-guid-kv"
+        --name "vp-ocptest"
+        --query value -o tsv
+

--- a/ansible/roles-infra/infra-azure-ssh-key/defaults/main.yml
+++ b/ansible/roles-infra/infra-azure-ssh-key/defaults/main.yml
@@ -2,3 +2,5 @@
 output_dir: /tmp/output_dir
 key_name: temporary_opentlc
 ssh_key: "{{ output_dir }}/ssh-key-{{ project_tag }}"
+az_dnszone_resource_group: gpte-infra
+az_ssh_keyvault: rhpds-guid-kv

--- a/ansible/roles-infra/infra-azure-ssh-key/tasks/main.yml
+++ b/ansible/roles-infra/infra-azure-ssh-key/tasks/main.yml
@@ -37,8 +37,8 @@
         AZURE_CONFIG_DIR: "{{ output_dir }}/.azure-{{project_tag}}"
       command: >
         az keyvault secret show
-        --vault-name 'rhpds-{{guid[:12]}}-kv'
-        --name 'sshPrivateKey'
+        --vault-name '{{ az_ssh_keyvault }}'
+        --name '{{guid[:12]}}'
         --query value -o tsv
       register: r_ssh_key
       failed_when:
@@ -67,20 +67,11 @@
 
 - when: stat_infra_ssh_key.stat.exists
   block:
-    - name: Create project specific keyvault
-      environment:
-        AZURE_CONFIG_DIR: "{{ output_dir }}/.azure-{{project_tag}}"
-      command: >
-          az keyvault create
-          --name 'rhpds-{{guid[:12]}}-kv'
-          --resource-group '{{ az_resource_group }}'
-          --enable-soft-delete false
-
     - name: Store SSH Key in keyvault
       environment:
         AZURE_CONFIG_DIR: "{{ output_dir }}/.azure-{{project_tag}}"
       command: >
           az keyvault secret set
-          --vault-name 'rhpds-{{guid[:12]}}-kv'
-          --name 'sshPrivateKey'
+          --vault-name '{{ az_ssh_keyvault }}'
+          --name '{{guid[:12]}}'
           --file '{{ infra_ssh_key }}'

--- a/ansible/roles-infra/infra-azure-template-destroy/tasks/main.yml
+++ b/ansible/roles-infra/infra-azure-template-destroy/tasks/main.yml
@@ -69,7 +69,7 @@
             t_dest: "{{output_dir}}/{{ env_type }}.{{ guid }}.{{cloud_provider}}_cloud_template"
 
         - name: Get all resources from the deployment
-          command: az group deployment show --name {{env_type}}.{{guid}} --resource-group {{az_resource_group}}
+          command: az deployment group show --name {{env_type}}.{{guid}} --resource-group {{az_resource_group}}
           changed_when: false
           register: az_dep
           until: az_dep is succeeded


### PR DESCRIPTION
##### SUMMARY
Included:
 - Azure CLI no longer needs to add an extension for ARO. The extension was phased out when it went from Beta to GA.
 - Fixing up some Ansible depreciated code in the same playbooks
 - Cleaning up how keyvaults are used to remove a bottleneck
 - Updating ocp4-cluster to allow zero windows VMs or up to 4. There is no reason to allow more for demo purposes.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
config/ocp4-cluster (keyvault changes + roles-infra/azure*ssh*)
cloud-provider/gcp (ansible depreciation)
cloud-provider/azure (ansible + aro extension fix + allowing zero windows VMs with a limit of 4)


##### ADDITIONAL INFORMATION
Just about two months worth of little edits that need to get tested and tagged
