### PR TITLE
Use fixed version (8.1) of UBI image so it's compatible with RHEL8.1 repo

### DIFF
--- a/ansible/configs/rhel-custom-security-content/data/Dockerfiles/test_suite-rhel8
+++ b/ansible/configs/rhel-custom-security-content/data/Dockerfiles/test_suite-rhel8
@@ -1,5 +1,5 @@
 # This Dockerfile is a minimal example for a RHEL 8-based SSG test suite target container.
-FROM registry.access.redhat.com/ubi8
+FROM registry.access.redhat.com/ubi8:8.1
 
 ENV AUTH_KEYS=/root/.ssh/authorized_keys
 


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
We have to use a specific version of UBI because we use the repo configured in the HOST to install new packages into the built UBI image. in this case the repo configured is RHEL8.1, otherwise it there is package conflicts.

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
rhel-custom-security-content

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
