### PR TITLE
Add retries for k8s tasks to ocp4_workload_nexus_operator

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_nexus_operator/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_nexus_operator/tasks/remove_workload.yml
@@ -14,12 +14,14 @@
   k8s:
     state: absent
     definition: "{{ lookup('template', item ) | from_yaml }}"
+  retries: 20
+  delay: 10
   loop:
-  - ./templates/operator.j2
-  - ./templates/cluster_role_binding.j2
-  - ./templates/cluster_role.j2
-  - ./templates/service_account.j2
-  - ./templates/crd.j2
+  - operator.j2
+  - cluster_role_binding.j2
+  - cluster_role.j2
+  - service_account.j2
+  - crd.j2
 
 # Leave this as the last task in the playbook.
 - name: remove_workload tasks complete

--- a/ansible/roles_ocp_workloads/ocp4_workload_nexus_operator/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_nexus_operator/tasks/workload.yml
@@ -23,13 +23,15 @@
   k8s:
     state: present
     definition: "{{ lookup('template', item ) | from_yaml }}"
+  retries: 20
+  delay: 10
   loop:
-  - ./templates/project.j2
-  - ./templates/crd.j2
-  - ./templates/service_account.j2
-  - ./templates/cluster_role.j2
-  - ./templates/cluster_role_binding.j2
-  - ./templates/operator.j2
+  - project.j2
+  - crd.j2
+  - service_account.j2
+  - cluster_role.j2
+  - cluster_role_binding.j2
+  - operator.j2
 
 - name: Wait for Nexus operator Pod to be ready
   k8s_info:


### PR DESCRIPTION
##### SUMMARY

Add retries to k8s tasks for ocp4_workload_nexus_operator to make the workload more robust for intermittent api connectivity issues.

Also remove unnecessary `./templates/` prefix for template lookup.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role ocp4_workload_nexus_operator