### PR TITLE
Add ocp4_ansible_managed_osp_external_network to host-ocp4-installer

### DIFF
--- a/ansible/roles/host-ocp4-destroy/defaults/main.yml
+++ b/ansible/roles/host-ocp4-destroy/defaults/main.yml
@@ -3,3 +3,11 @@
 gcp_credentials_file: '{{ output_dir }}/gcp_credentials_file_{{ guid }}.json'
 # This needs to match what is in ocp4-cluster default_vars.yml
 cluster_name: 'cluster-{{ guid }}'
+
+# Configure OCP4 install to not configure the OpenStack external network
+# and have Ansible manage it instead.
+ocp4_ansible_managed_osp_external_network: false
+
+# Configure OpenStack networking to set machinesSubnet in the install config
+# to place the nodes on the internal subnet with the bastion.
+ocp_use_single_network: false

--- a/ansible/roles/host-ocp4-destroy/tasks/main.yml
+++ b/ansible/roles/host-ocp4-destroy/tasks/main.yml
@@ -24,6 +24,13 @@
     path: "/home/{{ ansible_user }}/{{ cluster_name }}/metadata.json"
   register: r_stat_metadata_json
 
+- name: Remove ansible manage external network configuration
+  when:
+  - ocp4_ansible_managed_osp_external_network
+  - r_stat_metadata_json.stat.exists
+  include_tasks:
+    file: remove-osp-external-network.yml
+
 - name: Run openshift-installer destroy cluster
   become: false
   tags:

--- a/ansible/roles/host-ocp4-destroy/tasks/remove-osp-external-network.yml
+++ b/ansible/roles/host-ocp4-destroy/tasks/remove-osp-external-network.yml
@@ -37,7 +37,7 @@
     __floating_ip_query: >-
       [?"Fixed IP Address"==`{{ __fixed_ip | to_json }}`].ID|[0]
     __floating_ip: >-
