### PR TITLE
Update OCP 4 HA Lab Config for RHEL 8.2 and dynamic dns

### DIFF
--- a/ansible/configs/ocp4-disconnected-osp-lab/default_vars.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/default_vars.yml
@@ -92,7 +92,7 @@ install_k8s_modules: false
 # This var will set the version of ftl-injector to use.
 # In addition, it implies that FTL should be installed, eventually
 # removing the need for install_ftl var.
-ftl_injector_tag: v0.16.0
+ftl_injector_tag: v0.17.1
 
 # FTL injector will try to install python-pip and we only have python3-pip available
 # This var will force the ftl-injector role to adapt accordingly
@@ -101,16 +101,11 @@ ftl_use_python3: true
 # TODO: Decide on whether to use sat or give access to repos directly with key
 # This will tell Agnosticd to use either:
 # sattelite, rhn, or file for repos
-repo_method: file
+repo_method: satellite
 # If using satellite, these are needed:
 # satellite_url: satellite.opentlc.com
 # satellite_activationkey: # This should be stored in secrets
 # satellite_org: # This should be stored in secrets
-# use_content_view: true
-# If using file, these are needed in addition to the repos_template.j2 file:
-osrelease: 4.2.0
-repo_version: '4.2'
-own_repo_path: # Should be defined in secrets
 
 # Packages to install on all of the hosts deployed as part of the agnosticd config
 # This invokes the "common" role
@@ -121,19 +116,23 @@ update_packages: true
 
 # The packages that will be installed by the "common" role. Only put things
 # in this list that are needed, stable, and useful on every node.
-common_packages:
-  - unzip
-  - bash-completion
-  - tmux
-  - bind-utils
-  - wget
-  - ansible
-  - git
-  - vim-enhanced
-  - httpd-tools
-  - openldap-clients
-  - podman
-  - tree
+common_packages_el8:
+- python3
+- unzip
+- bash-completion
+- tmux
+- bind-utils
+- wget
+- nano
+- git
+- vim-enhanced
+- httpd-tools
+- openldap-clients
+- podman
+- skopeo
+- buildah
+- tree
+- ansible
 
 # This will run in the post_software phase and run playbooks in the
 # software_playbooks directory
@@ -145,17 +144,19 @@ use_dynamic_dns: true
 # This is not fully implemented yet
 # use_route53: false
 
-# The domain that you want to add DNS entries to
-osp_cluster_dns_zone: blue.osp.opentlc.com
-
-# The dynamic DNS server you will add entries to.
-# NOTE: This is only applicable when {{ use_dynamic_dns}} is true
-osp_cluster_dns_server: ddns01.opentlc.com
-
 # Whether to wait for an ack from the DNS servers before continuing
 wait_for_dns: true
 
-# Authenticaion for DDNS
+# ---
+# All DNS configuration should come from the destination OpenStack secret
+# The domain that you want to add DNS entries to
+# osp_cluster_dns_zone: blue.osp.opentlc.com
+
+# The dynamic DNS server you will add entries to.
+# NOTE: This is only applicable when {{ use_dynamic_dns}} is true
+# osp_cluster_dns_server: ddns01.opentlc.com
+
+# Authentication for DDNS
 # ddns_key_name:
 # ddns_key_algorithm:                # default value set to: "hmac-md5"
 # ddns_secret_name:
@@ -231,34 +232,36 @@ query_subnet_cidr: "[?name=='{{ ocp_network }}'].subnet_cidr"
 # You can create as many as you want, but at least one is required.
 # Use the name of the networks where appropriate in the instance list
 networks:
-  - name: ocp
-    shared: "false"
-    subnet_cidr: 192.168.47.0/24
-    gateway_ip: 192.168.47.1
-    allocation_start: 192.168.47.10
-    allocation_end: 192.168.47.254
-    dns_nameservers: []
-    create_router: true
+- name: ocp
+  shared: "false"
+  subnet_cidr: 192.168.47.0/24
+  gateway_ip: 192.168.47.1
+  allocation_start: 192.168.47.10
+  allocation_end: 192.168.47.254
+  dns_nameservers:
+  - 1.1.1.1
+  - 8.8.8.8
+  create_router: true
 # Another example network if you need more than one deployed
