### PR TITLE
Update ocp-worksload-ccnrd to fix a wrong console url

### DIFF
--- a/ansible/roles/ocp4-workload-ccnrd/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-ccnrd/tasks/pre_workload.yml
@@ -22,13 +22,13 @@
     name: cluster
   register: r_api_url
 
-- name: Get Web Console route
-  k8s_facts:
-    api_version: route.openshift.io/v1
-    kind: Route
-    namespace: openshift-console
-    name: console
-  register: r_console_route
+- name: set the master
+  set_fact:
+    master_url: "{{ r_api_url.resources[0].status.apiServerURL }}"
+
+- name: extract console_url
+  command: oc whoami --show-console
+  register: console_url_r
 
 - name: get route subdomain
   k8s_info:
@@ -41,14 +41,6 @@
   set_fact:
     console_url: "{{ console_url_r.stdout | trim }}"
     route_subdomain: "{{ route_subdomain_r.resources[0].status.domain }}"
-
-- name: set the master
-  set_fact:
-    master_url: "{{ r_api_url.resources[0].status.apiServerURL }}"
-
-- name: set the console
-  set_fact:
-    console_url: "https://{{ r_console_route.resources[0].spec.host }}"
 
 - name: debug values
   debug:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Update ocp-worksload-ccnrd to fix a wrong console url
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
