### PR TITLE
Change role host-ocp4-install to implement retry

### DIFF
--- a/ansible/roles/host-ocp4-installer/.yamllint
+++ b/ansible/roles/host-ocp4-installer/.yamllint
@@ -1,0 +1,2 @@
+---
+extends: ../../../tests/static/.yamllint

--- a/ansible/roles/host-ocp4-installer/create-manifests.yml
+++ b/ansible/roles/host-ocp4-installer/create-manifests.yml
@@ -1,0 +1,28 @@
+---
+- name: Run openshift-install create manifests
+  become: false
+  command: openshift-install create manifests --dir=/home/{{ ansible_user }}/{{ cluster_name }}
+
+# For Windows Nodes OVN is required.
+# For 4.6 this requires an install workaround to generate
+# manifests and then change the manifests
+# For SDN this is not necessary. Regardless the installation will either generate
+# manifests if there aren't any (default) or use the updated ones (OVN)
+- name: Create install workaround manifests/cluster-network-03-config.yml for OVN
+  when: ocp4_network_ovn_install_workaround | bool
+  copy:
+    src: cluster-network-03-config.yml
+    dest: "/home/{{ ansible_user }}/{{ cluster_name }}/manifests/cluster-network-03-config.yml"
+    owner: "{{ ansible_user }}"
+    mode: ug=rw,o=
+
+# On OpenStack 16 device ids are not truncated to 20 characters.
+# This MachineConfig adds a udev configuration to work around this issue.
+# https://bugzilla.redhat.com/show_bug.cgi?id=1897603
+- name: Create install workaround manifests/99-scsi-device-detection-machineconfig.yml
+  when: ocp4_scsi_device_detection_workaround | bool
+  template:
+    src: 99-scsi-device-detection-machineconfig.yml.j2
+    dest: "/home/{{ ansible_user }}/{{ cluster_name }}/manifests/99-scsi-device-detection-machineconfig.yml"
+    owner: "{{ ansible_user }}"
+    mode: ug=rw,o=

--- a/ansible/roles/host-ocp4-installer/tasks/install_installer.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/install_installer.yml
@@ -19,10 +19,10 @@
     - ocp4_client_url    | default('') | length > 0
 
 - name: Get the OpenShift Installer
-  become: yes
+  become: true
   unarchive:
     src: "{{ ocp4_installer_url}} "
-    remote_src: yes
+    remote_src: true
     dest: /usr/bin
     mode: 0755
     owner: root
@@ -33,10 +33,10 @@
   delay: 30
 
 - name: Get the OpenShift CLI
-  become: yes
+  become: true
   unarchive:
     src: "{{ ocp4_client_url }}"
-    remote_src: yes
+    remote_src: true
     dest: /usr/bin
     mode: 0775
     owner: root

--- a/ansible/roles/host-ocp4-installer/tasks/main.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/main.yml
@@ -23,7 +23,7 @@
     become: false
     command: openshift-install create cluster --dir=/home/{{ ansible_user }}/{{ cluster_name }}
     async: "{{ 2 * 60 * 60 }}"
-    poll: 30
+    poll: 15
 
   rescue:
   - name: Run destroy to reset before retry
@@ -49,7 +49,7 @@
     become: false
     command: openshift-install create cluster --dir=/home/{{ ansible_user }}/{{ cluster_name }}
     async: "{{ 2 * 60 * 60 }}"
-    poll: 30
+    poll: 15
 
   always:
   - name: Gzip Install log

--- a/ansible/roles/host-ocp4-installer/tasks/main.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/main.yml
@@ -12,74 +12,42 @@
 - name: Generate install_config.yaml
   import_tasks: generate_install_config.yml
 
