### PR TITLE
Change role ocp4_workload_dso to add retries to cluster image config

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_dso/tasks/infrastructure.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_dso/tasks/infrastructure.yml
@@ -54,7 +54,19 @@
   become: true
 
 - name: Add quay route to insecure registries
-  command: "{{ ocp4_dso_openshift_cli }} patch image.config.openshift.io/cluster -p '{ \"spec\" : { \"registrySources\" : { \"insecureRegistries\" : [\"quayecosystem-quay-quay-enterprise.{{ route_subdomain }}\"] }}}' --type=merge"
+  vars:
+    __patch:
+      spec:
+        registrySources:
+          insecureRegistries:
+          - quayecosystem-quay-quay-enterprise.{{ route_subdomain }}
+  command: >-
+    {{ ocp4_dso_openshift_cli }} patch image.config.openshift.io/cluster
+     --type=merge -p {{ __patch | to_json | quote }}
+  register: r_command
+  until: r_command is success
+  retries: 10
+  delay: 10
 
 - name: create custom jenkins image
   shell: |


### PR DESCRIPTION
##### SUMMARY

The role `ocp4_workload_dso` uses the `oc patch` command to update the cluster image config, but sometimes the cluster image config API may be unavailable due to components restarting. This PR add retries to this task to make it more robust.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Role ocp4_workload_dso