### PR TITLE
add information to use and configure own AK when no Sat server is available

### DIFF
--- a/training/02_Getting_Started/06_deploying_a_base_config_osp.adoc
+++ b/training/02_Getting_Started/06_deploying_a_base_config_osp.adoc
@@ -57,6 +57,8 @@ set_repositories_satellite_activationkey: CHANGEME # Activation key to register 
 ----
 And populate them with the correct values.
 
+IMPORTANT: If you don't have access to a Satellite server, you can always use your own personal activation key for your own RHN account. Please refer to this link:#https://github.com/redhat-cop/agnosticd/blob/development/training/03_Infrastructure/01_Foundational/04_a_Create_an_AK.adoc[page] for guidance.
+
 == Deploy a base config
 
 Execute the main AgnosticD playbook (bear in mind the path to your files, which may differ):

--- a/training/03_Infrastructure/02_Advanced/Adding_Versions_RHEL.adoc
+++ b/training/03_Infrastructure/02_Advanced/Adding_Versions_RHEL.adoc
@@ -192,7 +192,7 @@ set_repositories_satellite_activationkey: gpte-rhel8 # Activation key to registe
 #rhsm_pool_ids: 8a85f99c6c8b9588016c8be0f38a0ee9
 
 # Packages
-use_content_view: false    # Repo dictionary can contain both rhel 7 and 8 if using satellite content view
+use_content_view: true    # Repo dictionary can contain both rhel 7 and 8 if using satellite content view
 # See roles/set-repositories/tasks/satellite-repos.yml
 ----
 

--- a/training/03_Infrastructure/02_Advanced/Adding_Versions_RHEL.adoc
+++ b/training/03_Infrastructure/02_Advanced/Adding_Versions_RHEL.adoc
@@ -147,6 +147,55 @@ RHN is populated using the following tasks file `roles/set-repositories/tasks/rh
     state: enabled
 ----
 
+Last, we need to add the environment configuration variables, in this case we are going to use a Satellite sever and an activation key, but we could as well use our own activation key (or even a pool id) in our personal RHN account. As explained in the Foundational Level of this training, we need to add this to our `secrets.yaml` file:
+[source,bash]
+----
+[agilpipp-redhat.com@bastion ~]$ vi ~/secrets.yaml
+## Environment Repositories
+
+## The variable repo_method defines the method of receiving packages.
+## There are three defineable options 'file', 'rhn', and 'satellite'.
+## Shown here are examples for all three methods.
+
+## Defining 'file' requires a path to the repository typically in url format.
+## own_repo_path explaination,if no access use other methods
+
+# repo_method: file
+# own_repo_path: https://changeme.com/repo-file-path/
+
+## Defining 'rhn' registers systems to the Red Hat Network using subscription-manager.
+## Define only ONE of the below options. Defining both option 1 & 2 will result in failure.
+
+# repo_method: rhn
+
+## Option 1: Credentials
+# rhel_subscription_user: CHANGEME
+# rhel_subscription_pass: CHANGEME
+# rhsm_pool_ids: CHANGEME
+
+## Option 2: Activation key
+# rhel_subscription_activation_key: CHANGEME
+# rhel_subscription_org_id: CHANGEME
+# rhsm_pool_ids: CHANGEME
+
+## Defining 'satellite' registers systems to an existing Red Hat Satellite server.
+
+repo_method: satellite
+set_repositories_satellite_hostname: labsat.opentlc.com      # Hostname of satellite server.
+set_repositories_satellite_org: Red_Hat_GPTE_Labs       # CA certificate used to validate satellite server TLS
+set_repositories_satellite_ca_rpm_url: https://labsat.opentlc.com/pub/katello-ca-consumer-latest.noarch.rpm    # URL to download the Katello/Satellite CA certificate configuration RPM
+set_repositories_satellite_activationkey: gpte-rhel8 # Activation key to register to satellite.
+
+#repo_method: rhn
+#rhel_subscription_activation_key: gpte-training-rhel8
+#rhel_subscription_org_id: 1979710
+#rhsm_pool_ids: 8a85f99c6c8b9588016c8be0f38a0ee9
+
+# Packages
+use_content_view: false    # Repo dictionary can contain both rhel 7 and 8 if using satellite content view
+# See roles/set-repositories/tasks/satellite-repos.yml
+----
+
 In this example you can see that we use the two *rhel_repos_el7* and *rhel_repos_el8* lists to enable repositories on different versions of RHEL based on the Ansible facts of the systems.
 
 *NOTE*: The *rhel_repos* variable and the *_el7* and *_el8* variables are exclusive of each other. This means you cannot define all three at the same time, this is checked prior to the *rhn-repos.yml* within `roles/set-repositories/tasks/pre_checks_rhn.yml`

--- a/training/03_Infrastructure/02_Advanced/Adding_Versions_RHEL.adoc
+++ b/training/03_Infrastructure/02_Advanced/Adding_Versions_RHEL.adoc
@@ -148,25 +148,11 @@ RHN is populated using the following tasks file `roles/set-repositories/tasks/rh
 ----
 
 Last, we need to add the environment configuration variables, in this case we are going to use a Satellite sever and an activation key, but we could as well use our own activation key (or even a pool id) in our personal RHN account. As explained in the Foundational Level of this training, we need to add this to our `secrets.yaml` file:
