### PR TITLE
Fix version mismatch in role ocp4_workload_cyberark_dap

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_cyberark_dap/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cyberark_dap/defaults/main.yml
@@ -9,6 +9,6 @@ num_users: "100"
 ocp4_workload_cyberark_project: "cyberlab"
 
 # Hosted location of CyberArk Setup files
-ocp4_workload_cyberark_setup_files_url: "https://github.com/conjurdemos/ocp4-workshop-setup/archive/v1.0.7.tar.gz"
-
-ocp4_workload_cyberark_setup_files_release: "ocp4-workshop-setup-1.0.6"
+ocp4_workload_cyberark_setup_version: "1.0.7"
+ocp4_workload_cyberark_setup_files_url: "https://github.com/conjurdemos/ocp4-workshop-setup/archive/v{{ ocp4_workload_cyberark_setup_version }}.tar.gz"
+ocp4_workload_cyberark_setup_files_release: "ocp4-workshop-setup-{{ ocp4_workload_cyberark_setup_version }}"


### PR DESCRIPTION
##### SUMMARY

The version for ocp4_workload_cyberark_dap was mismatched between 1.0.6 and 1.0.7 in two variables. This consolidates the version to one variable.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role ocp4_workload_cyberark_dap