### PR TITLE
Fix role tower-settings-update to handle dict with one key

### DIFF
--- a/ansible/roles/tower-settings-update/tasks/main.yml
+++ b/ansible/roles/tower-settings-update/tasks/main.yml
@@ -1,16 +1,15 @@
 ---
-#update tower setting path
-
-- name: Set the value of AWX_PROOT_BASE_PATH
+- name: Update tower settings
   tower_settings:
-    name:               "{{ tower_setting.key }}"
-    value:              "{{ tower_setting.value }}"
+    name:               "{{ __tower_setting.key }}"
+    value:              "{{ __tower_setting.value }}"
     tower_host:         "{{ tower_hostname }}"
     tower_username:     "{{ tower_admin_username | default('admin') }}"
     tower_password:     "{{ tower_admin_password }}"
     tower_verify_ssl:   "{{ tower_verify_ssl | default(false) }}"
   when: tower_setting_params is defined
-  loop: "{{ lookup('dict', tower_setting_params) }}"
+  loop: "{{ tower_setting_params | dict2items }}"
   loop_control:
-    loop_var: tower_setting
+    loop_var: __tower_setting
+    label: "{{ __tower_setting.key }}"
 ...


### PR DESCRIPTION
##### SUMMARY

Fix role tower-settings-update to function when `tower_setting_params` has only one key in the dictionary.

The `dict` lookup by default does not return a list when the dictionary has only one entry. The `dict2items` filter is a cleaner approach and does not have this issue.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role tower-settings-update