### PR TITLE
change ocp4-workload-cnvlab welcome email to use OpenShift Virtualization naming instead of CNV

### DIFF
--- a/ansible/roles/ocp4-workload-cnvlab/tasks/post_workload.yml
+++ b/ansible/roles/ocp4-workload-cnvlab/tasks/post_workload.yml
@@ -13,13 +13,13 @@
 
 - name: Print CNV Lab Workbook Route
   debug:
-    msg: "CNV Lab Workbook: https://{{ getroute.resources[0].spec.host }}"
+    msg: "OpenShift Virtualization Lab Workbook: https://{{ getroute.resources[0].spec.host }}"
   when:
     - not silent | bool
 
 - name: Report URL for web console
   agnosticd_user_info:
-    msg: "CNV Lab Workbook: https://{{ getroute.resources[0].spec.host }}"
+    msg: "OpenShift Virtualization Lab Workbook: https://{{ getroute.resources[0].spec.host }}"
 
 - name: Get kubeadmin password
   command: cat ~/cluster-{{ guid }}/auth/kubeadmin-password


### PR DESCRIPTION
…in ocp4-workload-cnvlab

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

Changing the naming on the link to our lan environment to use OpenShift Virtualization instead of CNV, ie: 
From: CNV Lab Workbook: https://cnv-workbook.apps....
To: OpenShift Virtualization Lab Workbook: https://cnv-workbook.apps....
No change to the variables, just the description text.

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
Welcome email text in ocp4-workload-cnvlab

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
