### PR TITLE
Add Red Hat Edge Computing role

### DIFF
--- a/ansible/roles/ocp-workload-aiedge-computing-blueprint/.yamllint
+++ b/ansible/roles/ocp-workload-aiedge-computing-blueprint/.yamllint
@@ -1,0 +1,10 @@
+extends: default
+rules:
+  comments:
+    require-starting-space: false
+  comments-indentation: disable
+  indentation:
+    indent-sequences: consistent
+  line-length:
+    max: 120
+    allow-non-breakable-inline-mappings: true

--- a/ansible/roles/ocp-workload-aiedge-computing-blueprint/defaults/main.yml
+++ b/ansible/roles/ocp-workload-aiedge-computing-blueprint/defaults/main.yml
@@ -1,0 +1,36 @@
+---
+become_override: false
+ocp_username: llasmith-redhat.com
+silent: false
+
+ocp_workload_aiedge_computing_blueprint_defaults:
+  # For all of the repos reset the master branch to the specified tag/branch
+  git_repo_reset: true
+  acm_blueprint_hub_repo_upstream:
+    "https://github.com/redhat-edge-computing/blueprint-management-hub.git"
+  acm_blueprint_hub_repo_name: "blueprint-management-hub"
+  acm_blueprint_hub_repo_branch: "1.0"
+  manuela_gitops_repo_upstream:
+    "https://github.com/redhat-edge-computing/manuela-gitops.git"
+  manuela_gitops_repo_name: "manuela-gitops"
+  manuela_gitops_repo_branch: "1.0"
+  manuela_dev_repo_upstream:
+    "https://github.com/redhat-edge-computing/manuela-dev.git"
+  manuela_dev_repo_name: "manuela-dev"
+  manuela_dev_repo_branch: "master"
+  industrial_edge_docs_repo_upstream:
+    "https://github.com/redhat-edge-computing/industrial-edge-docs.git"
+  industrial_edge_docs_repo_name: "industrial-edge-docs"
+  industrial_edge_docs_repo_branch: "1.0"
+  acm_blueprint_edge_repo_upstream:
+    "https://github.com/redhat-edge-computing/blueprint-industrial-edge.git"
+  acm_blueprint_edge_repo_name: "blueprint-industrial-edge"
+  acm_blueprint_edge_repo_branch: "1.0"
+  gitea_user: "user1"
+  gitea_user_pw: "openshift"
+  git_config_user_name: "Edge Computing Demo"
+  git_config_user_email: "edge.computing@redhat"
+  # yamllint disable-line rule:line-length
+  dockerconfigjson_template: '{"auths":{"INTERNAL_REGISTRY_URL": { "auth": "INTERNAL_REGISTRY_AUTH_TOKEN" }}}'
+  image_registry_auth_user: "admin"
+  pipeline_namespace: "manuela-ci"

