### PR TITLE
ocp4-cluster Improve instance type of master

### DIFF
--- a/ansible/configs/ocp4-cluster/default_vars_ec2.yml
+++ b/ansible/configs/ocp4-cluster/default_vars_ec2.yml
@@ -76,11 +76,14 @@ bastion_instance_image: RHEL82GOLD
 # Root Filesystem Size
 bastion_rootfs_size: 30
 
-master_instance_type: >-
-  {{ 'c5d.xlarge' if worker_instance_count|int <= 10
-  else 'c5d.2xlarge' if worker_instance_count|int <= 20
-  else 'c5d.4xlarge'
+master_instance_type_family: c5d
+master_instance_type_size: >-
+  {{ 'xlarge' if worker_instance_count|int <= 10
+  else '2xlarge' if worker_instance_count|int <= 20
+  else '4xlarge'
   }}
+master_instance_type: "{{ master_instance_type_family }}.{{ master_instance_type_size }}"
+
 master_instance_count: 3
 master_storage_type: "gp2"
 worker_instance_type: "m5a.4xlarge"

--- a/ansible/configs/ocp4-cluster/default_vars_ec2.yml
+++ b/ansible/configs/ocp4-cluster/default_vars_ec2.yml
@@ -76,7 +76,11 @@ bastion_instance_image: RHEL82GOLD
 # Root Filesystem Size
 bastion_rootfs_size: 30
 
-master_instance_type: "m5a.2xlarge"
+master_instance_type: >-
+  {{ 'c5d.xlarge' if worker_instance_count|int <= 10
+  else 'c5d.2xlarge' if worker_instance_count|int <= 20
+  else 'c5d.4xlarge'
+  }}
 master_instance_count: 3
 master_storage_type: "gp2"
 worker_instance_type: "m5a.4xlarge"


### PR DESCRIPTION
- change to c5d (better perf)
- the sizing depends on number of workers. xlarge is generally enough,
  but can be a problem if the number of workers is high.