-- name: Run openshift-install create manifests
-  become: false
-  tags:
-  - run_installer
-  command: openshift-install create manifests --dir=/home/{{ ansible_user }}/{{ cluster_name }}
-
-# For Windows Nodes OVN is required.
-# For 4.6 this requires an install workaround to generate
-# manifests and then change the manifests
-# For SDN this is not necessary. Regardless the installation will either generate
-# manifests if there aren't any (default) or use the updated ones (OVN)
-- name: Create install workaround manifests/cluster-network-03-config.yml for OVN
-  when: ocp4_network_ovn_install_workaround | bool
-  copy:
-    src: cluster-network-03-config.yml
-    dest: "/home/{{ ansible_user }}/{{ cluster_name }}/manifests/cluster-network-03-config.yml"
-    owner: "{{ ansible_user }}"
-    mode: ug=rw,o=
-
-# On OpenStack 16 device ids are not truncated to 20 characters.
-# This MachineConfig adds a udev configuration to work around this issue.
-# https://bugzilla.redhat.com/show_bug.cgi?id=1897603
-- name: Create install workaround manifests/99-scsi-device-detection-machineconfig.yml
-  when: ocp4_scsi_device_detection_workaround | bool
-  template:
-    src: 99-scsi-device-detection-machineconfig.yml.j2
-    dest: "/home/{{ ansible_user }}/{{ cluster_name }}/manifests/99-scsi-device-detection-machineconfig.yml"
-    owner: "{{ ansible_user }}"
-    mode: ug=rw,o=
-
 - name: Installation and getting the logs
   tags:
   - run_installer
   block:
+  - name: Create openshift-install manifests
+    include_tasks: create-manifests.yml
+
   - name: Run the installer
     become: false
     command: openshift-install create cluster --dir=/home/{{ ansible_user }}/{{ cluster_name }}
     async: "{{ 2 * 60 * 60 }}"
     poll: 30
-    ignore_errors: true
-    register: r_openshift_install
 
-  - name: Destroy and retry the installer
-    when:
-    - r_openshift_install is failed
-    - r_openshift_install.stderr is match('failed waiting for Kubernetes API')
-    block:
-    - name: Run destroy to reset before retry
-      become: false
-      command: openshift-install destroy cluster --dir=/home/{{ ansible_user }}/{{ cluster_name }}
-
-    - name: Restore install config from backup copy
-      copy:
-        remote_src: true
-        src: /home/{{ ansible_user }}/{{ cluster_name }}/install-config.yaml.bak
-        dest: /home/{{ ansible_user }}/{{ cluster_name }}/install-config.yaml
-        owner: "{{ ansible_user }}"
-        mode: ug=rw,o=
-
-    - name: Retry the installer
-      become: false
-      command: openshift-install create cluster --dir=/home/{{ ansible_user }}/{{ cluster_name }}
-      async: "{{ 2 * 60 * 60 }}"
-      poll: 30
-
-  - name: Retry OpenShift installation (wait-for install-complete)
+  rescue:
+  - name: Run destroy to reset before retry
     become: false
-    command: openshift-install wait-for install-complete --dir=/home/{{ ansible_user }}/{{ cluster_name }}
+    command: openshift-install destroy cluster --dir=/home/{{ ansible_user }}/{{ cluster_name }}
+
+  - name: Pause briefly for cloud provider cleanup to finish
+    pause:
+      minutes: 2
+
+  - name: Restore install config from backup copy
+    copy:
+      remote_src: true
+      src: /home/{{ ansible_user }}/{{ cluster_name }}/install-config.yaml.bak
+      dest: /home/{{ ansible_user }}/{{ cluster_name }}/install-config.yaml
+      owner: "{{ ansible_user }}"
+      mode: ug=rw,o=
+
+  - name: Recreate openshift-install manifests
+    include_tasks: create-manifests.yml
+
+  - name: Retry the installer
+    become: false
+    command: openshift-install create cluster --dir=/home/{{ ansible_user }}/{{ cluster_name }}
     async: "{{ 2 * 60 * 60 }}"
     poll: 30
 

