### PR TITLE
Fix role host-ocp4-installer to use bool filter for ocp4_fips_enable

### DIFF
--- a/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
+++ b/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 metadata:
   name: {{ cluster_name | to_json }}
 baseDomain: {{ ocp4_base_domain | to_json }}
-fips: {{ ocp4_fips_enable | to_json }}
+fips: {{ ocp4_fips_enable | bool | to_json }}
 controlPlane:
   name: master
   hyperthreading: Enabled


### PR DESCRIPTION
##### SUMMARY

The `ocp4_fips_enable` template was not using the ansible `| bool` filter which is likely to cause the string `"true"` or `"false"` to be set in the generated yaml when values are passed by command line.

Compare:

```
$ ansible localhost -e ocp4_fips_enable=false -m debug -a "msg='fips: {{ ocp4_fips_enable | to_json }}'"
Friday 05 February 2021  20:56:11 -0600 (0:00:00.059)       0:00:00.059 ******* 
localhost | SUCCESS => {
    "msg": "fips: \"false\""
}
```

To

```
$ ansible localhost -e ocp4_fips_enable=false -m debug -a "msg='fips: {{ ocp4_fips_enable | bool | to_json }}'"
Friday 05 February 2021  20:57:53 -0600 (0:00:00.058)       0:00:00.058 ******* 
localhost | SUCCESS => {
    "msg": "fips: false"
}
```

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role host-ocp4-installer