### PR TITLE
Fix role ocp4-workload-dil-streaming loop var usage

### DIFF
--- a/ansible/roles/ocp4-workload-dil-streaming/templates/datagrid-operatorgroup.yaml.j2
+++ b/ansible/roles/ocp4-workload-dil-streaming/templates/datagrid-operatorgroup.yaml.j2
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
     name: datagrid
-    namespace: user{{ item }}
+    namespace: {{ __user }}
 spec:
     targetNamespaces:
-    - user{{ item }}
+    - {{ __user }}

--- a/ansible/roles/ocp4-workload-dil-streaming/templates/datagrid-subscription.yaml.j2
+++ b/ansible/roles/ocp4-workload-dil-streaming/templates/datagrid-subscription.yaml.j2
@@ -2,11 +2,11 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: datagrid
-  namespace: user{{ item }}
+  namespace: {{ __user }}
 spec:
   channel: 8.0.x
   installPlanApproval: Manual
   name: datagrid
   source: redhat-operators-snapshot-dil
-  sourceNamespace: user{{ item }}
+  sourceNamespace: {{ __user }}
   startingCSV: datagrid-operator.v{{ csv_version }}


### PR DESCRIPTION
##### SUMMARY

Fix role ocp4-workload-dil-streaming use of `item` variable in favor of `__user`.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role ocp4-workload-dil-streaming