+
 [source,bash]
 ----
 [agilpipp-redhat.com@bastion ~]$ vi ~/secrets.yaml
 ## Environment Repositories
-
-## The variable repo_method defines the method of receiving packages.
-## There are three defineable options 'file', 'rhn', and 'satellite'.
-## Shown here are examples for all three methods.
-
-## Defining 'file' requires a path to the repository typically in url format.
-## own_repo_path explaination,if no access use other methods
-
-# repo_method: file
-# own_repo_path: https://changeme.com/repo-file-path/
-
-## Defining 'rhn' registers systems to the Red Hat Network using subscription-manager.
-## Define only ONE of the below options. Defining both option 1 & 2 will result in failure.
-
-# repo_method: rhn
 
 ## Option 1: Credentials
 # rhel_subscription_user: CHANGEME
@@ -181,20 +167,17 @@ Last, we need to add the environment configuration variables, in this case we ar
 ## Defining 'satellite' registers systems to an existing Red Hat Satellite server.
 
 repo_method: satellite
-set_repositories_satellite_hostname: labsat.opentlc.com      # Hostname of satellite server.
-set_repositories_satellite_org: Red_Hat_GPTE_Labs       # CA certificate used to validate satellite server TLS
-set_repositories_satellite_ca_rpm_url: https://labsat.opentlc.com/pub/katello-ca-consumer-latest.noarch.rpm    # URL to download the Katello/Satellite CA certificate configuration RPM
-set_repositories_satellite_activationkey: gpte-rhel8 # Activation key to register to satellite.
-
-#repo_method: rhn
-#rhel_subscription_activation_key: gpte-training-rhel8
-#rhel_subscription_org_id: 1979710
-#rhsm_pool_ids: 8a85f99c6c8b9588016c8be0f38a0ee9
+set_repositories_satellite_hostname: CHANGEME      # Hostname of satellite server.
+set_repositories_satellite_org: CHANGEME       # CA certificate used to validate satellite server TLS
+set_repositories_satellite_ca_rpm_url: CHANGEME    # URL to download the Katello/Satellite CA certificate configuration RPM
+set_repositories_satellite_activationkey: CHANGEME # Activation key to register to satellite.
 
 # Packages
 use_content_view: true    # Repo dictionary can contain both rhel 7 and 8 if using satellite content view
 # See roles/set-repositories/tasks/satellite-repos.yml
 ----
+
+IMPORTANT: If you don't have access to a Satellite server, you can always use your own personal activation key for your own RHN account. Please refer to this link:#https://github.com/redhat-cop/agnosticd/blob/development/training/03_Infrastructure/01_Foundational/04_a_Create_an_AK.adoc[page] for guidance.
 
 In this example you can see that we use the two *rhel_repos_el7* and *rhel_repos_el8* lists to enable repositories on different versions of RHEL based on the Ansible facts of the systems.
 


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

add information to use and configure own AK when no Sat server is available

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
training/03_Infrastructure/02_Advanced/Adding_Versions_RHEL.adoc