### PR TITLE
Fix role infra-osp-template-generate router name determination

### DIFF
--- a/ansible/roles-infra/infra-osp-template-generate/templates/cloud_template_master.j2
+++ b/ansible/roles-infra/infra-osp-template-generate/templates/cloud_template_master.j2
@@ -223,7 +223,7 @@ resources:
       floating_network: "{{ additional_fips[fipname].network }}"
       floating_subnet:
         get_attr:
-          - {{ instance['network'] | default('default') }}-router
+          - {{ networks | json_query('[?create_router].name|[0]') | default('default', true) }}-router
           - external_gateway_info
           - external_fixed_ips
           - 0


### PR DESCRIPTION
##### SUMMARY

Fix router name determination in additional fip logic.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role infra-osp-template-generate