--- a/ansible/roles/host-ocp4-installer/tasks/main.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/main.yml
@@ -1,18 +1,19 @@
+---
 - name: Install client and OpenShift Installer binaries
   import_tasks: install_installer.yml
 
 ## Open the port for the api
 - name: OpenStack specific requirement - find network port id
-  when: 
-    - cloud_provider == "osp"
-    - ocp_use_single_network | default(false) | bool
+  when:
+  - cloud_provider == "osp"
+  - ocp_use_single_network | default(false) | bool
   import_tasks: osp_pre.yml
 
 - name: Generate install_config.yaml
   import_tasks: generate_install_config.yml
 
 - name: Run openshift-install create manifests
-  become: no
+  become: false
   tags:
   - run_installer
   command: openshift-install create manifests --dir=/home/{{ ansible_user }}/{{ cluster_name }}
@@ -42,31 +43,45 @@
     mode: ug=rw,o=
 
 - name: Installation and getting the logs
+  tags:
+  - run_installer
   block:
   - name: Run the installer
-    become: no
-    tags:
-      - run_installer
+    become: false
     command: openshift-install create cluster --dir=/home/{{ ansible_user }}/{{ cluster_name }}
     async: "{{ 2 * 60 * 60 }}"
-    ignore_errors: yes
-  - name: Retry OpenShift installation (wait-for install-complete)
-    command: openshift-install --dir=/home/{{ ansible_user }}/{{ cluster_name }} wait-for install-complete
+    poll: 30
+    ignore_errors: true
+    register: r_openshift_install
 
-  rescue:
-    - name: Restarting OpenStack nodes
-      when: cloud_provider == "osp"
-      shell: openstack server reboot --hard {{ item }}
-      with_lines: openstack server list | awk '/{{ cluster_name }}/ { print $2 };'
-      ignore_errors: yes
-    - pause:
-        minutes: 10
-        prompt: "Pausing whilst OpenStack nodes recover..."
-      when: cloud_provider == "osp"
-    - name: Retry OpenShift installation (wait-for bootstrap-complete)
-      command: openshift-install --dir=/home/{{ ansible_user }}/{{ cluster_name }} wait-for bootstrap-complete
-    - name: Retry OpenShift installation (wait-for install-complete)
-      command: openshift-install --dir=/home/{{ ansible_user }}/{{ cluster_name }} wait-for install-complete
+  - name: Destroy and retry the installer
+    when:
+    - r_openshift_install is failed
+    - r_openshift_install.stderr is match('failed waiting for Kubernetes API')
+    block:
+    - name: Run destroy to reset before retry
+      become: false
+      command: openshift-install destroy cluster --dir=/home/{{ ansible_user }}/{{ cluster_name }}
+
+    - name: Restore install config from backup copy
+      copy:
+        remote_src: true
+        src: /home/{{ ansible_user }}/{{ cluster_name }}/install-config.yaml.bak
+        dest: /home/{{ ansible_user }}/{{ cluster_name }}/install-config.yaml
+        owner: "{{ ansible_user }}"
+        mode: ug=rw,o=
+
+    - name: Retry the installer
+      become: false
+      command: openshift-install create cluster --dir=/home/{{ ansible_user }}/{{ cluster_name }}
+      async: "{{ 2 * 60 * 60 }}"
+      poll: 30
+
+  - name: Retry OpenShift installation (wait-for install-complete)
+    become: false
+    command: openshift-install wait-for install-complete --dir=/home/{{ ansible_user }}/{{ cluster_name }}
+    async: "{{ 2 * 60 * 60 }}"
+    poll: 30
 
   always:
   - name: Gzip Install log
@@ -79,7 +94,7 @@
     fetch:
       src: /home/{{ ansible_user }}/{{ cluster_name }}/.openshift_install.log.gz
       dest: "{{ output_dir }}/{{ env_type }}_{{ guid }}_log/"
-      flat: yes
+      flat: true
 
 # OpenStack does not have a way to add userTags via the install-config.yaml
 # https://bugzilla.redhat.com/show_bug.cgi?id=1868517
