### PR TITLE
Updated logic to allow for stable releases of OC Client rather than h…

### DIFF
--- a/ansible/roles_studentvm/studentvm_ocp4/defaults/main.yml
+++ b/ansible/roles_studentvm/studentvm_ocp4/defaults/main.yml
@@ -12,20 +12,33 @@ studentvm_ocp4_bin_path: /usr/local/bin
 ocp4_installer_root_url: http://d3s3zqyaz8cp2d.cloudfront.net/pub/openshift-v4/clients
 
 # Software Version defaults
+# -------------------------
 
 # https://mirror.openshift.com/pub/openshift-v4/clients/ocp
-studentvm_ocp4_oc_version: 4.6.1
+# Set studentvm_ocp4_oc_version to the major OpenShift version
+# to install the latest available *stable* version for that major
+# release
+# Set to a specific version to install a specific version of the client
+studentvm_ocp4_oc_version: 4.6
+# studentvm_ocp4_oc_version: 4.6.15
+
 # https://mirror.openshift.com/pub/openshift-v4/clients/odo
-studentvm_ocp4_odo_version: v2.0.0
+studentvm_ocp4_odo_version: v2.0.4
+
 # https://mirror.openshift.com/pub/openshift-v4/clients/helm
-studentvm_ocp4_helm_version: 3.3.4
+studentvm_ocp4_helm_version: 3.5.0
+
 # https://mirror.openshift.com/pub/openshift-v4/clients/pipeline
-studentvm_ocp4_tkn_version: 0.11.0
+studentvm_ocp4_tkn_version: 0.15.0
+
 # https://mirror.openshift.com/pub/openshift-v4/clients/serverless
-studentvm_ocp4_kn_version: 0.16.1
+studentvm_ocp4_kn_version: 0.18.4
+
 # https://github.com/istio/istio/releases
 studentvm_ocp4_istioctl_version: 1.4.9
+
 # https://github.com/operator-framework/operator-registry/releases
-studentvm_ocp4_opm_version: v1.14.3
+studentvm_ocp4_opm_version: v1.16.1
+
 # Source to Image URL (can't use just version because of random hash in the file name)
 studentvm_ocp4_s2i_url: https://github.com/openshift/source-to-image/releases/download/v1.3.1/source-to-image-v1.3.1-a5a77147-linux-amd64.tar.gz

--- a/ansible/roles_studentvm/studentvm_ocp4/tasks/main.yml
+++ b/ansible/roles_studentvm/studentvm_ocp4/tasks/main.yml
@@ -2,7 +2,33 @@
 - name: Install all Binaries
   become: true
   block:
-  - name: Download OpenShift CLI
+  - name: Check studentvm_ocp4_oc_version variable
+    assert:
+      that:
+      - studentvm_ocp4_oc_version is defined
+      - studentvm_ocp4_oc_version | string | length  >= 3
+      fail_msg: "studentvm_ocp4_oc_version must be defined and contain at least 3 characters."
+
+  # 4.1 .. 4.99 -> latest stable client for that major version
+  - name: Download latest stable OpenShift CLI
+    when:
+    - studentvm_ocp4_oc_version | string | length <= 4
+    unarchive:
+      src: >-
+        {{ ocp4_installer_root_url }}/ocp/stable-{{
+        studentvm_ocp4_oc_version }}/openshift-client-linux.tar.gz
+      remote_src: true
+      dest: "{{ studentvm_ocp4_bin_path }}"
+      owner: root
+      group: root
+      mode: 0775
+    args:
+      creates: "{{ studentvm_ocp4_bin_path }}/oc"
+
+  # 4.1.1 .. 4.99.99 -> specific client version
+  - name: Download specific OpenShift CLI version
+    when:
+    - studentvm_ocp4_oc_version | string | length > 4
     unarchive:
       src: >-
         {{ ocp4_installer_root_url }}/ocp/{{


### PR DESCRIPTION
##### SUMMARY

Updated logic to allow for stable releases of OC Client rather than having to specify the full release number.

Now the variable **studentvm_ocp4_oc_version** can be either just the major OpenShift release (4.4, 4.5, 4.6, ...) and it will install the latest available **stable** version. Or the variable can be set to a specific release (e.g. 4.6.15).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
roles_studentvm / studentvm_ocp4
