### PR TITLE
Update ocp-workload-3scale-demo to use rh-sso operator

### DIFF
--- a/ansible/roles/ocp-workload-3scale-demo/tasks/config.yml
+++ b/ansible/roles/ocp-workload-3scale-demo/tasks/config.yml
@@ -1,7 +1,7 @@
 ---
 - name: Wait until RH SSO API is available 
   uri: 
-    url: https://secure-sso-{{sso_project}}.{{ocp_apps_domain}}
+    url: https://keycloak-{{sso_project}}.{{ocp_apps_domain}}
     method: HEAD
     follow_redirects: safe
     validate_certs: no
@@ -10,9 +10,22 @@
   retries: 15
   delay: 60
 
+- name: Retrieve SSO admin credentials
+  k8s_facts:
+    kind: secret
+    name: credential-sso
+    namespace: '{{sso_project}}'
+  register: _sso_credentials
+
+- debug: var=_sso_credentials
+
+- set_fact:
+    _sso_admin_user: '{{ _sso_credentials.resources[0].data.ADMIN_USERNAME | b64decode }}'
+    _sso_admin_password: '{{ _sso_credentials.resources[0].data.ADMIN_PASSWORD | b64decode }}'
+
 - name: Get SSO token
-  shell: "curl --insecure -X POST 'https://secure-sso-{{sso_project}}.{{ocp_apps_domain}}/auth/realms/master/protocol/openid-connect/token' \
-  -H 'Content-Type: application/x-www-form-urlencoded' -d 'username=keyadmin' -d 'password=keypassword' -d 'grant_type=password' -d 'client_id=admin-cli'"
+  shell: "curl --insecure -X POST 'https://keycloak-{{sso_project}}.{{ocp_apps_domain}}/auth/realms/master/protocol/openid-connect/token' \
+  -H 'Content-Type: application/x-www-form-urlencoded' -d 'username={{_sso_admin_user}}' -d 'password={{_sso_admin_password}}' -d 'grant_type=password' -d 'client_id=admin-cli'"
   register: token_text
 
 - set_fact: TKN={{ (token_text.stdout | from_json).access_token }}
@@ -29,7 +42,7 @@
 
 - name: Create Insurance Realm
   uri: 
-    url: 'https://secure-sso-{{sso_project}}.{{ocp_apps_domain}}/auth/admin/realms'
+    url: 'https://keycloak-{{sso_project}}.{{ocp_apps_domain}}/auth/admin/realms'
     method: POST
     body: "{{get_realm.content}}"
     body_format: json
@@ -41,7 +54,7 @@
     status_code: 201
 
 - name: Get id for client 'real-management'
-  shell: "curl --insecure 'https://secure-sso-{{sso_project}}.{{ocp_apps_domain}}/auth/admin/realms/insurance/clients' \
+  shell: "curl --insecure 'https://keycloak-{{sso_project}}.{{ocp_apps_domain}}/auth/admin/realms/insurance/clients' \
   -H 'Content-Type: application/json' -H 'Authorization: Bearer {{TKN}}'"
   register: clients_text
 
@@ -52,7 +65,7 @@
 - debug: var=IdClient
 
 - name: Get id for service account '3scale-admin'
-  shell: "curl --insecure 'https://secure-sso-{{sso_project}}.{{ocp_apps_domain}}/auth/admin/realms/insurance/clients/1/service-account-user' \
+  shell: "curl --insecure 'https://keycloak-{{sso_project}}.{{ocp_apps_domain}}/auth/admin/realms/insurance/clients/1/service-account-user' \
   -H 'Content-Type: application/json' -H 'Authorization: Bearer {{TKN}}'"
   register: users_text
 
@@ -61,7 +74,7 @@
 - debug: var=IdUser
 
 - name: Get id for role 'manage-clients'
-  shell: "curl --insecure 'https://secure-sso-{{sso_project}}.{{ocp_apps_domain}}/auth/admin/realms/insurance/users/{{IdUser}}/role-mappings/clients/{{IdClient}}/available' \
+  shell: "curl --insecure 'https://keycloak-{{sso_project}}.{{ocp_apps_domain}}/auth/admin/realms/insurance/users/{{IdUser}}/role-mappings/clients/{{IdClient}}/available' \
   -H 'Content-Type: application/json' -H 'Authorization: Bearer {{TKN}}'"
   register: roles_text
 
