### PR TITLE
Tighten up security groups for ansible-windows after UDP LDAP attack

### DIFF
--- a/ansible/configs/ansible-windows/Makefile
+++ b/ansible/configs/ansible-windows/Makefile
@@ -1,0 +1,34 @@
+GUID=00
+ENVTYPE=ansible-windows
+BASESUFFIX='.example.opentlc.com'
+CLOUDPROVIDER=ec2
+REGION=us-east-1
+HOSTZONEID='Z3IHLWJZOU9SRT'
+KEYNAME=ocpkey
+SECRET=~/secrets/aws-gpte-windows.yml
+
+deploy:
+	ansible-playbook main.yml \
+		-e "guid=$(GUID)" \
+		-e "env_type=$(ENVTYPE)" \
+		-e "key_name=$(KEYNAME)" \
+		-e "subdomain_base_suffix=$(BASESUFFIX)" \
+		-e "cloud_provider=$(CLOUDPROVIDER)" \
+		-e "aws_region=$(REGION)" \
+		-e "HostedZoneId=$(HOSTZONEID)" \
+		-e "email=name@example.com" \
+		-e guid=win-$(GUID) \
+		-e @$(SECRET)
+
+destroy:
+	ansible-playbook destroy.yml \
+		-e "guid=$(GUID)" \
+		-e "env_type=$(ENVTYPE)" \
+		-e "key_name=$(KEYNAME)" \
+		-e "subdomain_base_suffix=$(BASESUFFIX)" \
+		-e "cloud_provider=$(CLOUDPROVIDER)" \
+		-e "aws_region=$(REGION)" \
+		-e "HostedZoneId=$(HOSTZONEID)" \
+		-e "email=name@example.com" \
+		-e guid=win-$(GUID)
+		-e @$(SECRET)

--- a/ansible/configs/ansible-windows/env_vars.yml
+++ b/ansible/configs/ansible-windows/env_vars.yml
@@ -1,27 +1,16 @@
 ---
-## TODO: What variables can we strip out of here to build complex variables?
-## i.e. what can we add into group_vars as opposed to config_vars?
-## Example: We don't really need "subdomain_base_short". If we want to use this,
-## should just toss in group_vars/all.
-### Also, we should probably just create a variable reference in the README.md
-### For now, just tagging comments in line with configuration file.
 
-### Vars that can be removed:
-# use_satellite: true
-# use_subscription_manager: false
-# use_own_repos: false
-
-###### VARIABLES YOU SHOULD CONFIGURE FOR YOUR DEPLOYEMNT
-###### OR PASS as "-e" args to ansible-playbook command
-
-
-### Common Host settings
+env_type: ansible-windows
+guid: ans-win-00
+cloud_provider: ec2
 
 repo_method: file # Other Options are: file, satellite and rhn
 windows_password: 'jVMijRwLbI02gFCo2xkjlZ9lxEA7bm7zgg=='
 tower_admin_password: 'r3dh4t1!'
+
 # Do you want to run a full yum update
 update_packages: false
+
 #If using repo_method: satellite, you must set these values as well.
 # satellite_url: satellite.example.com
 # satellite_org: Sat_org_name
@@ -29,7 +18,6 @@ update_packages: false
 
 ## guid is the deployment unique identifier, it will be appended to all tags,
 ## files and anything that identifies this environment from another "just like it"
-guid: defaultguid
 
 install_bastion: true
 install_common: true
@@ -44,17 +32,18 @@ osrelease: 3.6
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
 # if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
+
 use_own_key: true
-env_authorized_key: "{{guid}}key"
-ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem
+env_authorized_key: "{{ guid }}key"
+ansible_ssh_private_key_file: ~/.ssh/{{ key_name }}.pem
 set_env_authorized_key: true
+
 # Is this running from Red Hat Ansible Tower
 tower_run: false
 
 ### FTL settings
 
 install_ftl: false
-
 
 ### AWS EC2 Environment settings
 
@@ -70,7 +59,7 @@ key_name: "default_key_name"
 ## Networking (AWS)
 subdomain_base_short: "{{ guid }}"
 subdomain_base_suffix: ".example.opentlc.com"
-subdomain_base: "{{subdomain_base_short}}{{subdomain_base_suffix}}"
+subdomain_base: "{{ subdomain_base_short }}{{ subdomain_base_suffix }}"
 
 ## Environment Sizing
 
@@ -88,6 +77,7 @@ subnets:
     routing_table: true
 
 security_groups:
+
   - name: BastionSG
     rules:
       - name: BasSSHPublic
@@ -97,22 +87,82 @@ security_groups:
         protocol: tcp
         cidr: "0.0.0.0/0"
         rule_type: Ingress
+
   - name: WINSG
     rules:
-      - name: WINPortsTCP
-        description: "Win tcp"
-        from_port: 0
+
+      - name: WINPortsSSH
+        description: "Win ssh"
+        from_port: 22
+        to_port: 22
+        protocol: tcp
+        cidr: "0.0.0.0/0"
+        rule_type: Ingress
+
+      - name: WINPortsKerberos
+        description: "Win AD Ports Kerberos"
+        from_port: 88
+        to_port: 88
+        protocol: tcp
+        cidr: "0.0.0.0/0"
+        rule_type: Ingress
+
+      - name: WINPortsRPCmapper
+        description: "Win AD Ports RPC Mapper"
+        from_port: 135
+        to_port: 135
+        protocol: tcp
+        cidr: "0.0.0.0/0"
+        rule_type: Ingress
+
+      - name: WINPortsWINLDAP
+        description: "Win AD Ports LDAP"
+        from_port: 389
+        to_port: 389
+        protocol: tcp
+        cidr: "0.0.0.0/0"
+        rule_type: Ingress
+
+      - name: WINPortsWINLDAPSSL
+        description: "Win AD Ports LDAP SSL"
+        from_port: 636
+        to_port: 636
+        protocol: tcp
+        cidr: "0.0.0.0/0"
+        rule_type: Ingress
+
+      - name: WINPortsRPCDynamic
+        description: "Win AD Ports RPC Dynamic"
+        from_port: 1024
         to_port: 65535
         protocol: tcp
         cidr: "0.0.0.0/0"
         rule_type: Ingress
-      - name: WINPortsUdp
-        description: "Win udp"
-        from_port: 0
-        to_port: 65535
+
+      - name: WINPortsWINRM
+        description: "Win winRM for Ansible"
+        from_port: 5986
+        to_port: 5986
+        protocol: tcp
+        cidr: "0.0.0.0/0"
+        rule_type: Ingress
+
+      - name: WINPortsRDP
+        description: "Win RDP"
+        from_port: 3389
+        to_port: 3389
+        protocol: tcp
+        cidr: "0.0.0.0/0"
+        rule_type: Ingress
+
+      - name: WINPortsUdpRDP
+        description: "Win UDP for RDP"
+        from_port: 3389
+        to_port: 3389
         protocol: udp
         cidr: "0.0.0.0/0"
         rule_type: Ingress
+
   - name: HostSG
     rules:
       - name: HostSSHPublic
@@ -122,6 +172,7 @@ security_groups:
         protocol: tcp
         cidr: "0.0.0.0/0"
         rule_type: Ingress
+
       - name: HostUDPPorts
         description: "Only from Itself udp"
         from_port: 0
@@ -129,6 +180,7 @@ security_groups:
         protocol: udp
         group: HostSG
         rule_type: Ingress
+
       - name: HostTCPPorts
         description: "Only from Itself tcp"
         from_port: 0
@@ -136,6 +188,7 @@ security_groups:
         protocol: tcp
         group: HostSG
         rule_type: Ingress
+
       - name: BastionUDPPorts
         description: "Only from bastion"
         from_port: 0
@@ -143,6 +196,7 @@ security_groups:
         protocol: udp
         group: BastionSG
         rule_type: Ingress
+
       - name: BastionTCPPorts
         description: "Only from bastion"
         from_port: 0
@@ -153,11 +207,11 @@ security_groups:
 
 instances:
   - name: "ad"
-    count: "{{activedirectory_instance_count}}"
+    count: "{{ activedirectory_instance_count }}"
     public_dns: true
     security_group: "WINSG"
     flavor:
-      "ec2": "{{activedirectory_instance_type}}"
+      "ec2": "{{ activedirectory_instance_type }}"
     image_id: WIN2012R2AMI
     # yamllint disable rule:line-length
     UserData: |
@@ -167,7 +221,7 @@ instances:
                      - ""
                      - - "<powershell>\n"
                        - "$admin = [adsi]('WinNT://./administrator, user')\n"
