### PR TITLE
Add role ocp4_approve_certificate_signing_requests

### DIFF
--- a/ansible/configs/ocp4-cluster/lifecycle_hook_post_start.yml
+++ b/ansible/configs/ocp4-cluster/lifecycle_hook_post_start.yml
@@ -41,41 +41,6 @@
     set_fact:
       ansible_python_interpreter: /opt/virtualenvs/k8s/bin/python
 
-  - name: Recover cluster if it missed cert rotation
-    when: ACTION == 'start'
-    block:
-    - name: Wait (default 3m) for Nodes to settle and pods to start
-      pause:
-        seconds: "{{ lifecycle_start_pause | default(180) }}"
-
-    - name: Get CSRs that need to be approved
-      k8s_facts:
-        api_version: certificates.k8s.io/v1beta1
-        kind: CertificateSigningRequest
-        # Field selectors don't seem to work
-        # field_selectors:
-        # - status.conditions[0].type="Pending"
-      register: r_csrs
-
-    - name: Approve all Pending CSRs
-      when: r_csrs.resources | length > 0
-      command: "oc adm certificate approve {{ item.metadata.name }}"
-      loop: "{{ r_csrs.resources }}"
-
-    - name: Wait 10s for additional CSRs to appear
-      pause:
-        seconds: 10
-
-    - name: Get additional CSRs that need to be approved
-      k8s_facts:
-        api_version: certificates.k8s.io/v1beta1
-        kind: CertificateSigningRequest
-        # Field selectors don't seem to work
-        # field_selectors:
-        # - status.conditions[0].type = "Pending"
-      register: r_new_csrs
-
-    - name: Approve all additional Pending CSRs
-      when: r_new_csrs.resources | length > 0
-      command: "oc adm certificate approve {{ item.metadata.name }}"
-      loop: "{{ r_new_csrs.resources }}"
+  - name: Approve CertificateSigningRequests
+    include_role:
+      name: ocp4_approve_certificate_signing_requests

--- a/ansible/configs/ocp4-cluster/lifecycle_hook_post_start.yml
+++ b/ansible/configs/ocp4-cluster/lifecycle_hook_post_start.yml
@@ -42,5 +42,6 @@
       ansible_python_interpreter: /opt/virtualenvs/k8s/bin/python
 
   - name: Approve CertificateSigningRequests
+    when: ACTION == 'start'
     include_role:
       name: ocp4_approve_certificate_signing_requests

--- a/ansible/roles/ocp4_approve_certificate_signing_requests/README.adoc
+++ b/ansible/roles/ocp4_approve_certificate_signing_requests/README.adoc
@@ -1,0 +1,17 @@
+= ocp4_approve_certificate_signing_requests
+
+Find and approve CertificateSigningRequests (CSRs) in OpenShift 4 clusters.
+
+While these certificates are normally automatically approved, there are some circumstances where this fails and manual approval is needed, particularly after cluster restart.
+
+== Configuration
+
+`ocp4_approve_certificate_signing_requests_initial_delay` -
+Initial delay to wait for cluster node and pod start-up. Default 210 seconds.
+
+`ocp4_approve_certificate_signing_requests_recheck_delay` -
+Delay between rechecks for more CertificateSigningRequests to appear. Default 30 seconds.
+
+`ocp4_approve_certificate_signing_requests_retries` -
+Maximum number of retries when waiting for CertificateSigningRequests to appear. Default 10.
+

--- a/ansible/roles/ocp4_approve_certificate_signing_requests/defaults/main.yml
+++ b/ansible/roles/ocp4_approve_certificate_signing_requests/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+# Initial delay to wait for cluster node and pod start-up
+ocp4_approve_certificate_signing_requests_initial_delay: 210
+
+# Delay between rechecks for more CertificateSigningRequests to appear
+ocp4_approve_certificate_signing_requests_recheck_delay: 30
+
+# Maximum number of retries when waiting for CertificateSigningRequests to appear
+ocp4_approve_certificate_signing_requests_retries: 10
+...

