### PR TITLE
Take the GUID subdomain out of OSP hostnames

### DIFF
--- a/ansible/roles-infra/infra-osp-create-inventory/tasks/main.yml
+++ b/ansible/roles-infra/infra-osp-create-inventory/tasks/main.yml
@@ -88,7 +88,7 @@
 - name: Make sure bastion has public DNS name defined
   add_host:
     name: "{{ host }}"
-    public_dns_name: "{{ host }}.{{ guid }}.{{osp_cluster_dns_zone}}"
+    public_dns_name: "{{ host }}.{{osp_cluster_dns_zone}}"
   loop: "{{ groups['bastions'] }}"
   loop_control:
     loop_var: host


### PR DESCRIPTION
##### SUMMARY

This change takes the GUID subdomain out of OSP hostnames.  From my understanding dynamic DNS no longer creates a GUID subdomain.  Hostnames should be host-GUID.dynamic.opentlc.com NOT host-GUID.GUID.dynamic.opentlc.com.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
infra-osp-create-inventory

##### ADDITIONAL INFORMATION
