### PR TITLE
Fix AI Edge workshop failure when creating PipelineRun

### DIFF
--- a/ansible/roles/ocp-workload-aiedge-computing-blueprint/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-aiedge-computing-blueprint/tasks/workload.yml
@@ -552,27 +552,25 @@
     name: manuela-ml-workspace
     kind: Namespace
 
-  # yamllint disable rule:line-length
 - name: Create the Open Data Hub resources
   command:
+    # yamllint disable-line rule:line-length
     cmd: "oc apply -f '{{ hub_repo_dir }}/base/03_services/odh-resources/odh-kfdef.yaml'"
 
-- name: Create the tekton PipelineRuns seed-iot-anomaly-detection-run
+- name: Create the tekton PipelineRuns
   command:
-    cmd: "oc apply -f '{{ hub_repo_dir }}/base/03_services/tekton/seed-iot-anomaly-detection-run.yaml'"
+    cmd: "oc apply -f '{{ hub_repo_dir }}/base/03_services/tekton/{{ item }}'"
+  loop:
+    - "seed-iot-anomaly-detection-run.yaml"
+    - "seed-iot-consumer-run.yaml"
+    - "seed-iot-frontend-run.yaml"
+    - "seed-iot-software-sensor-run.yaml"
+  # Retry and wait for tekton endpoints to come online
+  register: result
+  until: result.rc == 0
+  retries: 10
+  delay: 20
 
-- name: Create the tekton PipelineRuns seed-iot-consumer-run
-  command:
-    cmd: "oc apply -f '{{ hub_repo_dir }}/base/03_services/tekton/seed-iot-consumer-run.yaml'"
-
-- name: Create the tekton PipelineRuns seed-iot-frontend-run
-  command:
-    cmd: "oc apply -f '{{ hub_repo_dir }}/base/03_services/tekton/seed-iot-frontend-run.yaml'"
-
-- name: Create the tekton PipelineRuns seed-iot-software-sensor-run
-  command:
-    cmd: "oc apply -f '{{ hub_repo_dir }}/base/03_services/tekton/seed-iot-software-sensor-run.yaml'"
-  # yamllint enable rule:line-length
 
 # Leave this as the last task in the playbook.
 # --------------------------------------------


### PR DESCRIPTION
##### SUMMARY
Fixes issue where creation of tekton PipelineRun fails due to the openshift-pipeline operator still initializing the required endpoints. This adds a simple retry for each PipelineRun creation

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ocp-workload-aiedge-computing-blueprint

##### ADDITIONAL INFORMATION
Fix is in response to this failure
```
Internal error occurred: failed calling webhook \"webhook.pipeline.tekton.dev\": Post https://tekton-pipelines-webhook.openshift-pipelines.svc:443/defaulting?timeout=30s: no endpoints available for service \"tekton-pipelines-webhook\""
```