### PR TITLE
Fix role ocp4-workload-dil-streaming route_subdomain var

### DIFF
--- a/ansible/roles/ocp4-workload-dil-streaming/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-dil-streaming/tasks/pre_workload.yml
@@ -32,9 +32,11 @@
   set_fact:
     console_url: "{{ console_url_r.stdout | trim }}"
 
-- name: extract route_subdomain
-  k8s_facts:
+- name: Get the cluster ingress config
+  k8s_info:
+    api_version: config.openshift.io/v1
     kind: Ingress
+    name: cluster
   register: route_subdomain_r
 
 - name: set the route

--- a/ansible/roles/ocp4-workload-dil-streaming/tasks/provision_che.yaml
+++ b/ansible/roles/ocp4-workload-dil-streaming/tasks/provision_che.yaml
@@ -59,14 +59,6 @@
     state: present
     resource_definition: "{{ lookup('template', 'che-cluster.yaml.j2') }}"
 
-- name: extract route_subdomain
-  k8s_facts:
-    kind: Ingress
-  register: route_subdomain_r
-  
-- set_fact:
-    route_subdomain: "{{ route_subdomain_r.resources[0].spec.domain | trim }}"
-
 - name: Wait for Eclipse Che to be running
   uri:
     url: http://che-{{ che_project }}.{{ route_subdomain }}/api/system/state
@@ -75,7 +67,6 @@
   until: result.status == 200
   retries: 90
   delay: 30
-
 
 - name: Extract key_cloak_admin_password
   k8s_facts: 

--- a/ansible/roles/ocp4-workload-dil-streaming/tasks/provision_crw.yaml
+++ b/ansible/roles/ocp4-workload-dil-streaming/tasks/provision_crw.yaml
@@ -58,14 +58,6 @@
     state: present
     resource_definition: "{{ lookup('template', 'crw-cluster.yaml.j2') }}"
 
-- name: extract route_subdomain
-  k8s_facts:
-    kind: Ingress
-  register: route_subdomain_r
-  
-- set_fact:
-    route_subdomain: "{{ route_subdomain_r.resources[0].spec.domain | trim }}"
-
 - name: Wait for Code Ready to be running
   uri:
     url: http://codeready-{{ che_project }}.{{ route_subdomain }}/api/system/state

--- a/ansible/roles/ocp4-workload-dil-streaming/tasks/single_cluster.yaml
+++ b/ansible/roles/ocp4-workload-dil-streaming/tasks/single_cluster.yaml
@@ -16,12 +16,3 @@
   k8s:
     state: present
     resource_definition: "{{ lookup('template', 'fuse-cluster.yaml.j2') }}"
-
-- name: extract route_subdomain
-  k8s_facts:
-    kind: Ingress
-  register: route_subdomain_r
-  
-- set_fact:
-    route_subdomain: "{{ route_subdomain_r.resources[0].spec.domain | trim }}"
-


### PR DESCRIPTION
##### SUMMARY

Fix setting rout_subdomain in ocp4-workload-dil-streaming.

The role did not specify `api_version` when attempting to fetch the ingress configuration, resulting in getting a result from the wrong api group.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role ocp4-workload-dil-streaming