### PR TITLE
Bumping up the versions of MTC in OCP Migration workshop to 1.4

### DIFF
--- a/ansible/roles/ocp-workload-migration/templates/operator.yml.j2
+++ b/ansible/roles/ocp-workload-migration/templates/operator.yml.j2
@@ -149,7 +149,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: migration-operator
-  namespace: "openshift-migration"
+  namespace: "{{ mig_migration_namespace }}"
 rules:
 - apiGroups:
   - ""
@@ -287,7 +287,7 @@ spec:
       serviceAccountName: migration-operator
       containers:
       - name: operator
-        image: registry.redhat.io/rhmtc/{{ mig_migration_namespace }}-rhel7-operator:v1.3.2
+        image: registry.redhat.io/rhmtc/{{ mig_migration_namespace }}-rhel7-operator:v1.4.0
         imagePullPolicy: Always
         volumeMounts:
         - mountPath: /tmp/ansible-operator/runner
@@ -307,18 +307,30 @@ spec:
           value: registry.redhat.io
         - name: PROJECT
           value: rhmtc
+        - name: RSYNC_TRANSFER_REPO
+          value: {{ mig_migration_namespace }}-rsync-transfer-rhel8@sha256
+        - name: RSYNC_TRANSFER_TAG
+          value: 0925295b74c81e526c6b751307b0219b3e4c28b53e4923192f2b050148594552
         - name: HOOK_RUNNER_REPO
           value: {{ mig_migration_namespace }}-hook-runner-rhel7@sha256
         - name: HOOK_RUNNER_TAG
-          value: 30267eda1374a7f7e989ca8cdb0997fe4ddb77a97385d8c7f21b20db57c46aa8
+          value: af3afd99516d2f7b6e70486d03ba60d623e93e9cbf3ea9519017ba169895b0e6
         - name: MIG_CONTROLLER_REPO
           value: {{ mig_migration_namespace }}-controller-rhel8@sha256
+        - name: MIG_CONTROLLER_TAG
+          value: 6c66a6e3c2d522f9dce005e2aecc087c2943a45a49c0aec97d23cd3ee34f3aa9
         - name: MIG_UI_REPO
           value: {{ mig_migration_namespace }}-ui-rhel8@sha256
+        - name: MIG_UI_TAG
+          value: 1f1d744a7e1d5f5699d7ea0507d230c0d5f1c317c6b2acc2e75e4dcdf5fc5b12
+        - name: MIG_LOG_READER_REPO
+          value: {{ mig_migration_namespace }}-log-reader-rhel8@sha256
+        - name: MIG_LOG_READER_TAG
+          value: 2594b4bf8757ed6e27df2c0a7c24e63ca89d5d1c4f81ddcc3c40f68795a1f845
         - name: MIGRATION_REGISTRY_REPO
           value: {{ mig_migration_namespace }}-registry-rhel8@sha256
         - name: MIGRATION_REGISTRY_TAG
-          value: 980b8ab84e7cf3e8664a052e2fcbda74123a31b674e64f0648d49bcc472ba3a2
+          value: 7848df78d613036039a0213489b96b83a8fef7f547b624bfcfd8cc5ae9621f03
         - name: VELERO_REPO
           value: {{ mig_migration_namespace }}-velero-rhel8@sha256
         - name: VELERO_PLUGIN_REPO
@@ -332,21 +344,17 @@ spec:
         - name: VELERO_AZURE_PLUGIN_REPO
           value: {{ mig_migration_namespace }}-velero-plugin-for-microsoft-azure-rhel8@sha256
         - name: VELERO_TAG
-          value: 349db22c468b5923e415a88e03a9f14a4df249969a7275b94197bc78f2a0b26c
+          value: 1edda955a8032023cd3a4ca53aaccdb627613269e4b266b81aee4bee7b6cc863
         - name: VELERO_RESTIC_RESTORE_HELPER_TAG
-          value: 0ca2ea8742025edf6ac4940507b92a699a10b3685831b22a31ab5a35050f23bb
+          value: 5db9336273b7832ca176167086b55425d29b49f800b0fb6f2314a05b1194849e
         - name: VELERO_PLUGIN_TAG
-          value: cff7527e3906dbfc494bbfc9573b645dcaa7b8d5d5777b8d013ccaac211a3dff
+          value: bb31d93d677f2a3d1700238558ed972e7b9eb01a0ba79600d5054534f3a656e0
         - name: VELERO_AWS_PLUGIN_TAG
-          value: d62b80789e77c64eeed61abe362c2239a726905474e85e5996911f2361b49227
+          value: c0f9d4bcb210035c676f51dbcfd085ccdbf96bad2e6dc0354a1e9df3bbba1ad1
         - name: VELERO_GCP_PLUGIN_TAG
-          value: c5c354d0b1f068d32929c372af1729fe3fc2715dd90643f689dcf6912d939919
+          value: ad93c13a853356184255665917793f213b9e13a08a92e76eb67c49ff3451a507
         - name: VELERO_AZURE_PLUGIN_TAG
-          value: d3115f650e1265df663233af6b788d925376713478a0b6ecbfd9355d8fff8623
-        - name: MIG_UI_TAG
-          value: a616ba1d16459b376e2a8c77ecc8c0d2122fd04881cf3493d422184434ddd559
-        - name: MIG_CONTROLLER_TAG
-          value: a8f9edd91b5a2a722d65035e6c00b4c594d3c9e3583a48865c1d3047aae9ed0c
+          value: 68a2b56ce48c1e6326ef7b817244e60a0eda7bc63e0c14c25cc3c14a8eaf13bb
       volumes:
         - name: runner
           emptyDir: {}

--- a/ansible/roles/ocp4-workload-migration/templates/mig-operator-subscription-downstream.yml.j2
+++ b/ansible/roles/ocp4-workload-migration/templates/mig-operator-subscription-downstream.yml.j2
@@ -4,9 +4,9 @@ metadata:
   name: mtc-operator
   namespace: {{ mig_migration_namespace }}
 spec:
-  channel: release-v1.3
+  channel: release-v1.4
   installPlanApproval: Manual
-  startingCSV: mtc-operator.v1.3.2
+  startingCSV: mtc-operator.v1.4.0
   name: mtc-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
##### SUMMARY

This PR is pulling in the updates to the MTC versions for the workshop roles. 
Fixes #3429  .

##### ISSUE TYPE

- Update role template Pull Request

##### COMPONENT NAME

Updating the required templates within the following roles:

- ocp-workload-migration
- ocp4-workload-migration
