### PR TITLE
Update config ocp4-cluster post_software.yml to remove PHP test

### DIFF
--- a/ansible/configs/ocp4-workshop/post_software.yml
+++ b/ansible/configs/ocp4-workshop/post_software.yml
@@ -310,19 +310,10 @@
       register: mysqlw
       changed_when: false
 
-    - name: Wait for php
-      command: timeout 300 oc rollout status dc/cakephp-mysql-persistent -w -n postflightcheck
-      register: phpw
-      changed_when: false
-      retries: 2
-      delay: 60
-      until: phpw is succeeded
-
     - name: Get route
       command: >-
         oc get route
         -l template=cakephp-mysql-persistent
-        --false-headers
         -o json
         -n postflightcheck
       register: getroute
@@ -355,7 +346,7 @@
       - "Web console ................... {{ 'OK' if testwebconsole is succeeded else 'FAIL' }}"
       - "API ........................... {{ 'OK' if clusterinfor.rc == 0 else 'FAIL' }}"
       - "Create Project with PV ........ {{ 'OK' if newproject.rc == 0 else 'FAIL' }}"
-      - "App deployed .................. {{ 'OK' if phpw.rc == 0 and mysqlw.rc == 0 else 'FAIL' }}"
+      - "App deployed .................. {{ 'OK' if mysqlw.rc == 0 else 'FAIL' }}"
       - "Route ......................... {{ 'OK' if testroute is succeeded else 'FAIL' }}"
       when: ocp4_workshop_show_flight_check_user_info | bool
 
@@ -367,7 +358,6 @@
         or testwebconsole is failed
         or clusterinfor.rc != 0
         or newproject.rc != 0
-        or phpw.rc != 0
         or mysqlw.rc != 0
         or testroute is failed
       fail:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

Remove obsolete PHP test from post_software stage.  It always fails and slows down all deployments using ocp4-workshop.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-workshop post_software

##### ADDITIONAL INFORMATION