--- a/ansible/roles/ocp4_approve_certificate_signing_requests/meta/main.yaml
+++ b/ansible/roles/ocp4_approve_certificate_signing_requests/meta/main.yaml
@@ -1,0 +1,10 @@
+---
+galaxy_info:
+  author: Johnathan Kupferer <jkupfere@redhat.com>
+  description: OpenShift 4 CertificateSigningRequests approval.
+  company: Red Hat
+  license: BSD
+  min_ansible_version: 2.9
+  galaxy_tags: []
+
+dependencies: []

--- a/ansible/roles/ocp4_approve_certificate_signing_requests/tasks/approve-certificate-signing-requests.yml
+++ b/ansible/roles/ocp4_approve_certificate_signing_requests/tasks/approve-certificate-signing-requests.yml
@@ -1,0 +1,30 @@
+---
+- name: Get CertificateSigningRequests that need to be approved
+  k8s_info:
+    api_version: certificates.k8s.io/v1beta1
+    kind: CertificateSigningRequest
+  register: r_csrs
+
+- name: Approve CerrtificateSigningRequests
+  when: r_csrs.resources | default([]) | length > 0
+  block:
+  - name: Approve all pending CertificateSigningRequests
+    loop: "{{ r_csrs.resources | default([]) }}"
+    command: "oc adm certificate approve {{ item.metadata.name }}"
+
+  - name: Wait and recheck for more CertificateSigningRequests
+    when: ocp4_approve_certificate_signing_requests_iteration < ocp4_approve_certificate_signing_requests_retries
+    block:
+    - name: Wait for additional CertificateSigningRequests to appear
+      pause:
+        seconds: "{{ ocp4_approve_certificate_signing_requests_recheck_delay }}"
+
+    - name: Increment ocp4_approve_certificate_signing_requests_iteration
+      set_fact:
+        ocp4_approve_certificate_signing_requests_iteration: >-
+          {{ 1 + ocp4_approve_certificate_signing_requests_iteration | int }}
+
+    - name: Repeat CertificateSigningRequest approval
+      include_tasks:
+        file: approve-certificate-signing-requests.yml
+...

--- a/ansible/roles/ocp4_approve_certificate_signing_requests/tasks/approve-certificate-signing-requests.yml
+++ b/ansible/roles/ocp4_approve_certificate_signing_requests/tasks/approve-certificate-signing-requests.yml
@@ -6,14 +6,20 @@
   register: r_csrs
 
 - name: Approve CerrtificateSigningRequests
-  when: r_csrs.resources | default([]) | length > 0
+  vars:
+    __unsigned_csr_names: >-
+      {{ r_csrs.resources | default([]) | to_json | from_json
+       | json_query("[?status.conditions[?type=='Approved' && status=='True']==`null`].metadata.name")
+      }}
+  when: __unsigned_csr_names | length > 0
   block:
   - name: Approve all pending CertificateSigningRequests
-    loop: "{{ r_csrs.resources | default([]) }}"
-    command: "oc adm certificate approve {{ item.metadata.name }}"
+    loop: "{{ __unsigned_csr_names | default([]) }}"
+    command: "oc adm certificate approve {{ item }}"
+    ignore_errors: true
 
   - name: Wait and recheck for more CertificateSigningRequests
-    when: ocp4_approve_certificate_signing_requests_iteration < ocp4_approve_certificate_signing_requests_retries
+    when: ocp4_approve_certificate_signing_requests_iteration | int <= ocp4_approve_certificate_signing_requests_retries | int
     block:
     - name: Wait for additional CertificateSigningRequests to appear
       pause:

--- a/ansible/roles/ocp4_approve_certificate_signing_requests/tasks/main.yml
+++ b/ansible/roles/ocp4_approve_certificate_signing_requests/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+- name: Wait for Nodes to settle and pods to start
+  pause:
+    seconds: "{{ ocp4_approve_certificate_signing_requests_initial_delay }}"
+
+- name: Initialize ocp4_approve_certificate_signing_requests_iteration
+  set_fact:
+    ocp4_approve_certificate_signing_requests_iteration: 0
+
+- name: Approve CertificateSigningRequests
+  include_tasks:
+    file: approve-certificate-signing-requests.yml
+...


### PR DESCRIPTION
##### SUMMARY

Add role ocp4_approve_certificate_signing_requests to implement retry loop to wait for CertificateSigningRequests and approve them. Use new role in ocp4-cluster start lifecycle hook.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Role ocp4_approve_certificate_signing_requests
Config ocp4-cluster