### PR TITLE
Fix role set-repositories not removing existing repos before enabling repos from rhel_repos variable

### DIFF
--- a/ansible/roles/set-repositories/tasks/satellite-repos.yml
+++ b/ansible/roles/set-repositories/tasks/satellite-repos.yml
@@ -117,6 +117,16 @@
   - use_content_view
   - set_repositories_satellite_activationkey != ''
 
+# Remove all repos when using rhel_repos 
+# This will resolve any dependency issues with unwanted repositories still being enabled
+- name: Purge existing repos
+  rhsm_repository:
+    name: '*'
+    purge: true
+  when:
+    - not use_content_view
+    - rhel_repos is defined
+
 - name: Enable repos for RHEL
   rhsm_repository:
     name: "{{ item }}"


### PR DESCRIPTION
##### SUMMARY

I am using ansible-multitier-infra as the basis for a new config.  When `repo_method: satellite` and `use_content_view: false`, the role `set-repositories` runs `satellite-repos.yml`.  The  task `Enable repos for RHEL` only verifies that repos that are not in the `rhel_repos` variable are enabled.  The EPEL 8 repo is still enabled, even though it's not my `rhel_repos` and causes issues with dependencies on several packages
Adding a task to `satellite-repos.yml` to purge all repos before applying the `rhel_repos` list resolves this as only defined repos will be used.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
satellite-repos.yml

##### ADDITIONAL INFORMATION
variables used: 

```
# Default Image

__image: rhel-server-7.8

use_content_view: false
rhel_repos:
  - rhel-7-server-rpms
  - rhel-7-server-rh-common-rpms
  - rhel-7-server-extras-rpms
  - Red_Hat_GPTE_Labs_Extra_Packages_for_Enterprise_Linux_EPEL_RHEL_7
  - rhel-7-server-optional-rpms
  - rhel-server-rhscl-7-rpms
  - rhel-7-server-ansible-2.9-rpms
```
Without purging repos: (truncated)

```
TASK [common : install common packages for RHEL 7] ****
fatal: [tower]: FAILED! => {"attempts": 10, "changed": false, "changes": {"installed": ["python3", "python3-pip", "unzip", "bash-completion", "tmux", "bind-utils", "wget", "git", "vim-enhanced", "at", "tree", "nano", "ansible"]}, 
"msg": "Error: Package: ansible-2.9.17-1.el8.noarch (Red_Hat_GPTE_Labs_Extra_Packages_for_Enterprise_Linux_EPEL_8)\n  
```
With purging repos there are no dependency issues.

```
TASK [common : install common packages for RHEL 7] ****************************************************************************************************
Monday 15 March 2021  15:57:42 -0700 (0:00:00.015)       0:04:33.088 ********** 
changed: [bastion]
changed: [tower]
```


