### PR TITLE
Add entries on both HANA and S4HANA hosts to workaround OSP DNS issues

### DIFF
--- a/ansible/configs/sap-hana/software.yml
+++ b/ansible/configs/sap-hana/software.yml
@@ -94,6 +94,21 @@
         opts: "rw,bg,hard,_netdev"
         state: mounted
 
+- name: Add short and fqdn resolution for every host
+  hosts: hanas:s4hanas
+  become: true
+  gather_facts: true
+  tasks:
+
+    - name: Add HANA and S4HANA hosts info to /etc/hosts
+      lineinfile:
+        path: /etc/hosts
+        state: present
+        line: "{{ hostvars[item].ansible_default_ipv4.address }}    {{ hostvars[item].ansible_hostname }}.example.com    {{ hostvars[item].ansible_hostname }}"
+      when:
+        - item not in ['localhost', '127.0.0.1']
+        - cloud_provider is match("osp")
+      with_items: "{{ groups['all'] }}"
 
 - name: Deploy Ansible Tower
   hosts: towers


### PR DESCRIPTION

##### SUMMARY

The last changes in OSP have caused SAP software not to deploy due to DNS issues. This will manually add every host address entry on HANA and S4HANA servers

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
sap-hana

