### PR TITLE
Fix failing tkn bash completion by createing a link

### DIFF
--- a/ansible/roles_studentvm/studentvm_ocp4/tasks/main.yml
+++ b/ansible/roles_studentvm/studentvm_ocp4/tasks/main.yml
@@ -82,7 +82,13 @@
       group: root
       mode: 0775
     args:
-      creates: "{{ studentvm_ocp4_bin_path }}/tkn"
+      creates: "{{ studentvm_ocp4_bin_path }}/tkn-linux-amd64"
+
+      - name: Link tkn-linux-amd64 to tkn
+    file:
+      state: link
+      path: "{{ studentvm_ocp4_bin_path }}/tkn"
+      src: "{{ studentvm_ocp4_bin_path }}/tkn-linux-amd64"
 
   - name: Download OpenShift Serverless CLI (kn)
     unarchive:


### PR DESCRIPTION
##### SUMMARY

StudentVM kept failing because the binary in the Tekton archive changed from `tkn` to `tkn-linux-amd64`. Fixed by creating a link from `tkn-linux-amd64` to `tkn`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
studentvm_ocp4
