### PR TITLE
ocp4-cluster config: IOPS setting for master storage

### DIFF
--- a/ansible/configs/ocp4-cluster/default_vars_ec2.yml
+++ b/ansible/configs/ocp4-cluster/default_vars_ec2.yml
@@ -76,6 +76,8 @@ bastion_instance_image: RHEL82GOLD
 # Root Filesystem Size
 bastion_rootfs_size: 30
 
+# Masters
+
 master_instance_type_family: c5d
 master_instance_type_size: >-
   {{ 'xlarge' if worker_instance_count|int <= 10
@@ -85,7 +87,14 @@ master_instance_type_size: >-
 master_instance_type: "{{ master_instance_type_family }}.{{ master_instance_type_size }}"
 
 master_instance_count: 3
-master_storage_type: "gp2"
+master_storage_type: >-
+  {{ 'io1' if worker_instance_count|int >= 10
+  else 'gp2' }}
+
+# When master_storage_type is io1 or io2, you can set the IOPS.
+# You usually want to leave it as the default IOPS value is calculated in the role host-ocp4-installer
+# master_storage_iops: 2000
+
 worker_instance_type: "m5a.4xlarge"
 worker_instance_count: 2
 worker_storage_type: "gp2"

--- a/ansible/configs/ocp4-cluster/default_vars_ec2.yml
+++ b/ansible/configs/ocp4-cluster/default_vars_ec2.yml
@@ -22,7 +22,7 @@ ansible_user: ec2-user
 # See roles-infra/infra-ec2-project-create/defaults/main.yml
 
 # The region to be used, if not specified by -e in the command line
-aws_region: us-east-1
+aws_region: us-east-2
 
 # The availability Zones for which to create worker MachineSets for.
 # Leave empty for the default (set up one MachineSet for
@@ -78,7 +78,7 @@ bastion_rootfs_size: 30
 
 # Masters
 
-master_instance_type_family: c5d
+master_instance_type_family: m5a
 master_instance_type_size: >-
   {{ 'xlarge' if worker_instance_count|int <= 10
   else '2xlarge' if worker_instance_count|int <= 20

--- a/ansible/roles/host-ocp4-installer/defaults/main.yml
+++ b/ansible/roles/host-ocp4-installer/defaults/main.yml
@@ -12,3 +12,18 @@ ocp4_scsi_device_detection_workaround: false
 
 # To enable FIPS mode on an OpenShift 4 cluster
 ocp4_fips_enable: false
+# When master_storage_type == io1 or io2,
+# calculate the IOPS:
+# IOPS = 2000 << number of worker * 100 << 32000
+# ex: 10 workers == 2000 iops
+#     20 workers == 2000 iops
+#     30 workers == 3000 iops
+#     40 workers == 4000 iops
+# See OpenShift documentation: https://docs.openshift.com/container-platform/4.6/installing/installing_aws/installing-aws-customizations.html
+# And AWS documentation: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html
+host_ocp4_installer_master_storage_iops: >-
+  {{ [
+  2000,
+  [ 32000, worker_instance_count|default(2)|int * 100 ] | min
+  ] | max | int
+  }}

--- a/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
+++ b/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
@@ -16,6 +16,9 @@ controlPlane:
       type: {{ master_instance_type | to_json }}
       rootVolume:
         type: {{ master_storage_type | to_json }}
+{%   if master_storage_type in ['io1', 'io2'] %}
+        iops: {{ master_storage_iops | default(host_ocp4_installer_master_storage_iops) | to_json }}
+{%   endif %}
 {% endif %}
 {% if cloud_provider == 'azure' %}
     azure:

--- a/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
+++ b/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
@@ -17,7 +17,7 @@ controlPlane:
       rootVolume:
         type: {{ master_storage_type | to_json }}
 {%   if master_storage_type in ['io1', 'io2'] %}
-        iops: {{ master_storage_iops | default(host_ocp4_installer_master_storage_iops) | to_json }}
+        iops: {{ master_storage_iops | default(host_ocp4_installer_master_storage_iops) | int | to_json }}
 {%   endif %}
 {% endif %}
 {% if cloud_provider == 'azure' %}


### PR DESCRIPTION
Allow user to specify the desired IOPS for master storage.

In case of large clusters the master instance should have provisioned
IOPS for the etcd database to work properly.

This change, if applied, automatically sets the
`controlPlane.platform.aws.rootVolume.type` to `io1` if the number of
workers is greater than 10.

In that case, the IOPS value is also calculated:

* minimum of 2000 IOPS,
* if number of wokers > 20, then it's 100 IOPS per node
* maximum of 32000 IOPS

That IOPS value can be overridden by the user with the `master_storage_iops` variable, directly in the config or agnosticv.

According to OpenShift documentation
https://docs.openshift.com/container-platform/4.6/installing/installing_aws/installing-aws-customizations.html

* type = io1 / 2000 IOPS  is a good setting for large clusters

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME
* ocp4-cluster config
* host-ocp4-installer role
##### ADDITIONAL INFORMATION
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html
