### PR TITLE
Fix multiple roles fetching Ingress without api_group

### DIFF
--- a/ansible/roles/ocp4-workload-camelk-crw/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-camelk-crw/tasks/pre_workload.yml
@@ -41,14 +41,17 @@
     src: templates
     dest: "{{ tmp_dir }}"
 
-- name: extract route_subdomain
-  k8s_facts:
+- name: Get cluster ingress config
+  k8s_info:
+    api_version: config.openshift.io/v1
     kind: Ingress
-  register: route_subdomain_r
+    name: cluster
+  register: r_ingress_config
+  failed_when: r_ingress_config.resources | length < 1
 
 - name: set the route
   set_fact:
-    route_subdomain: "{{ route_subdomain_r.resources[0].spec.domain | trim }}"
+    route_subdomain: "{{ r_ingress_config.resources[0].spec.domain }}"
 
 # Leave this as the last task in the playbook.
 - name: pre_workload tasks complete

--- a/ansible/roles/ocp4-workload-debezium-demo/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-debezium-demo/tasks/pre_workload.yml
@@ -25,12 +25,15 @@
 
 - name: extract route_subdomain
   k8s_info:
+    api_version: config.openshift.io/v1
     kind: Ingress
-  register: route_subdomain_r
+    name: cluster
+  register: r_ingress_config
+  failed_when: r_ingress_config.resources | length < 1
 
 - name: set the route
   set_fact:
-    route_subdomain: "{{ route_subdomain_r.resources[0].spec.domain | trim }}"
+    route_subdomain: "{{ r_ingress_config.resources[0].spec.domain }}"
 
 - name: set bastion_fqdn
   set_fact:

--- a/ansible/roles/ocp4-workload-debugging-workshop/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-debugging-workshop/tasks/pre_workload.yml
@@ -33,13 +33,16 @@
     console_url: "{{ console_url_r.stdout | trim }}"
 
 - name: extract route_subdomain
-  k8s_facts:
+  k8s_info:
+    api_version: config.openshift.io/v1
     kind: Ingress
-  register: route_subdomain_r
+    name: cluster
+  register: r_ingress_config
+  failed_when: r_ingress_config.resources | length < 1
 
 - name: set the route
   set_fact:
-    route_subdomain: "{{ route_subdomain_r.resources[0].spec.domain | trim }}"
+    route_subdomain: "{{ r_ingress_config.resources[0].spec.domain }}"
 
 - name: set bastion_fqdn
   set_fact:

--- a/ansible/roles/ocp4-workload-iot-managed/tasks/provision_che.yaml
+++ b/ansible/roles/ocp4-workload-iot-managed/tasks/provision_che.yaml
@@ -43,11 +43,14 @@
 
 - name: extract route_subdomain
   k8s_info:
+    api_version: config.openshift.io/v1
     kind: Ingress
-  register: route_subdomain_r
+    name: cluster
+  register: r_ingress_config
+  failed_when: r_ingress_config.resources | length < 1
   
 - set_fact:
-    route_subdomain: "{{ route_subdomain_r.resources[0].spec.domain | trim }}"
+    route_subdomain: "{{ r_ingress_config.resources[0].spec.domain }}"
 
 - name: Wait for Eclipse Che to be running
   uri:

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/tasks/workload.yml
@@ -185,11 +185,12 @@
     api_version: config.openshift.io/v1
     name: cluster
     kind: Ingress
-  register: cluster_apps_domain_out
+  register: r_ingress_config
+  failed_when: r_ingress_config.resources | length < 1
 
 - name: register cluster apps domain as a fact
   set_fact:
-    cluster_apps_domain: "{{ cluster_apps_domain_out.resources[0].spec.domain}}"
+    cluster_apps_domain: "{{ r_ingress_config.resources[0].spec.domain }}"
     notebook_suffix: "/notebooks/data-engineering-and-machine-learning-workshop.git/source/notebooks/hybrid-data-engineering.ipynb"
 
 - name: make sure the guides project exists

