### PR TITLE
Add crw to shared env

### DIFF
--- a/ansible/action_plugins/agnosticd_user_info.py
+++ b/ansible/action_plugins/agnosticd_user_info.py
@@ -39,7 +39,7 @@ class ActionModule(ActionBase):
     '''Print statements during execution and save user info to file'''
 
     TRANSFERS_FILES = False
-    _VALID_ARGS = frozenset(('msg','data','user'))
+    _VALID_ARGS = frozenset(('msg','data','user','body'))
 
     def run(self, tmp=None, task_vars=None):
         self._supports_check_mode = True
@@ -93,7 +93,7 @@ class ActionModule(ActionBase):
                 fh.close()
             if not user and body != None:
                 fh = open(os.path.join(output_dir, 'user-body.yaml'), 'a')
-                fh.write('- ' + json.dumps(msg) + "\n")
+                fh.write('- ' + json.dumps(body) + "\n")
                 fh.close()
             if data or user:
                 user_data = None

--- a/ansible/roles_ocp_workloads/ocp4_workload_shared_cluster_access/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_shared_cluster_access/defaults/main.yml
@@ -30,3 +30,9 @@ ocp4_workload_shared_cluster_access_quota:
     persistentvolumeclaims: "15"
     requests.storage: 50Gi
  
+# Add CRW access for the user. Access is granted automatically via OAuth login, this will just
+# add a message with the CRW route to the provisioning e-mail.
+ocp4_workload_shared_cluster_access_enable_crw: false
+
+# Namespace with the CRW installation:
+ocp4_workload_shared_cluster_access_crw_namespace: gpte-crw

--- a/ansible/roles_ocp_workloads/ocp4_workload_shared_cluster_access/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_shared_cluster_access/tasks/post_workload.yml
@@ -1,38 +1,8 @@
 ---
 # Implement your Post Workload deployment tasks here
-#--- --------------------------------------------------
-- name: Get console route
-  k8s_info:
-    api_version: route.openshift.io/v1
-    kind: Route
-    namespace: openshift-console
-    name: console
-  register: r_console_route
+# --------------------------------------------------
 
-- name: Get API server URL
-  k8s_info:
-    api_version: config.openshift.io/v1
-    kind: Infrastructure
-    name: cluster
-  register: r_api_url
 
-- name: Print user body
-  agnosticd_user_body:
-    msg: "{{ item }}"
-  loop:
-    - "**********"
-    - "IMPORTANT: You cannot SSH into the shared cluster."
-    - "Please refer to the demo or lab instructions in order"
-    - "to get the steps on how to access the environment properly."
-    - "**********"
-
-- name: Print user info
-  agnosticd_user_info:
-    msg: "{{ item }}"
-  loop:
-    - ""
-    - "Openshift Master Console: https://{{ r_console_route.resources[0].spec.host }}"
-    - "Openshift API for command line 'oc' client: {{ r_api_url.resources[0].status.apiServerURL }}"
 
 # Leave these as the last tasks in the playbook
 # ---------------------------------------------

--- a/ansible/roles_ocp_workloads/ocp4_workload_shared_cluster_access/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_shared_cluster_access/tasks/workload.yml
@@ -25,6 +25,54 @@
   loop:
   - ./templates/cluster_resource_quota.j2
 
+- name: Get console route
+  k8s_info:
+    api_version: route.openshift.io/v1
+    kind: Route
+    namespace: openshift-console
+    name: console
+  register: r_console_url
+
+- name: Get API server URL
+  k8s_info:
+    api_version: config.openshift.io/v1
+    kind: Infrastructure
+    name: cluster
+  register: r_api_url
+
+- name: Print AgnosticD user body
+  agnosticd_user_info:
+    body: "{{ item }}"
+  loop:
+  - "***********************************************************"
+  - "IMPORTANT: You cannot SSH into the shared cluster."
+  - "Please refer to the demo or lab instructions in order"
+  - "to get the steps on how to access the environment properly."
+  - "***********************************************************"
+
+- name: Print AgnosticD user info
+  agnosticd_user_info:
+    msg: "{{ item }}"
+  loop:
+  - ""
+  - "Openshift Master Console: https://{{ r_console_url.resources[0].spec.host }}"
+  - "Openshift API for command line 'oc' client: {{ r_api_url.resources[0].status.apiServerURL }}"
+
+- name: Print CRW route
+  when: ocp4_workload_shared_cluster_access_enable_crw | bool
+  block:
+  - name: Get CRW Route
+    k8s_info:
+      api_version: route.openshift.io/v1
+      kind: Route
+      namespace: "{{ ocp4_workload_shared_cluster_access_crw_namespace }}"
+      name: codeready
+    register: r_crw_url
+  - name: Print CRW user info
+    when: r_crw_url.resources | length == 1
+    agnosticd_user_info:
+      msg: "Your CodeReady Workspaces URL is https://{{ r_crw_url.resources[0].spec.host}}."
+
 # Leave this as the last task in the playbook.
 # --------------------------------------------
 - name: workload tasks complete

--- a/ansible/roles_ocp_workloads/ocp4_workload_shared_cluster_access/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_shared_cluster_access/tasks/workload.yml
@@ -42,21 +42,18 @@
 
 - name: Print AgnosticD user body
   agnosticd_user_info:
-    body: "{{ item }}"
-  loop:
-  - "***********************************************************"
-  - "IMPORTANT: You cannot SSH into the shared cluster."
-  - "Please refer to the demo or lab instructions in order"
-  - "to get the steps on how to access the environment properly."
-  - "***********************************************************"
+    body: |
+      ***********************************************************
+      IMPORTANT: You cannot SSH into the shared cluster.
+      Please refer to the demo or lab instructions in order
+      to get the steps on how to access the environment properly.
+      ***********************************************************
 
 - name: Print AgnosticD user info
   agnosticd_user_info:
-    msg: "{{ item }}"
-  loop:
-  - ""
-  - "Openshift Master Console: https://{{ r_console_url.resources[0].spec.host }}"
-  - "Openshift API for command line 'oc' client: {{ r_api_url.resources[0].status.apiServerURL }}"
+    msg: | 
+      Openshift Master Console: https://{{ r_console_url.resources[0].spec.host }}
+      Openshift API for command line 'oc' client: {{ r_api_url.resources[0].status.apiServerURL }}
 
 - name: Print CRW route
   when: ocp4_workload_shared_cluster_access_enable_crw | bool


### PR DESCRIPTION
##### SUMMARY

Added support for Shared Cluster CodeReady Workspaces access to shared cluster access workload.
This only prints out the URL of the CRW installation in the cluster.

Also fix agnosticd_user_info's body function.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
agnosticd_user_info.py
ocp4_workload_shared_cluster_access