### PR TITLE
Fix role infra-osp-template-generate additional fip depends_on clause

### DIFF
--- a/ansible/roles-infra/infra-osp-template-generate/templates/cloud_template_master.j2
+++ b/ansible/roles-infra/infra-osp-template-generate/templates/cloud_template_master.j2
@@ -233,7 +233,7 @@ resources:
         description: "{{ additional_fips[fipname].description }}"
 {%     endif %}
     depends_on:
-      - {{ instance['network'] | default('default') }}-router_private_interface
+      - {{ networks | json_query('[?create_router].name|[0]') | default('default', true) }}-router_private_interface
 {%   endfor %}
 {% endif %}
 


### PR DESCRIPTION
##### SUMMARY

Fix `depends_on` clause in heat template to use name of first network with a router.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role nfra-osp-template-generate