### PR TITLE
Retry channels set up while serverless is coming ready

### DIFF
--- a/ansible/configs/sap-integration/custom_workloads.yml
+++ b/ansible/configs/sap-integration/custom_workloads.yml
@@ -234,11 +234,19 @@
   k8s:
     state: present
     resource_definition: "{{ lookup( 'template', './files/k8s/channel_ordercheck.j2' ) | from_yaml }}"
+  register: k8sres
+  until: k8sres.failed == False
+  retries: 30
+  delay: 10
 
 - name: Create Channel ReturnTxt
   k8s:
     state: present
     resource_definition: "{{ lookup( 'template', './files/k8s/channel_returntxt.j2' ) | from_yaml }}"
+  register: k8sres
+  until: k8sres.failed == False
+  retries: 30
+  delay: 10
 
 - name: Create Integration ODATA
   k8s:


### PR DESCRIPTION
##### SUMMARY

Deployment is failing while creating Channels as the CRD does not exist. Adding retry option to the play to give it enough option for the CRD to be created.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
sap-integration

