### PR TITLE
Increase the number of retries while waiting for 'istio-sidecar-injector' service to be ready

### DIFF
--- a/ansible/roles/ocp4-workload-debugging-workshop/tasks/post_workload.yml
+++ b/ansible/roles/ocp4-workload-debugging-workshop/tasks/post_workload.yml
@@ -37,7 +37,7 @@
   register: istio_deployment
   until:
     - istio_deployment.result is defined
-  retries: 30
+  retries: 50
   delay: 120
   changed_when: false
 - name: Wait for the Istio to be ready


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
