### PR TITLE
Fix osp-satellite-vm user info

### DIFF
--- a/ansible/configs/osp-satellite-vm/post_infra.yml
+++ b/ansible/configs/osp-satellite-vm/post_infra.yml
@@ -43,7 +43,7 @@
       with_items:
         - "user.info: "
         - "user.info: You can access your bastion via SSH:"
-        - "user.info: SSH Access: ssh {{ student_name }}@{{ groups.bastions.0 ~ '-' ~ osp_cluster_dns_zone }}"
+        - "user.info: SSH Access: ssh {{ student_name }}@{{ groups.bastions.0 ~ '.' ~ osp_cluster_dns_zone }}"
 
     - name: Print Student SSH password as user.info
       debug:
@@ -84,6 +84,10 @@
   tags:
     - step002
   tasks:
+    - name: Run infra-osp-wait_for_linux_hosts Role
+      import_role:
+        name: infra-osp-wait_for_linux_hosts
+
     - name: Set hostname as a fact
       set_fact:
         satellite_hostname: "satellite.{{ guid ~ '.' ~ osp_cluster_dns_zone }}"


### PR DESCRIPTION
##### SUMMARY

* Fix domain name
* Import role `infra-osp-wait_for_linux_hosts` for satellite servers

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`config/osp-satellite-vm`

