### PR TITLE
Fix ocp-workload-migration syntax error

### DIFF
--- a/ansible/roles/ocp-workload-migration/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-migration/tasks/workload.yml
@@ -32,8 +32,7 @@
 - name: "Create CR instance and namespace"
   k8s:
     state: "{{ mig_state }}"
-    definition: "{{ lookup('template', 'cr.yml.j2' }}"
-
+    definition: "{{ lookup('template', 'cr.yml.j2') }}"
 
 # Leave this as the last task in the playbook.
 - name: workload tasks complete


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Fixes a small syntax error introduced by another PR. 
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp-workload-migration


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
