### PR TITLE
Change workload ocp4-workload-homeroomlab-starter-guides remove cluster-monitoring-view for users

### DIFF
--- a/ansible/roles/ocp4-workload-homeroomlab-starter-guides/tasks/per_user.yml
+++ b/ansible/roles/ocp4-workload-homeroomlab-starter-guides/tasks/per_user.yml
@@ -28,10 +28,6 @@
       command: "{{ openshift_cli }} adm policy add-role-to-user admin {{ my_user }} -n {{ my_user }}"
       tags: always
 
-    - name: Add cluster-role cluster-monitoring-view for user "{{ my_user }}"
-      command: "{{ openshift_cli }} adm policy add-cluster-role-to-user cluster-monitoring-view {{ my_user }}"
-      tags: always
-
     - name: per_user {{my_user}} Tasks Complete
       debug:
         msg: "per_user {{my_user}} Tasks - Completed"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

Change workload ocp4-workload-homeroomlab-starter-guides remove cluster-monitoring-view for users

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
 ocp4-workload-homeroomlab-starter-guides 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
