### PR TITLE
Change action_plugin user_info: create output_dir if not existent

### DIFF
--- a/ansible/action_plugins/agnosticd_user_info.py
+++ b/ansible/action_plugins/agnosticd_user_info.py
@@ -88,19 +88,19 @@ class ActionModule(ActionBase):
                 )
             )
             if not user and msg != None:
-                os.makedirs(os.path.dirname(os.path.join(output_dir, 'user-info.yaml')), exist_ok=True)
+                os.makedirs(output_dir, exist_ok=True)
                 fh = open(os.path.join(output_dir, 'user-info.yaml'), 'a')
                 fh.write('- ' + json.dumps(msg) + "\n")
                 fh.close()
             if not user and body != None:
-                os.makedirs(os.path.dirname(os.path.join(output_dir, 'user-body.yaml')), exist_ok=True)
+                os.makedirs(output_dir, exist_ok=True)
                 fh = open(os.path.join(output_dir, 'user-body.yaml'), 'a')
                 fh.write('- ' + json.dumps(body) + "\n")
                 fh.close()
             if data or user:
                 user_data = None
                 try:
-                    os.makedirs(os.path.dirname(os.path.join(output_dir, 'user-data.yaml')), exist_ok=True)
+                    os.makedirs(output_dir, exist_ok=True)
                     fh = open(os.path.join(output_dir, 'user-data.yaml'), 'r')
                     user_data = yaml.safe_load(fh)
                     fh.close()
@@ -132,7 +132,7 @@ class ActionModule(ActionBase):
                 else:
                     user_data.update(data)
 
-                os.makedirs(os.path.dirname(os.path.join(output_dir, 'user-data.yaml')), exist_ok=True)
+                os.makedirs(os.path.dirname(output_dir), exist_ok=True)
                 fh = open(os.path.join(output_dir, 'user-data.yaml'), 'w')
                 yaml.safe_dump(user_data, stream=fh, explicit_start=True)
                 fh.close()

--- a/ansible/action_plugins/agnosticd_user_info.py
+++ b/ansible/action_plugins/agnosticd_user_info.py
@@ -88,16 +88,19 @@ class ActionModule(ActionBase):
                 )
             )
             if not user and msg != None:
+                os.makedirs(os.path.dirname(os.path.join(output_dir, 'user-info.yaml')), exist_ok=True)
                 fh = open(os.path.join(output_dir, 'user-info.yaml'), 'a')
                 fh.write('- ' + json.dumps(msg) + "\n")
                 fh.close()
             if not user and body != None:
+                os.makedirs(os.path.dirname(os.path.join(output_dir, 'user-body.yaml')), exist_ok=True)
                 fh = open(os.path.join(output_dir, 'user-body.yaml'), 'a')
                 fh.write('- ' + json.dumps(body) + "\n")
                 fh.close()
             if data or user:
                 user_data = None
                 try:
+                    os.makedirs(os.path.dirname(os.path.join(output_dir, 'user-data.yaml')), exist_ok=True)
                     fh = open(os.path.join(output_dir, 'user-data.yaml'), 'r')
                     user_data = yaml.safe_load(fh)
                     fh.close()
@@ -129,6 +132,7 @@ class ActionModule(ActionBase):
                 else:
                     user_data.update(data)
 
+                os.makedirs(os.path.dirname(os.path.join(output_dir, 'user-data.yaml')), exist_ok=True)
                 fh = open(os.path.join(output_dir, 'user-data.yaml'), 'w')
                 yaml.safe_dump(user_data, stream=fh, explicit_start=True)
                 fh.close()


### PR DESCRIPTION
##### SUMMARY

When testing ocp_workloads independently (like on an existing OCP cluster, from localhost), the user_info script will fail if the output_dir does not exist.
This PR adds basic directory check and creation to the script. This does not change behaviour in a full deployment when the directory has already been created, but prevents failing on workload test.
Added line example:
`os.makedirs(os.path.dirname(os.path.join(output_dir, 'user-info.yaml')), exist_ok=True)`
