### PR TITLE
Update migration workloads to use MTC v1.3.2

### DIFF
--- a/ansible/roles/ocp-workload-migration/templates/operator.yml.j2
+++ b/ansible/roles/ocp-workload-migration/templates/operator.yml.j2
@@ -287,7 +287,7 @@ spec:
       serviceAccountName: migration-operator
       containers:
       - name: operator
-        image: registry.redhat.io/rhmtc/{{ mig_migration_namespace }}-rhel7-operator:v1.3.1
+        image: registry.redhat.io/rhmtc/{{ mig_migration_namespace }}-rhel7-operator:v1.3.2
         imagePullPolicy: Always
         volumeMounts:
         - mountPath: /tmp/ansible-operator/runner
@@ -310,7 +310,7 @@ spec:
         - name: HOOK_RUNNER_REPO
           value: {{ mig_migration_namespace }}-hook-runner-rhel7@sha256
         - name: HOOK_RUNNER_TAG
-          value: 779af420a02683fc8288b56d70e1d026fdc790f7248d4aa68a256b811c20608e
+          value: 30267eda1374a7f7e989ca8cdb0997fe4ddb77a97385d8c7f21b20db57c46aa8
         - name: MIG_CONTROLLER_REPO
           value: {{ mig_migration_namespace }}-controller-rhel8@sha256
         - name: MIG_UI_REPO
@@ -318,7 +318,7 @@ spec:
         - name: MIGRATION_REGISTRY_REPO
           value: {{ mig_migration_namespace }}-registry-rhel8@sha256
         - name: MIGRATION_REGISTRY_TAG
-          value: 68d1d072d485ed79e16a4808f39dd62745b1a308b7278ba50268bce0915f492b
+          value: 980b8ab84e7cf3e8664a052e2fcbda74123a31b674e64f0648d49bcc472ba3a2
         - name: VELERO_REPO
           value: {{ mig_migration_namespace }}-velero-rhel8@sha256
         - name: VELERO_PLUGIN_REPO
@@ -332,21 +332,21 @@ spec:
         - name: VELERO_AZURE_PLUGIN_REPO
           value: {{ mig_migration_namespace }}-velero-plugin-for-microsoft-azure-rhel8@sha256
         - name: VELERO_TAG
-          value: b9297b801115abe344cf85f78fa895d5eb8f05b56993d73cf84984c0ef106bd3
+          value: 349db22c468b5923e415a88e03a9f14a4df249969a7275b94197bc78f2a0b26c
         - name: VELERO_RESTIC_RESTORE_HELPER_TAG
-          value: c2a30aed87caddfa95d15fd1363c4ed3e02803e84a627b64f9d31a5206ddc51d
+          value: 0ca2ea8742025edf6ac4940507b92a699a10b3685831b22a31ab5a35050f23bb
         - name: VELERO_PLUGIN_TAG
-          value: f82430cceadd4a45696bb4ea84ee5f72365b0a92c3b6880fac724cae086e37fb
+          value: cff7527e3906dbfc494bbfc9573b645dcaa7b8d5d5777b8d013ccaac211a3dff
         - name: VELERO_AWS_PLUGIN_TAG
-          value: cae3f43d754c0b8d334c22fe50c8dbbda78953813819674ee66dc99d8e9ca259
+          value: d62b80789e77c64eeed61abe362c2239a726905474e85e5996911f2361b49227
         - name: VELERO_GCP_PLUGIN_TAG
-          value: 510953b3c2c930f436f70e8ffbc717e5c33bf3164668c3953b3d820b417ad048
+          value: c5c354d0b1f068d32929c372af1729fe3fc2715dd90643f689dcf6912d939919
         - name: VELERO_AZURE_PLUGIN_TAG
-          value: df27eabda39e07c18e995ff528a31540999088039b1fe8766a66247b9f718813
+          value: d3115f650e1265df663233af6b788d925376713478a0b6ecbfd9355d8fff8623
         - name: MIG_UI_TAG
-          value: 029b0cc4ae4855a290241b240c8360c0fac831f3d5a2d554450c38133a220811
+          value: a616ba1d16459b376e2a8c77ecc8c0d2122fd04881cf3493d422184434ddd559
         - name: MIG_CONTROLLER_TAG
-          value: 6141fd9a8670ba59245d3429d88ace528851974042ab7261b443bc6899ca44b1
+          value: a8f9edd91b5a2a722d65035e6c00b4c594d3c9e3583a48865c1d3047aae9ed0c
       volumes:
         - name: runner
           emptyDir: {}

--- a/ansible/roles/ocp4-workload-migration/templates/mig-operator-subscription-downstream.yml.j2
+++ b/ansible/roles/ocp4-workload-migration/templates/mig-operator-subscription-downstream.yml.j2
@@ -6,7 +6,7 @@ metadata:
 spec:
   channel: release-v1.3
   installPlanApproval: Manual
-  startingCSV: mtc-operator.v1.3.1
+  startingCSV: mtc-operator.v1.3.2
   name: mtc-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
This PR updates the SHAs for MTC operator deployment in OpenShift 3 migration workload to use v1.3.2

Also updates the subscription of MTC operator in OpenShift 4 workload and pins down to v1.3.2 

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp-workload-migration
ocp4-workload-migration

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
