### PR TITLE
Add support for AWS region me-south-1

### DIFF
--- a/ansible/roles-infra/infra-ec2-template-generate/defaults/main.yml
+++ b/ansible/roles-infra/infra-ec2-template-generate/defaults/main.yml
@@ -186,6 +186,20 @@ aws_ami_region_mapping:
     RHEL74: ami-90a201fe # RHEL-7.4_HVM-20180122-x86_64-1-Hourly2-GP2
     WIN2012R2: ami-0b556f49b82ce9aa4 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2020.08.12
     WIN2019: ami-0769516a1517adf13 # Windows_Server-2019-English-Full-Base-2020.08.12
+  me-south-1:
+    RHEL82GOLD: ami-0918cf0d061dd0f7d # RHEL-8.2_HVM-20200803-x86_64-0-Access2-GP2
+    RHEL81GOLD: ami-024f898d9a2978cc4 # RHEL-8.1.0_HVM-20191029-x86_64-0-Access2-GP2
+    RHEL77GOLD: ami-0c52b34f568677259 # RHEL-7.7_HVM-20191119-x86_64-2-Access2-GP2
+    RHEL75GOLD: ami-0a7051de0d19fdcf0 # RHEL-7.5_HVM_GA-20180522-x86_64-0-Access2-GP2
+    RHEL74GOLD: ami-0b08ec4924168c956 # RHEL-7.4_HVM_GA-20180122-x86_64-0-Access2-GP2
+    RHEL82: ami-0ea154ecbf7c8b3de # RHEL-8.2_HVM-20200803-x86_64-0-Hourly2-GP2
+    RHEL81: ami-01bc798104367e3ef # RHEL-8.1.0_HVM-20191029-x86_64-0-Hourly2-GP2
+    RHEL78: ami-04c5a64178193c259 # RHEL-7.8_HVM-20200803-x86_64-0-Hourly2-GP2
+    RHEL77: ami-0595b40184ea4f7ee # RHEL-7.7_HVM-20191119-x86_64-2-Hourly2-GP2
+    RHEL75: ami-0814d4549e66c77d7 # RHEL-7.5_HVM_GA-20180522-x86_64-0-Hourly2-GP2
+    RHEL74: ami-00cf5bff4d41f4286 # RHEL-7.4_HVM_GA-20180122-x86_64-0-Hourly2-GP2
+    WIN2012R2: ami-0cabf723b1032f552 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2020.12.09
+    WIN2019: ami-04f95f8fff5f01620 # Windows_Server-2019-English-Full-Base-2020.12.09
   ap-northeast-1:
     RHEL82GOLD: ami-048d3825243e3d95d # RHEL-8.2_HVM-20200803-x86_64-0-Access2-GP2
     RHEL81GOLD: ami-0b7b06f79c39e9dfc # RHEL-8.1.0_HVM-20191029-x86_64-0-Access2-GP2
@@ -337,6 +351,7 @@ aws_ami_region_mapping:
     WIN2012R2: ami-0bfd72d59f05f83f0 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2020.08.12
     WIN2019: ami-029e27fb2fc8ce9d8 # Windows_Server-2019-English-Full-Base-2020.08.12
 
+
 # DNSMapping is unlikely to change.  It's useful to keep env_type CF templates small
 aws_dns_mapping:
   "us-east-1":
@@ -361,6 +376,8 @@ aws_dns_mapping:
     domain: "sa-east-1.compute.internal"
   "ap-south-1":
     domain: "ap-south-1.compute.internal"
+  "me-south-1":
+    domain: "me-south-1.compute.internal"
 
 # When infra_ec2_template_generate_auto_select_availability_zone is set to true,
 # the role will set aws_availability_zone to an availability that can host

--- a/ansible/roles-infra/infra-ec2-template-generate/defaults/main.yml
+++ b/ansible/roles-infra/infra-ec2-template-generate/defaults/main.yml
@@ -351,7 +351,6 @@ aws_ami_region_mapping:
     WIN2012R2: ami-0bfd72d59f05f83f0 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2020.08.12
     WIN2019: ami-029e27fb2fc8ce9d8 # Windows_Server-2019-English-Full-Base-2020.08.12
 
-
 # DNSMapping is unlikely to change.  It's useful to keep env_type CF templates small
 aws_dns_mapping:
   "us-east-1":


### PR DESCRIPTION
##### SUMMARY

Add support for AWS Region Bahrain (me-south-1)

##### ISSUE TYPE
- New config Pull Request

##### COMPONENT NAME

- infra-ec2-template-generate

##### ADDITIONAL INFORMATION

We are looking to add support for the me-south-1 region. Note that the `RHEL81NBDE` image doesn't appear to be available and returned `None` so I left that one out. Other than that one AMI, I was able to get the rest of the images using `tools/find_ami.sh`

Also, I added a DNS mapping for `me-south-1.compute.internal`