--- a/ansible/roles/ocp4-workload-workshop-dashboard-cluster-admin-student/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-workshop-dashboard-cluster-admin-student/tasks/pre_workload.yml
@@ -28,13 +28,16 @@
 - set_fact:
     master_url: "https://{{ master_url_r.resources[0].spec.host | trim }}"
 
-- name: extract route_subdomain
-  k8s_facts:
+- name: Get cluster ingress config
+  k8s_info:
+    api_version: config.openshift.io/v1
     kind: Ingress
-  register: route_subdomain_r
+    name: cluster
+  register: r_ingress_config
+  failed_when: r_ingress_config.resources | length < 1
 
 - set_fact:
-    route_subdomain: "{{ route_subdomain_r.resources[0].spec.domain | trim }}"
+    route_subdomain: "{{ r_ingress_config.resources[0].spec.domain }}"
 
 - name: cat the kubeadmin-password
   command: "cat /home/{{ ansible_user }}/cluster-{{ guid }}/auth/kubeadmin-password"

--- a/ansible/roles_ocp_workloads/ocp4_workload_dso/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_dso/tasks/pre_workload.yml
@@ -55,14 +55,17 @@
   set_fact:
     ocp4_dso_ocp_registry_route: "{{ r_get_registry_route.resources[0].spec.host }}"
 
-- name: extract route_subdomain
+- name: Get cluster ingress config
   k8s_info:
+    api_version: config.openshift.io/v1
     kind: Ingress
-  register: route_subdomain_r
+    name: cluster
+  register: r_ingress_config
+  failed_when: r_ingress_config.resources | length < 1
 
 - name: set the route
   set_fact:
-    route_subdomain: "{{ route_subdomain_r.resources[0].spec.domain | trim }}"
+    route_subdomain: "{{ r_ingress_config.resources[0].spec.domain }}"
 
 - name: make the temp dir
   file:

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_workshop_user/tasks/pre_workload.yml
@@ -23,14 +23,17 @@
     name: cluster
   register: r_api_url
 
-- name: extract route_subdomain
-  k8s_facts:
+- name: Get cluster ingress config
+  k8s_info:
+    api_version: config.openshift.io/v1
     kind: Ingress
-  register: route_subdomain_r
+    name: cluster
+  register: r_ingress_config
+  failed_when: r_ingress_config.resources | length < 1
 
 - name: set the route
   set_fact:
-    route_subdomain: "{{ route_subdomain_r.resources[0].spec.domain | trim }}"
+    route_subdomain: "{{ r_ingress_config.resources[0].spec.domain }}"
 
 - name: Get codeready keycloak deployment
   k8s_facts:

--- a/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/tasks/workload.yml
@@ -68,6 +68,7 @@
     kind: Ingress
     name: cluster
   register: r_ingress_config
+  failed_when: r_ingress_config.resources | length < 1
 
 - name: Use Provided Quay route
   when: ocp4_workload_quay_operator_route | default("") | length > 0


### PR DESCRIPTION
##### SUMMARY

Fix multiple roles where the OpenShift cluster ingress config was fetched without specifying `api_group`, resulting in unpredictable behavior.

Across multiple roles this PR will:
- Add `api_version` if missing
- Add `name: cluster` if missing
- Switch from `k8s_facts` to `k8s_info`
- Add `failed_when` condition to fail on fetching the the resource rather than fail on the subsequent `set_fact` task.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Roles:
- ocp4-workload-camelk-crw
- ocp4-workload-debezium-demo
- ocp4-workload-debugging-workshop
- ocp4-workload-iot-managed
- ocp4-workload-rhte-analytics_data_ocp_workshop
- ocp4-workload-workshop-dashboard-cluster-admin-student
- ocp4_workload_dso
- ocp4_workload_quarkus_workshop_user
- ocp4_workload_quarkus_workshop_user