### PR TITLE
Remove k8s library from python requirements

### DIFF
--- a/ansible/configs/kni-osp/files/requirements_k8s.txt
+++ b/ansible/configs/kni-osp/files/requirements_k8s.txt
@@ -13,7 +13,6 @@ google-auth==1.10.2
 idna==2.8
 Jinja2==2.10.3
 jmespath==0.9.4
-k8s==0.14.0
 kubernetes==11.0.0
 MarkupSafe==1.1.1
 oauthlib==3.1.0

--- a/ansible/configs/ocp4-cluster/files/requirements_k8s.txt
+++ b/ansible/configs/ocp4-cluster/files/requirements_k8s.txt
@@ -18,7 +18,6 @@ google-auth==1.10.2
 idna==2.8
 Jinja2==2.10.3
 jmespath==0.9.4
-k8s==0.14.0
 kubernetes==11.0.0
 MarkupSafe==1.1.1
 oauthlib==3.1.0

--- a/ansible/configs/ocp4-workshop/files/requirements_k8s.txt
+++ b/ansible/configs/ocp4-workshop/files/requirements_k8s.txt
@@ -18,7 +18,6 @@ google-auth==1.10.2
 idna==2.8
 Jinja2==2.10.3
 jmespath==0.9.4
-k8s==0.14.0
 kubernetes==11.0.0
 MarkupSafe==1.1.1
 oauthlib==3.1.0

--- a/ansible/configs/ocs4-external-implementation/files/requirements_k8s.txt
+++ b/ansible/configs/ocs4-external-implementation/files/requirements_k8s.txt
@@ -18,7 +18,6 @@ google-auth==1.10.2
 idna==2.8
 Jinja2==2.10.3
 jmespath==0.9.4
-k8s==0.14.0
 kubernetes==11.0.0
 MarkupSafe==1.1.1
 oauthlib==3.1.0

--- a/ansible/configs/sap-integration/files/requirements_k8s.txt
+++ b/ansible/configs/sap-integration/files/requirements_k8s.txt
@@ -13,7 +13,6 @@ google-auth==1.10.2
 idna==2.8
 Jinja2==2.10.3
 jmespath==0.9.4
-k8s==0.14.0
 kubernetes==11.0.0
 MarkupSafe==1.1.1
 oauthlib==3.1.0

--- a/ansible/roles/ocp-workload-migration/files/requirements.txt
+++ b/ansible/roles/ocp-workload-migration/files/requirements.txt
@@ -13,7 +13,6 @@ google-auth==1.10.2
 idna==2.8
 Jinja2==2.10.3
 jmespath==0.9.4
-k8s==0.14.0
 kubernetes==10.0.1
 MarkupSafe==1.1.1
 oauthlib==3.1.0


### PR DESCRIPTION
##### SUMMARY

Remove reference to k8s python module in requirements which are causing virtualenvs to fail pip.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Config kni-osp
Config ocp4-cluster
Config ocp4-workshop
Config ocs4-external-implementation
Config sap-integration
Role ocp-workload-migration