### PR TITLE
Fixes three-tier-app to externally expose ssh TCP/22 on app and appdb

### DIFF
--- a/ansible/configs/three-tier-app/default_vars_ec2.yml
+++ b/ansible/configs/three-tier-app/default_vars_ec2.yml
@@ -103,10 +103,11 @@ instances:
       - DefaultSG
       - FrontendSG
       - HostSG
+      - BastionSG
 
   - name: "app"
     count: "{{ app_instance_count | default(2) }}"
-    public_dns: false
+    public_dns: true
     image: "{{ app_instance_image | default(__image) }}"
     flavor:
       ec2: "{{ app_instance_type | default(__instance_type) }}"
@@ -121,10 +122,11 @@ instances:
     security_groups:
       - DefaultSG
       - HostSG
+      - BastionSG
 
   - name: "appdb"
     count: "{{ appdb_instance_count | default(1) }}"
-    public_dns: false
+    public_dns: true
     image: "{{ appdb_instance_image | default(__image) }}"
     flavor:
       ec2: "{{ appdb_instance_type | default(__instance_type) }}"
@@ -139,5 +141,6 @@ instances:
     security_groups:
       - DefaultSG
       - HostSG
+      - BastionSG
 
 ...


### PR DESCRIPTION
##### SUMMARY

Existing labs expect external ssh access to nodes app1, app2, appdb1

Ansible Advanced Homework lab is breaking on this issue

Re-attaches the correct Security Group to allow this

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
