### PR TITLE
Adding selinux restorecon command for the tkn files to resolve selinu…

### DIFF
--- a/ansible/roles_studentvm/studentvm_ocp4/tasks/main.yml
+++ b/ansible/roles_studentvm/studentvm_ocp4/tasks/main.yml
@@ -90,6 +90,9 @@
       path: "{{ studentvm_ocp4_bin_path }}/tkn"
       src: "{{ studentvm_ocp4_bin_path }}/tkn-linux-amd64"
 
+  - name: Run restore context to reload selinux
+    shell: restorecon -R -v "{{ studentvm_ocp4_bin_path }}/tkn {{ studentvm_ocp4_bin_path }}/tkn-linux-amd64"
+
   - name: Download OpenShift Serverless CLI (kn)
     unarchive:
       src: >-


### PR DESCRIPTION
…x error in the deployer
##### SUMMARY

TASK [studentvm_ocp4 : Link tkn-linux-amd64 to tkn] ****************************
Thursday 11 March 2021  06:29:27 +0000 (0:00:08.559)       0:11:38.217 ******** 
fatal: [studentvm.xsznv.internal]: FAILED! => {"changed": false, "gid": 0, "group": "root", "mode": "0775", "msg": "src file does not exist, use \\"force=yes\\" if you really want to create the link: /usr/local/bin/tkn-linux-amd64", "owner": "root", "path": "/usr/local/bin/tkn", "secontext": "unconfined_u:object_r:bin_t:s0", "size": 48966480, "src": "/usr/local/bin/tkn-linux-amd64", "state": "file", "uid": 0}

Adding a restorecon command to force context back in

##### ISSUE TYPE
- Bugfix Pull Request

##### OCP4_STUDENTVM tasks main.yml
