### PR TITLE
Fix pipelines workload - check for the operator name with `contains` …

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_pipelines/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_pipelines/tasks/remove_workload.yml
@@ -82,7 +82,7 @@
     ocp4_workload_pipelines_install_plan_name: "{{ r_install_plans.resources | to_json | from_json | json_query(query) }}"
   vars:
     query: >-
-      [?starts_with(spec.clusterServiceVersionNames[0], 'openshift-pipelines-operator')].metadata.name|[0]
+      [?contains(spec.clusterServiceVersionNames[0], 'openshift-pipelines-operator')].metadata.name|[0]
 
 - name: Remove InstallPlan
   when:

--- a/ansible/roles_ocp_workloads/ocp4_workload_pipelines/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_pipelines/tasks/workload.yml
@@ -44,7 +44,7 @@
   register: r_install_plans
   vars:
     _query: >-
-      [?starts_with(spec.clusterServiceVersionNames[0], 'openshift-pipelines-operator')]
+      [?contains(spec.clusterServiceVersionNames[0], 'openshift-pipelines-operator')]
   retries: 30
   delay: 5
   until:
@@ -56,7 +56,7 @@
     ocp4_workload_pipelines_install_plan_name: "{{ r_install_plans.resources | to_json | from_json | json_query(query) }}"
   vars:
     query: >-
-      [?starts_with(spec.clusterServiceVersionNames[0], 'openshift-pipelines-operator')].metadata.name|[0]
+      [?contains(spec.clusterServiceVersionNames[0], 'openshift-pipelines-operator')].metadata.name|[0]
 
 - name: Get InstallPlan
   k8s_info:


### PR DESCRIPTION
…rather than `starts_with`

##### SUMMARY

OpenShift Pipelines Operator changed names in the `ocp4-6` channel. It's now `redhat-openshift-pipelines-operator` instead of just `openshift-pipelines-operator`. To Enable both 4.5 and 4.6 channels change the json_query statements to use *contains* instead of *starts_with*.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_pipelines