### PR TITLE
Update device names sap-rhvh

### DIFF
--- a/ansible/configs/sap-rhvh/default_vars.yml
+++ b/ansible/configs/sap-rhvh/default_vars.yml
@@ -63,6 +63,10 @@ rootfs_size_rhvm: "{{ rootfs_size_rhvh }}"
 sap_software_image: sap-software-v1.2
 sap_software_size: "{{ sap_software_size }}"
 
+rhvm_data_device: vdc
+rhvm_image_device: vdb
+bastion_extra_device: vdb
+
 # RHEL SAP image and variables
 sap_rhel_images: sap-images-v1.1
 images_size: "{{ images_size }}"

--- a/ansible/configs/sap-rhvh/pre_software.yml
+++ b/ansible/configs/sap-rhvh/pre_software.yml
@@ -213,10 +213,10 @@
         dest: "/usr/local/src/rhvm_answers.ini"
         force: yes
 
-    - name: Create a xfs filesystem on /dev/vdc
+    - name: Create a xfs filesystem on /dev/{{ rhvm_data_device }}
       filesystem:
         fstype: xfs
-        dev: /dev/vdc
+        dev: "/dev/{{ rhvm_data_device }}"
 
     - name: Ensure RHV Data NFS directory exists
       file:
@@ -231,14 +231,14 @@
     - name: Mount up device by UUID
       mount:
         path: /rhv_data
-        src: /dev/vdc
+        src: "/dev/{{ rhvm_data_device }}"
         fstype: xfs
         state: mounted
 
     - name: Mount up device by UUID
       mount:
         path: /rhv_img
-        src: /dev/vdb
+        src: "/dev/{{ rhvm_image_device }}"
         fstype: xfs
         state: mounted
     
@@ -293,7 +293,7 @@
     - name: Mount up device by UUID
       mount:
         path: /nfs
-        src: /dev/vdb
+        src: "/dev/{{ bastion_extra_device }}"
         fstype: xfs
         state: present
 


### PR DESCRIPTION
##### SUMMARY

Add variable used to mount extra device, OpenStack 13 and AWS use device `/dev/xvX` and in OpenStack 16 use `/dev/sdX`

Default values
`rhvm_data_device: vdc`
`rhvm_image_device: vdb`
`bastion_extra_device: vdb`


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
config/sap-integration

