### PR TITLE
set-repositories role update

### DIFF
--- a/ansible/roles/set-repositories/tasks/pre_checks_rhn.yml
+++ b/ansible/roles/set-repositories/tasks/pre_checks_rhn.yml
@@ -35,3 +35,34 @@
         - rhsm_pool_ids is defined
         - rhel_subscription_user is not defined
         - rhel_subscription_pass is not defined
+
+- name: Ensure rhel_repo dictionary is exclusively defined
+  when:
+    - rhel_repos is defined
+  assert:
+    that: "{{ check.that }}"
+    fail_msg: "{{ check.msg }}"
+    quiet: true
+  loop_control:
+    loop_var: check
+    label: "{{ check.msg }}"
+  loop:
+    - msg: Ensure no exclusive variables are set.
+      that:
+        - rhel_repos_el7 is not defined
+        - rhel_repos_el8 is not defined
+
+- name: Ensure el7 and el8 dictionaries are exclusively defined
+  when:
+    - rhel_repos_el7 is defined or rhel_repos_el8 is defined
+  assert:
+    that: "{{ check.that }}"
+    fail_msg: "{{ check.msg }}"
+    quiet: true
+  loop_control:
+    loop_var: check
+    label: "{{ check.msg }}"
+  loop:
+    - msg: Ensure no exclusive variables are set.
+      that:
+        - rhel_repos is not defined

--- a/ansible/roles/set-repositories/tasks/pre_checks_rhn.yml
+++ b/ansible/roles/set-repositories/tasks/pre_checks_rhn.yml
@@ -4,65 +4,40 @@
   when:
     - rhel_subscription_user is defined
   assert:
-    that: "{{ check.that }}"
-    fail_msg: "{{ check.msg }}"
+    that: 
+      - rhel_subscription_pass is defined
+      - rhsm_pool_ids is defined
+      - rhel_subscription_activation_key is not defined
+      - rhel_subscription_org_id is not defined
+    fail_msg: Ensure no exclusive variables are set.
     quiet: true
-  loop_control:
-    loop_var: check
-    label: "{{ check.msg }}"
-  loop:
-    - msg: Ensure no exclusive variables are set.
-      that:
-        - rhel_subscription_pass is defined
-        - rhsm_pool_ids is defined
-        - rhel_subscription_activation_key is not defined
-        - rhel_subscription_org_id is not defined
 
 - name: Ensure mandatory variables are set for activation key
   when:
     - rhel_subscription_activation_key is defined
   assert:
-    that: "{{ check.that }}"
-    fail_msg: "{{ check.msg }}"
+    that: 
+      - rhel_subscription_org_id is defined
+      - rhsm_pool_ids is defined
+      - rhel_subscription_user is not defined
+      - rhel_subscription_pass is not defined
+    fail_msg: Ensure no exclusive variables are set.
     quiet: true
-  loop_control:
-    loop_var: check
-    label: "{{ check.msg }}"
-  loop:
-    - msg: Ensure no exclusive variables are set.
-      that:
-        - rhel_subscription_org_id is defined
-        - rhsm_pool_ids is defined
-        - rhel_subscription_user is not defined
-        - rhel_subscription_pass is not defined
 
 - name: Ensure rhel_repo dictionary is exclusively defined
   when:
     - rhel_repos is defined
   assert:
-    that: "{{ check.that }}"
-    fail_msg: "{{ check.msg }}"
+    that:
+      - rhel_repos_el7 is not defined
+      - rhel_repos_el8 is not defined
+    fail_msg: "Ensure no exclusive variables are set."
     quiet: true
-  loop_control:
-    loop_var: check
-    label: "{{ check.msg }}"
-  loop:
-    - msg: Ensure no exclusive variables are set.
-      that:
-        - rhel_repos_el7 is not defined
-        - rhel_repos_el8 is not defined
 
 - name: Ensure el7 and el8 dictionaries are exclusively defined
   when:
     - rhel_repos_el7 is defined or rhel_repos_el8 is defined
   assert:
-    that: "{{ check.that }}"
-    fail_msg: "{{ check.msg }}"
+    that: rhel_repos is not defined
+    fail_msg: "Ensure no exclusive variables are set." 
     quiet: true
-  loop_control:
-    loop_var: check
-    label: "{{ check.msg }}"
-  loop:
-    - msg: Ensure no exclusive variables are set.
-      that:
-        - rhel_repos is not defined

--- a/ansible/roles/set-repositories/tasks/rhn-repos.yml
+++ b/ansible/roles/set-repositories/tasks/rhn-repos.yml
@@ -1,6 +1,6 @@
 # vim: set ft=ansible:
 ---
-  # Checking to ensure both options are not defined at the same time
+# Checking to ensure both options are not defined at the same time
 - name: Ensure no mutually exclusive variables exist
   include_tasks: ./pre_checks_rhn.yml
 
