### PR TITLE
Update Contributing.adoc: add idem-potent rule

### DIFF
--- a/docs/Contributing.adoc
+++ b/docs/Contributing.adoc
@@ -30,8 +30,7 @@ These are our contribution guidelines for helping out with the project. Any sugg
 * If your Pull Request is not ready for review, open it as link:https://github.blog/2019-02-14-introducing-draft-pull-requests/[Draft] or prefix with `WIP` in the title.
 * AgnosticD is part of the Red Hat Community of Practices; the link:https://redhat-cop.github.io/contrib/[Red Hat CoP Contribution Guidelines] apply.
 * Do not push binary files or large files into Git. Instead, expose them, for example using public Object storage like S3, and fetch them with ansible using modules like `get_url`.
-
-
+* Destroy playbooks must be idem-potent. If run twice, they should not exit with an error.
 
 === Code Quality Rules
 


### PR DESCRIPTION
All destroy playbooks must be idem-potent.

OPS should be able to run a destroy playbook several times, until it succeeds.

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Docs Pull Request
