### PR TITLE
Change agnosticd_user_info to always print data to log

### DIFF
--- a/ansible/action_plugins/agnosticd_user_info.py
+++ b/ansible/action_plugins/agnosticd_user_info.py
@@ -48,6 +48,7 @@ class ActionModule(ActionBase):
             task_vars = dict()
 
         result = super(ActionModule, self).run(tmp, task_vars)
+        result['_ansible_verbose_always'] = True
         del tmp # tmp no longer has any effect
 
         msg = self._task.args.get('msg')
@@ -64,13 +65,11 @@ class ActionModule(ActionBase):
             # Output msg in result, prepend "user.info: " for cloudforms compatibility
             result['msg'] = 'user.info: ' + msg
             # Force display of result like debug
-            result['_ansible_verbose_always'] = True
 
         if not user and body != None:
             # Output msg in result, prepend "user.info: " for cloudforms compatibility
             result['msg'] = 'user.body: ' + body
             # Force display of result like debug
-            result['_ansible_verbose_always'] = True
 
         if data:
             result['data'] = data


### PR DESCRIPTION
##### SUMMARY

Change agnosticd_user_info to print data to log as currently occurs for `msg` and `body`.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

agnosticd_user_info

##### ADDITIONAL INFORMATION

Example output:

```
TASK [agnosticd_user_info] *******************************************************************************************************************************************************************************************************************
Thursday 07 January 2021  11:19:32 -0600 (0:00:00.041)       0:00:00.041 ****** 
ok: [localhost] => {
    "changed": false,
    "data": {
        "testkey": "val"
    }
}
```