@@ -9,11 +9,11 @@
   args:
     warn: false
   loop:
-    - 'subscription-manager clean'
     - 'subscription-manager remove --all'
+    - 'subscription-manager clean'
     - 'yum remove -y "katello-ca-consumer-*"'
 
-  # Registering without activationkey
+# Registering without activationkey
 - name: 'Register system using Red Hat Subscription Manager'
   when:
     - rhel_subscription_user is defined
@@ -24,7 +24,7 @@
     pool_ids: "{{ rhsm_pool_ids }}"
     auto_attach: false
 
-  # Registering with activationkey
+# Registering with activationkey
 - name: 'Register system using Red Hat Subscription Manager Activation Key'
   when:
     - rhel_subscription_activation_key is defined
@@ -35,9 +35,40 @@
     pool_ids: "{{ rhsm_pool_ids }}"
     auto_attach: false
 
-- name: "Run 'subscription-manager to disable/enable repos"
-  command: >-
-    subscription-manager repos {% for repo in rhel_repos %}
-    --enable={{ repo }}
-    {% endfor %}
-  when: rhel_repos | default([]) | length > 0
+# Enable Repositories with rhsm_repository module
+- name: Enable repos with rhsm_repository
+  when: 
+    - rhel_repos is defined 
+  rhsm_repository:
+    name: "{{ __rhel_repos }}"
+    state: enabled
+  loop:
+    - '{{ rhel_repos }}'
+  loop_control:
+    loop_var: __rhel_repos
+  
+- name: Enable repos for RHEL 7
+  when: 
+    - rhel_repos_el7 is defined 
+    - ansible_facts['distribution'] == "RedHat" 
+    - ansible_facts['distribution_major_version'] == "7"
+  rhsm_repository:
+    name: "{{ __el7_repos }}"
+    state: enabled
+  loop:
+    - '{{ rhel_repos_el7 }}'
+  loop_control:
+    loop_var: __el7_repos
+  
+- name: Enable repos for RHEL 8
+  when:
+    - rhel_repos_el8 is defined
+    - ansible_facts['distribution'] == "RedHat" 
+    - ansible_facts['distribution_major_version'] == "8"
+  rhsm_repository:
+    name: "{{ __el8_repos }}"
+    state: enabled
+  loop:
+    - '{{ rhel_repos_el8 }}'
+  loop_control:
+    loop_var: __el8_repos

--- a/ansible/roles/set-repositories/tasks/rhn-repos.yml
+++ b/ansible/roles/set-repositories/tasks/rhn-repos.yml
@@ -37,38 +37,26 @@
 
 # Enable Repositories with rhsm_repository module
 - name: Enable repos with rhsm_repository
-  when: 
-    - rhel_repos is defined 
+  when:
+    - rhel_repos is defined
   rhsm_repository:
-    name: "{{ __rhel_repos }}"
+    name: "{{ rhel_repos }}"
     state: enabled
-  loop:
-    - '{{ rhel_repos }}'
-  loop_control:
-    loop_var: __rhel_repos
-  
+
 - name: Enable repos for RHEL 7
-  when: 
-    - rhel_repos_el7 is defined 
-    - ansible_facts['distribution'] == "RedHat" 
+  when:
+    - rhel_repos_el7 is defined
+    - ansible_facts['distribution'] == "RedHat"
     - ansible_facts['distribution_major_version'] == "7"
   rhsm_repository:
-    name: "{{ __el7_repos }}"
+    name: "{{ rhel_repos_el7 }}"
     state: enabled
-  loop:
-    - '{{ rhel_repos_el7 }}'
-  loop_control:
-    loop_var: __el7_repos
-  
+
 - name: Enable repos for RHEL 8
   when:
     - rhel_repos_el8 is defined
-    - ansible_facts['distribution'] == "RedHat" 
+    - ansible_facts['distribution'] == "RedHat"
     - ansible_facts['distribution_major_version'] == "8"
   rhsm_repository:
-    name: "{{ __el8_repos }}"
+    name: "{{ rhel_repos_el8 }}"
     state: enabled
-  loop:
-    - '{{ rhel_repos_el8 }}'
-  loop_control:
-    loop_var: __el8_repos


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

When registering a system to rhn directly we could not specify which systems were RHEL 7 or RHEL 8. This change preserves the original function of the role, but adds the option to exclusively define rhel_repos_el7 or rhel_repos_el8 in the case that a developer requires two systems running different major versions of RHEL.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
role, set-repositories

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Example use:

rhel_repos:
 - not defined, is exclusive to _el7 and _el8, preserving original functionality

rhel_repos_el7:
  - rhel-7-server-rpms
  - rhel-7-server-rh-common-rpms
  - rhel-7-server-extras-rpms

rhel_repos_el8:                           
  - rhel-8-for-x86_64-baseos-rpms
  - rhel-8-for-x86_64-appstream-rpms

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