--- a/ansible/roles/ocp-workload-aiedge-computing-blueprint/readme.adoc
+++ b/ansible/roles/ocp-workload-aiedge-computing-blueprint/readme.adoc
@@ -1,0 +1,179 @@
+= ocp_workload_aiedge_computing_blueprint - Red Hat Edge Computing Solution
+
+== Role overview
+
+* This role is responsible for configuring and deploying the link:https://github.com/redhat-edge-computing[Red Hat Edge Computing] blueprint.
+  The role **MUST** be deployed on an OpenShift 4.4+ cluster after the Red Hat Advanced Cluster Management link:../.././ansible/roles_ocp_workloads/ocp4_workload_rhacm[role] and Gitea link:../../ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/readme.adoc[role]
+
+  Workflow:
+  1. Customize all gitops repos in gitea to update routes, registries, ... to use the OCP wildcard domain for this server
+  1. Deploy the infrastructure for the industrial edge demo: ArgoCD, OpenShift Pipelines, Open Data Hub
+  1. Execute gitops manifests to deploy the Industrial demo applications for the central datacenter & factory datacenter using ACM and ArgoCD
+  1. Deploy ACM objects so that the managed cluster can be imported and we can deploy ArgoCD automatically
+
+** Tasks: link:./tasks/workload.yml[workload.yml] - Customizes and deploys the edge computing blueprint
+*** This role customize and deploy the Edge Computing Blueprint
+*** Debug task will print out: `workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to delete the workload
+*** This role doesn't do anything here
+*** Debug task will print out: `remove_workload Tasks completed successfully.`
+
+== The defaults variable file
+
+* This file link:./defaults/main.yml[./defaults/main.yml] contains all the variables you need to define to control the deployment of your workload.
+* The variable *ocp_username* is mandatory to assign the workload to the correct OpenShift user.
+* A variable *silent=True* can be passed to suppress debug messages.
+* You can modify any of these default values by adding `-e "variable_name=variable_value"` to the command line
+* You can modify any of these default values by adding `-e "variable_name=variable_value"` to the command line
+* Your deployer will override any of these variables (usually CloudForms)
+* Add long-name scoped workload parameters. Example: `ocp4_workload_example_machineconfigpool_name: worker`
+
+=== Variable Naming
+
+You *must* use long-name scope parameters for your workload to avoid variable clashing.
+Ansible lacks robust variable scoping.
+For example, parameters named `ocp4_workload_example_*` would be recognized as unique to this workload
+
+== Deploy a Workload with the `ocp-workload` playbook [Mostly for testing]
+
+. If your workload uses parameters create a `<role name>_vars.yaml` input file.
++
+.ocp_workload_aiedge_computing_blueprint_vars.yaml
+[source,yaml]
+----
+# You can set any variable, not just the dictionary
+silent: true
+
+# Set Variable 2
+ocp4_workload_example_variable_2: "My variable 2"
+----
+
+. Set up Environment Variables for the bastion you want to run this role on.
++
+[source,yaml]
+----
+TARGET_HOST="bastion.dev.openshift.opentlc.com"
+OCP_USERNAME="wkulhane-redhat.com"
+ANSIBLE_USER="ec2-user"
+WORKLOAD="ocp-workload-aiedge-computing-blueprint"
+GUID=1001
+----
+
+. Finally run the workload passing the input files as parameters:
++
+[source,sh]
+----
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=${ANSIBLE_USER}" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"guid=${GUID}" \
+    -e"ACTION=create" \
+    -e @./ocp_workload_aiedge_computing_blueprint_vars.yaml
+----
++
+
+=== To Delete an environment
+
+----
+TARGET_HOST="bastion.dev.openshift.opentlc.com"
+OCP_USERNAME="wkulhane-redhat.com"
+ANSIBLE_USER="ec2-user"
+WORKLOAD="ocp4_workload_example"
+GUID=1002
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=ec2-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"guid=${GUID}" \
+    -e"ACTION=remove" \
+    -e @./ocp_workload_example_vars.yaml \
+    -e @./ocp_workload_example_secrets.yaml
+----
+
+== Deploying a Workload with AgnosticV
+
+When creating a configuration in AgnosticV that includes the deployment of the workload you can specify the variables straight in the AgnosticV config.
+AgnosticV configs are usually created by combining a `common.yaml` file with either `dev.yaml`, `test.yaml` or `prod.yaml`.
+You can specify different variables in each of these files.
+For example you could have common values defined in the `common.yaml` file and then specific values overriding the common ones for development or production environments in `dev.yaml` or `prod.yaml`.
+
+AgnosticV merges the definition files starting with `common.yaml` and then adding/overwriting what comes from either `dev.yaml` or `prod.yaml`.
+
+Example of a simple AgnosticV config:
+
+.common.yaml
+[source,yaml]
+----
+# --- Quay Shared Workload Deployment for RPDS
+# --- System: RHPDS
+# --- Catalog: OpenShift Demos
+# --- Catalog Item: Quay 3 on OpenShift 4
+
+# --- Platform
+platform: rhpds
+
+# --- Cloud Provider
+cloud_provider: none
+
+# --- Config
+env_type: ocp4-cluster
+ocp_workload: ocp4_workload_quay_operator
+# This workload must be run as ec2-user (or cloud-user on OpenStack)
+# because it has tasks requiring sudo.
+ansible_user: ec2-user
+ansible_ssh_private_key_file: /home/opentlc-mgr/.ssh/opentlc_admin_backdoor.pem
+
+# --- Ensure the workload prints the correct statements for CloudForms to realize it finished
+workload_shared_deployment: true
+
+# --- Workload Configuration
+ocp4_workload_quay_operator_project: "quay-{{ guid }}"
+
+# --- AgnosticV Meta variables
+agnosticv_meta:
+  params_to_variables:
+    user: ocp_username
+  secrets:
+  # This secret file holds the token to pull the Quay image
+  - ocp4_workload_quay_secrets
+----
+
+.dev.yaml
+[source,yaml]
+----
+purpose: development
+
+# --- Use specific variable values for Development
+target_host: bastion.dev4.openshift.opentlc.com
+
+# --- Workload Configuration Overrides
+# Deploy Quay v3.2.0 in dev for testing purposes
+ocp4_workload_quay_operator_quay_image_tag:  "v3.2.0"
+ocp4_workload_quay_operator_clair_image_tag: "v3.2.0"
+----
+
+.prod.yaml
+[source,yaml]
+----
+---
+purpose: production
+
+# --- Use specific variable values for Production
+target_host: bastion.rhpds.openshift.opentlc.com
+
+# --- Workload Configuration Overrides
+# Deploy Quay v3.1.3 in prod for production purposes
+ocp4_workload_quay_operator_quay_image_tag:  "v3.1.3"
+ocp4_workload_quay_operator_clair_image_tag: "v3.1.3"
+
+# --- AgnosticV Meta variables
+agnosticv_meta:
+  agnosticd_git_tag_prefix: ocp4-workload-quay-rhpds-prod
+----

--- a/ansible/roles/ocp-workload-aiedge-computing-blueprint/tasks/main.yml
+++ b/ansible/roles/ocp-workload-aiedge-computing-blueprint/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+# Do not modify this file
+
+- name: Running Pre Workload Tasks
+  include_tasks:
+    file: ./pre_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload Tasks
+  include_tasks:
+    file: ./workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  include_tasks:
+    file: ./post_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload removal Tasks
+  include_tasks:
+    file: ./remove_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles/ocp-workload-aiedge-computing-blueprint/tasks/post_workload.yml
+++ b/ansible/roles/ocp-workload-aiedge-computing-blueprint/tasks/post_workload.yml
@@ -1,0 +1,26 @@
+---
+# Implement your Post Workload deployment tasks here
+# --------------------------------------------------
+
+# Leave these as the last tasks in the playbook
+# ---------------------------------------------
+
+# For deployment onto a dedicated cluster (as part of the
+# cluster deployment) set workload_shared_deployment to False
+# This is the default so it does not have to be set explicitely
+- name: post_workload tasks complete
+  debug:
+    msg: "Post-Workload tasks completed successfully."
+  when:
+    - not silent|bool
+    - not workload_shared_deployment|d(False)
+
+# For RHPDS deployment (onto a shared cluster) set
+# workload_shared_deployment to True
+# (in the deploy script or AgnosticV configuration)
+- name: post_workload tasks complete
+  debug:
+    msg: "Post-Software checks completed successfully"
+  when:
+    - not silent|bool
+    - workload_shared_deployment|d(False)

--- a/ansible/roles/ocp-workload-aiedge-computing-blueprint/tasks/pre_workload.yml
+++ b/ansible/roles/ocp-workload-aiedge-computing-blueprint/tasks/pre_workload.yml
@@ -1,0 +1,26 @@
+---
+# Implement your Pre Workload deployment tasks here
+# -------------------------------------------------
+
+# Leave these as the last tasks in the playbook
+# ---------------------------------------------
+
+# For deployment onto a dedicated cluster (as part of the
+# cluster deployment) set workload_shared_deployment to False
+# This is the default so it does not have to be set explicitely
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Workload tasks completed successfully."
+  when:
+    - not silent|bool
+    - not workload_shared_deployment|d(False)
+
+# For RHPDS deployment (onto a shared cluster) set
+# workload_shared_deployment to True
+# (in the deploy script or AgnosticV configuration)
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Software checks completed successfully"
+  when:
+    - not silent|bool
+    - workload_shared_deployment|d(False)

--- a/ansible/roles/ocp-workload-aiedge-computing-blueprint/tasks/remove_workload.yml
+++ b/ansible/roles/ocp-workload-aiedge-computing-blueprint/tasks/remove_workload.yml
@@ -1,0 +1,21 @@
+---
+# Set up the combined dictionary for the workload
+#
+# To Do: Adjust the names of your dictionaries here
+- name: Set up ocp4_workload_example combined dictionary
+  set_fact:
+    ocp_workload_aiedge_computing_blueprint: >-
+      {{ ocp_workload_aiedge_computing_blueprint_defaults
+       | combine(ocp_workload_aiedge_computing_blueprint_vars   | default( {} ),
+                 ocp_workload_aiedge_computing_blueprint_secrets| default( {} ),
+        recursive=true )
+      }}
+# Implement your Workload removal tasks here
+# ------------------------------------------
+
+# Leave this as the last task in the playbook.
+# --------------------------------------------
+- name: remove_workload tasks complete
+  debug:
+    msg: "Remove Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp-workload-aiedge-computing-blueprint/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-aiedge-computing-blueprint/tasks/workload.yml
@@ -1,0 +1,582 @@
+---
+- name: Setting up workload for user
+  debug:
+    msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
+
+# Set up the combined dictionary for the workload
+- name: Set up ocp_workload_aiedge_computing_blueprint combined dictionary
+  set_fact:
+    ocp_workload_aiedge_computing_blueprint: >-
+      {{ ocp_workload_aiedge_computing_blueprint_defaults
+       | combine(ocp_workload_aiedge_computing_blueprint_vars   | default( {} ),
+                 ocp_workload_aiedge_computing_blueprint_secrets| default( {} ),
+                 recursive=true )
+      }}
+
+# Because now secrets are part of the combined dictionary use
+# verbosity 2 to prevent printing the dictionary during every run.
+- name: Print combined role variables
+  debug:
+    var: ocp_workload_aiedge_computing_blueprint
+    verbosity: 2
+
+- name: Get cluster ingress config
+  k8s_info:
+    api_version: config.openshift.io/v1
+    kind: ingress
+    name: cluster
+  register: core_cluster_config_ingress_object
+  until: core_cluster_config_ingress_object.resources | length > 0
+  retries: 10
+  delay: 20
+
+# Wildcard domain is the base domain for all project routes in the cluster
+- set_fact:
+    core_cluster_wildcard_domain:
+      "{{ core_cluster_config_ingress_object.resources[0].spec.domain }}"
+
+# Expose internal registry for core cluster
+- name: Expose the OpenShift internal registry
+  k8s:
+    state: present
+    definition:
+      apiVersion: imageregistry.operator.openshift.io/v1
+      kind: Config
+      metadata:
+        name: cluster
+      spec:
+        defaultRoute: true
+
+- name: Get the OpenShift registry route object
+  k8s_info:
+    name: default-route
+    api_version: route.openshift.io/v1
+    kind: route
+    namespace: openshift-image-registry
+  register: image_registry_object
+  until: image_registry_object.resources | length > 0
+  retries: 10
+  delay: 20
+
+- name: Set the url for the exposed image registry url
+  set_fact:
+    core_imageregistry_url: "{{ image_registry_object.resources[0].spec.host }}"
+
+- name: Get the gitea route
+  k8s_info:
+    name: gitea
+    api_version: route.openshift.io/v1
+    kind: route
+    namespace: gitea
+    label_selectors:
+      - "app = gitea"
+  register: gitea_route_object
+  until: gitea_route_object|length > 0
+  retries: 10
+  delay: 20
+
+- name: Set the gitea server host
+  set_fact:
+    gitea_server_host: "{{ gitea_route_object.resources[0].spec.host }}"
+
+- name: Set the url gitea server and organization
+  set_fact:
+    gitea_server_host_org: "{{ gitea_server_host }}/{{ gitea_user }}"
+    gitea_repo_org_url: "https://{{ gitea_server_host }}/{{ gitea_user }}"
+  vars:
+    gitea_user: "{{ ocp_workload_aiedge_computing_blueprint.gitea_user }}"
+
+
+####################################################################################################
+# GIT REPO SETUP
+####################################################################################################
+- name: Set the temporary location directory where the repo will be saved
+  tempfile:
+    state: directory
+    suffix: -redhat-edge-computing
+  register: edge_computing_root_dir
+
+- set_fact:
+    hub_repo_dir: "{{ edge_computing_root_dir.path }}/blueprint-management-hub"
+    edge_repo_dir: "{{ edge_computing_root_dir.path }}/blueprint-industrial-edge"
+    manuela_dev_repo_dir: "{{ edge_computing_root_dir.path }}/manuela-dev"
+    manuela_gitops_repo_dir: "{{ edge_computing_root_dir.path }}/manuela-gitops"
+
+# Clone the manuela dev & gitops repo and create a branch for the demo
+- name: Clone the MANUela repos
+  git:
+    repo: "{{ item.repo }}"
+    dest: "{{ item.dest }}"
+    refspec: '+refs/tags/*:refs/tags/*'
+  loop:
+    # yamllint disable rule:line-length
+    - repo: "{{ gitea_repo_org_url }}/{{ ocp_workload_aiedge_computing_blueprint.acm_blueprint_hub_repo_name }}"
+      dest: "{{ hub_repo_dir }}"
+    - repo: "{{ gitea_repo_org_url }}/{{ ocp_workload_aiedge_computing_blueprint.acm_blueprint_edge_repo_name }}"
+      dest: "{{ edge_repo_dir }}"
+    - repo: "{{ gitea_repo_org_url }}/{{ ocp_workload_aiedge_computing_blueprint.manuela_dev_repo_name }}"
+      dest: "{{ manuela_dev_repo_dir }}"
+    - repo: "{{ gitea_repo_org_url }}/{{ ocp_workload_aiedge_computing_blueprint.manuela_gitops_repo_name }}"
+      dest: "{{ manuela_gitops_repo_dir }}"
+    # yamllint enable rule:line-length
+
+- name: Set the git config user name
+  git_config:
+    name: user.name
+    repo: "{{ item }}"
+    scope: local
+    value: "{{ ocp_workload_aiedge_computing_blueprint.git_config_user_name }}"
+  loop:
+    - "{{ hub_repo_dir }}"
+    - "{{ edge_repo_dir }}"
+    - "{{ manuela_gitops_repo_dir }}"
+    - "{{ manuela_dev_repo_dir }}"
+
+- name: Set the git config email
+  git_config:
+    name: user.email
+    repo: "{{ item }}"
+    scope: local
+    value: "{{ ocp_workload_aiedge_computing_blueprint.git_config_user_email }}"
+  loop:
+    - "{{ hub_repo_dir }}"
+    - "{{ edge_repo_dir }}"
+    - "{{ manuela_gitops_repo_dir }}"
+    - "{{ manuela_dev_repo_dir }}"
+
+- name: Add remote tracking for gitea with auth in url
+  command:
+    chdir: "{{ item.repo_dir }}"
+    cmd: >-
+      git remote add gitea https://{{
+      ocp_workload_aiedge_computing_blueprint.gitea_user }}:{{
+      ocp_workload_aiedge_computing_blueprint.gitea_user_pw }}@{{
+      gitea_server_host_org }}/{{ item.repo_name }}
+  loop:
+    # yamllint disable rule:line-length
+    - repo_name: "{{ ocp_workload_aiedge_computing_blueprint.acm_blueprint_hub_repo_name }}"
+      repo_dir: "{{ hub_repo_dir }}"
+    - repo_name: "{{ ocp_workload_aiedge_computing_blueprint.acm_blueprint_edge_repo_name }}"
+      repo_dir: "{{ edge_repo_dir }}"
+    - repo_name: "{{ ocp_workload_aiedge_computing_blueprint.manuela_dev_repo_name }}"
+      repo_dir: "{{ manuela_dev_repo_dir }}"
+    - repo_name: "{{ ocp_workload_aiedge_computing_blueprint.manuela_gitops_repo_name }}"
+      repo_dir: "{{ manuela_gitops_repo_dir }}"
+    # yamllint enable rule:line-length
+
+  # We are pulling a stable tag for the demo and resetting master to that commit
+- name: Reset each repo master to the specified tag
+  command:
+    chdir: "{{ item.repo_dir }}"
+    cmd: "git reset --hard {{ item.repo_branch }}"
+  loop:
+    # yamllint disable rule:line-length
+    - repo_branch: "{{ ocp_workload_aiedge_computing_blueprint.acm_blueprint_hub_repo_branch }}"
+      repo_dir: "{{ hub_repo_dir }}"
+    - repo_branch: "{{ ocp_workload_aiedge_computing_blueprint.acm_blueprint_edge_repo_branch }}"
+      repo_dir: "{{ edge_repo_dir }}"
+    - repo_branch: "{{ ocp_workload_aiedge_computing_blueprint.manuela_dev_repo_branch }}"
+      repo_dir: "{{ manuela_dev_repo_dir }}"
+    - repo_branch: "{{ ocp_workload_aiedge_computing_blueprint.manuela_gitops_repo_branch }}"
+      repo_dir: "{{ manuela_gitops_repo_dir }}"
+    # yamllint enable rule:line-length
+  when: ocp_workload_aiedge_computing_blueprint.git_repo_reset | bool
+
+- name: Update all git repo urls to reference gitea as the host
+  replace:
+    path: "{{ item }}"
+    regexp: 'github\.com\/redhat-edge-computing'
+    replace: "{{ gitea_server_host_org }}"
+  loop:
+    # yamllint disable rule:line-length
+    - "{{ hub_repo_dir }}/README.md"
+    - "{{ hub_repo_dir }}/base/02_cluster-addons/07_tekton/configmaps/environment.yaml"
+    - "{{ hub_repo_dir }}/base/03_services/argocd-operator-subs/channel.yaml"
+    - "{{ hub_repo_dir }}/base/03_services/manuela-central/argocd-hub-centraldatacenter.yaml"
+    - "{{ hub_repo_dir }}/base/03_services/manuela-ml-workspace/kustomization.yaml"
+    - "{{ hub_repo_dir }}/sites/edge-mgmt-hub.gcp.devcluster.openshift.com/00_install-config/kustomization.yaml"
+    - "{{ hub_repo_dir }}/sites/edge-mgmt-hub.gcp.devcluster.openshift.com/README.md"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-data-lake/manuela-data-lake-central-kafka-cluster.yaml"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-data-lake/manuela-data-lake-central-s3-store.yaml"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-data-lake/manuela-data-lake-factory-mirror-maker.yaml"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-tst/manuela-tst-all-application.yaml"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-stormshift-staging-aws/manuela-stormshift-line-dashboard-application.yaml"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-stormshift-staging-aws/manuela-stormshift-machine-sensor-application.yaml"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-stormshift-staging-aws/manuela-stormshift-messaging-application.yaml"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-stormshift-staging-gcp/manuela-stormshift-line-dashboard-application.yaml"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-stormshift-staging-gcp/manuela-stormshift-machine-sensor-application.yaml"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-stormshift-staging-gcp/manuela-stormshift-messaging-application.yaml"
+    - "{{ manuela_gitops_repo_dir }}/meta/argocd-hub-centraldatacenter.yaml"
+    - "{{ manuela_gitops_repo_dir }}/meta/argocd-hub-factorydatacenter.yaml"
+    - "{{ manuela_gitops_repo_dir }}/meta/argocd-staging-gcp-linedataserver.yaml"
+    - "{{ edge_repo_dir }}/sites/mvp.edge.industrial/00_install-config/kustomization.yaml"
+    - "{{ edge_repo_dir }}/sites/mvp.edge.industrial/03_services/manuela-edge/channel-sensors.yaml"
+    - "{{ edge_repo_dir }}/sites/staging-edge.devcluster.openshift.com/00_install-config/kustomization.yaml"
+    - "{{ edge_repo_dir }}/sites/staging-edge.devcluster.openshift.com/03_services/argocd-gitops-factory/argocd-staging-aws-factorydatacenter.yaml"
+    - "{{ edge_repo_dir }}/sites/staging-edge.devcluster.openshift.com/03_services/argocd-gitops-factory/argocd-staging-aws-linedataserver.yaml"
+    - "{{ edge_repo_dir }}/sites/staging-edge.gcp.devcluster.openshift.com/00_install-config/kustomization.yaml"
+    - "{{ edge_repo_dir }}/sites/staging-edge.gcp.devcluster.openshift.com/03_services/argocd-gitops-factory/argocd-staging-gcp-factorydatacenter.yaml"
+    - "{{ edge_repo_dir }}/sites/staging-edge.gcp.devcluster.openshift.com/03_services/argocd-gitops-factory/argocd-staging-gcp-linedataserver.yaml"
+    # yamllint enable rule:line-length
+
+- name: Commit changes to the application repoURLs
+  command:
+    chdir: "{{ item }}"
+    cmd: "git commit -a -m 'Update git repo URLs to use gitea server'"
+  loop:
+    - "{{ hub_repo_dir }}"
+    - "{{ edge_repo_dir }}"
+    - "{{ manuela_gitops_repo_dir }}"
+    - "{{ manuela_dev_repo_dir }}"
+  ignore_errors: yes
+
+- name: Update all quay urls to using internal registry
+  replace:
+    path: "{{ item }}"
+    # yamllint disable-line rule:line-length
+    regexp: 'quay\.io/(redhat-edge-computing|manuela)/(iot-(consumer|frontend|software-sensor|anomaly-detection))'
+    replace: '{{ core_imageregistry_url }}/manuela-tst-all/\2'
+  loop:
+    # yamllint disable rule:line-length
+    - "{{ hub_repo_dir }}/base/02_cluster-addons/07_tekton/configmaps/environment.yaml"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-quickstart/line-dashboard/kustomization.yaml"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-quickstart/machine-sensor/kustomization.yaml"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-quickstart/messaging/kustomization.yaml"
+    - "{{ manuela_gitops_repo_dir }}/config/templates/manuela-openshift-prod/anomaly-detection/anomaly-detection-is.yaml"
+    - "{{ manuela_gitops_repo_dir }}/config/templates/manuela-openshift-prod/line-dashboard/line-dashboard-is.yaml"
+    - "{{ manuela_gitops_repo_dir }}/config/templates/manuela-openshift-prod/machine-sensor/machine-sensor-is.yaml"
+    - "{{ manuela_gitops_repo_dir }}/config/templates/manuela-openshift-prod/messaging/messaging-is.yaml"
+    # yamllint enable rule:line-length
+
+- name: Commit changes to the application repoURLs
+  command:
+    chdir: "{{ item }}"
+    cmd: "git commit -a -m 'Update quay repo URLs to use internal registry'"
+  loop:
+    - "{{ hub_repo_dir }}"
+    - "{{ edge_repo_dir }}"
+    - "{{ manuela_gitops_repo_dir }}"
+    - "{{ manuela_dev_repo_dir }}"
+  ignore_errors: yes
+
+- name: Update all references to the route for edge-mgmt-hub.gcp.devcluster domain
+  replace:
+    path: "{{ item }}"
+    # yamllint disable-line rule:line-length
+    regexp: 'apps\.(edge-mgmt-hub\.gcp\.devcluster|staging-edge(\.gcp)?\.devcluster)\.openshift\.com'
+    replace: '{{ core_cluster_wildcard_domain }}'
+  loop:
+    # yamllint disable rule:line-length
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-argocd-aggregator/hub/prometheus-route.yaml"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-argocd-aggregator/hub/pushprox-proxy-route.yaml"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-argocd-aggregator/spoke-ocp4/pushprox-client-deployment.yaml"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-data-lake/central-kafka-cluster/kafka-cluster.yaml"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-data-lake/central-kafka-cluster/kafka-tls-certificate-and-key.yaml"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-data-lake/central-s3-store/kafka-to-s3-cm.yaml"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-data-lake/factory-mirror-maker/factory-to-central-mirror-maker2.yaml"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-quickstart/line-dashboard/kustomization.yaml"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-stormshift-staging-aws/line-dashboard/line-dashboard-configmap-config.json"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-stormshift-staging-aws/line-dashboard/line-dashboard-route.yaml"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-stormshift-staging-aws/machine-sensor/machine-sensor-1-configmap.properties"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-stormshift-staging-aws/machine-sensor/machine-sensor-2-configmap.properties"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-stormshift-staging-aws/messaging/route.yaml"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-stormshift-staging-gcp/line-dashboard/line-dashboard-configmap-config.json"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-stormshift-staging-gcp/line-dashboard/line-dashboard-route.yaml"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-stormshift-staging-gcp/machine-sensor/machine-sensor-1-configmap.properties"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-stormshift-staging-gcp/machine-sensor/machine-sensor-2-configmap.properties"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-stormshift-staging-gcp/messaging/route.yaml"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-tst/line-dashboard-configmap-config.json"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-tst/line-dashboard-route.yaml"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-tst/machine-sensor-1-configmap.properties"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-tst/machine-sensor-2-configmap.properties"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-tst/messaging-route.yaml"
+    # yamllint enable rule:line-length
+
+- name: Commit changes to the gitops routes
+  command:
+    chdir: "{{ item }}"
+    cmd: "git commit -a -m 'Update route to use cluster wildcard domain'"
+  loop:
+    - "{{ hub_repo_dir }}"
+    - "{{ edge_repo_dir }}"
+    - "{{ manuela_gitops_repo_dir }}"
+    - "{{ manuela_dev_repo_dir }}"
+  ignore_errors: yes
+
+
+- name: Add gitea user to blueprint secret
+  replace:
+    # yamllint disable rule:line-length
+    path: "{{ hub_repo_dir }}/base/02_cluster-addons/07_tekton/secrets/github.yaml"
+    regexp: 'GITHUBUSER'
+    replace: "{{ ocp_workload_aiedge_computing_blueprint.gitea_user | b64encode }}"
+    # yamllint enable rule:line-length
+
+- name: Add gitea user token to blueprint
+  replace:
+    # yamllint disable rule:line-length
+    path: "{{ hub_repo_dir }}/base/02_cluster-addons/07_tekton/secrets/github.yaml"
+    regexp: 'GITHUBTOKEN'
+    replace: "{{ ocp_workload_aiedge_computing_blueprint.gitea_user_pw | b64encode }}"
+    # yamllint enable rule:line-length
+
+- name: Commit changes to the tekton git secret
+  command:
+    chdir: "{{ hub_repo_dir }}"
+    cmd: "git commit -a -m 'Update git user auth for tekton pipelines'"
+  ignore_errors: yes
+
+###################################################################################################
+# Deploy infrastructure for the Core DataCenter
+###################################################################################################
+- name: Install Auto Approver kustomize manifest
+  command:
+    cmd: "oc apply -f '{{ hub_repo_dir }}/base/02_cluster-addons/{{ item }}'"
+  loop:
+    - "01_autoapprover/00_sa.yaml"
+    - "01_autoapprover/01_crb.yaml"
+    - "01_autoapprover/02_approver.yaml"
+
+- name: Install ArgoCD kustomize manifest
+  command:
+    cmd: "oc apply -k '{{ hub_repo_dir }}/base/02_cluster-addons/03_argocd'"
+  # Retry while we wait for the ArgoCD CRD creation
+  register: result
+  until: result.rc == 0
+  retries: 10
+  delay: 20
+
+- name: Install OpenShift Pipeline kustomize manifest
+  command:
+    # yamllint disable-line rule:line-length
+    cmd: "oc apply -k '{{ hub_repo_dir }}/base/02_cluster-addons/04_openshift-pipelines'"
+
+- name: Install manuela-ci objects
+  command:
+    cmd: "oc apply -k '{{ hub_repo_dir }}/base/02_cluster-addons/05_manuela-ci'"
+
+- name: Install Open Data Hub operator
+  command:
+    # yamllint disable-line rule:line-length
+    cmd: "oc apply -f '{{ hub_repo_dir }}/base/02_cluster-addons/06_opendatahub/subscription.yaml'"
+
+###################################################################################################
+# Create Image Registry auth info
+###################################################################################################
+
+- name: Enable anonymous image pulls from the exposed registry
+  k8s:
+    state: present
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: image-puller
+      subjects:
+        - kind: Group
+          apiGroup: rbac.authorization.k8s.io
+          name: system:unauthenticated
+        - kind: Group
+          apiGroup: rbac.authorization.k8s.io
+          name: system:authenticated
+      roleRef:
+        kind: ClusterRole
+        apiGroup: rbac.authorization.k8s.io
+        name: system:image-puller
+
+- name: Create Service Account for Image Registry Access
+  k8s:
+    state: present
+    name: edge-computing
+    kind: ServiceAccount
+    namespace: >-
+      {{ ocp_workload_aiedge_computing_blueprint.pipeline_namespace }}
+
+- name: Query the server for the service account with secrets
+  k8s_info:
+    name: edge-computing
+    kind: ServiceAccount
+    namespace: >-
+      {{ ocp_workload_aiedge_computing_blueprint.pipeline_namespace }}
+  register: edge_computing_service_account
+  until: edge_computing_service_account|length > 0
+  retries: 10
+  delay: 20
+
+- name: Get the dockercfg secret name for edge-computing service account
+  set_fact:
+    edge_computing_dockercfg_secret_name:
+      # yamllint disable-line rule:line-length
+      "{{ edge_computing_service_account.resources[0].secrets | map(attribute='name') | list | select('match', '.+dockercfg.+' ) | list | first }}"
+
+- name: Create ClusterRoleBinding for edge-computing SA as registry-editor
+  k8s:
+    state: present
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: edge-computing-registry-editor
+        namespace: >-
+          {{ ocp_workload_aiedge_computing_blueprint.pipeline_namespace }}
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: registry-editor
+      subjects:
+        - kind: ServiceAccount
+          name: edge-computing
+          namespace: >-
+            {{ ocp_workload_aiedge_computing_blueprint.pipeline_namespace }}
+
+- name: Get edge-computing dockerconfig secret
+  k8s_info:
+    name: "{{ edge_computing_dockercfg_secret_name }}"
+    namespace: >-
+      {{ ocp_workload_aiedge_computing_blueprint.pipeline_namespace }}
+    kind: Secret
+  register: edge_computing_dockercfg_secret
+  until: edge_computing_dockercfg_secret|length > 0
+  retries: 10
+  delay: 20
+
+- name: "Get the dockercfg auth tokens for authenticating to the registry"
+  set_fact:
+    edge_computing_dockercfg: >-
+      {{ edge_computing_dockercfg_secret.resources[0].data['.dockercfg'] |
+      b64decode | from_json }}
+
+- name: "Get the dockercfg auth token for the internal registry"
+  set_fact:
+    # yamllint disable-line rule:line-length
+    core_registry_auth_token: "{{ edge_computing_dockercfg['image-registry.openshift-image-registry.svc:5000'].auth }}"
+
+- name: Create image registry build secret
+  set_fact:
+    dockerconfigjson: >-
+      {{ ocp_workload_aiedge_computing_blueprint.dockerconfigjson_template |
+      replace('INTERNAL_REGISTRY_URL', core_imageregistry_url ) |
+      replace('INTERNAL_REGISTRY_AUTH_TOKEN', core_registry_auth_token) |
+      from_json }}
+
+- name: Base64 encrypt dockerconfig json
+  set_fact:
+    dockerconfigjson_base64: "{{ dockerconfigjson | to_json | b64encode }}"
+
+- name: Add image registry build secret
+  replace:
+    # yamllint disable-line rule:line-length
+    path: "{{ hub_repo_dir }}/base/02_cluster-addons/07_tekton/secrets/quay-build-secret.yaml"
+    regexp: 'DOCKERCONFIGJSON'
+    replace: "{{ dockerconfigjson_base64 }}"
+
+- name: Commit quay build secret changes to the blueprint
+  command:
+    chdir: "{{ hub_repo_dir }}"
+    cmd: "git commit -a -m 'Update quay build secret'"
+  ignore_errors: yes
+
+- name: Push all changes back to the git repos
+  command:
+    chdir: "{{ item.repo_dir }}"
+    cmd: "git push -f gitea master"
+  loop:
+    # yamllint disable rule:line-length
+    - repo_name: "{{ ocp_workload_aiedge_computing_blueprint.acm_blueprint_hub_repo_name }}"
+      repo_dir: "{{ hub_repo_dir }}"
+    - repo_name: "{{ ocp_workload_aiedge_computing_blueprint.acm_blueprint_edge_repo_name }}"
+      repo_dir: "{{ edge_repo_dir }}"
+    - repo_name: "{{ ocp_workload_aiedge_computing_blueprint.manuela_dev_repo_name }}"
+      repo_dir: "{{ manuela_dev_repo_dir }}"
+    - repo_name: "{{ ocp_workload_aiedge_computing_blueprint.manuela_gitops_repo_name }}"
+      repo_dir: "{{ manuela_gitops_repo_dir }}"
+    # yamllint enable rule:line-length
+
+- name: Check for tekton pipeline CRD
+  k8s_info:
+    api_version: apiextensions.k8s.io/v1
+    kind: customresourcedefinition
+    name: pipelines.tekton.dev
+  register: result
+  until: result.resources|length > 0
+  retries: 10
+  delay: 20
+
+- name: Create tekton pipelines
+  command:
+    cmd: "oc apply -k '{{ hub_repo_dir }}/base/02_cluster-addons/07_tekton'"
+  # Retry while we wait for OpenShift Pipelines CRD creation
+  retries: 30
+  delay: 20
+
+- name: Update the github-push tekton task to use gitea as the push server
+  k8s:
+    state: present
+    definition: >-
+      {{ lookup('template', './templates/github-push.task.yaml.j2' ) |
+      from_yaml }}
+
+###################################################################################################
+# Advanced Cluster Management
+###################################################################################################
+- name: Create the ACM gitops namespace
+  command:
+    # yamllint disable rule:line-length
+    cmd: "oc apply -f '{{ hub_repo_dir }}/base/03_services/argocd-operator-subs/namespace.yaml'"
+
+- name: Create the ACM gitops channel
+  command:
+    cmd: "oc apply -f '{{ hub_repo_dir }}/base/03_services/argocd-operator-subs/channel.yaml'"
+
+- name: Create the ACM gitops placementrule
+  command:
+    cmd: "oc apply -f '{{ hub_repo_dir }}/base/03_services/argocd-operator-subs/placementrule.yaml'"
+
+- name: Create the ACM gitops subscription
+  command:
+    cmd: "oc apply -f '{{ hub_repo_dir }}/base/03_services/argocd-operator-subs/subscription.yaml'"
+
+- name: Create the Manuela centraldatacenter argocd application
+  command:
+    cmd: "oc apply -f '{{ hub_repo_dir }}/base/03_services/manuela-central/argocd-hub-centraldatacenter.yaml'"
+
+- name: Create the Manuela factorydatacenter argocd application
+  command:
+    cmd: "oc apply -f '{{ edge_repo_dir }}/sites/staging-edge.devcluster.openshift.com/03_services/argocd-gitops-factory/argocd-staging-aws-factorydatacenter.yaml'"
+    # yamllint enable rule:line-length
+
+- name: Create the Manuela ML workspace
+  k8s:
+    state: present
+    api_version: v1
+    name: manuela-ml-workspace
+    kind: Namespace
+
+  # yamllint disable rule:line-length
+- name: Create the Open Data Hub resources
+  command:
+    cmd: "oc apply -f '{{ hub_repo_dir }}/base/03_services/odh-resources/odh-kfdef.yaml'"
+
+- name: Create the tekton PipelineRuns seed-iot-anomaly-detection-run
+  command:
+    cmd: "oc apply -f '{{ hub_repo_dir }}/base/03_services/tekton/seed-iot-anomaly-detection-run.yaml'"
+
+- name: Create the tekton PipelineRuns seed-iot-consumer-run
+  command:
+    cmd: "oc apply -f '{{ hub_repo_dir }}/base/03_services/tekton/seed-iot-consumer-run.yaml'"
+
+- name: Create the tekton PipelineRuns seed-iot-frontend-run
+  command:
+    cmd: "oc apply -f '{{ hub_repo_dir }}/base/03_services/tekton/seed-iot-frontend-run.yaml'"
+
+- name: Create the tekton PipelineRuns seed-iot-software-sensor-run
+  command:
+    cmd: "oc apply -f '{{ hub_repo_dir }}/base/03_services/tekton/seed-iot-software-sensor-run.yaml'"
+  # yamllint enable rule:line-length
+
+# Leave this as the last task in the playbook.
+# --------------------------------------------
+- name: workload tasks complete
+  debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp-workload-aiedge-computing-blueprint/templates/github-push.task.yaml.j2
+++ b/ansible/roles/ocp-workload-aiedge-computing-blueprint/templates/github-push.task.yaml.j2
@@ -1,0 +1,36 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: github-push
+  namespace: "{{ ocp_workload_aiedge_computing_blueprint.pipeline_namespace }}"
+spec:
+  params:
+  - default: user
+    name: GITHUB_USERNAME_CONFIGMAPKEY
+    type: string
+  - default: token
+    name: GITHUB_TOKEN_CONFIGMAPKEY
+    type: string
+  - default: dev
+    description: subdirectory inside the "gitrepos" workspace to clone the git repo
+      into
+    name: subdirectory
+    type: string
+  - default: ""
+    description: additional flags for git push
+    name: PUSH_FLAGS
+    type: string
+  steps:
+  - image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.11.0
+    name: push
+    resources: {}
+    script: |
+      echo "https://$(cat $(workspaces.github-secret.path)/$(params.GITHUB_USERNAME_CONFIGMAPKEY)):$(cat $(workspaces.github-secret.path)/$(params.GITHUB_TOKEN_CONFIGMAPKEY))@{{ gitea_server_host }}" > ~/.git-credentials
+      git config --global credential.helper store 'store --file ~/.git-credentials'
+      git branch -r | grep -q origin/$(git rev-parse --abbrev-ref HEAD) && git pull --ff-only --no-edit
+      git push $(params.PUSH_FLAGS)
+    workingDir: $(workspaces.gitrepos.path)/$(params.subdirectory)
+  workspaces:
+  - description: The git repo will be cloned onto the volume backing this workspace
+    name: gitrepos
+  - name: github-secret


### PR DESCRIPTION
DEV Role to deploy the Red Hat Edge Computing blueprint
https://github.com/redhat-edge-computing

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>

##### SUMMARY
Add an agnosticd role to deploy the [Red Hat Edge Computing](https://github.com/redhat-edge-computing) blueprint. This is the last role that will be applied in a OCP4 workload after the deployment of Red Hat Advanced Cluster Management and Gitea

##### ISSUE TYPE
- New role Pull Request

##### COMPONENT NAME
ocp-workload-aiedge-computing-blueprint

##### ADDITIONAL INFORMATION
This will be called in the agnosticv config OCP4_ACM_AIEDGE_COMPUTING and is the initial PR to start DEV testing of this agnosticv config before submitting it for final PROD testing
