### PR TITLE
Add variable extra_device - sap-integration

### DIFF
--- a/ansible/configs/sap-integration/default_vars_ec2.yml
+++ b/ansible/configs/sap-integration/default_vars_ec2.yml
@@ -60,7 +60,7 @@ ocp4_base_domain: "{{ subdomain_base }}"
 cloud_storageclass_name: gp2
 
 # SAP Extra Device
-sap_extra_device: vdb
+sap_extra_device: xvdb
 
 # -------------------------------------------------------------------
 # AWS EC2 Instances

--- a/ansible/configs/sap-integration/default_vars_ec2.yml
+++ b/ansible/configs/sap-integration/default_vars_ec2.yml
@@ -59,6 +59,9 @@ ocp4_base_domain: "{{ subdomain_base }}"
 
 cloud_storageclass_name: gp2
 
+# SAP Extra Device
+sap_extra_device: vdb
+
 # -------------------------------------------------------------------
 # AWS EC2 Instances
 # -------------------------------------------------------------------

--- a/ansible/configs/sap-integration/default_vars_osp.yml
+++ b/ansible/configs/sap-integration/default_vars_osp.yml
@@ -187,6 +187,9 @@ pv_size_s4hana: 100
 sap_software_image: sap-software-v1.5
 sap_software_size: "{{ software_size }}"
 
+# SAP Extra Device
+sap_extra_device: vdb
+
 # Instances to be provisioned in new project
 # Provide these as a list.
 # Each instance type can have any number of replicas deployed with the same

--- a/ansible/configs/sap-integration/sap_software.yml
+++ b/ansible/configs/sap-integration/sap_software.yml
@@ -14,7 +14,7 @@
       - name: Mount up device by UUID
         mount:
           path: /nfs
-          src: /dev/vdb
+          src: "/dev/{{ sap_extra_device }}"
           fstype: xfs
           state: present
 


### PR DESCRIPTION
##### SUMMARY

Add variable used to mount extra device, OpenStack 13 and AWS use device `/dev/xvX` and in OpenStack 16 use `/dev/sdX`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
config/sap-integration

