### PR TITLE
Fix role ocp4-workload-homeroomlab-tekton-pipelines: update lab to OCP 4.6 and Pipelines 1.2.x

### DIFF
--- a/ansible/roles/ocp4-workload-homeroomlab-tekton-pipelines/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-homeroomlab-tekton-pipelines/defaults/main.yml
@@ -9,4 +9,4 @@ tmp_git_location: "{{ tmp_dir }}/git"
 
 project_name: labs
 lab_repo: https://github.com/openshift-labs/lab-tekton-pipelines
-lab_branch: '4.1'
+lab_branch: '4.6'


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
This lab was broken since long time, we aligned it to latest content from [learn.openshift.com](https://learn.openshift.com/middleware/pipelines) and update it to OCP 4.6 and Pipelines 1.2.x

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4-workload-homeroomlab-tekton-pipelines

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
**ATTENTION**
Before merging it, we need to fix a permission issue from RHPDS side:
https://github.com/openshift-labs/lab-tekton-pipelines/pull/79#issuecomment-749681286


<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
