### PR TITLE
Updated size on Windows node

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/templates/windows-ms.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/templates/windows-ms.j2
@@ -38,7 +38,7 @@ spec:
           deviceIndex: 0
           iamInstanceProfile:
             id: "{{ cluster_id }}-worker-profile"
-          instanceType: m5a.large
+          instanceType: m5a.4xlarge
           kind: AWSMachineProviderConfig
           placement:
             availabilityZone: "{{ cluster_az }}"


### PR DESCRIPTION
##### SUMMARY

Updated size of Windows Node to be the same as the Linux node: m5a.4xlarge

This is to support the .NET application sample that will be coming in the next few weeks. The current size is too small for the application being deployed.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Windows machine set

##### ADDITIONAL INFORMATION

This PR just updates the size of the machineset used.
