### PR TITLE
Add loop labels in host-ocp4-installer

### DIFF
--- a/ansible/roles/host-ocp4-installer/tasks/main.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/main.yml
@@ -86,6 +86,8 @@
         guid: "{{ guid }}"
         env_type: "{{ env_type }}"
     loop: "{{ r_servers.openstack_servers }}"
+    loop_control:
+      label: "{{ item.name }}"
 
   - name: Add additional metadata to instances
     when: hostvars.localhost.cf_tags_final | default({}) | length > 0
@@ -93,6 +95,8 @@
       server: "{{ item.name }}"
       meta: "{{ hostvars.localhost.cf_tags_final | default({}) | to_json }}"
     loop: "{{ r_servers.openstack_servers }}"
+    loop_control:
+      label: "{{ item.name }}"
 
 - name: Fetch kube config
   fetch:

--- a/ansible/roles/host-ocp4-installer/tasks/osp_pre.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/osp_pre.yml
@@ -30,6 +30,7 @@
   loop: "{{ __subnets.stdout }}"
   loop_control:
     loop_var: __subnet
+    label: "{{ __subnet.Name }} {{ __subnet.ID }}"
 
 - name: print internal network's subnet id
   debug:


### PR DESCRIPTION
##### SUMMARY

Add loop_control label to tasks in host-ocp4-installer to make the logs easier to read...

Currently it is puking stuff like this to the logs:

```
TASK [host-ocp4-installer : Add additional metadata to instances] **************
Thursday 14 January 2021  14:01:05 -0500 (0:00:27.251)       0:41:47.090 ******
skipping: [bastion] => (item={u'vm_state': u'active', u'OS-EXT-STS:task_state': None, u'addresses': {u'cluster-02ce-8t5j5-openshift': [{u'OS-EXT-IPS-MAC:mac_addr': u'fa:16:3e:3b:c9:da', u'version': 4, u'addr': u'10.0.1.75', u'OS-EXT-IPS:type': u'fixed'}]}, u'image': {u'id': u'f136604f-a1a8-4a51-ab2f-e9c45fb99547'}, u'OS-EXT-SRV-ATTR:user_data': None, u'OS-EXT-SRV-ATTR:root_device_name': None, u'OS-SRV-USG:launched_at': u'2021-01-14T18:43:39.000000', u'flavor': {u'vcpus': 4, u'disk': 30, u'extra_specs': {}, u'swap': 0, u'original_name': u'4c16g30d', u'ram': 16384, u'ephemeral': 0}, u'reservation_id': None, u'networks': {}, u'cloud': u'02ce-project', u'scheduler_hints': None, u'user_id': u'77f8136a520746cda52e83c4cf94a6d9', u'hostname': None, u'location': {u'project': {u'id': u'935bbf1bc16e431d84e40af0a18723f1', u'domain_id': None, u'name': u'02ce-project', u'domain_name': None}, u'zone': u'nova', u'region_name': u'regionOne', u'cloud': u'02ce-project'}, u'OS-EXT-SRV-ATTR:reservation_id': None, u'interface_ip': u'', u'personality': None, u'OS-EXT-SRV-ATTR:ramdisk_id': None, u'updated': u'2021-01-14T18:43:39Z', u'power_state': 1, u'block_device_mapping': None, u'key_name': None, u'host_id': u'a8abf2578b64511f1632e2abc63b41b60cfbc5c3c527b819ab656898', u'project_id': u'935bbf1bc16e431d84e40af0a18723f1', u'locked': False, u'name': u'cluster-02ce-8t5j5-worker-dwn4f', u'adminPass': None, u'launch_index': None, u'host_status': None, u'config_drive': u'', u'region': u'regionOne', u'server_groups': None, u'terminated_at': None, u'os-extended-volumes:volumes_attached': [], u'ramdisk_id': None, u'user_data': None, u'OS-EXT-STS:vm_state': u'active', u'OS-EXT-SRV-ATTR:instance_name': None, u'az': u'nova', u'id': u'4b62037f-faaa-4ecd-a859-8a6aa7fd8f0a', u'security_groups': [{u'name': u'cluster-02ce-8t5j5-worker'}], u'OS-SRV-USG:terminated_at': None, u'instance_name': None, u'OS-EXT-SRV-ATTR:hostname': None, u'disk_config': u'MANUAL', u'OS-DCF:diskConfig': u'MANUAL', u'accessIPv4': u'', u'accessIPv6': u'', u'OS-SCH-HNT:scheduler_hints': None, u'progress': 0, u'OS-EXT-STS:power_state': 1, u'OS-EXT-AZ:availability_zone': u'nova', u'launched_at': u'2021-01-14T18:43:39.000000', u'metadata': {u'openshiftClusterID': u'cluster-02ce-8t5j5', u'Name': u'cluster-02ce-8t5j5-worker'}, u'status': u'ACTIVE', u'hostId': u'a8abf2578b64511f1632e2abc63b41b60cfbc5c3c527b819ab656898', u'OS-EXT-SRV-ATTR:host': None, u'description': None, u'tags': [u'cluster-api-provider-openstack', u'openshift-machine-api-cluster-02ce-8t5j5', u'openshiftClusterID=cluster-02ce-8t5j5'], u'kernel_id': None, u'public_v4': u'', u'public_v6': u'', u'hypervisor_hostname': None, u'private_v4': u'10.0.1.75', u'host': None, u'OS-EXT-SRV-ATTR:kernel_id': None, u'task_state': None, u'properties': {u'OS-EXT-SRV-ATTR:ramdisk_id': None, u'OS-EXT-STS:task_state': None, u'OS-EXT-SRV-ATTR:host': None, u'OS-SRV-USG:terminated_at': None, u'OS-EXT-SRV-ATTR:reservation_id': None, u'OS-EXT-SRV-ATTR:user_data': None, u'OS-EXT-STS:vm_state': u'active', u'OS-EXT-SRV-ATTR:instance_name': None, u'OS-EXT-SRV-ATTR:root_device_name': None, u'OS-SRV-USG:launched_at': u'2021-01-14T18:43:39.000000', u'OS-EXT-SRV-ATTR:hypervisor_hostname': None, u'OS-EXT-SRV-ATTR:kernel_id': None, u'host_status': None, u'locked': False, u'OS-EXT-SRV-ATTR:launch_index': None, u'OS-EXT-SRV-ATTR:hostname': None, u'OS-DCF:diskConfig': u'MANUAL', u'os-extended-volumes:volumes_attached': [], u'trusted_image_certificates': None, u'OS-SCH-HNT:scheduler_hints': None, u'OS-EXT-STS:power_state': 1, u'OS-EXT-AZ:availability_zone': u'nova'}, u'OS-EXT-SRV-ATTR:hypervisor_hostname': None, u'OS-EXT-SRV-ATTR:launch_index': None, u'created': u'2021-01-14T18:42:54Z', u'tenant_id': u'935bbf1bc16e431d84e40af0a18723f1', u'created_at': u'2021-01-14T18:42:54Z', u'has_config_drive': False, u'trusted_image_certificates': None, u'root_device_name': None, u'volumes': []})
skipping: [bastion] => (item={u'vm_state': u'active', u'OS-EXT-STS:task_state': None, u'addresses': {u'cluster-02ce-8t5j5-openshift': [{u'OS-EXT-IPS-MAC:mac_addr': u'fa:16:3e:08:4e:aa', u'version': 4, u'addr': u'10.0.2.3', u'OS-EXT-IPS:type': u'fixed'}]}, u'image': {u'id': u'f136604f-a1a8-4a51-ab2f-e9c45fb99547'}, u'OS-EXT-SRV-ATTR:user_data': None, u'OS-EXT-SRV-ATTR:root_device_name': None, u'OS-SRV-USG:launched_at': u'2021-01-14T18:42:38.000000', u'flavor': {u'vcpus': 4, u'disk': 30, u'extra_specs': {}, u'swap': 0, u'original_name': u'4c16g30d', u'ram': 16384, u'ephemeral': 0}, u'reservation_id': None, u'networks': {}, u'cloud': u'02ce-project', u'scheduler_hints': None, u'user_id': u'77f8136a520746cda52e83c4cf94a6d9', u'hostname': None, u'location': {u'project': {u'id': u'935bbf1bc16e431d84e40af0a18723f1', u'domain_id': None, u'name': u'02ce-project', u'domain_name': None}, u'zone': u'nova', u'region_name': u'regionOne', u'cloud': u'02ce-project'}, u'OS-EXT-SRV-ATTR:reservation_id': None, u'interface_ip': u'', u'personality': None, u'OS-EXT-SRV-ATTR:ramdisk_id': None, u'updated': u'2021-01-14T18:42:38Z', u'power_state': 1, u'block_device_mapping': None, u'key_name': None, u'host_id': u'f446482b025dd35416150925c3b5a023c4adf97c95b11896ebc76a02', u'project_id': u'935bbf1bc16e431d84e40af0a18723f1', u'locked': False, u'name': u'cluster-02ce-8t5j5-worker-79hcb', u'adminPass': None, u'launch_index': None, u'host_status': None, u'config_drive': u'', u'region': u'regionOne', u'server_groups': None, u'terminated_at': None, u'os-extended-volumes:volumes_attached': [], u'ramdisk_id': None, u'user_data': None, u'OS-EXT-STS:vm_state': u'active', u'OS-EXT-SRV-ATTR:instance_name': None, u'az': u'nova', u'id': u'ee2b4b6e-c6d0-4d0a-987c-b6ff58543843', u'security_groups': [{u'name': u'cluster-02ce-8t5j5-worker'}], u'OS-SRV-USG:terminated_at': None, u'instance_name': None, u'OS-EXT-SRV-ATTR:hostname': None, u'disk_config': u'MANUAL', u'OS-DCF:diskConfig': u'MANUAL', u'accessIPv4': u'', u'accessIPv6': u'', u'OS-SCH-HNT:scheduler_hints': None, u'progress': 0, u'OS-EXT-STS:power_state': 1, u'OS-EXT-AZ:availability_zone': u'nova', u'launched_at': u'2021-01-14T18:42:38.000000', u'metadata': {u'openshiftClusterID': u'cluster-02ce-8t5j5', u'Name': u'cluster-02ce-8t5j5-worker'}, u'status': u'ACTIVE', u'hostId': u'f446482b025dd35416150925c3b5a023c4adf97c95b11896ebc76a02', u'OS-EXT-SRV-ATTR:host': None, u'description': None, u'tags': [u'cluster-api-provider-openstack', u'openshift-machine-api-cluster-02ce-8t5j5', u'openshiftClusterID=cluster-02ce-8t5j5'], u'kernel_id': None, u'public_v4': u'', u'public_v6': u'', u'hypervisor_hostname': None, u'private_v4': u'10.0.2.3', u'host': None, u'OS-EXT-SRV-ATTR:kernel_id': None, u'task_state': None, u'properties': {u'OS-EXT-SRV-ATTR:ramdisk_id': None, u'OS-EXT-STS:task_state': None, u'OS-EXT-SRV-ATTR:host': None, u'OS-SRV-USG:terminated_at': None, u'OS-EXT-SRV-ATTR:reservation_id': None, u'OS-EXT-SRV-ATTR:user_data': None, u'OS-EXT-STS:vm_state': u'active', u'OS-EXT-SRV-ATTR:instance_name': None, u'OS-EXT-SRV-ATTR:root_device_name': None, u'OS-SRV-USG:launched_at': u'2021-01-14T18:42:38.000000', u'OS-EXT-SRV-ATTR:hypervisor_hostname': None, u'OS-EXT-SRV-ATTR:kernel_id': None, u'host_status': None, u'locked': False, u'OS-EXT-SRV-ATTR:launch_index': None, u'OS-EXT-SRV-ATTR:hostname': None, u'OS-DCF:diskConfig': u'MANUAL', u'os-extended-volumes:volumes_attached': [], u'trusted_image_certificates': None, u'OS-SCH-HNT:scheduler_hints': None, u'OS-EXT-STS:power_state': 1, u'OS-EXT-AZ:availability_zone': u'nova'}, u'OS-EXT-SRV-ATTR:hypervisor_hostname': None, u'OS-EXT-SRV-ATTR:launch_index': None, u'created': u'2021-01-14T18:42:22Z', u'tenant_id': u'935bbf1bc16e431d84e40af0a18723f1', u'created_at': u'2021-01-14T18:42:22Z', u'has_config_drive': False, u'trusted_image_certificates': None, u'root_device_name': None, u'volumes': []})
...
```
##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Role host-ocp4-installer