### PR TITLE
adding floating_subnet: workaround to additional_fips in ansible/role…

### DIFF
--- a/ansible/roles-infra/infra-osp-template-generate/templates/cloud_template_master.j2
+++ b/ansible/roles-infra/infra-osp-template-generate/templates/cloud_template_master.j2
@@ -221,6 +221,15 @@ resources:
     type: OS::Neutron::FloatingIP
     properties:
       floating_network: "{{ additional_fips[fipname].network }}"
+      floating_subnet:
+        get_attr:
+          - {{ instance['network'] | default('default') }}-router
+          - external_gateway_info
+          - external_fixed_ips
+          - 0
+          - subnet_id
+    depends_on:
+      - {{ instance['network'] | default('default') }}-router_private_interface
 {% if additional_fips[fipname].description is defined %}
       value_specs:
         description: "{{ additional_fips[fipname].description }}"


### PR DESCRIPTION
##### SUMMARY

  Change to add the floating_subnet: workaround to the additional_fips section.  the fip_iname section on line 131, but had been missed for the "additional_fips" object down near line 222, so some labs are failing due to mismatches on these IPs (for OCP labs especially)

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
- ansible/roles-infra/infra-osp-template-generate/templates/cloud_template_master.j2
