### PR TITLE
Fix windows powershell remoting issue caused, we think, by github TLS 1.2

### DIFF
--- a/ansible/configs/ans-tower-ops-demo/env_vars.yml
+++ b/ansible/configs/ans-tower-ops-demo/env_vars.yml
@@ -287,6 +287,7 @@ instances:
                      - - "<powershell>\n"
                        - "$admin = [adsi]('WinNT://./administrator, user')\n"
                        - "$admin.PSBase.Invoke('SetPassword', '{{ windows_password }}')\n"
+                       - "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12\n"
                        - "$scriptPath=((New-Object System.Net.Webclient).DownloadString('https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1'))\n"
                        - "Invoke-Command -ScriptBlock ([scriptblock]::Create($scriptPath)) -ArgumentList '-skipNetworkProfileCheck'\n"
                        - "</powershell>"

--- a/ansible/configs/ans-tower-ops-demo/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/ans-tower-ops-demo/files/cloud_providers/ec2_cloud_template.j2
@@ -1,48 +1,23 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Mappings:
   RegionMapping:
+
     us-east-1:
       RHELAMI: ami-c998b6b2
-      WIN2012R2AMI: ami-0beaf9aa0c32e3c86 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
+      WIN2012R2AMI: ami-079fe16082fb837c5 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2021.01.14
     us-east-2:
       RHELAMI: ami-cfdafaaa
-      WIN2012R2AMI: ami-0ab42de9c8a0568ec # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
+      WIN2012R2AMI: ami-0f5f950bd81ec96e0 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2021.01.14
     us-west-1:
       RHELAMI: ami-66eec506
-      WIN2012R2AMI: ami-0b6117669629fdfa4 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
-    us-west-2:
-      RHELAMI: ami-9fa343e7
-      WIN2012R2AMI: ami-0400e85cb701a4f42 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
+      WIN2012R2AMI: ami-0f1bd3e0f73a95b37 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2020.01.14
     eu-central-1:
       RHELAMI: ami-d74be5b8
-      WIN2012R2AMI: ami-00eebf449d7861f82 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
-    eu-west-1:
-      RHELAMI: ami-bb9a6bc2
-      WIN2012R2AMI: ami-069dc3ef2330b5e38 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
-    eu-west-2:
-      WIN2012R2AMI: ami-0416ae4f6060116ad # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
-    eu-west-3:
-      WIN2012R2AMI: ami-09d8c503ec9b242e0 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
-    ca-central-1:
-      WIN2012R2AMI: ami-067e4426b17364c26 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
-    ap-northeast-1:
-      RHELAMI: ami-30ef0556
-      WIN2012R2AMI: ami-0b0e19e32c767102c # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
-    ap-northeast-2:
-      RHELAMI: ami-44db152a
-      WIN2012R2AMI: ami-033a1501143ab3c9a # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
+      WIN2012R2AMI: ami-03a092d4ec340dbbf # Windows_Server-2012-R2_RTM-English-64Bit-Base-2021.01.14
     ap-southeast-1:
       RHELAMI: ami-10bb2373
-      WIN2012R2AMI: ami-0a3c01d262f41ca19 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
-    ap-southeast-2:
-      RHELAMI: ami-ccecf5af
-      WIN2012R2AMI: ami-01048eb9bccc4829d # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
-    sa-east-1:
-      RHELAMI: ami-a789ffcb
-      WIN2012R2AMI: ami-0a0f24f427c390730 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
-    ap-south-1:
-      RHELAMI: ami-cdbdd7a2
-      WIN2012R2AMI: ami-0d46eaf1c637bc632 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
+      WIN2012R2AMI: ami-0d65a2f7b6c8b4380 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2021.01.14
+
   DNSMapping:
     "us-east-1":
       domain: "us-east-1.compute.internal"

--- a/ansible/configs/ansible-integrations/env_vars.yml
+++ b/ansible/configs/ansible-integrations/env_vars.yml
@@ -162,6 +162,7 @@ instances:
                      - - "<powershell>\n"
                        - "$admin = [adsi]('WinNT://./administrator, user')\n"
                        - "$admin.PSBase.Invoke('SetPassword', '{{windows_password}}')\n"
+                       - "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12\n"
                        - "$scriptPath=((New-Object System.Net.Webclient).DownloadString('https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1'))\n"
                        - "Invoke-Command -ScriptBlock ([scriptblock]::Create($scriptPath)) -ArgumentList '-skipNetworkProfileCheck'\n"
                        - "</powershell>"

--- a/ansible/configs/ansible-integrations/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/ansible-integrations/files/cloud_providers/ec2_cloud_template.j2
@@ -1,48 +1,23 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Mappings:
   RegionMapping:
+
     us-east-1:
       RHELAMI: ami-c998b6b2
-      WIN2012R2AMI: ami-0beaf9aa0c32e3c86 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
+      WIN2012R2AMI: ami-079fe16082fb837c5 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2021.01.14
     us-east-2:
       RHELAMI: ami-cfdafaaa
