### PR TITLE
Fixe glitch on sandboxes - CI AgD training

### DIFF
--- a/ansible/roles-infra/infra-osp-project-create/tasks/main.yml
+++ b/ansible/roles-infra/infra-osp-project-create/tasks/main.yml
@@ -27,7 +27,7 @@
     OS_PROJECT_NAME: "{{ osp_project_name }}"
     OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
     OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"
-  block: 
+  block:
   - name: Get public subnet to use
     shell: |
       openstack ip availability show external -f json | jq -r '.subnet_ip_availability | min_by(.used_ips) | .subnet_id'

--- a/ansible/roles-infra/infra-osp-project-create/tasks/main.yml
+++ b/ansible/roles-infra/infra-osp-project-create/tasks/main.yml
@@ -18,6 +18,25 @@
     osp_auth_username_member: "{{ guid }}-user"
 
 - when: >-
+    not osp_project_create | bool
+    or osp_project_id is defined
+  environment:
+    OS_AUTH_URL: "{{ osp_auth_url }}"
+    OS_USERNAME: "{{ osp_auth_username_member }}"
+    OS_PASSWORD: "{{ osp_auth_password_member }}"
+    OS_PROJECT_NAME: "{{ osp_project_name }}"
+    OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
+    OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"
+  block: 
+  - name: Get public subnet to use
+    shell: |
+      openstack ip availability show external -f json | jq -r '.subnet_ip_availability | min_by(.used_ips) | .subnet_id'
+    register: r_floating_subnet
+  - name: Set fact for public subnet
+    set_fact:
+      osp_public_subnet: "{{ r_floating_subnet.stdout }}"
+
+- when: >-
     osp_project_create | bool
     or osp_project_id is not defined
     or osp_create_sandbox | bool


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

fixing the bug on OSP sanboxes where it was not generating the OSP public subnet variable due to the when conditional set to look for a newly created project.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
roles-infra/infra-osp-project-create/tasks/main.yml

##### ADDITIONAL INFORMATION
