### PR TITLE
add more retries for sso pod to start

### DIFF
--- a/ansible/roles/ocp-workload-3scale-demo/tasks/config.yml
+++ b/ansible/roles/ocp-workload-3scale-demo/tasks/config.yml
@@ -7,7 +7,7 @@
     validate_certs: no
   register: wait_sso_result
   until: wait_sso_result is succeeded
-  retries: 15
+  retries: 30
   delay: 60
 
 - name: Retrieve SSO admin credentials


### PR DESCRIPTION
add more retries for sso pod to start

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
the SSO Pod showing not enough time to start so the deployment fails. Upped the retries from 15 to 30x

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
