### PR TITLE
Added instructions for Operator Index snapshots for 4.6+

### DIFF
--- a/docs/Operator_Catalog_Snapshots.adoc
+++ b/docs/Operator_Catalog_Snapshots.adoc
@@ -90,7 +90,7 @@ The OpenShift pull secret already has credentials for the Quay container registr
 
 == Creating an operator catalog snapshot image for OpenShift 4.4/4.5
 
-The following process works for both OpenShift 4.4 and OpenShift 4.5. It should still work with OpenShift 4.6 - although this process will be deprecated.
+The following process works for both OpenShift 4.4 and OpenShift 4.5. Refer to the following section for OpenShift 4.6 and later.
 
 [NOTE]
 ====
@@ -132,6 +132,65 @@ oc adm catalog build \
   --filter-by-os="linux/amd64" \
   --to=quay.io/gpte-devops-automation/olm_snapshot_certified_catalog:${IMAGE_TAG} \
   -a merged_pullsecret.json
+----
+
+== Creating an operator catalog snapshot image for OpenShift 4.6 and later
+
+The following process works for OpenShift 4.6 and later.
+
+[NOTE]
+====
+* Docs for 4.6: https://docs.openshift.com/container-platform/4.5/operators/olm-managing-custom-catalogs.html
+*               https://docs.openshift.com/container-platform/4.6/operators/admin/olm-restricted-networks.html#olm-understanding-operator-catalog-images_olm-restricted-networks
+====
+
+* Create catalog images for redhat-operators, community-operators and certified-operators catalogs using the version of the base image matching the version of your OpenShift cluster and the current date the tag (e.g. `v4.5_2020_07_23`).
++
+The simple use case is to just copy the current version of the Operator index image and tag it appropriately. This will create a complete copy of the state of the Operator Index on the day you execute the mirror. This is as simple as pulling the image, tagging the image and pushing the tagged image to your registry.
++
+[source]
+----
+# Set OpenShift Version
+OCP_VERSION=v4.6
+IMAGE_TAG=${OCP_VERSION}_$(date +"%Y_%m_%d")
+
+# Red Hat Operators Catalog
+echo "Building Red Hat Operators Catalog ${IMAGE_TAG}"
+podman pull --authfile merged_pullsecret.json registry.redhat.io/redhat/redhat-operator-index:${OCP_VERSION}
+podman tag registry.redhat.io/redhat/redhat-operator-index:${OCP_VERSION} quay.io/gpte-devops-automation/olm_snapshot_redhat_catalog:${IMAGE_TAG}
+podman push --authfile merged_pullsecret.json quay.io/gpte-devops-automation/olm_snapshot_redhat_catalog:${IMAGE_TAG}
+
+# Community Operators Catalog
+echo "Building Community Operators Catalog ${IMAGE_TAG}"
+podman pull --authfile merged_pullsecret.json registry.redhat.io/redhat/community-operator-index:${OCP_VERSION}
+podman tag registry.redhat.io/redhat/community-operator-index:${OCP_VERSION} quay.io/gpte-devops-automation/olm_snapshot_community_catalog:${IMAGE_TAG}
+podman push --authfile merged_pullsecret.json quay.io/gpte-devops-automation/olm_snapshot_community_catalog:${IMAGE_TAG}
+
+# Certified Operators Catalog
+echo "Building Certified Operators Catalog ${IMAGE_TAG}"
+podman pull --authfile merged_pullsecret.json registry.redhat.io/redhat/certified-operator-index:${OCP_VERSION}
+podman tag registry.redhat.io/redhat/certified-operator-index:${OCP_VERSION} quay.io/gpte-devops-automation/olm_snapshot_certified_catalog:${IMAGE_TAG}
+podman push --authfile merged_pullsecret.json quay.io/gpte-devops-automation/olm_snapshot_certified_catalog:${IMAGE_TAG}
+----
+
+=== Creating an operator catalog snapshot image for just one (or a few) operator(s)
+
+Using the new Operator bundle format it is now possible to just include the operators that you care about in snapshot image.
+
+Follow the instructions at https://docs.openshift.com/container-platform/4.6/operators/admin/olm-restricted-networks.html#olm-pruning-index-image_olm-restricted-networks
+
+Example to just mirror Advanced Cluster Management, Jaeger and Quay:
++
+[source,sh]
+----
+podman pull --authfile merged_pullsecret.json registry.redhat.io/redhat/redhat-operator-index:v4.6
+
+opm index prune \
+    -f registry.redhat.io/redhat/redhat-operator-index:v4.6 \
+    -p advanced-cluster-management,jaeger-product,quay-operator \
+    -t <target_registry>:<port>/<namespace>/redhat-operator-index:v4.6
+
+podman push --authfile merged_pullsecret.json <target_registry>:<port>/<namespace>/redhat-operator-index:v4.6
 ----
 
 == Installing an operator from a catalog snapshot


### PR DESCRIPTION
##### SUMMARY

In OCP 4.6 the way OpenShift Operator Snapshot images need to be created changed. This PR adds documentation for 4.6 an later.

##### ISSUE TYPE
- Docs Pull Request
