### PR TITLE
Update migration workloads to add ability to download lab content on the bastion hosts

### DIFF
--- a/ansible/roles/ocp-workload-migration/defaults/main.yml
+++ b/ansible/roles/ocp-workload-migration/defaults/main.yml
@@ -7,5 +7,17 @@ migration_workload_title: "{{ 'Creating' if not migration_workload_destroy else 
 migration_workload_state: "{{ 'present' if not migration_workload_destroy else 'absent' }}"     # state of k8s resources
 silent: false
 
+mig_download_content:
+- url: "https://raw.githubusercontent.com/konveyor/mtc-breakfix/master/02-Stage-Pods/02-stage-pod.sh"
+  target_dir: "/files/debug/ex2/"
+- url: "https://raw.githubusercontent.com/konveyor/mtc-breakfix/master/02-Stage-Pods/02-stage-pod-restore.sh"
+  target_dir: "/files/debug/ex2"
+- url: "https://raw.githubusercontent.com/konveyor/mtc-breakfix/master/03-Gvk/03-source-cr.yml"
+  target_dir: "/files/debug/ex3/"
+- url: "https://raw.githubusercontent.com/konveyor/mtc-breakfix/master/03-Gvk/03-source-crd.yml"
+  target_dir: "/files/debug/ex3/"
+- url: "https://raw.githubusercontent.com/konveyor/mtc-breakfix/master/03-Gvk/03-source-ns.yml"
+  target_dir: "/files/debug/ex3/"
+
 # undefined variables
 # mig_operator_ui_cluster_api_endpoint:

--- a/ansible/roles/ocp-workload-migration/tasks/download-content.yml
+++ b/ansible/roles/ocp-workload-migration/tasks/download-content.yml
@@ -1,0 +1,18 @@
+---
+- block:
+  - name: "Ensure target directory exists"
+    file:
+      state: directory
+      path: "/home/{{ student_name }}/{{ mig_download_content_item.target_dir }}"
+      recurse: true
+      owner: "{{ student_name }}"
+      mode: "u+rw"
+
+  - name: "Copy content to target directory"
+    get_url:
+      url: "{{ mig_download_content_item.url }}"
+      dest: "/home/{{ student_name }}/{{ mig_download_content_item.target_dir }}/"
+      owner: "{{ student_name }}"
+      mode: "{{ mig_download_content_item.mode | default('u+rwx') }}"
+  become: true
+  

--- a/ansible/roles/ocp-workload-migration/tasks/download-content.yml
+++ b/ansible/roles/ocp-workload-migration/tasks/download-content.yml
@@ -15,4 +15,3 @@
       owner: "{{ student_name }}"
       mode: "{{ mig_download_content_item.mode | default('u+rwx') }}"
   become: true
-  

--- a/ansible/roles/ocp-workload-migration/tasks/pre_workload.yml
+++ b/ansible/roles/ocp-workload-migration/tasks/pre_workload.yml
@@ -45,7 +45,7 @@
     loop: "{{ mig_download_content }}"
     loop_control:
       loop_var: "mig_download_content_item"
-  
+
   - name: "Downloading lab scripts [1]"
     tempfile:
       state: directory

--- a/ansible/roles/ocp-workload-migration/tasks/pre_workload.yml
+++ b/ansible/roles/ocp-workload-migration/tasks/pre_workload.yml
@@ -40,6 +40,12 @@
   ignore_errors: true
 
 - block:
+  - name: "Download lab content to bastion"
+    include_tasks: "./download-content.yml"
+    loop: "{{ mig_download_content }}"
+    loop_control:
+      loop_var: "mig_download_content_item"
+  
   - name: "Downloading lab scripts [1]"
     tempfile:
       state: directory

--- a/ansible/roles/ocp4-workload-migration/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-migration/defaults/main.yml
@@ -12,7 +12,15 @@ mig_expected_crds:
 mig_state: "present"
 mig_migration_namespace: "openshift-migration"
 mig_download_content:
-- "https://raw.githubusercontent.com/konveyor/mig-agnosticd/master/demos/2020_Summit/labs/scripts/bookbag.yml"
+- url: "https://raw.githubusercontent.com/konveyor/mig-agnosticd/master/demos/2020_Summit/labs/scripts/bookbag.yml"
+  target_dir: ""
+- url: "https://raw.githubusercontent.com/konveyor/mig-agnosticd/master/demos/2020_Summit/labs/scripts/lab8/probe.sh"
+  target_dir: ""
+- url: "https://raw.githubusercontent.com/konveyor/mtc-breakfix/master/01-Misconfiguration/01-misconfig.yml"
+  target_dir: "/files/debug/ex1/"
+- url: "https://raw.githubusercontent.com/konveyor/mtc-breakfix/master/03-Gvk/03-dest-manifest.yml"
+  target_dir: "/files/debug/ex3/"
+
 migration_workload_destroy: "{{ false if (ACTION=='create' or ACTION=='provision') else true }}"
 migration_workload_title: "{{ 'Creating' if not migration_workload_destroy else 'Removing' }}"
 migration_workload_state: "{{ 'present' if not migration_workload_destroy else 'absent' }}"     # state of k8s resources

--- a/ansible/roles/ocp4-workload-migration/tasks/download-content.yml
+++ b/ansible/roles/ocp4-workload-migration/tasks/download-content.yml
@@ -1,0 +1,17 @@
+---
+- block:
+  - name: "Ensure target directory exists"
+    file:
+      state: directory
+      path: "/home/{{ student_name }}/{{ mig_download_content_item.target_dir }}"
+      recurse: true
+      owner: "{{ student_name }}"
+      mode: "u+rw"
+
+  - name: "Copy content to target directory"
+    get_url:
+      url: "{{ mig_download_content_item.url }}"
+      dest: "/home/{{ student_name }}/{{ mig_download_content_item.target_dir }}/"
+      owner: "{{ student_name }}"
+      mode: "{{ mig_download_content_item.mode | default('u+rwx') }}"
+  become: true

--- a/ansible/roles/ocp4-workload-migration/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-migration/tasks/workload.yml
@@ -57,20 +57,12 @@
     state: "{{ mig_state }}"
     definition: "{{ lookup('template', 'controller-4.yml.j2' ) }}"
 
-- name: "Download lab scripts to bastion"
-  become: true
-  get_url:
-    url: "{{ item }}"
-    dest: "/home/{{ student_name }}/"
-  when: student_name is defined
+- name: "Download lab content to bastion"
+  include_tasks: "./download-content.yml"
   loop: "{{ mig_download_content }}"
-
-- name: Copy lab scripts to bastion
-  become: true
-  copy:
-    src: "{{ role_path }}/files/"
-    dest: "/home/{{ student_name }}/"
   when: student_name is defined
+  loop_control:
+    loop_var: "mig_download_content_item"
 
 - when: ocs_migstorage
   block:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

This PR adds ability to download lab content on the bastion hosts. The content is hosted in official repo maintained by migration engineering. The content includes a bunch of YML files and bash scripts. Size of the content is a few megabytes.

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp-workload-migration
ocp4-workload-migration

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
