### PR TITLE
Revert / fix tkn executable name

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_pipelines/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_pipelines/tasks/workload.yml
@@ -17,14 +17,7 @@
     owner: root
     group: root
   args:
-    creates: /usr/bin/tkn-linux-amd64
-
-- name: Link tkn-linux-amd64 to tkn
-  become: true
-  file:
-    state: link
-    path: /usr/bin/tkn
-    src: /usr/bin/tkn-linux-amd64
+    creates: /usr/bin/tkn
 
 - name: Create tkn bash completion file
   become: true

--- a/ansible/roles_studentvm/studentvm_ocp4/tasks/main.yml
+++ b/ansible/roles_studentvm/studentvm_ocp4/tasks/main.yml
@@ -82,13 +82,7 @@
       group: root
       mode: 0775
     args:
-      creates: "{{ studentvm_ocp4_bin_path }}/tkn-linux-amd64"
-
-  - name: Link tkn-linux-amd64 to tkn
-    file:
-      state: link
-      path: "{{ studentvm_ocp4_bin_path }}/tkn"
-      src: "{{ studentvm_ocp4_bin_path }}/tkn-linux-amd64"
+      creates: "{{ studentvm_ocp4_bin_path }}/tkn"
 
   - name: Download OpenShift Serverless CLI (kn)
     unarchive:


### PR DESCRIPTION
##### SUMMARY

tkn executable changed back to just `tkn`... removing the link step again.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
studentvm_ocp4
ocp4_workload_pipelines
