### PR TITLE
Update Java StudentVM workload to optionally install Mandrel

### DIFF
--- a/ansible/roles_studentvm/studentvm_java_development/.yamllint
+++ b/ansible/roles_studentvm/studentvm_java_development/.yamllint
@@ -9,5 +9,5 @@ rules:
   indentation:
     indent-sequences: consistent
   line-length:
-    max: 120
+    max: 150
     allow-non-breakable-inline-mappings: true

--- a/ansible/roles_studentvm/studentvm_java_development/defaults/main.yml
+++ b/ansible/roles_studentvm/studentvm_java_development/defaults/main.yml
@@ -2,10 +2,24 @@
 # Where to install all the executables
 studentvm_java_development_bin_path: /usr/local/bin
 
+# Install JDK
+studentvm_java_development_install_jdk: true
+
 # Software Version defaults
 studentvm_java_development_jdk_package: "java-11-openjdk-devel"
 # studentvm_java_development_jdk_package: "java-1.8.0-openjdk-devel"
 
+# Install Maven
+studentvm_java_development_install_maven: true
+
 # Maven must be in the GPTE Public Bucket on AWS to prevent download failures
- # https://s3.console.aws.amazon.com/s3/buckets/gpte-public/?region=us-east-1
+# https://s3.console.aws.amazon.com/s3/buckets/gpte-public/?region=us-east-1
 studentvm_java_development_maven_version: '3.6.3'
+
+# Mandrel (GraalVM)
+studentvm_java_development_install_mandrel: false
+
+# Mandrel must be in the GPTE Public Bucket on AWS to prevent download failures
+# https://s3.console.aws.amazon.com/s3/buckets/gpte-public/?region=us-east-1
+# Version of Mandrel to install
+studentvm_java_development_mandrel_version: "20.3.1.2.Final"

--- a/ansible/roles_studentvm/studentvm_java_development/defaults/main.yml
+++ b/ansible/roles_studentvm/studentvm_java_development/defaults/main.yml
@@ -23,4 +23,3 @@ studentvm_java_development_install_mandrel: false
 # https://s3.console.aws.amazon.com/s3/buckets/gpte-public/?region=us-east-1
 # Version of Mandrel to install
 studentvm_java_development_mandrel_version: "20.3.1.2.Final"
-

--- a/ansible/roles_studentvm/studentvm_java_development/defaults/main.yml
+++ b/ansible/roles_studentvm/studentvm_java_development/defaults/main.yml
@@ -23,3 +23,4 @@ studentvm_java_development_install_mandrel: false
 # https://s3.console.aws.amazon.com/s3/buckets/gpte-public/?region=us-east-1
 # Version of Mandrel to install
 studentvm_java_development_mandrel_version: "20.3.1.2.Final"
+

--- a/ansible/roles_studentvm/studentvm_java_development/tasks/main.yml
+++ b/ansible/roles_studentvm/studentvm_java_development/tasks/main.yml
@@ -1,34 +1,77 @@
 ---
-- name: Install Java Development Envrionment
+- name: Install Java Development Environment
   become: true
   block:
   - name: Install JDK
+    when: studentvm_java_development_install_jdk | bool
     package:
       state: present
       name: "{{ studentvm_java_development_jdk_package }}"
 
-  - name: Create /usr/local/maven directory
-    file:
-      path: /usr/local/maven
-      state: directory
-      owner: root
-      group: root
-      mode: 0775
+  - name: Install Maven
+    when: studentvm_java_development_install_maven | bool
+    block:
+    - name: Create /usr/local/maven directory
+      file:
+        path: /usr/local/maven
+        state: directory
+        owner: root
+        group: root
+        mode: 0775
 
-  - name: Download and unarchive Maven Distribution
-    unarchive:
-      src: "https://gpte-public.s3.amazonaws.com/apache-maven-{{ studentvm_java_development_maven_version }}-bin.tar.gz"
-      remote_src: true
-      dest: /usr/local/maven
-      owner: root
-      group: root
-      extra_opts:
-      - --strip=1
+    - name: Download and unarchive Maven Distribution
+      unarchive:
+        src: "https://gpte-public.s3.amazonaws.com/apache-maven-{{ studentvm_java_development_maven_version }}-bin.tar.gz"
+        remote_src: true
+        dest: /usr/local/maven
+        owner: root
+        group: root
+        extra_opts:
+        - --strip=1
 
-  - name: Set up Link in bin_path
-    file:
-      state: link
-      src: "/usr/local/maven/bin/mvn"
-      dest: "{{ studentvm_java_development_bin_path }}/mvn"
-      owner: root
-      group: root
+    - name: Set up Link in bin_path
+      file:
+        state: link
+        src: "/usr/local/maven/bin/mvn"
+        dest: "{{ studentvm_java_development_bin_path }}/mvn"
+        owner: root
+        group: root
+
+  - name: Install Mandrel (GraalVM)
+    when: studentvm_java_development_install_mandrel | bool
+    block:
+    - name: Install prerequisite RHEL packages
+      package:
+        state: present
+        name:
+        - gcc
+        - zlib-devel
+        - glibc-devel
+
+    - name: Create /usr/local/mandrel directory
+      file:
+        path: /usr/local/mandrel
+        state: directory
+        owner: root
+        group: root
+        mode: 0775
+
+    - name: Download and unarchive Mandrel
+      unarchive:
+        src: "https://gpte-public.s3.amazonaws.com/mandrel-java11-linux-amd64-{{ studentvm_java_development_mandrel_version }}.tar.gz"
+        remote_src: true
+        dest: /usr/local/mandrel
+        owner: root
+        group: root
+        extra_opts:
+        - --strip=1
+
+    - name: Add Mandrel/bin to PATH
+      blockinfile:
+        dest: "/home/{{ studentvm_ocp4_user_name }}/.bashrc"
+        insertafter: EOF
+        marker: "# <!-- {mark} ANSIBLE MANAGED BLOCK (Mandrel) -->"
+        block: |
+          export JAVA_HOME=/usr/local/mandrel
+          export GRAALVM_HOME=/usr/local/mandrel
+          export PATH=/usr/local/mandrel/bin:$PATH


### PR DESCRIPTION
##### SUMMARY

Add capability to install the Mandrel (GraalVM) distribution (required for updated App Deploy ILT).
Also made installing the JDK optional.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
studentvm_roles / studentvm_java_development