### PR TITLE
Add role infra_osp_bastion_on_openshift_network

### DIFF
--- a/ansible/roles-infra/infra_osp_bastion_on_openshift_network/.yamllint
+++ b/ansible/roles-infra/infra_osp_bastion_on_openshift_network/.yamllint
@@ -1,0 +1,2 @@
+---
+extends: ../../../tests/static/.yamllint

--- a/ansible/roles-infra/infra_osp_bastion_on_openshift_network/README.adoc
+++ b/ansible/roles-infra/infra_osp_bastion_on_openshift_network/README.adoc
@@ -1,0 +1,3 @@
+# infra_osp_bastion_on_openshift_network
+
+Add bastion to the OpenShift node network to support capabilities such as SSH from bastion to nodes.

--- a/ansible/roles-infra/infra_osp_bastion_on_openshift_network/defaults/main.yaml
+++ b/ansible/roles-infra/infra_osp_bastion_on_openshift_network/defaults/main.yaml
@@ -1,12 +1,2 @@
 ---
 osp_auth_username_member: "{{ guid }}-user"
-
-# Defaults to match infra-osp-project-create
-osp_project_create: true
-osp_create_sandbox: false
-
-# This is useful if you're working with osp_project_create = false but
-# still want to cleanup your project *and* because you're the only one
-# working in the project.
-# by default, the cleanup of resource only occurs when osp_project_create is true
-osp_force_delete_all_resources: false

--- a/ansible/roles-infra/infra_osp_bastion_on_openshift_network/defaults/main.yaml
+++ b/ansible/roles-infra/infra_osp_bastion_on_openshift_network/defaults/main.yaml
@@ -1,0 +1,12 @@
+---
+osp_auth_username_member: "{{ guid }}-user"
+
+# Defaults to match infra-osp-project-create
+osp_project_create: true
+osp_create_sandbox: false
+
+# This is useful if you're working with osp_project_create = false but
+# still want to cleanup your project *and* because you're the only one
+# working in the project.
+# by default, the cleanup of resource only occurs when osp_project_create is true
+osp_force_delete_all_resources: false

--- a/ansible/roles-infra/infra_osp_bastion_on_openshift_network/meta/main.yml
+++ b/ansible/roles-infra/infra_osp_bastion_on_openshift_network/meta/main.yml
@@ -1,0 +1,10 @@
+---
+galaxy_info:
+  author: Johnathan Kupferer <jkupfere@redhat.com>
+  description: Add bastion OpenShift to node network on OpenStack
+  company: Red Hat
+  license: BSD
+  min_ansible_version: 2.9
+  galaxy_tags: []
+
+dependencies: []

--- a/ansible/roles-infra/infra_osp_bastion_on_openshift_network/tasks/add-bastion-to-openstack-network.yml
+++ b/ansible/roles-infra/infra_osp_bastion_on_openshift_network/tasks/add-bastion-to-openstack-network.yml
@@ -1,0 +1,26 @@
+---
+- name: Get OpenStack bastion server info
+  os_server_info:
+    filters:
+      name: bastion
+      project_id: "{{ __os_project_id }}"
+  register: r_server_info
+  failed_when: r_server_info.openstack_servers | length == 0
+
+- name: Get OpenStack network info
+  os_networks_info:
+    filters:
+      project_id: "{{ __os_project_id }}"
+  register: r_networks_info
+
+- name: Add bastion to openshift network
+  vars:
+    __bastion_info: "{{ r_server_info.openstack_servers[0] }}"
+    __bastion_networks: "{{ __bastion_info.addresses.keys() }}"
+    __openshift_network: >-
+      {{ r_networks_info.openstack_networks | to_json | from_json
+       | json_query("[?ends_with(name, '-openshift')]|[0].name")
+      }}
+  when: __openshift_network not in __bastion_networks
+  command: openstack server add network bastion {{ __openshift_network }}
+...

--- a/ansible/roles-infra/infra_osp_bastion_on_openshift_network/tasks/main.yml
+++ b/ansible/roles-infra/infra_osp_bastion_on_openshift_network/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+- name: Assert that osp_project_name is defined
+  assert:
+    that: osp_project_name is defined
+
+- name: Get project information
+  environment: >-
+    {{ __infra_osp_bastion_on_openshift_network_environment | combine({
+      "OS_PROJECT_NAME": "admin"
+    }) }}
+  os_project_info:
+    name: "{{ osp_project_name }}"
+  register: r_os_project_info
+  failed_when: r_os_project_info.openstack_projects | length == 0
+
+- name: Add bastion to openstack network
+  vars:
+    __os_project_id: "{{ r_os_project_info.openstack_projects[0].id }}"
+  include_tasks:
+    file: add-bastion-to-openstack-network.yml
+    apply:
+      environment: >-
+        {{ __infra_osp_bastion_on_openshift_network_environment | combine({
+          "OS_PROJECT_ID": __os_project_id
+        }) }}
+...

--- a/ansible/roles-infra/infra_osp_bastion_on_openshift_network/vars/main.yml
+++ b/ansible/roles-infra/infra_osp_bastion_on_openshift_network/vars/main.yml
@@ -1,0 +1,8 @@
+---
+__infra_osp_bastion_on_openshift_network_environment:
+  OS_AUTH_URL: "{{ osp_auth_url }}"
+  OS_USERNAME: "{{ osp_auth_username | default(osp_auth_username_member) }}"
+  OS_PASSWORD: "{{ osp_auth_password | default(osp_auth_password_member) }}"
+  OS_PROJECT_NAME: "{{ osp_project_name }}"
+  OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
+  OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"


### PR DESCRIPTION
##### SUMMARY

Add role infra_osp_bastion_on_openshift_network to add bastion to OpenShift node network.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Role infra_osp_bastion_on_openshift_network