### PR TITLE
Fix workload ocp4-workload-homeroomlab-tekton-pipelines remove serviceaccount and use ocp users

### DIFF
--- a/ansible/roles/ocp4-workload-homeroomlab-tekton-pipelines/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-homeroomlab-tekton-pipelines/defaults/main.yml
@@ -10,3 +10,11 @@ tmp_git_location: "{{ tmp_dir }}/git"
 project_name: labs
 lab_repo: https://github.com/openshift-labs/lab-tekton-pipelines
 lab_branch: '4.6'
+
+homeroom_template_path: "https://raw.githubusercontent.com/openshift-homeroom/workshop-homeroom/2.1.0/templates/production.json"
+
+openshift_cli: oc
+user_count_start: 1
+num_users: 20
+user_format: user%d
+

--- a/ansible/roles/ocp4-workload-homeroomlab-tekton-pipelines/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-homeroomlab-tekton-pipelines/defaults/main.yml
@@ -17,4 +17,3 @@ openshift_cli: oc
 user_count_start: 1
 num_users: 20
 user_format: user%d
-

--- a/ansible/roles/ocp4-workload-homeroomlab-tekton-pipelines/tasks/per_user.yml
+++ b/ansible/roles/ocp4-workload-homeroomlab-tekton-pipelines/tasks/per_user.yml
@@ -1,0 +1,33 @@
+---
+- name: per user
+  block:
+    - name: per_user {{my_user}} Tasks Started
+      debug:
+        msg: "per_user {{my_user}} Tasks - Started"
+
+    # Create user project and make it admin
+    - name: check if workshop user's project for user "{{ my_user }}" exists
+      shell: "{{ openshift_cli }} get project {{ my_user }}"
+      register: user_project
+      ignore_errors: true
+      changed_when: false
+      tags: always
+
+    - name: Create workshop user's project for user "{{ my_user }}"
+      command: "{{ openshift_cli }} adm new-project {{ my_user }}"
+      when: user_project is failed
+      tags: always
+
+    - name: Annotate the project as requested by user for user "{{ my_user }}"
+      command: >-
+        {{ openshift_cli }} annotate namespace {{ my_user }}
+        openshift.io/requester={{ my_user }} --overwrite
+      tags: always
+
+    - name: Award admin permission for user "{{ my_user }}"
+      command: "{{ openshift_cli }} adm policy add-role-to-user admin {{ my_user }} -n {{ my_user }}"
+      tags: always
+
+    - name: per_user {{my_user}} Tasks Complete
+      debug:
+        msg: "per_user {{my_user}} Tasks - Completed"

--- a/ansible/roles/ocp4-workload-homeroomlab-tekton-pipelines/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-homeroomlab-tekton-pipelines/tasks/pre_workload.yml
@@ -1,4 +1,7 @@
 ---
+- set_fact:
+    user_count_end: "{{ (user_count_start | int) + (num_users | int) - 1 }}"
+
 # Implement your Pre Workload deployment tasks here
 - name: Ensure directory exists
   file:

--- a/ansible/roles/ocp4-workload-homeroomlab-tekton-pipelines/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-homeroomlab-tekton-pipelines/tasks/workload.yml
@@ -90,7 +90,7 @@
   with_sequence: start={{user_count_start}} end={{ user_count_end }} format={{ user_format }}
   loop_control:
     loop_var: my_user
- 
+
 # Leave this as the last task in the playbook.
 - name: workload tasks complete
   debug:

--- a/ansible/roles/ocp4-workload-homeroomlab-tekton-pipelines/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-homeroomlab-tekton-pipelines/tasks/workload.yml
@@ -45,6 +45,57 @@
         var: result.stderr_lines
       when: result.stderr_lines is defined and result.stderr_lines | length > 0
 
+- environment:
+    KUBECONFIG: "{{ tmp_kubeconfig }}"
+  vars:
+    __homeroom_installed: false
+  block:
+    - name: "Get homeroom deployment (fact)"
+      k8s_facts:
+        api_version: "apps.openshift.io/v1"
+        kind: DeploymentConfig
+        name: "homeroom"
+        namespace: "{{ project_name }}"
+      register: __homeroom_dc
+
+    - name: "Get homeroom deployment (value)"
+      debug:
+        var: __homeroom_dc
+        verbosity: 1
+
+    - name: "Is homeroom installed (fact)"
+      set_fact:
+        __homeroom_installed: "{{ __homeroom_dc.resources[0].status.replicas == 1 | default(false) | bool }}"
+      when: __homeroom_dc.resources is defined and (__homeroom_dc.resources|length>0)
+
+    - name: Is homeroom installed (value)
+      debug:
+        var: __homeroom_installed
+        verbosity: 1
+
+    - name: Deploy homeroom
+      block:
+        - name: Create homeroom resources
+          shell: >
+            oc process -f {{ homeroom_template_path }} \
+            --param APPLICATION_NAME="homeroom" | oc apply -n {{ project_name }} -f -
+          when: not __homeroom_installed
+
+        - name: Wait for the homeroom to deploy
+          command: oc rollout status dc/homeroom -n {{ project_name }}
+          when: not __homeroom_installed
+
+
+
+
+
+- name: Create all users and projects with correct permissions
+  include_tasks: per_user.yml
+  with_sequence: start={{user_count_start}} end={{ user_count_end }} format={{ user_format }}
+  loop_control:
+    loop_var: my_user
+
+ 
 # Leave this as the last task in the playbook.
 - name: workload tasks complete
   debug:

--- a/ansible/roles/ocp4-workload-homeroomlab-tekton-pipelines/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-homeroomlab-tekton-pipelines/tasks/workload.yml
@@ -94,7 +94,6 @@
   with_sequence: start={{user_count_start}} end={{ user_count_end }} format={{ user_format }}
   loop_control:
     loop_var: my_user
-
  
 # Leave this as the last task in the playbook.
 - name: workload tasks complete

--- a/ansible/roles/ocp4-workload-homeroomlab-tekton-pipelines/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-homeroomlab-tekton-pipelines/tasks/workload.yml
@@ -85,10 +85,6 @@
           command: oc rollout status dc/homeroom -n {{ project_name }}
           when: not __homeroom_installed
 
-
-
-
-
 - name: Create all users and projects with correct permissions
   include_tasks: per_user.yml
   with_sequence: start={{user_count_start}} end={{ user_count_end }} format={{ user_format }}


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4-workload-homeroomlab-tekton-pipelines
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
