### PR TITLE
Expose internal registry for core cluster

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_dso/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_dso/tasks/pre_workload.yml
@@ -28,6 +28,18 @@
   set_fact:
     ocp4_dso_gogs_generate_user_count: "{{ user_count_end }}"
 
+- name: Expose the OpenShift internal registry
+  k8s:
+    state: present
+    definition:
+      apiVersion: imageregistry.operator.openshift.io/v1
+      kind: Config
+      metadata:
+        name: cluster
+      spec:
+        defaultRoute: true
+        managementState: Managed
+
 - name: Retrieve registry route
   k8s_info:
     api_version: route.openshift.io/v1


### PR DESCRIPTION
##### SUMMARY

Expose internal registry for core cluster.

Without this patch the `Retrieve registry route` task on line 43 fails because the registry route is not exposed by default.

Fixes merged [PR 3071](https://github.com/redhat-cop/agnosticd/pull/3071/files)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Role ocp4_workload_dso