### PR TITLE
Update ocp4-workload-ccnrd to update the elasticsearch operator version

### DIFF
--- a/ansible/roles/ocp4-workload-ccnrd/files/elasticsearch_subscription.yaml
+++ b/ansible/roles/ocp4-workload-ccnrd/files/elasticsearch_subscription.yaml
@@ -5,7 +5,7 @@ metadata:
   name: elasticsearch-operator
   namespace: openshift-operators
 spec:
-  channel: "4.5"
+  channel: "4.6"
   installPlanApproval: Automatic
   name: elasticsearch-operator
   source: redhat-operators


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Update ocp4-workload-ccnrd to update the elasticsearch operator version 4.6. It's working with 4.5 in naked OCP 4.6 but it doesn't in ccnrd cluster based on ocp 4.6 so I updated to 4.6 by default.

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
