### PR TITLE
updated jh pod sizing

### DIFF
--- a/ansible/roles/ocp4_workload_ai_ml_workflows_demo/templates/workshop-singleuser-profile.yml.j2
+++ b/ansible/roles/ocp4_workload_ai_ml_workflows_demo/templates/workshop-singleuser-profile.yml.j2
@@ -14,10 +14,10 @@ data:
           value: s3.odh.com
       resources:
         requests:
-          memory: 1Gi
+          memory: 2Gi
           cpu: 500m
         limits:
-          memory: 2Gi
+          memory: 4Gi
           cpu: 1
 
     - name: Workshop Notebook


### PR DESCRIPTION
Increased Pod Sizing for JupyterHub. 

This means users can run the lab or demo without shutting down notebooks. 