### PR TITLE
Fix default OSP variables

### DIFF
--- a/ansible/configs/satellite-vm/default_vars_osp.yml
+++ b/ansible/configs/satellite-vm/default_vars_osp.yml
@@ -10,8 +10,6 @@ install_student_user: false
 
 ansible_user: cloud-user
 remote_user: cloud-user
-osp_cluster_dns_zone: red.osp.opentlc.com
-osp_cluster_dns_server: ddns01.opentlc.com
 use_dynamic_dns: true
 osp_project_create: true
 student_name: student


### PR DESCRIPTION
##### SUMMARY
Remove variables `osp_cluster_dns_zone` and `osp_cluster_dns_server` from `default_vars_osp.yaml`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
config/satellite-vm