-      WIN2012R2AMI: ami-0ab42de9c8a0568ec # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
+      WIN2012R2AMI: ami-0f5f950bd81ec96e0 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2021.01.14
     us-west-1:
       RHELAMI: ami-66eec506
-      WIN2012R2AMI: ami-0b6117669629fdfa4 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
-    us-west-2:
-      RHELAMI: ami-9fa343e7
-      WIN2012R2AMI: ami-0400e85cb701a4f42 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
+      WIN2012R2AMI: ami-0f1bd3e0f73a95b37 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2020.01.14
     eu-central-1:
       RHELAMI: ami-d74be5b8
-      WIN2012R2AMI: ami-00eebf449d7861f82 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
-    eu-west-1:
-      RHELAMI: ami-bb9a6bc2
-      WIN2012R2AMI: ami-069dc3ef2330b5e38 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
-    eu-west-2:
-      WIN2012R2AMI: ami-0416ae4f6060116ad # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
-    eu-west-3:
-      WIN2012R2AMI: ami-09d8c503ec9b242e0 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
-    ca-central-1:
-      WIN2012R2AMI: ami-067e4426b17364c26 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
-    ap-northeast-1:
-      RHELAMI: ami-30ef0556
-      WIN2012R2AMI: ami-0b0e19e32c767102c # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
-    ap-northeast-2:
-      RHELAMI: ami-44db152a
-      WIN2012R2AMI: ami-033a1501143ab3c9a # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
+      WIN2012R2AMI: ami-03a092d4ec340dbbf # Windows_Server-2012-R2_RTM-English-64Bit-Base-2021.01.14
     ap-southeast-1:
       RHELAMI: ami-10bb2373
-      WIN2012R2AMI: ami-0a3c01d262f41ca19 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
-    ap-southeast-2:
-      RHELAMI: ami-ccecf5af
-      WIN2012R2AMI: ami-01048eb9bccc4829d # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
-    sa-east-1:
-      RHELAMI: ami-a789ffcb
-      WIN2012R2AMI: ami-0a0f24f427c390730 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
-    ap-south-1:
-      RHELAMI: ami-cdbdd7a2
-      WIN2012R2AMI: ami-0d46eaf1c637bc632 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2019.02.09
+      WIN2012R2AMI: ami-0d65a2f7b6c8b4380 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2021.01.14
+
   DNSMapping:
     "us-east-1":
       domain: "us-east-1.compute.internal"

--- a/ansible/configs/ansible-windows/env_vars.yml
+++ b/ansible/configs/ansible-windows/env_vars.yml
@@ -168,6 +168,7 @@ instances:
                      - - "<powershell>\n"
                        - "$admin = [adsi]('WinNT://./administrator, user')\n"
                        - "$admin.PSBase.Invoke('SetPassword', '{{windows_password}}')\n"
+                       - "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12\n"
                        - "$scriptPath=((New-Object System.Net.Webclient).DownloadString('https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1'))\n"
                        - "Invoke-Command -ScriptBlock ([scriptblock]::Create($scriptPath)) -ArgumentList '-skipNetworkProfileCheck'\n"
                        - "</powershell>"

--- a/ansible/configs/ansible-windows/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/ansible-windows/files/cloud_providers/ec2_cloud_template.j2
@@ -3,16 +3,13 @@ Mappings:
   RegionMapping:
     us-east-1:
       RHELAMI: ami-c998b6b2
-      WIN2012R2AMI: ami-041ae41077bc47aa5 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2020.11.11
+      WIN2012R2AMI: ami-079fe16082fb837c5 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2021.01.14
     eu-central-1:
       RHELAMI: ami-d74be5b8
-      WIN2012R2AMI: ami-06032c95ea1ffa069 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2020.11.11
-    ap-northeast-1:
-      RHELAMI: ami-30ef0556
-      WIN2012R2AMI: ami-0738be8d7de9c11a7 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2020.11.11
+      WIN2012R2AMI: ami-03a092d4ec340dbbf # Windows_Server-2012-R2_RTM-English-64Bit-Base-2021.01.14
     ap-southeast-1:
       RHELAMI: ami-10bb2373
-      WIN2012R2AMI: ami-0c14ad1e38cf03e8a # Windows_Server-2012-R2_RTM-English-64Bit-Base-2020.11.11
+      WIN2012R2AMI: ami-0d65a2f7b6c8b4380 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2021.01.14
 
   DNSMapping:
     "us-east-1":


### PR DESCRIPTION
##### SUMMARY

All Windows based configs appeared to break and non AgnosticD teams saw the same.
Windows AMIs use cloud-init/userdata to pull in a github based winrm activation powershell script.
This fix updates the Windows AMIs, and forces the powershell script download to use TLS 1.2

##### ISSUE TYPE
- Bug Fix Pull Request

##### COMPONENT NAME
./configs/ansible-integrations/env_vars.yml
./configs/ansible-windows/env_vars.yml
./configs/ans-tower-ops-demo/env_vars.yml


##### ADDITIONAL INFORMATION
