### PR TITLE
Add role ocp4_workload_couchbase_cluster

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_couchbase_cluster/.yamllint
+++ b/ansible/roles_ocp_workloads/ocp4_workload_couchbase_cluster/.yamllint
@@ -1,0 +1,13 @@
+---
+extends: default
+
+rules:
+  comments:
+    require-starting-space: false
+    min-spaces-from-content: 1
+  comments-indentation: disable
+  indentation:
+    indent-sequences: consistent
+  line-length:
+    max: 120
+    allow-non-breakable-inline-mappings: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_couchbase_cluster/.yamllint
+++ b/ansible/roles_ocp_workloads/ocp4_workload_couchbase_cluster/.yamllint
@@ -11,3 +11,6 @@ rules:
   line-length:
     max: 120
     allow-non-breakable-inline-mappings: true
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 1

--- a/ansible/roles_ocp_workloads/ocp4_workload_couchbase_cluster/README.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_couchbase_cluster/README.adoc
@@ -1,0 +1,65 @@
+= Ceph Workload
+
+This workload deploys and configures Rook Ceph operator on OpenShift 4 cluster. 
+
+== Deploy the workload
+[source, bash]
+----
+ansible-playbook -i "bastion.${GUID}.${BASE_DOMAIN}", ./ansible/configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=${ANSIBLE_USER_KEY_FILE}" \
+    -e"ansible_user=${ANSIBLE_USER}" \ 
+    -e"ocp_workload=ocp4-workload-ceph" \ 
+    -e"silent=False" \
+    -e"ACTION=create" \
+    -e @./secret.yaml \ <1>
+    -e @./workload_vars.yaml <2>
+----
+<1> This is the same file you used while deploying OCP cluster using agnosticd. Your AWS credentials go in this file
+
+== Configuration
+
+The workload is tested on a OCP 4.2 cluster with 3 workers (m4.xlarge) and 3 masters.
+
+According to the size of your cluster, you may need to tune the resources by making use of some of the variables from below list.
+
+=== Variables
+[source, yaml]
+----
+ceph_osd:
+  resources:
+    requests:
+      cpu: '0.1'
+      memory: 2Gi
+ceph_mon:
+  resources:
+    requests:
+      cpu: '0.2'
+      memory: 3Gi
+ceph_mgr:
+  resources:
+    requests:
+      cpu: '0.2'
+      memory: 3Gi
+ceph_mds:
+  resources:
+    requests:
+      cpu: '0.1'
+      memory: 2Gi
+ocs_operator_channel: stable-4.2
+ocs_operator_csv: ocs-operator.v4.2.1
+ocs_source_namespace: openshift-marketplace
+ocs_source: redhat-operators
+----
+
+== Delete the workload
+----
+ansible-playbook -i "bastion.${GUID}.${BASE_DOMAIN}", ./ansible/configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=${ANSIBLE_USER_KEY_FILE}" \
+    -e"ansible_user=${ANSIBLE_USER}" \ 
+    -e"ocp_workload=ocp4-workload-ceph" \ 
+    -e"silent=False" \
+    -e"ACTION=remove" \
+    -e @./secret.yaml \ <1>
+    -e @./workload_vars.yaml <2>
+----
+<1> This is the same file you used while deploying OCP cluster using agnosticd. Your AWS credentials go in this file

--- a/ansible/roles_ocp_workloads/ocp4_workload_couchbase_cluster/README.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_couchbase_cluster/README.adoc
@@ -1,48 +1,67 @@
-= Couchbase Cluster Workload
+= ocp4_workload_couchbase_cluster - Deploys a Couchbase Cluster on OCP 4.6
 
-This workload deploys a Couchbase Cluster operator on a dedicated OpenShift 4 cluster. 
+== Role overview
 
