### PR TITLE
Fix FTL condition that is too loose

### DIFF
--- a/ansible/roles/bastion-lite/tasks/main.yml
+++ b/ansible/roles/bastion-lite/tasks/main.yml
@@ -37,9 +37,7 @@
   register: statiptables
 
 - name: Install FTL
-  when: >-
-    install_ftl | default(false) | bool or
-    ftl_injector_tag is defined
+  when: install_ftl | default(false) | bool
   block:
     - name: Install FTL
       include_role:

--- a/ansible/roles/bastion/tasks/main.yml
+++ b/ansible/roles/bastion/tasks/main.yml
@@ -104,9 +104,7 @@
       when: ensuresshpresent.rc == 0
 
 - name: Install FTL
-  when: >-
-    install_ftl | default(false) | bool or
-    ftl_injector_tag is defined
+  when: install_ftl | default(false) | bool
   block:
     - name: Install FTL
       include_role:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
The condition to run FTL is currently too loose.
Fix it and use only the boolean `install_ftl`
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Bugfix Pull Request
