### PR TITLE
Fix ocp4_workload_cyberark_dap command with stray yaml quote marker

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_cyberark_dap/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cyberark_dap/tasks/workload.yml
@@ -98,7 +98,7 @@
 
 - name: Apply Policies to user namespaces
   command: >-
-    ~{{ansible_user}}/cyberark_setup/{{ ocp4_workload_cyberark_setup_files_release }}/apply_namespace_policies.sh>-
+    ~{{ansible_user}}/cyberark_setup/{{ ocp4_workload_cyberark_setup_files_release }}/apply_namespace_policies.sh
     {{ ocp4_workload_cyberark_project }} {{ dap_pwd }} {{item}} {{ ocp4_workload_cyberark_setup_files_release }}
   loop: "{{ range(1, num_users | int + 1, 1) | list }}"
 


### PR DESCRIPTION
##### SUMMARY

Stray `>-` introduced in earlier commit.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role ocp4_workload_cyberark_dap