### PR TITLE
Add bash shell init flag to deploy_certs.sh

### DIFF
--- a/ansible/roles/ocp4-workload-enable-lets-encrypt-certificates/files/deploy_certs.sh
+++ b/ansible/roles/ocp4-workload-enable-lets-encrypt-certificates/files/deploy_certs.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/bash -l
 cd ${HOME}/certbot/renewal-hooks/deploy/
 ansible-playbook ./deploy_certs.yml

--- a/ansible/roles/ocp4-workload-idm/files/deploy_certs.sh
+++ b/ansible/roles/ocp4-workload-idm/files/deploy_certs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -l
 cd ${HOME}/certbot/renewal-hooks/deploy/
 ansible-playbook ./deploy_certs.yml \
   -e "_certbot_domain={{ idm_dns_name }}" \

--- a/ansible/roles_ocp_workloads/ocp4_workload_le_certificates/templates/deploy_certs.sh.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_le_certificates/templates/deploy_certs.sh.j2
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -l
 cd ${HOME}/certbot/renewal-hooks/deploy/
 . /opt/virtualenvs/k8s/bin/activate
 {% if ocp4_workload_le_certificates_install_api | bool %}


### PR DESCRIPTION
##### SUMMARY

Without the "login" shell flag, `-l` bash does not initialize the shell environment which causes problems for ansible execution from cron. This PR adds this flag to the shebang `#!` line of teh deploy_certs.sh in the three roles in which it is used.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Roles:
- ocp4-workload-enable-lets-encrypt-certificates
- ocp4-workload-idm
- ocp4_workload_le_certificates
