### PR TITLE
Set default ocp4_ansible_managed_osp_external_network to false

### DIFF
--- a/ansible/roles/host-ocp4-destroy/tasks/main.yml
+++ b/ansible/roles/host-ocp4-destroy/tasks/main.yml
@@ -26,7 +26,7 @@
 
 - name: Remove ansible manage external network configuration
   when:
-  - ocp4_ansible_managed_osp_external_network
+  - ocp4_ansible_managed_osp_external_network | bool
   - r_stat_metadata_json.stat.exists
   include_tasks:
     file: remove-osp-external-network.yml

--- a/ansible/roles/host-ocp4-installer/defaults/main.yml
+++ b/ansible/roles/host-ocp4-installer/defaults/main.yml
@@ -12,7 +12,7 @@ ocp4_scsi_device_detection_workaround: false
 
 # Configure OCP4 install to not configure the OpenStack external network
 # and have Ansible manage it instead.
-ocp4_ansible_managed_osp_external_network: true
+ocp4_ansible_managed_osp_external_network: false
 
 # To enable FIPS mode on an OpenShift 4 cluster
 ocp4_fips_enable: false

--- a/ansible/roles/host-ocp4-installer/tasks/main.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/main.yml
@@ -23,7 +23,7 @@
     become: false
     command: openshift-install create cluster --dir=/home/{{ ansible_user }}/{{ cluster_name }}
     async: "{{ 2 * 60 * 60 }}"
-    poll: "{{ 0 if ocp4_ansible_managed_osp_external_network else 15 }}"
+    poll: "{{ 0 if ocp4_ansible_managed_osp_external_network | bool else 15 }}"
     register: r_openshift_install
 
   - name: Setup OpenStack external network during install
@@ -55,7 +55,7 @@
     become: false
     command: openshift-install create cluster --dir=/home/{{ ansible_user }}/{{ cluster_name }}
     async: "{{ 2 * 60 * 60 }}"
-    poll: "{{ 0 if ocp4_ansible_managed_osp_external_network else 15 }}"
+    poll: "{{ 0 if ocp4_ansible_managed_osp_external_network | bool else 15 }}"
     register: r_openshift_install
 
   - name: Setup OpenStack external network during install retry


### PR DESCRIPTION
##### SUMMARY

This new feature was supposed to default to disabled. Fix default value in host-ocp4-installer

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role host-ocp4-installer