### PR TITLE
Fix s4hana duplicate host for OSP deployments

### DIFF
--- a/ansible/configs/sap-hana/default_vars.yml
+++ b/ansible/configs/sap-hana/default_vars.yml
@@ -109,7 +109,7 @@ ansible_tower:
         hosts:
         - name: "{{ ansible_hana1_hostname }}"
         - name: "{{ ansible_hana2_hostname }}"
-        - name: "s4hana"
+        - name: "{{ ansible_s4hana_hostname }}"
       - name: "hanas"
         hosts:
         - name: "{{ ansible_hana1_hostname }}"


### PR DESCRIPTION
##### SUMMARY
S/4HANA host is coming twice due to an issue with a missing variable

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
sap-hana