-      {{ r_list_floating_ip.stdout | from_json 
+      {{ r_list_floating_ip.stdout | from_json
        | json_query(__floating_ip_query)
       }}
   when: >-
@@ -66,7 +66,7 @@
     __floating_ip_query: >-
       [?"Fixed IP Address"==`{{ __fixed_ip | to_json }}`].ID|[0]
     __floating_ip: >-
-      {{ r_list_floating_ip.stdout | from_json 
+      {{ r_list_floating_ip.stdout | from_json
        | json_query(__floating_ip_query)
       }}
   when: >-

--- a/ansible/roles/host-ocp4-destroy/tasks/remove-osp-external-network.yml
+++ b/ansible/roles/host-ocp4-destroy/tasks/remove-osp-external-network.yml
@@ -1,0 +1,101 @@
+---
+- name: Read metadata.json
+  slurp:
+    path: ~{{ ansible_user }}/{{ cluster_name }}/metadata.json
+  register: r_read_metadata_json
+  until: r_read_metadata_json is success
+  retries: 10
+  delay: 5
+
+- name: Set ocp4_cluster_infra_id
+  set_fact:
+    ocp4_cluster_infra_id: "{{ (r_read_metadata_json.content | b64decode | from_json).infraID }}"
+
+- name: List floating ips
+  command: >-
+    openstack --os-cloud={{ osp_cloud_name }}
+    floating ip list -f json
+  changed_when: false
+  register: r_list_floating_ip
+
+- name: Get api-port
+  command: >-
+    openstack --os-cloud={{ osp_cloud_name }}
+    port show {{ ocp4_cluster_infra_id }}-api-port -f json
+  register: r_show_api_port
+  changed_when: false
+  failed_when: >-
+    r_show_api_port.rc != 0 and
+    'No Port found' not in r_show_api_port.stderr
+
+- name: Unset floating ip for api-port
+  vars:
+    __fixed_ip: >-
+      {{ r_show_api_port.stdout | from_json
+       | json_query('fixed_ips[0].ip_address')
+      }}
+    __floating_ip_query: >-
+      [?"Fixed IP Address"==`{{ __fixed_ip | to_json }}`].ID|[0]
+    __floating_ip: >-
+      {{ r_list_floating_ip.stdout | from_json 
+       | json_query(__floating_ip_query)
+      }}
+  when: >-
+    r_show_api_port.rc == 0 and
+    __floating_ip | default('') != ''
+  command: >-
+    openstack --os-cloud={{ osp_cloud_name }}
+    floating ip unset --port {{ __floating_ip }}
+
+- name: Get ingress-port
+  command: >-
+    openstack --os-cloud={{ osp_cloud_name }}
+    port show {{ ocp4_cluster_infra_id }}-ingress-port -f json
+  register: r_show_ingress_port
+  changed_when: false
+  failed_when: >-
+    r_show_ingress_port.rc != 0 and
+    'No Port found' not in r_show_ingress_port.stderr
+
+- name: Unset floating ip for ingress-port
+  vars:
+    __fixed_ip: >-
+      {{ r_show_ingress_port.stdout | from_json
+       | json_query('fixed_ips[0].ip_address')
+      }}
+    __floating_ip_query: >-
+      [?"Fixed IP Address"==`{{ __fixed_ip | to_json }}`].ID|[0]
+    __floating_ip: >-
+      {{ r_list_floating_ip.stdout | from_json 
+       | json_query(__floating_ip_query)
+      }}
+  when: >-
+    r_show_ingress_port.rc == 0 and
+    __floating_ip | default('') != ''
+  command: >-
+    openstack --os-cloud={{ osp_cloud_name }}
+    floating ip unset --port {{ __floating_ip }}
+
+- name: Remove node subnet from external router
+  command: >-
+    openstack --os-cloud={{ osp_cloud_name }}
+    router remove subnet {{ ocp4_cluster_infra_id }}-external-router
+    {% if ocp_use_single_network | bool %}
+    {{ internal_network_subnet_id }}
+    {% else %}
+    {{ ocp4_cluster_infra_id }}-nodes
+    {% endif %}
+  register: r_remove_subnet_for_external_router
+  failed_when: >-
+    r_remove_subnet_for_external_router.rc != 0 and
+    'No Subnet found' not in r_remove_subnet_for_external_router.stderr and
+    'No Router found' not in r_remove_subnet_for_external_router.stderr
+
+- name: Remove external router
+  command: >-
+    openstack --os-cloud={{ osp_cloud_name }}
+    router delete {{ ocp4_cluster_infra_id }}-external-router
+  register: r_delete_external_router
+  failed_when: >-
+    r_delete_external_router.rc != 0 and
+    'No Router found' not in r_delete_external_router.stderr

--- a/ansible/roles/host-ocp4-installer/defaults/main.yml
+++ b/ansible/roles/host-ocp4-installer/defaults/main.yml
@@ -10,8 +10,17 @@ ocp4_network_ovn_install_workaround: false
 # https://bugzilla.redhat.com/show_bug.cgi?id=1897603
 ocp4_scsi_device_detection_workaround: false
 
+# Configure OCP4 install to not configure the OpenStack external network
+# and have Ansible manage it instead.
+ocp4_ansible_managed_osp_external_network: true
+
 # To enable FIPS mode on an OpenShift 4 cluster
 ocp4_fips_enable: false
+
+# Configure OpenStack networking to set machinesSubnet in the install config
+# to place the nodes on the internal subnet with the bastion.
+ocp_use_single_network: false
+
 # When master_storage_type == io1 or io2,
 # calculate the IOPS:
 # IOPS = 2000 << number of worker * 100 << 32000

--- a/ansible/roles/host-ocp4-installer/tasks/configure-osp-external-network-for-install.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/configure-osp-external-network-for-install.yml
@@ -1,0 +1,67 @@
+---
+- name: Read metadata.json
+  slurp:
+    path: ~{{ ansible_user }}/{{ cluster_name }}/metadata.json
+  register: r_read_metadata_json
+  until: r_read_metadata_json is success
+  retries: 10
+  delay: 5
+
+- name: Set ocp4_cluster_infra_id
+  set_fact:
+    ocp4_cluster_infra_id: "{{ (r_read_metadata_json.content | b64decode | from_json).infraID }}"
+
+- name: Create OpenShift external router
+  command: >-
+    openstack --os-cloud={{ osp_cloud_name }}
+    router create {{ ocp4_cluster_infra_id }}-external-router
+
+- name: Set external gateway for OpenShift external router
+  command: >-
+    openstack --os-cloud={{ osp_cloud_name }}
+    router set {{ ocp4_cluster_infra_id }}-external-router
+    --external-gateway={{ provider_network | default('external') }}
+
+- name: Add OpenShift nodes subnet to router
+  command: >-
+    openstack --os-cloud={{ osp_cloud_name }}
+    router add subnet {{ ocp4_cluster_infra_id }}-external-router
+    {% if ocp_use_single_network | bool %}
+    {{ internal_network_subnet_id }}
+    {% else %}
+    {{ ocp4_cluster_infra_id }}-nodes
+    {% endif %}
+  # Initial attempt to add subnet may occur before the install creates the subnet
+  register: r_router_add_subnet
+  until: r_router_add_subnet is success
+  retries: 30
+  delay: 10
+  
+- name: Set floating ip to point to OpenShift api port
+  command: >-
+    openstack --os-cloud={{ osp_cloud_name }}
+    floating ip set --port {{ ocp4_cluster_infra_id }}-api-port {{ hostvars.localhost.ocp_api_fip }}
+  # Initial attempt to add subnet may occur before the install creates the api port
+  register: r_set_api_fip_port
+  until: r_set_api_fip_port is success
+  retries: 30
+  delay: 10
+
+- name: Set floating ip to point to OpenShift ingress port
+  command: >-
+    openstack --os-cloud={{ osp_cloud_name }}
+    floating ip set --port {{ ocp4_cluster_infra_id }}-ingress-port {{ hostvars.localhost.ocp_ingress_fip }}
+  # Initial attempt to add subnet may occur before the install creates the api port
+  register: r_ingress_fip_port
+  until: r_ingress_fip_port is success
+  retries: 30
+  delay: 10
+
+
+- name: Wait for openshift-install to complete
+  async_status:
+    jid: "{{ r_openshift_install.ansible_job_id }}"
+  register: r_openshift_install_wait
+  until: r_openshift_install_wait.finished
+  retries: 200
+  delay: 30

--- a/ansible/roles/host-ocp4-installer/tasks/configure-osp-external-network-for-install.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/configure-osp-external-network-for-install.yml
@@ -36,7 +36,7 @@
   until: r_router_add_subnet is success
   retries: 30
   delay: 10
-  
+
 - name: Set floating ip to point to OpenShift api port
   command: >-
     openstack --os-cloud={{ osp_cloud_name }}

--- a/ansible/roles/host-ocp4-installer/tasks/main.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/main.yml
@@ -6,7 +6,7 @@
 - name: OpenStack specific requirement - find network port id
   when:
   - cloud_provider == "osp"
-  - ocp_use_single_network | default(false) | bool
+  - ocp_use_single_network | bool
   import_tasks: osp_pre.yml
 
 - name: Generate install_config.yaml
@@ -23,7 +23,13 @@
     become: false
     command: openshift-install create cluster --dir=/home/{{ ansible_user }}/{{ cluster_name }}
     async: "{{ 2 * 60 * 60 }}"
-    poll: 15
+    poll: "{{ 0 if ocp4_ansible_managed_osp_external_network else 15 }}"
+    register: r_openshift_install
+
+  - name: Setup OpenStack external network during install
+    when: ocp4_ansible_managed_osp_external_network | bool
+    include_tasks:
+      file: configure-osp-external-network-for-install.yml
 
   rescue:
   - name: Run destroy to reset before retry
@@ -49,7 +55,13 @@
     become: false
     command: openshift-install create cluster --dir=/home/{{ ansible_user }}/{{ cluster_name }}
     async: "{{ 2 * 60 * 60 }}"
-    poll: 15
+    poll: "{{ 0 if ocp4_ansible_managed_osp_external_network else 15 }}"
+    register: r_openshift_install
+
+  - name: Setup OpenStack external network during install retry
+    when: ocp4_ansible_managed_osp_external_network | bool
+    include_tasks:
+      file: configure-osp-external-network-for-install.yml
 
   always:
   - name: Gzip Install log

--- a/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
+++ b/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
@@ -105,14 +105,16 @@ platform:
 {% if cloud_provider == 'osp' %}
   openstack:
     cloud: {{ osp_cloud_name | to_json }}
-{% if ocp_use_single_network | default(false) | bool %}
+{%   if ocp_use_single_network | bool %}
     machinesSubnet: "{{ internal_network_subnet_id }}"
-{% endif %}
+{%   endif %}
     computeFlavor: {{ worker_instance_type | to_json }}
+{%   if not ocp4_ansible_managed_osp_external_network | bool %}
     externalNetwork: {{ provider_network | default('external') | to_json }}
     lbFloatingIP: {{ hostvars.localhost.ocp_api_fip | to_json }}
-{%   if ocp4_installer_version is version_compare('4.6.0', '>=') %}
+{%     if ocp4_installer_version is version_compare('4.6.0', '>=') %}
     ingressFloatingIP: {{ hostvars.localhost.ocp_ingress_fip | to_json }}
+{%     endif %}
 {%   endif %}
 {%   if ocp4_installer_version is version_compare('4.6.0', '<') %}
     octaviaSupport: {{ osp_octavia_support | default(true) | bool | to_json }}


### PR DESCRIPTION
##### SUMMARY

Add feature to use Ansible to manage the external network setup for the host-ocp4-installer role. This allows avoiding using a floating IP address for the bootstrap node and so provides a work-around for our current issues with OpenStack floating ips assigned to separate subnets.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Roles host-ocp4-installer & host-ocp4-destroy