### PR TITLE
Change sap-smart config to use download with vault for satellite manifest

### DIFF
--- a/ansible/configs/sap-smart/default_vars.yml
+++ b/ansible/configs/sap-smart/default_vars.yml
@@ -497,7 +497,8 @@ workflow_schema: |
           - job_template: 'sap-netweaver-preconfigure'
 
 #Satellite mysql_variables
-manifest_file_path: "files/sat_manifest.zip"
+#sap_smart_satellite_manifest_path: ... will override sap_smart_satellite_manifest_url if provided ...
+sap_smart_satellite_manifest_url: "https://gpte-public.s3.amazonaws.com/sap-smart-management-satellite-manifest.zip.ansible-vaulted"
 satellite_organization: "SAPLab"
 satellite_location: "NovelloDC"
 satellite_username: "admin"

--- a/ansible/configs/sap-smart/sat_workload.yml
+++ b/ansible/configs/sap-smart/sat_workload.yml
@@ -27,10 +27,42 @@
     line: 127.0.0.1 access.redhat.com
     create: yes
 
+- name: Get satellite-manifest.zip
+  when: sap_smart_satellite_manifest_path is undefined
+  block:
+  - name: Tempfile for satellite-manifest.zip
+    tempfile:
+      state: file
+      suffix: .zip
+    register: r_satellite_manifest_tmp
+    delegate_to: localhost
+    run_once: true
+    become: false
+
+  # Get then copy to allow vault to decrypt
+  - name: Get satellite-manifest.zip
+    get_url:
+      url: "{{ sap_smart_satellite_manifest_url }}"
+      dest: "{{ r_satellite_manifest_tmp.path }}"
+      force: true
+      mode: u=rw,go=
+    delegate_to: localhost
+    run_once: true
+    become: false
+
 - name: "Copy subscription manifest .zip file"
   copy:
-    src: "{{ manifest_file_path }}"
+    src: "{{ sap_smart_satellite_manifest_path | default(r_satellite_manifest_tmp.path) }}"
     dest: /root/manifest.zip
+
+- name: Remove tempfile for satellite-manifest.zip
+  when: sap_smart_satellite_manifest_path is undefined
+  file:
+    state: absent
+    path: "{{ r_satellite_manifest_tmp.path }}"
+  delegate_to: localhost
+  run_once: true
+  become: false
 
 - name: "Add manifest to Satellite"
   command: >


### PR DESCRIPTION
##### SUMMARY

The sap-smart config has been relying on a satellite manifest file being present on the host from which it is depolyed. This PR changes this logic to instead download a vault protected file from a public url.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Config sap-smart