-  # - name: testnet
-  #   shared: "false"
-  #   subnet_cidr: 192.47.0.0/24
-  #   gateway_ip: 192.47.0.1
-  #   allocation_start: 192.47.0.25
-  #   allocation_end: 192.47.0.156
-  #   dns_nameservers:
-  #     - 8.8.8.8
-  #     - 1.1.1.1
-  #   create_router: true
+# - name: testnet
+#   shared: "false"
+#   subnet_cidr: 192.47.0.0/24
+#   gateway_ip: 192.47.0.1
+#   allocation_start: 192.47.0.25
+#   allocation_end: 192.47.0.156
+#   dns_nameservers:
+#   - 8.8.8.8
+#   - 1.1.1.1
+#   create_router: true
 
 # These will influence the bastion if it is being deployed
 bastion_instance_type: 2c2g30d
-bastion_instance_image: rhel-server-7.7-update-2
+bastion_instance_image: rhel-8.2
 
 # These will influence the utility VM, which is primarily used for disconnected
 # install, but can be used for anything really.
 utilityvm_instance_type: 2c2g30d
-utilityvm_instance_image: rhel-server-7.7-update-2
+utilityvm_instance_image: rhel-8.2
 
 # Instances to be provisioned in new project
 # Provide these as a list.
@@ -267,43 +270,43 @@ utilityvm_instance_image: rhel-server-7.7-update-2
 # Metadata in OpenStack is equivelent to tags in AWS
 # These instances will be created with Cinder persistent volumes
 instances:
-  - name: bastion
-    count: 1
-    unique: true
-    alt_name: bastion
-    image_id: "{{ bastion_instance_image }}"
-    floating_ip: true
-    flavor:
-      osp: "{{ bastion_instance_type }}"
-    metadata:
-      - AnsibleGroup: "bastions,clientvms"
-      - function: bastion
-      - user: nate
-      - project: "{{ project_tag }}"
-      - ostype: linux
-      - Purpose: "{{ purpose }}"
-    rootfs_size: 30
-    network: ocp
-    security_groups:
-      - bastion_sg
+- name: bastion
+  count: 1
+  unique: true
+  alt_name: bastion
+  image_id: "{{ bastion_instance_image }}"
+  floating_ip: true
+  flavor:
+    osp: "{{ bastion_instance_type }}"
+  metadata:
+  - AnsibleGroup: "bastions,clientvms"
+  - function: bastion
+  - user: nate
+  - project: "{{ project_tag }}"
+  - ostype: linux
+  - Purpose: "{{ purpose }}"
+  rootfs_size: 30
+  network: ocp
+  security_groups:
+  - bastion_sg
 
-  - name: utilityvm
-    count: 1
-    image_id: "{{ utilityvm_instance_image }}"
-    floating_ip: false
-    flavor:
-      osp: "{{ utilityvm_instance_type }}"
-    metadata:
-      - AnsibleGroup: "utility"
-      - function: bastion
-      - user: nate
-      - project: "{{ project_tag }}"
-      - ostype: linux
-      - Purpose: "{{ purpose }}"
-    rootfs_size: 50
-    network: ocp
-    security_groups:
-      - utility_sg
+- name: utilityvm
+  count: 1
+  image_id: "{{ utilityvm_instance_image }}"
+  floating_ip: false
+  flavor:
+    osp: "{{ utilityvm_instance_type }}"
+  metadata:
+  - AnsibleGroup: "utility"
+  - function: bastion
+  - user: nate
+  - project: "{{ project_tag }}"
+  - ostype: linux
+  - Purpose: "{{ purpose }}"
+  rootfs_size: 50
+  network: ocp
+  security_groups:
+  - utility_sg
 
 # Set this if you need security groups in the list created
 # even if they are unused by an instance initially
@@ -312,323 +315,323 @@ create_unused_security_groups: true
 # Security groups and associated rules. This will be provided
 #when the Heat template is generated separate groups and rules
 security_groups:
-  - name: bastion_sg
-    description: Bastion security group allows basic icmp and SSH ingress and egress to *
-    rules:
-      - protocol: icmp
-        direction: ingress
-      - protocol: tcp
-        direction: ingress
-        port_range_min: 22
-        port_range_max: 22
-        remote_ip_prefix: 0.0.0.0/0
-  - name: utility_sg
-    description: Utility security group allows SSH from bastion and egress to *
-    rules:
-      - protocol: icmp
-        direction: ingress
-        remote_group: "bastion_sg"
-      - protocol: tcp
-        direction: ingress
-        port_range_min: 22
-        port_range_max: 22
-        remote_group: "bastion_sg"
-      - protocol: tcp
-        direction: ingress
-        port_range_min: 5000
-        port_range_max: 5000
-        remote_ip_prefix: "{{ ocp_network_subnet_cidr }}"
-        description: "local container registry"
-      - protocol: tcp
-        direction: ingress
-        port_range_min: 80
-        port_range_max: 80
-        remote_ip_prefix: "{{ ocp_network_subnet_cidr }}"
-        description: "http traffic for ignition files"
-      - protocol: tcp
-        direction: ingress
-        port_range_min: 2049
-        port_range_max: 2049
-        remote_ip_prefix: "{{ ocp_network_subnet_cidr }}"
-        description: "NFS traffic"
-  - name: isolated_sg
-    description: All instances in the disconnected network
-    rules:
-      - protocol: icmp
-        direction: ingress
-        remote_group: "bastion_sg"
-      - protocol: tcp
-        direction: ingress
-        port_range_min: 22
-        port_range_max: 22
-        remote_group: "bastion_sg"
-  - name: master_sg
-    description: Security group for OpenShift master and bootstrap
-    rules:
-      - protocol: icmp
-        direction: ingress
-        description: "icmp"
-      - protocol: tcp
-        direction: ingress
-        port_range_min: 22623
-        port_range_max: 22623
-        remote_ip_prefix: "{{ ocp_network_subnet_cidr }}"
-        description: "machine config server"
-      - protocol: tcp
-        direction: ingress
-        port_range_min: 22
-        port_range_max: 22
-        remote_ip_prefix: "{{ ocp_network_subnet_cidr }}"
-        description: "SSH"
-      - protocol: tcp
-        direction: ingress
-        port_range_min: 53
-        port_range_max: 53
-        remote_ip_prefix: "{{ ocp_network_subnet_cidr }}"
-        description: "DNS (tcp)"
-      - protocol: udp
-        direction: ingress
-        port_range_min: 53
-        port_range_max: 53
-        remote_ip_prefix: "{{ ocp_network_subnet_cidr }}"
-        description: "DNS (udp)"
-      - protocol: udp
-        direction: ingress
-        port_range_min: 5353
-        port_range_max: 5353
-        remote_ip_prefix: "{{ ocp_network_subnet_cidr }}"
-        description: "mDNS"
-      - protocol: tcp
-        direction: ingress
-        port_range_min: 6443
-        port_range_max: 6443
-        remote_ip_prefix: 0.0.0.0/0
-        description: "OpenShift API"
-      - protocol: udp
-        direction: ingress
-        port_range_min: 4789
-        port_range_max: 4789
-        remote_group: "master_sg"
-        description: "VXLAN"
-      - protocol: udp
-        direction: ingress
-        port_range_min: 4789
-        port_range_max: 4789
-        remote_group: "worker_sg"
-        description: "VXLAN (worker)"
-      - protocol: udp
-        direction: ingress
-        port_range_min: 6081
-        port_range_max: 6081
-        remote_group: "master_sg"
-        description: "Geneve"
-      - protocol: udp
-        direction: ingress
-        port_range_min: 6081
-        port_range_max: 6081
-        remote_group: "worker_sg"
-        description: "Geneve (worker)"
-      - protocol: tcp
-        direction: ingress
-        port_range_min: 6641
-        port_range_max: 6642
-        remote_group: "master_sg"
-        description: "OVNDB"
-      - protocol: tcp
-        direction: ingress
-        port_range_min: 6641
-        port_range_max: 6642
-        remote_group: "worker_sg"
-        description: "OVNDB (worker)"
-      - protocol: tcp
-        direction: ingress
-        port_range_min: 9000
-        port_range_max: 9999
-        remote_group: "master_sg"
-        description: "Master ingress internal (tcp)"
-      - protocol: tcp
-        direction: ingress
-        port_range_min: 9000
-        port_range_max: 9999
-        remote_group: "worker_sg"
-        description: "Master ingress from worker (tcp)"
-      - protocol: udp
-        direction: ingress
-        port_range_min: 9000
-        port_range_max: 9999
-        remote_group: "master_sg"
-        description: "Master ingress internal (udp)"
-      - protocol: udp
-        direction: ingress
-        port_range_min: 9000
-        port_range_max: 9999
-        remote_group: "worker_sg"
-        description: "Master ingress from worker (udp)"
-      - protocol: tcp
-        direction: ingress
-        port_range_min: 10259
-        port_range_max: 10259
-        remote_group: "master_sg"
-        description: "Kube Scheduler"
-      - protocol: tcp
-        direction: ingress
-        port_range_min: 10259
-        port_range_max: 10259
-        remote_group: "worker_sg"
-        description: "Kube Scheduler (worker)"
-      - protocol: tcp
-        direction: ingress
-        port_range_min: 10257
-        port_range_max: 10257
-        remote_group: "master_sg"
-        description: "Kube controller manager"
-      - protocol: tcp
-        direction: ingress
-        port_range_min: 10257
-        port_range_max: 10257
-        remote_group: "worker_sg"
-        description: "Kube controller manager (worker)"
-      - protocol: tcp
-        direction: ingress
-        port_range_min: 10250
-        port_range_max: 10250
-        remote_group: "master_sg"
-        description: "master ingress kubelet secure"
-      - protocol: tcp
-        direction: ingress
-        port_range_min: 10250
-        port_range_max: 10250
-        remote_group: "worker_sg"
-        description: "master ingress kubelet secure from worker"
-      - protocol: tcp
-        direction: ingress
-        port_range_min: 2379
-        port_range_max: 2380
-        remote_group: "master_sg"
-        description: "etcd"
-      - protocol: tcp
-        direction: ingress
-        port_range_min: 30000
-        port_range_max: 32767
-        remote_group: "master_sg"
-        description: "master ingress services (tcp)"
-      - protocol: udp
-        direction: ingress
-        port_range_min: 30000
-        port_range_max: 32767
-        remote_group: "master_sg"
-        description: "master ingress services (udp)"
-      - protocol: vrrp
-        direction: ingress
-        remote_ip_prefix: "{{ ocp_network_subnet_cidr }}"
-        description: "VRRP"
-  - name: worker_sg
-    description: Security group for OpenShift workers
-    rules:
-      - protocol: icmp
-        direction: ingress
-        description: icmp
-      - protocol: tcp
-        direction: ingress
-        port_range_min: 22
-        port_range_max: 22
-        remote_ip_prefix: "{{ ocp_network_subnet_cidr }}"
-        description: "SSH"
-      - protocol: udp
-        direction: ingress
-        port_range_min: 5353
-        port_range_max: 5353
-        remote_ip_prefix: "{{ ocp_network_subnet_cidr }}"
-        description: "mDNS"
-      - protocol: tcp
-        direction: ingress
-        port_range_min: 80
-        port_range_max: 80
-        description: "Ingress HTTP"
-      - protocol: tcp
-        direction: ingress
-        port_range_min: 443
-        port_range_max: 443
-        description: "Ingress HTTPS"
-      - protocol: tcp
-        direction: ingress
-        port_range_min: 1936
-        port_range_max: 1936
-        remote_ip_prefix: "{{ ocp_network_subnet_cidr }}"
-        description: "router stats"
-      - protocol: udp
-        direction: ingress
-        port_range_min: 4789
-        port_range_max: 4789
-        remote_group: "master_sg"
-        description: "VXLAN from master"
-      - protocol: udp
-        direction: ingress
-        port_range_min: 4789
-        port_range_max: 4789
-        remote_group: "worker_sg"
-        description: "VXLAN"
-      - protocol: udp
-        direction: ingress
-        port_range_min: 6081
-        port_range_max: 6081
-        remote_group: "master_sg"
-        description: "Geneve from master"
-      - protocol: udp
-        direction: ingress
-        port_range_min: 6081
-        port_range_max: 6081
-        remote_group: "worker_sg"
-        description: "Geneve"
-      - protocol: tcp
-        direction: ingress
-        port_range_min: 9000
-        port_range_max: 9999
-        remote_group: "worker_sg"
-        description: "Worker ingress internal (tcp)"
-      - protocol: tcp
-        direction: ingress
-        port_range_min: 9000
-        port_range_max: 9999
-        remote_group: "master_sg"
-        description: "Worker ingress from master (tcp)"
-      - protocol: udp
-        direction: ingress
-        port_range_min: 9000
-        port_range_max: 9999
-        remote_group: "master_sg"
-        description: "Worker ingress from master (udp)"
-      - protocol: udp
-        direction: ingress
-        port_range_min: 9000
-        port_range_max: 9999
-        remote_group: "worker_sg"
-        description: "Worker ingress internal (udp)"
-      - protocol: tcp
-        direction: ingress
-        port_range_min: 10250
-        port_range_max: 10250
-        remote_group: "master_sg"
-        description: "master ingress kubelet secure from master"
-      - protocol: tcp
-        direction: ingress
-        port_range_min: 10250
-        port_range_max: 10250
-        remote_group: "worker_sg"
-        description: "master ingress kubelet secure"
-      - protocol: tcp
-        direction: ingress
-        port_range_min: 30000
-        port_range_max: 32767
-        remote_group: "worker_sg"
-        description: "worker ingress services (tcp)"
-      - protocol: udp
-        direction: ingress
-        port_range_min: 30000
-        port_range_max: 32767
-        remote_group: "worker_sg"
-        description: "worker ingress services (udp)"
-      - protocol: vrrp
-        direction: ingress
-        remote_ip_prefix: "{{ ocp_network_subnet_cidr }}"
-        description: "VRRP"
+- name: bastion_sg
+  description: Bastion security group allows basic icmp and SSH ingress and egress to *
+  rules:
+  - protocol: icmp
+    direction: ingress
+  - protocol: tcp
+    direction: ingress
+    port_range_min: 22
+    port_range_max: 22
+    remote_ip_prefix: 0.0.0.0/0
+- name: utility_sg
+  description: Utility security group allows SSH from bastion and egress to *
+  rules:
+  - protocol: icmp
+    direction: ingress
+    remote_group: "bastion_sg"
+  - protocol: tcp
+    direction: ingress
+    port_range_min: 22
+    port_range_max: 22
+    remote_group: "bastion_sg"
+  - protocol: tcp
+    direction: ingress
+    port_range_min: 5000
+    port_range_max: 5000
+    remote_ip_prefix: "{{ ocp_network_subnet_cidr }}"
+    description: "local container registry"
+  - protocol: tcp
+    direction: ingress
+    port_range_min: 80
+    port_range_max: 80
+    remote_ip_prefix: "{{ ocp_network_subnet_cidr }}"
+    description: "http traffic for ignition files"
+  - protocol: tcp
+    direction: ingress
+    port_range_min: 2049
+    port_range_max: 2049
+    remote_ip_prefix: "{{ ocp_network_subnet_cidr }}"
+    description: "NFS traffic"
+- name: isolated_sg
+  description: All instances in the disconnected network
+  rules:
+  - protocol: icmp
+    direction: ingress
+    remote_group: "bastion_sg"
+  - protocol: tcp
+    direction: ingress
+    port_range_min: 22
+    port_range_max: 22
+    remote_group: "bastion_sg"
+- name: master_sg
+  description: Security group for OpenShift master and bootstrap
+  rules:
+  - protocol: icmp
+    direction: ingress
+    description: "icmp"
+  - protocol: tcp
+    direction: ingress
+    port_range_min: 22623
+    port_range_max: 22623
+    remote_ip_prefix: "{{ ocp_network_subnet_cidr }}"
+    description: "machine config server"
+  - protocol: tcp
+    direction: ingress
+    port_range_min: 22
+    port_range_max: 22
+    remote_ip_prefix: "{{ ocp_network_subnet_cidr }}"
+    description: "SSH"
+  - protocol: tcp
+    direction: ingress
+    port_range_min: 53
+    port_range_max: 53
+    remote_ip_prefix: "{{ ocp_network_subnet_cidr }}"
+    description: "DNS (tcp)"
+  - protocol: udp
+    direction: ingress
+    port_range_min: 53
+    port_range_max: 53
+    remote_ip_prefix: "{{ ocp_network_subnet_cidr }}"
+    description: "DNS (udp)"
+  - protocol: udp
+    direction: ingress
+    port_range_min: 5353
+    port_range_max: 5353
+    remote_ip_prefix: "{{ ocp_network_subnet_cidr }}"
+    description: "mDNS"
+  - protocol: tcp
+    direction: ingress
+    port_range_min: 6443
+    port_range_max: 6443
+    remote_ip_prefix: 0.0.0.0/0
+    description: "OpenShift API"
+  - protocol: udp
+    direction: ingress
+    port_range_min: 4789
+    port_range_max: 4789
+    remote_group: "master_sg"
+    description: "VXLAN"
+  - protocol: udp
+    direction: ingress
+    port_range_min: 4789
+    port_range_max: 4789
+    remote_group: "worker_sg"
+    description: "VXLAN (worker)"
+  - protocol: udp
+    direction: ingress
+    port_range_min: 6081
+    port_range_max: 6081
+    remote_group: "master_sg"
+    description: "Geneve"
+  - protocol: udp
+    direction: ingress
+    port_range_min: 6081
+    port_range_max: 6081
+    remote_group: "worker_sg"
+    description: "Geneve (worker)"
+  - protocol: tcp
+    direction: ingress
+    port_range_min: 6641
+    port_range_max: 6642
+    remote_group: "master_sg"
+    description: "OVNDB"
+  - protocol: tcp
+    direction: ingress
+    port_range_min: 6641
+    port_range_max: 6642
+    remote_group: "worker_sg"
+    description: "OVNDB (worker)"
+  - protocol: tcp
+    direction: ingress
+    port_range_min: 9000
+    port_range_max: 9999
+    remote_group: "master_sg"
+    description: "Master ingress internal (tcp)"
+  - protocol: tcp
+    direction: ingress
+    port_range_min: 9000
+    port_range_max: 9999
+    remote_group: "worker_sg"
+    description: "Master ingress from worker (tcp)"
+  - protocol: udp
+    direction: ingress
+    port_range_min: 9000
+    port_range_max: 9999
+    remote_group: "master_sg"
+    description: "Master ingress internal (udp)"
+  - protocol: udp
+    direction: ingress
+    port_range_min: 9000
+    port_range_max: 9999
+    remote_group: "worker_sg"
+    description: "Master ingress from worker (udp)"
+  - protocol: tcp
+    direction: ingress
+    port_range_min: 10259
+    port_range_max: 10259
+    remote_group: "master_sg"
+    description: "Kube Scheduler"
+  - protocol: tcp
+    direction: ingress
+    port_range_min: 10259
+    port_range_max: 10259
+    remote_group: "worker_sg"
+    description: "Kube Scheduler (worker)"
+  - protocol: tcp
+    direction: ingress
+    port_range_min: 10257
+    port_range_max: 10257
+    remote_group: "master_sg"
+    description: "Kube controller manager"
+  - protocol: tcp
+    direction: ingress
+    port_range_min: 10257
+    port_range_max: 10257
+    remote_group: "worker_sg"
+    description: "Kube controller manager (worker)"
+  - protocol: tcp
+    direction: ingress
+    port_range_min: 10250
+    port_range_max: 10250
+    remote_group: "master_sg"
+    description: "master ingress kubelet secure"
+  - protocol: tcp
+    direction: ingress
+    port_range_min: 10250
+    port_range_max: 10250
+    remote_group: "worker_sg"
+    description: "master ingress kubelet secure from worker"
+  - protocol: tcp
+    direction: ingress
+    port_range_min: 2379
+    port_range_max: 2380
+    remote_group: "master_sg"
+    description: "etcd"
+  - protocol: tcp
+    direction: ingress
+    port_range_min: 30000
+    port_range_max: 32767
+    remote_group: "master_sg"
+    description: "master ingress services (tcp)"
+  - protocol: udp
+    direction: ingress
+    port_range_min: 30000
+    port_range_max: 32767
+    remote_group: "master_sg"
+    description: "master ingress services (udp)"
+  - protocol: vrrp
+    direction: ingress
+    remote_ip_prefix: "{{ ocp_network_subnet_cidr }}"
+    description: "VRRP"
+- name: worker_sg
+  description: Security group for OpenShift workers
+  rules:
+  - protocol: icmp
+    direction: ingress
+    description: icmp
+  - protocol: tcp
+    direction: ingress
+    port_range_min: 22
+    port_range_max: 22
+    remote_ip_prefix: "{{ ocp_network_subnet_cidr }}"
+    description: "SSH"
+  - protocol: udp
+    direction: ingress
+    port_range_min: 5353
+    port_range_max: 5353
+    remote_ip_prefix: "{{ ocp_network_subnet_cidr }}"
+    description: "mDNS"
+  - protocol: tcp
+    direction: ingress
+    port_range_min: 80
+    port_range_max: 80
+    description: "Ingress HTTP"
+  - protocol: tcp
+    direction: ingress
+    port_range_min: 443
+    port_range_max: 443
+    description: "Ingress HTTPS"
+  - protocol: tcp
+    direction: ingress
+    port_range_min: 1936
+    port_range_max: 1936
+    remote_ip_prefix: "{{ ocp_network_subnet_cidr }}"
+    description: "router stats"
+  - protocol: udp
+    direction: ingress
+    port_range_min: 4789
+    port_range_max: 4789
+    remote_group: "master_sg"
+    description: "VXLAN from master"
+  - protocol: udp
+    direction: ingress
+    port_range_min: 4789
+    port_range_max: 4789
+    remote_group: "worker_sg"
+    description: "VXLAN"
+  - protocol: udp
+    direction: ingress
+    port_range_min: 6081
+    port_range_max: 6081
+    remote_group: "master_sg"
+    description: "Geneve from master"
+  - protocol: udp
+    direction: ingress
+    port_range_min: 6081
+    port_range_max: 6081
+    remote_group: "worker_sg"
+    description: "Geneve"
+  - protocol: tcp
+    direction: ingress
+    port_range_min: 9000
+    port_range_max: 9999
+    remote_group: "worker_sg"
+    description: "Worker ingress internal (tcp)"
+  - protocol: tcp
+    direction: ingress
+    port_range_min: 9000
+    port_range_max: 9999
+    remote_group: "master_sg"
+    description: "Worker ingress from master (tcp)"
+  - protocol: udp
+    direction: ingress
+    port_range_min: 9000
+    port_range_max: 9999
+    remote_group: "master_sg"
+    description: "Worker ingress from master (udp)"
+  - protocol: udp
+    direction: ingress
+    port_range_min: 9000
+    port_range_max: 9999
+    remote_group: "worker_sg"
+    description: "Worker ingress internal (udp)"
+  - protocol: tcp
+    direction: ingress
+    port_range_min: 10250
+    port_range_max: 10250
+    remote_group: "master_sg"
+    description: "master ingress kubelet secure from master"
+  - protocol: tcp
+    direction: ingress
+    port_range_min: 10250
+    port_range_max: 10250
+    remote_group: "worker_sg"
+    description: "master ingress kubelet secure"
+  - protocol: tcp
+    direction: ingress
+    port_range_min: 30000
+    port_range_max: 32767
+    remote_group: "worker_sg"
+    description: "worker ingress services (tcp)"
+  - protocol: udp
+    direction: ingress
+    port_range_min: 30000
+    port_range_max: 32767
+    remote_group: "worker_sg"
+    description: "worker ingress services (udp)"
+  - protocol: vrrp
+    direction: ingress
+    remote_ip_prefix: "{{ ocp_network_subnet_cidr }}"
+    description: "VRRP"

--- a/ansible/configs/ocp4-disconnected-osp-lab/software.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/software.yml
@@ -300,7 +300,7 @@
             INFRA_ID: "{{ r_infra_id.stdout }}"
 
         - name: Wait for job to finish (1h max)
-          k8s_facts:
+          k8s_info:
             api_version: batch/v1
             kind: Job
             name: fio-test


### PR DESCRIPTION
##### SUMMARY

The OpenStack HA Config needed an update to run on the Orange (and Pink etc.) OpenStack clusters.
I also took the opportunity to update the bastion and utilityvms to RHEL 8.2 and Satellite.

Nameservers had to be set to override the ones coming from OpenStack to get acceptable performance.

Validated that the solver still works (except for registry PVC at the end which is no longer necessary).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4-disconnected-osp-lab