@@ -72,12 +85,12 @@
 - debug: var=IdRole
 
 - name: Add role 'manage-clients' to service account
-  shell: "curl --insecure -X POST 'https://secure-sso-{{sso_project}}.{{ocp_apps_domain}}/auth/admin/realms/insurance/users/{{IdUser}}/role-mappings/clients/{{IdClient}}' \
+  shell: "curl --insecure -X POST 'https://keycloak-{{sso_project}}.{{ocp_apps_domain}}/auth/admin/realms/insurance/users/{{IdUser}}/role-mappings/clients/{{IdClient}}' \
   -H 'Content-Type: application/json' -H 'Authorization: Bearer {{TKN}}' -d '{{IdRole | to_json}}'"
   register: outcome_text
 
 - name: Get client secret
-  shell: "curl --insecure 'https://secure-sso-{{sso_project}}.{{ocp_apps_domain}}/auth/admin/realms/insurance/clients/1/client-secret' \
+  shell: "curl --insecure 'https://keycloak-{{sso_project}}.{{ocp_apps_domain}}/auth/admin/realms/insurance/clients/1/client-secret' \
   -H 'Content-Type: application/json' -H 'Authorization: Bearer {{TKN}}'"
   register: secret_text
 
@@ -175,7 +188,7 @@
     body: "access_token={{access_token}}&endpoint={{ ('https://accidentalert-production-' + guid + '.' + ocp_apps_domain + ':443') | urlencode }}\
     &api_backend={{ ('http://accidentalert-backend-' + service_project + '.' +  ocp_apps_domain + ':80') | urlencode }}\
     &sandbox_endpoint={{ ('https://accidentalert-staging-' + guid + '.' + ocp_apps_domain + ':443') | urlencode }}\
-    &oidc_issuer_endpoint={{ ('http://3scale-admin:' + client_secret + '@sso-' + sso_project + '.' + ocp_apps_domain + '/auth/realms/insurance') | urlencode }}"
+    &oidc_issuer_endpoint={{ ('https://3scale-admin:' + client_secret + '@keycloak-' + sso_project + '.' + ocp_apps_domain + '/auth/realms/insurance') | urlencode }}"
     validate_certs: no
   register: config_proxy_result
 
@@ -223,15 +236,17 @@
 - debug: var=create_app_result
 
 - name: Get SSO token
-  shell: "curl --insecure -X POST 'https://secure-sso-{{sso_project}}.{{ocp_apps_domain}}/auth/realms/master/protocol/openid-connect/token' \
-  -H 'Content-Type: application/x-www-form-urlencoded' -d 'username=keyadmin' -d 'password=keypassword' -d 'grant_type=password' -d 'client_id=admin-cli'"
+  shell: "curl --insecure -X POST 'https://keycloak-{{sso_project}}.{{ocp_apps_domain}}/auth/realms/master/protocol/openid-connect/token' \
+  -H 'Content-Type: application/x-www-form-urlencoded' -d 'username={{_sso_admin_user}}' -d 'password={{_sso_admin_password}}' -d 'grant_type=password' -d 'client_id=admin-cli'"
   register: token2_text
 
 - set_fact: TKN2={{ (token2_text.stdout | from_json).access_token }}
 
+- debug: var=TKN2
+
 - name: Get id for client 'accidentalert-ui'
   uri:
-    url: 'https://secure-sso-{{sso_project}}.{{ocp_apps_domain}}/auth/admin/realms/insurance/clients'
+    url: 'https://keycloak-{{sso_project}}.{{ocp_apps_domain}}/auth/admin/realms/insurance/clients'
     return_content: yes
     headers:
       Authorization: 'Bearer {{TKN2}}'
@@ -249,7 +264,7 @@
 
 - name: Update the rh sso app
   uri: 
-    url: "https://secure-sso-{{sso_project}}.{{ocp_apps_domain}}/auth/admin/realms/insurance/clients/{{IdClientApp}}"
+    url: "https://keycloak-{{sso_project}}.{{ocp_apps_domain}}/auth/admin/realms/insurance/clients/{{IdClientApp}}"
     method: PUT
     return_content: yes
     headers:

--- a/ansible/roles/ocp-workload-3scale-demo/tasks/post_workload.yml
+++ b/ansible/roles/ocp-workload-3scale-demo/tasks/post_workload.yml
@@ -3,9 +3,20 @@
   agnosticd_user_info:
     msg: "{{ item }}"
   loop:
