### PR TITLE
Update sandbox config with student_name

### DIFF
--- a/ansible/configs/sandbox/default_vars.yml
+++ b/ansible/configs/sandbox/default_vars.yml
@@ -12,7 +12,7 @@ guid: notset
 
 # These values will be added to the account tracking database
 # and may be used as resources tags as well
-owner_name: "{{ user }}"
+owner_name: "{{ student_name }}"
 owner_email: "{{ email }}"
 
 

--- a/ansible/configs/sandbox/pre_infra.yml
+++ b/ansible/configs/sandbox/pre_infra.yml
@@ -32,7 +32,7 @@
             body_format: json
             body:
               guid: "{{ guid }}"
-              owner_name: "{{ user }}"
+              owner_name: "{{ student_name }}"
               env_type: "{{ env_type | default('') }}"
               owner_email: "{{ email }}"
               note: "{{ sandbox_note | default('') }}"


### PR DESCRIPTION

##### SUMMARY

Small change to fix an incorrect default var. `student_name` is provided by CloudForms and this was incorrectly expecting `user`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
sandbox config