### PR TITLE
Update ocp4-installer to allow FIPS mode

### DIFF
--- a/ansible/roles/host-ocp4-installer/defaults/main.yml
+++ b/ansible/roles/host-ocp4-installer/defaults/main.yml
@@ -9,3 +9,6 @@ ocp4_network_ovn_install_workaround: false
 # This MachineConfig adds a udev configuration to work around this issue.
 # https://bugzilla.redhat.com/show_bug.cgi?id=1897603
 ocp4_scsi_device_detection_workaround: false
+
+# To enable FIPS mode on an OpenShift 4 cluster
+ocp4_fips_enable: false

--- a/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
+++ b/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
@@ -3,6 +3,9 @@ apiVersion: v1
 metadata:
   name: {{ cluster_name | to_json }}
 baseDomain: {{ ocp4_base_domain | to_json }}
+{% if ocp4_fips_enable %}
+fips: true
+{% endif %}
 controlPlane:
   name: master
   hyperthreading: Enabled

--- a/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
+++ b/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
@@ -3,9 +3,7 @@ apiVersion: v1
 metadata:
   name: {{ cluster_name | to_json }}
 baseDomain: {{ ocp4_base_domain | to_json }}
-{% if ocp4_fips_enable %}
-fips: true
-{% endif %}
+fips: {{ ocp4_fips_enable | to_json }}
 controlPlane:
   name: master
   hyperthreading: Enabled

--- a/tests/static/syntax-check.sh
+++ b/tests/static/syntax-check.sh
@@ -47,7 +47,7 @@ do_yamllint() {
     local f=$1
     local conf
 
-    [[ $f =~ .*.ya?ml$ ]] || return
+    [[ $f =~ \.ya?ml$ ]] || [[ $f =~ \.yamllint$ ]] || return
 
     if ! conf=$(find_yamllint "${f}"); then
         echo "WARNING ........ yamllint:  No conf .yamllint found for ${f}"

--- a/tests/static/syntax-check.sh
+++ b/tests/static/syntax-check.sh
@@ -47,6 +47,8 @@ do_yamllint() {
     local f=$1
     local conf
 
+    [[ $f =~ .*.ya?ml$ ]] || return
+
     if ! conf=$(find_yamllint "${f}"); then
         echo "WARNING ........ yamllint:  No conf .yamllint found for ${f}"
         return

--- a/tests/static/syntax-check.sh
+++ b/tests/static/syntax-check.sh
@@ -47,7 +47,9 @@ do_yamllint() {
     local f=$1
     local conf
 
-    [[ $f =~ \.ya?ml$ ]] || [[ $f =~ \.yamllint$ ]] || return
+    if [ -f "${f}" ]; then
+        [[ $f =~ \.ya?ml$ ]] || [[ $f =~ \.yamllint$ ]] || return
+    fi
 
     if ! conf=$(find_yamllint "${f}"); then
         echo "WARNING ........ yamllint:  No conf .yamllint found for ${f}"


### PR DESCRIPTION

##### SUMMARY

There is sometimes a need to deploy an OpenShift cluster in FIPS mode. This change will allow that to happen by setting the `ocp4_fips_enable` variable to true.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
host-ocp4-installer