-== Deploy the workload
-[source, bash]
+* This role installs a Couchbase cluster into an OpenShift Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment.
+*** Debug task will print out: `pre_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy Couchbase
+*** This role deploys the Couchbase operator.
+*** Debug task will print out: `workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+ configure the workload after deployment
+*** This role doesn't do anything here
+*** Debug task will print out: `post_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+ delete the workload
+*** This role uninstalls Couchbase and related resources
+*** Debug task will print out: `remove_workload Tasks completed successfully.`
+
+== Review the defaults variable file
+
+* This file link:./defaults/main.yml[./defaults/main.yml] contains all the variables you need to define to control the deployment of your workload.
+
+* You can modify any of these default values by adding `-e "variable_name=variable_value"` to the command line
+
+=== Deploy a Workload with the `ocp-workload` playbook [Mostly for testing]
+
 ----
-ansible-playbook -i "${TARGET_HOST}", ./configs/ocp-workloads/ocp-workload.yml \
-    -e "ansible_ssh_private_key_file=${ANSIBLE_KEY}" \
-    -e "ansible_user=${ANSIBLE_USER}" \
-    -e "ocp_username=${OCP_USERNAME}" \
-    -e "ocp_workload=${WORKLOAD}" \
-    -e "ocp4_workload_couchbase_cluster=${PROJECT}" \
-    -e "num_users=${NUM_USERS}" \
-    -e "guid=${GUID}" \
-    -e "ACTION=create"
+TARGET_HOST="bastion.5ddc.example.opentlc.com"
+OCP_USERNAME="plamb-redhat.com"
+WORKLOAD="ocp4_workload_couchbase_cluster"
+GUID="pal016alpha"
+ANSIBLE_USER="plamb-redhat.com"
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=${ANSIBLE_USER}" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"silent=False" \
+    -e"guid=${GUID}" \
+    -e"ACTION=create"
 ----
 
-== Configuration
+=== To Delete an environment
 
-The workload is tested on a OCP 4.6 cluster using the OpenShift 4.6 Workshop (training) catalog instance.
-
-According to the size of your cluster, you may need to tune the resources by making use of some of the variables from below list.
-
-=== Variables
-[source, yaml]
 ----
-couchbase_cluster_namespace: cb-example
+TARGET_HOST="bastion.5ddc.example.opentlc.com"
+OCP_USERNAME="plamb-redhat.com"
+WORKLOAD="ocp4_workload_couchbase_cluster"
+GUID="pal016alpha"
+ANSIBLE_USER="plamb-redhat.com"
 
-ocs_operator_channel: stable
-ocs_source_namespace: openshift-marketplace
-ocs_source: certified-operators
-ocs_spec_name: couchbase-enterprise-certified
-couchbase_metadata_name: couchbase-operator-subscription
-----
-
-== Delete the workload
-----
-ansible-playbook -i "${TARGET_HOST}", ./configs/ocp-workloads/ocp-workload.yml \
-    -e "ansible_ssh_private_key_file=${ANSIBLE_KEY}" \
-    -e "ansible_user=${ANSIBLE_USER}" \
-    -e "ocp_username=${OCP_USERNAME}" \
-    -e "ocp_workload=${WORKLOAD}" \
-    -e "ocp4_workload_couchbase_cluster=${PROJECT}" \
-    -e "num_users=${NUM_USERS}" \
-    -e "guid=${GUID}" \
-    -e "ACTION=remove"
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=${ANSIBLE_USER}" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"silent=False" \
+    -e"guid=${GUID}" \
+    -e"ACTION=remove"
 ----

--- a/ansible/roles_ocp_workloads/ocp4_workload_couchbase_cluster/README.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_couchbase_cluster/README.adoc
@@ -1,65 +1,48 @@
-= Ceph Workload
+= Couchbase Cluster Workload
 
-This workload deploys and configures Rook Ceph operator on OpenShift 4 cluster. 
+This workload deploys a Couchbase Cluster operator on a dedicated OpenShift 4 cluster. 
 
 == Deploy the workload
 [source, bash]
 ----
-ansible-playbook -i "bastion.${GUID}.${BASE_DOMAIN}", ./ansible/configs/ocp-workloads/ocp-workload.yml \
-    -e"ansible_ssh_private_key_file=${ANSIBLE_USER_KEY_FILE}" \
-    -e"ansible_user=${ANSIBLE_USER}" \ 
-    -e"ocp_workload=ocp4-workload-ceph" \ 
-    -e"silent=False" \
-    -e"ACTION=create" \
-    -e @./secret.yaml \ <1>
-    -e @./workload_vars.yaml <2>
+ansible-playbook -i "${TARGET_HOST}", ./configs/ocp-workloads/ocp-workload.yml \
+    -e "ansible_ssh_private_key_file=${ANSIBLE_KEY}" \
+    -e "ansible_user=${ANSIBLE_USER}" \
+    -e "ocp_username=${OCP_USERNAME}" \
+    -e "ocp_workload=${WORKLOAD}" \
+    -e "ocp4_workload_couchbase_cluster=${PROJECT}" \
+    -e "num_users=${NUM_USERS}" \
+    -e "guid=${GUID}" \
+    -e "ACTION=create"
 ----
-<1> This is the same file you used while deploying OCP cluster using agnosticd. Your AWS credentials go in this file
 
 == Configuration
 
-The workload is tested on a OCP 4.2 cluster with 3 workers (m4.xlarge) and 3 masters.
+The workload is tested on a OCP 4.6 cluster using the OpenShift 4.6 Workshop (training) catalog instance.
 
 According to the size of your cluster, you may need to tune the resources by making use of some of the variables from below list.
 
 === Variables
 [source, yaml]
 ----
-ceph_osd:
-  resources:
-    requests:
-      cpu: '0.1'
-      memory: 2Gi
-ceph_mon:
-  resources:
-    requests:
-      cpu: '0.2'
-      memory: 3Gi
-ceph_mgr:
-  resources:
-    requests:
-      cpu: '0.2'
-      memory: 3Gi
-ceph_mds:
-  resources:
-    requests:
-      cpu: '0.1'
-      memory: 2Gi
-ocs_operator_channel: stable-4.2
-ocs_operator_csv: ocs-operator.v4.2.1
+couchbase_cluster_namespace: cb-example
+
+ocs_operator_channel: stable
 ocs_source_namespace: openshift-marketplace
-ocs_source: redhat-operators
+ocs_source: certified-operators
+ocs_spec_name: couchbase-enterprise-certified
+couchbase_metadata_name: couchbase-operator-subscription
 ----
 
 == Delete the workload
 ----
-ansible-playbook -i "bastion.${GUID}.${BASE_DOMAIN}", ./ansible/configs/ocp-workloads/ocp-workload.yml \
-    -e"ansible_ssh_private_key_file=${ANSIBLE_USER_KEY_FILE}" \
-    -e"ansible_user=${ANSIBLE_USER}" \ 
-    -e"ocp_workload=ocp4-workload-ceph" \ 
-    -e"silent=False" \
-    -e"ACTION=remove" \
-    -e @./secret.yaml \ <1>
-    -e @./workload_vars.yaml <2>
+ansible-playbook -i "${TARGET_HOST}", ./configs/ocp-workloads/ocp-workload.yml \
+    -e "ansible_ssh_private_key_file=${ANSIBLE_KEY}" \
+    -e "ansible_user=${ANSIBLE_USER}" \
+    -e "ocp_username=${OCP_USERNAME}" \
+    -e "ocp_workload=${WORKLOAD}" \
+    -e "ocp4_workload_couchbase_cluster=${PROJECT}" \
+    -e "num_users=${NUM_USERS}" \
+    -e "guid=${GUID}" \
+    -e "ACTION=remove"
 ----
-<1> This is the same file you used while deploying OCP cluster using agnosticd. Your AWS credentials go in this file

--- a/ansible/roles_ocp_workloads/ocp4_workload_couchbase_cluster/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_couchbase_cluster/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+couchbase_cluster_namespace: cb-example
+
+ocs_operator_channel: stable
+ocs_source_namespace: openshift-marketplace
+ocs_source: certified-operators
+ocs_spec_name: couchbase-enterprise-certified
+couchbase_metadata_name: couchbase-operator-subscription

--- a/ansible/roles_ocp_workloads/ocp4_workload_couchbase_cluster/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_couchbase_cluster/defaults/main.yml
@@ -1,6 +1,14 @@
 ---
+become_override: false
+ocp_username: opentlc-mgr
+silent: false
+
+num_users: "100"
+
+# Establish the Couchbase cluster namespace
 couchbase_cluster_namespace: cb-example
 
+# Define operator metadata
 ocs_operator_channel: stable
 ocs_source_namespace: openshift-marketplace
 ocs_source: certified-operators

--- a/ansible/roles_ocp_workloads/ocp4_workload_couchbase_cluster/meta/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_couchbase_cluster/meta/main.yml
@@ -1,0 +1,14 @@
+---
+galaxy_info:
+  role_name: ocp4_workload_couchbase_cluster
+  author: Phillip Lamb (plamb@redhat.com)
+  description: |
+    Set up a Couchbase Cluster on OpenShift 4.
+  license: MIT
+  min_ansible_version: 2.9
+  platforms: []
+  galaxy_tags:
+  - ocp
+  - openshift
+  - couchbase
+dependencies: []

--- a/ansible/roles_ocp_workloads/ocp4_workload_couchbase_cluster/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_couchbase_cluster/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: Running Pre Workload Tasks
+  import_tasks: ./pre_workload.yml
+  become: false
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload Tasks
+  import_tasks: ./workload.yml
+  become: false
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  import_tasks: ./post_workload.yml
+  become: false
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload removal Tasks
+  import_tasks: ./remove_workload.yml
+  become: false
+  when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles_ocp_workloads/ocp4_workload_couchbase_cluster/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_couchbase_cluster/tasks/post_workload.yml
@@ -1,0 +1,4 @@
+---
+- name: post_workload Tasks Complete
+  debug:
+    msg: "Post-Software checks completed successfully"

--- a/ansible/roles_ocp_workloads/ocp4_workload_couchbase_cluster/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_couchbase_cluster/tasks/pre_workload.yml
@@ -1,0 +1,12 @@
+---
+# Create Namespace
+- name: "Creating namespace"
+  k8s:
+    name: "{{ couchbase_cluster_namespace }}"
+    api_version: v1
+    kind: Namespace
+    state: present
+
+- name: pre_workload Tasks Complete
+  debug:
+    msg: "Pre-Software checks completed successfully"

--- a/ansible/roles_ocp_workloads/ocp4_workload_couchbase_cluster/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_couchbase_cluster/tasks/remove_workload.yml
@@ -1,0 +1,19 @@
+---
+# verify there are no ceph PVCs in use
+- name: "Delete Subscription"
+  k8s:
+    state: absent
+    definition: "{{ lookup('template', 'subscription.yml.j2') }}"
+
+- name: "Delete OperatorGroup"
+  k8s:
+    state: absent
+    definition: "{{ lookup('template', 'operatorgroup.yml.j2') }}"
+
+# delete namespace
+- name: "Deleting namespace"
+  k8s:
+    name: "{{ couchbase_cluster_namespace }}"
+    api_version: v1
+    kind: Namespace
+    state: absent

--- a/ansible/roles_ocp_workloads/ocp4_workload_couchbase_cluster/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_couchbase_cluster/tasks/workload.yml
@@ -1,0 +1,14 @@
+---
+- name: "Create OperatorGroup"
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'operatorgroup.yml.j2') }}"
+
+- name: "Create Subscription"
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'subscription.yml.j2') }}"
+
+- name: workload Tasks Complete
+  debug:
+    msg: workload Tasks Complete

--- a/ansible/roles_ocp_workloads/ocp4_workload_couchbase_cluster/templates/operatorgroup.yml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_couchbase_cluster/templates/operatorgroup.yml.j2
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:

--- a/ansible/roles_ocp_workloads/ocp4_workload_couchbase_cluster/templates/operatorgroup.yml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_couchbase_cluster/templates/operatorgroup.yml.j2
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: ocs-operatorgroup
+  namespace: {{ couchbase_cluster_namespace }}
+spec:
+  targetNamespaces:
+  - {{ couchbase_cluster_namespace }}

--- a/ansible/roles_ocp_workloads/ocp4_workload_couchbase_cluster/templates/subscription.yml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_couchbase_cluster/templates/subscription.yml.j2
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:

--- a/ansible/roles_ocp_workloads/ocp4_workload_couchbase_cluster/templates/subscription.yml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_couchbase_cluster/templates/subscription.yml.j2
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: {{ couchbase_metadata_name }}
+  namespace: {{ couchbase_cluster_namespace }}
+spec:
+  channel: {{ ocs_operator_channel }}
+  installPlanApproval: Automatic
+  name: {{ ocs_spec_name }}
+  source: {{ ocs_source }}
+  sourceNamespace: {{ ocs_source_namespace }}


### PR DESCRIPTION
##### SUMMARY
This role deploys the Couchbase cluster operator on an OpenShift Workshop. This is part of an effort to add RHPDS Catalog entries for our Partners, and provide the ability to perform demos and workshops.


##### ISSUE TYPE
- New role Pull Request

##### COMPONENT NAME
ocp4_workload_couchbase_cluster

##### ADDITIONAL INFORMATION

The workshop guide for users will be published on demo.openshift.com.
After running yamllint I received these results:

```
defaults/main.yml
meta/main.yml
tasks/main.yml
tasks/post_workload.yml
tasks/pre_workload.yml
tasks/remove_workload.yml
tasks/workload.yml
templates/operatorgroup.yml.j2
templates/subscription.yml.j2
```

```
ansible 2.10.4
  config file = None
  configured module search path = ['/Users/philliplamb/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.10.5/libexec/lib/python3.9/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.9.1 (default, Jan  8 2021, 17:17:43) [Clang 12.0.0 (clang-1200.0.32.28)]
```