### PR TITLE
Add host_virtualenv install virtualenv system-wide

### DIFF
--- a/ansible/roles/host_virtualenv/tasks/main.yml
+++ b/ansible/roles/host_virtualenv/tasks/main.yml
@@ -17,6 +17,11 @@
     name: "{{ host_virtualenv_package_prereqs }}"
   register: r_package
 
+- name: Install virtualenv module system-wide for compatibility with previous behavior
+  pip:
+    name: virtualenv
+    executable: /usr/bin/pip3
+
 - name: Make virtualenv path
   file:
     path: "{{ host_virtualenv_path }}"


### PR DESCRIPTION
##### SUMMARY

Add installation on `virtualenv` python library system-wide to the `host_virtualenv` module for backwards compatibility.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Role host_virtualenv.