### PR TITLE
Fix role host-lets-encrypt-certs-certbot virtualenv setup

### DIFF
--- a/ansible/roles/host-lets-encrypt-certs-certbot/defaults/main.yml
+++ b/ansible/roles/host-lets-encrypt-certs-certbot/defaults/main.yml
@@ -53,5 +53,3 @@ _certbot_cron_job_name: LETS_ENCRYPT_RENEW
 _certbot_user: "{{ ansible_user }}"
 
 _certbot_virtualenv: "/home/{{ _certbot_user }}/virtualenvs/certbot"
-
-use_python3: true

--- a/ansible/roles/host-lets-encrypt-certs-certbot/tasks/main.yml
+++ b/ansible/roles/host-lets-encrypt-certs-certbot/tasks/main.yml
@@ -51,20 +51,18 @@
   # For certbot, certbot-dns-route53 and certbot-dns-rfc2136
   - name: Copy requirements_certbot.txt to target for certbot virtualenv
     copy:
-      src: ./files/requirements_certbot.txt
+      src: requirements_certbot.txt
       dest: /tmp/requirements_certbot.txt
 
-  # The next two commands need to be run as _certbot_user in order to set up the correct permissions
+  # Run as _certbot_user in order to set up the correct permissions
   # Running without will create links to /root/.local/... which won't be readable
   - name: Create Virtualenv Certbot
     become: True
     become_user: "{{ _certbot_user }}"
-    command: "/usr/local/bin/virtualenv -p /usr/bin/python3 {{ _certbot_virtualenv }}"
-  
-  - name: Install Certbot into Virtualenv
-    become: true
-    become_user: "{{ _certbot_user }}"
-    command: "{{ _certbot_virtualenv }}/bin/pip3 install -r /tmp/requirements_certbot.txt"
+    pip:
+      requirements: /tmp/requirements_certbot.txt
+      virtualenv: "{{ _certbot_virtualenv }}"
+      virtualenv_command: /usr/bin/python3 -m venv
   
   - name: Copy certbot script to virtualenv
     template:


### PR DESCRIPTION
##### SUMMARY

Fix role hosts-lets-encrypt-certs-certbot virtualenv setup to use `pip` module with `python -m venv` command so that it functions without the dependence on /usr/local/bin/virtualenv

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role hosts-lets-encrypt-certs-certbot