### PR TITLE
Fix config ansible-windows for yamllint

### DIFF
--- a/ansible/configs/ansible-windows/.yamllint
+++ b/ansible/configs/ansible-windows/.yamllint
@@ -9,5 +9,5 @@ rules:
   indentation:
     indent-sequences: consistent
   line-length:
-    max: 120
+    max: 200
     allow-non-breakable-inline-mappings: true

--- a/ansible/configs/ansible-windows/post_software.yml
+++ b/ansible/configs/ansible-windows/post_software.yml
@@ -49,7 +49,7 @@
   gather_facts: false
   tags:
     - step005
-  tasks:      
+  tasks:
     - name: ec2 user.info
       when: cloud_provider == 'ec2'
       block:


### PR DESCRIPTION
##### SUMMARY

Fix ansible-windows config yamllint failures. This config is currently failing and causing problems with other items in checks.

Extend yamllint line length to 200 characters.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

config ansible-windows