### PR TITLE
Updated image used for pulling image

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/templates/job-image-pull.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/templates/job-image-pull.j2
@@ -15,7 +15,7 @@ spec:
         - -c
         - |
           ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /tmp/ssh/private-key.pem administrator@{{ windows_node }} docker pull mcr.microsoft.com/windows/servercore:ltsc2019
-        image: quay.io/redhatworkshops/welcome-php:latest
+        image: quay.io/redhatworkshops/winc-ssh:latest
         name: windows-image-pull
         volumeMounts:
         - name: sshkey


### PR DESCRIPTION

##### SUMMARY

There was an issue where the image used to pull the Windows containers was failing.

```
$ oc get pods -n openshift-windows-machine-config-operator
NAME                                               READY   STATUS    RESTARTS   AGE
winc-ssh-6ddf8c6cbb-gd87n                          1/1     Running   0          179m
windows-image-pull-9bp5g                           0/1     Error     0          179m
windows-image-pull-dpb5b                           0/1     Error     0          176m
windows-image-pull-hmlwt                           0/1     Error     0          178m
windows-image-pull-jc9lj                           0/1     Error     0          178m
windows-image-pull-ljkkt                           0/1     Error     0          178m
windows-image-pull-shtlk                           0/1     Error     0          175m
windows-machine-config-operator-5975bcbfc6-hgj2k   1/1     Running   0          3h7m
```

This was due to the image being used for the Job being rebuilt (`quay.io/redhatworkshops/welcome-php:latest`) without ssh support. A new, more permanent, image specific for this Job was built/used/tested: `quay.io/redhatworkshops/winc-ssh:latest`

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Windows Containers