+    - "These are important links for this demo:"
+    - ""
+    - "3scale Admin Console: https://3scale-admin.{{guid}}.{{ocp_apps_domain}}"
+    - "3scale Admin credentials:"
+    - "     username: admin"
+    - "     password: password"
+    - "3scale Developer Portal: https://3scale.{{guid}}.{{ocp_apps_domain}}"
+    - "Web Application URL: http://www-accidentalert-{{guid}}.{{ocp_apps_domain}}/accident.html"
+    - "Police credentials:"
+    - "     username: statepolice"
+    - "     password: password"
     - "OpenShift Console: https://console-openshift-console.{{ocp_apps_domain}}"
     - ""
-    - "Use your OPENTLC credentials to log into the console."
+    - "Use your OPENTLC credentials to log into the OpenShift console."
 
 - name: post_workload Tasks Complete
   debug:

--- a/ansible/roles/ocp-workload-3scale-demo/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-3scale-demo/tasks/workload.yml
@@ -25,18 +25,60 @@
 - name: Make sure we go back do default project
   shell: "oc project default"
 
-- name: Create service accounts and secrets for RH SSO
-  shell: "oc create -f https://raw.githubusercontent.com/jboss-openshift/application-templates/master/secrets/sso-app-secret.json -n {{sso_project}}"
+- name: Evaluate SSO OperatorGroup
+  k8s:
+    state: present
+    definition:
+      apiVersion: operators.coreos.com/v1
+      kind: OperatorGroup
+      metadata:
+        namespace: '{{sso_project}}'
+        name: '{{ sso_project }}-operatorgroup'
+      spec:
+        targetNamespaces:
+        - '{{ sso_project }}'
 
-- name: Create service account
-  shell: "oc create sa sso-service-account -n {{sso_project}}"
+- name: Evaluate SSO Operator
+  k8s:
+    state: present
+    definition:
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: sso-subscription
+        namespace: '{{sso_project}}'
+      spec:
+        channel: alpha
+        installPlanApproval: Automatic
+        name: rhsso-operator
+        source: redhat-operators
+        sourceNamespace: openshift-marketplace
 
-- name: Add cluster view policy to sa for clustering
-  shell: "oc policy add-role-to-user view system:serviceaccount:{{sso_project}}:sso-service-account -n {{sso_project}}"
+- name: Wait for SSO operator to install
+  k8s_info:
+    api_version: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    name: keycloaks.keycloak.org
+  register: crd_sso
+  until: crd_sso.resources | list | length == 1
+  retries: 30
+  delay: 10
 
-- name: Create RH SSO app
-  shell: "oc new-app sso73-https -p HTTPS_NAME=jboss -p HTTPS_PASSWORD=mykeystorepass -p SSO_ADMIN_USERNAME=keyadmin \
-  -p SSO_ADMIN_PASSWORD=keypassword -n {{sso_project}}"
+- name: Provision Keycloak CR
+  k8s:
+    state: present
+    definition:
+      apiVersion: keycloak.org/v1alpha1
+      kind: Keycloak
+      metadata:
+        name: sso
+        labels:
+          app: sso
+        namespace: '{{sso_project}}'
+      spec:
+        externalAccess:
+          enabled: true
+        instances: 1
 
 - name: Create project for API Implementation
   shell: "oc new-project {{service_project}} --display-name='Alert Center Backend Service'"
@@ -74,7 +116,7 @@
 
 - name: Create UI app
   shell: "oc process -f https://raw.githubusercontent.com/jbossdemocentral/3scale-security-oidc-demo/master/support/templates/accidentalert-ui-template.json \
-  -p SSO_URL='http://sso-{{sso_project}}.{{ocp_apps_domain}}' -p BACKEND_URL='http://accidentalert-backend-{{service_project}}.{{ocp_apps_domain}}' \
+  -p SSO_URL='https://keycloak-{{sso_project}}.{{ocp_apps_domain}}' -p BACKEND_URL='http://accidentalert-backend-{{service_project}}.{{ocp_apps_domain}}' \
   -p APPLICATION_HOSTNAME='www-accidentalert-{{guid}}.{{ocp_apps_domain}}' | oc -n {{www_project}} create -f -"
 
 - name: Create project for 3scale


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

Update to use RH SSO operator instead of the template, fixes the problem with the live and readiness probes.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

3scale security demo with OIDC

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