-                       - "$admin.PSBase.Invoke('SetPassword', '{{windows_password}}')\n"
+                       - "$admin.PSBase.Invoke('SetPassword', '{{ windows_password }}')\n"
                        - "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12\n"
                        - "$scriptPath=((New-Object System.Net.Webclient).DownloadString('https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1'))\n"
                        - "Invoke-Command -ScriptBlock ([scriptblock]::Create($scriptPath)) -ArgumentList '-skipNetworkProfileCheck'\n"
@@ -220,61 +274,47 @@ rhel_repos:
   - rhel-7-server-extras-rpms
   - rhel-7-server-optional-rpms
 
-
-## Currently there is no NFS created for this Environment - See ocp-workshop for clues.
-# ## NFS Server settings
-# nfs_vg: nfsvg
-# nfs_pvs: /dev/xvdb
-# nfs_export_path: /srv/nfs
-#
-# nfs_shares:
-#   - es-storage
-#   - user-vols
-#   - jenkins
-#   - nexus
-#   - nexus2
-
 project_tag: "{{ env_type }}-{{ guid }}"
 
-zone_internal_dns: "{{guid}}.internal."
-chomped_zone_internal_dns: "{{guid}}.internal"
+zone_internal_dns: "{{ guid }}.internal."
+chomped_zone_internal_dns: "{{ guid }}.internal"
 
-cloudapps_dns: '*.apps.{{subdomain_base}}.'
-tower_public_dns: "towerlb.{{subdomain_base}}."
+cloudapps_dns: '*.apps.{{ subdomain_base }}.'
+tower_public_dns: "towerlb.{{ subdomain_base }}."
 
-#tower_public_dns: "tower.{{subdomain_base}}."
-bastion_public_dns: "bastion.{{subdomain_base}}."
-bastion_public_dns_chomped: "bastion.{{subdomain_base}}"
+#tower_public_dns: "tower.{{ subdomain_base }}."
+bastion_public_dns: "bastion.{{ subdomain_base }}."
+bastion_public_dns_chomped: "bastion.{{ subdomain_base }}"
 # we don't use this anymore <sborenst>
-# activedirectory_public_dns: "ad.{{subdomain_base}}."
-# activedirectory_public_dns_chomped: "ad.{{subdomain_base}}"
+# activedirectory_public_dns: "ad.{{ subdomain_base }}."
+# activedirectory_public_dns_chomped: "ad.{{ subdomain_base }}"
 
 vpcid_cidr_block: "192.168.0.0/16"
-vpcid_name_tag: "{{subdomain_base}}"
+vpcid_name_tag: "{{ subdomain_base }}"
 
 az_1_name: "{{ aws_region }}a"
 az_2_name: "{{ aws_region }}b"
 
 subnet_private_1_cidr_block: "192.168.2.0/24"
 subnet_private_1_az: "{{ az_2_name }}"
-subnet_private_1_name_tag: "{{subdomain_base}}-private"
+subnet_private_1_name_tag: "{{ subdomain_base }}-private"
 
 subnet_private_2_cidr_block: "192.168.1.0/24"
 subnet_private_2_az: "{{ az_1_name }}"
-subnet_private_2_name_tag: "{{subdomain_base}}-private"
+subnet_private_2_name_tag: "{{ subdomain_base }}-private"
 
 subnet_public_1_cidr_block: "192.168.10.0/24"
 subnet_public_1_az: "{{ az_1_name }}"
-subnet_public_1_name_tag: "{{subdomain_base}}-public"
+subnet_public_1_name_tag: "{{ subdomain_base }}-public"
 
 subnet_public_2_cidr_block: "192.168.20.0/24"
 subnet_public_2_az: "{{ az_2_name }}"
-subnet_public_2_name_tag: "{{subdomain_base}}-public"
+subnet_public_2_name_tag: "{{ subdomain_base }}-public"
 
 dopt_domain_name: "{{ aws_region }}.compute.internal"
 
-rtb_public_name_tag: "{{subdomain_base}}-public"
-rtb_private_name_tag: "{{subdomain_base}}-private"
+rtb_public_name_tag: "{{ subdomain_base }}-public"
+rtb_private_name_tag: "{{ subdomain_base }}-private"
 
 
 cf_template_description: "{{ env_type }}-{{ guid }} Ansible Agnostic Deployer "


### PR DESCRIPTION
##### SUMMARY

Config ansible-windows had wide open UDP security group and a deployment was subject to an attack on UDP/LDAP

This PR cleans up the config and tightens up the SGs to reduce the attack surface including the port in question 389/udp

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
config ansible-windows

##### ADDITIONAL INFORMATION

