### PR TITLE
Add install RPM-GPG-KEY-EPEL-7 to sap-smart config

### DIFF
--- a/ansible/configs/sap-smart/software.yml
+++ b/ansible/configs/sap-smart/software.yml
@@ -146,6 +146,10 @@
       shell: >
         yum install -y python3 && alternatives --set python /usr/bin/python3
 
+    - name: Add RPM package key RPM-GPG-KEY-EPEL-7
+      rpm_key:
+        key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
+
     - name: Install Anisble Tower
       include_role:
         name: infra-ansible/roles/ansible/tower/config-ansible-tower


### PR DESCRIPTION
##### SUMMARY

The https://github.com/redhat-cop/infra-ansible.git role fails when setting up EPEL access because of GPG signature validation failure. This adds the key to the host's RPM config so this will not fail.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

config sap-smart