### PR TITLE
Change sap-smart RPM-GPG-KEY-EPEL-7 to RPM-GPG-KEY-EPEL-8

### DIFF
--- a/ansible/configs/sap-smart/software.yml
+++ b/ansible/configs/sap-smart/software.yml
@@ -146,9 +146,9 @@
       shell: >
         yum install -y python3 && alternatives --set python /usr/bin/python3
 
-    - name: Add RPM package key RPM-GPG-KEY-EPEL-7
+    - name: Add RPM package key RPM-GPG-KEY-EPEL-8
       rpm_key:
-        key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
+        key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8
 
     - name: Install Anisble Tower
       include_role:


### PR DESCRIPTION
##### SUMMARY

Change sap-smart config RPM-GPG-KEY-EPEL-7 to RPM-GPG-KEY-EPEL-8. It was the RHEL8 key that is needed, not RHEL7.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

config sap-smart