@@ -113,12 +128,12 @@
 
 - name: Fetch kube config
   fetch:
-    flat: yes
+    flat: true
     src: /home/{{ ansible_user }}/{{ cluster_name }}/auth/{{ item }}
     dest: "{{ hostvars.localhost.output_dir }}/{{ env_type }}_{{ guid }}_{{ item }}"
   loop:
-    - kubeconfig
-    - kubeadmin-password
+  - kubeconfig
+  - kubeadmin-password
 
 - name: Make sure .kube directory exists in home directory
   file:
@@ -129,12 +144,12 @@
 
 - name: Set up .kube/config
   copy:
-    remote_src: yes
+    remote_src: true
     src: "/home/{{ ansible_user }}/{{ cluster_name }}/auth/kubeconfig"
     dest: "/home/{{ ansible_user }}/.kube/config"
 
 - name: Make sure .kube directory exists in /root
-  become: yes
+  become: true
   file:
     state: directory
     path: /root/.kube
@@ -142,9 +157,9 @@
     mode: 0700
 
 - name: Set up .kube/config for root
-  become: yes
+  become: true
   copy:
-    remote_src: yes
+    remote_src: true
     src: "/home/{{ ansible_user }}/{{ cluster_name }}/auth/kubeconfig"
     dest: /root/.kube/config
 
@@ -152,7 +167,7 @@
   when: install_student_user | bool
   block:
   - name: Make sure .kube directory exists in /home/{{ student_name }}
-    become: yes
+    become: true
     file:
       state: directory
       path: "/home/{{ student_name }}/.kube"
@@ -160,16 +175,16 @@
       mode: 0700
 
   - name: Copy /home/{{ ansible_user }}/{{ cluster_name }}/auth/kubeconfig to /home/{{ student_name }}/.kube
-    become: yes
+    become: true
     copy:
       src: /home/{{ ansible_user }}/{{ cluster_name }}/auth/kubeconfig
       dest: /home/{{ student_name }}/.kube/config
-      remote_src: yes
+      remote_src: true
       owner: "{{ student_name }}"
       mode: 0600
 
 - name: Create OpenShift Bash completion file
-  become: yes
+  become: true
   shell: oc completion bash >/etc/bash_completion.d/openshift
 
 - name: Gather and Print cluster info

--- a/ansible/roles/host-ocp4-installer/tasks/osp_pre.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/osp_pre.yml
@@ -2,7 +2,7 @@
 
 - name: set internal network name
   set_fact:
-      internal_network_name: "{{ guid }}-{{ networks[0]['name'] }}-subnet"
+    internal_network_name: "{{ guid }}-{{ networks[0]['name'] }}-subnet"
 
 - name: print internal network name
   debug:
@@ -25,7 +25,7 @@
 
 - name: set internal network subnetid
   set_fact:
-    internal_network_subnet_id: "{{ __subnet.ID }}" 
+    internal_network_subnet_id: "{{ __subnet.ID }}"
   when: __subnet.Name == internal_network_name
   loop: "{{ __subnets.stdout }}"
   loop_control:
@@ -34,4 +34,3 @@
 - name: print internal network's subnet id
   debug:
     msg: "{{ internal_network_subnet_id }}"
-

--- a/ansible/roles/host-ocp4-installer/tasks/print_cluster_info.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/print_cluster_info.yml
@@ -11,7 +11,7 @@
   retries: 10
   delay: 30
   until: routeconsole is succeeded
-  ignore_errors: yes
+  ignore_errors: true
 
 - name: Get Webconsole URL
   environment:


### PR DESCRIPTION
##### SUMMARY

- Add retry OpenShift install on failed waiting for Kubernetes API.
- Also add yamllint and cleanup.
- Remove non-functional OpenStack host restart.
- Remove retry wait for bootstrap complete as I could find no evidence of this succeeding in the logs after initial failure, but many cases where it simply made the failure take longer to be reported.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Role host-ocp4-install