### PR TITLE
Update ansible / configs / aro

### DIFF
--- a/ansible/configs/aro/.yamllint
+++ b/ansible/configs/aro/.yamllint
@@ -9,5 +9,5 @@ rules:
   indentation:
     indent-sequences: consistent
   line-length:
-    max: 120
+    max: 160
     allow-non-breakable-inline-mappings: true

--- a/ansible/configs/aro/post_software.yml
+++ b/ansible/configs/aro/post_software.yml
@@ -113,11 +113,11 @@
     AZURE_CONFIG_DIR: "/tmp/.azure-{{ project_tag }}"
     PATH: '{{ output_dir }}:/usr/bin:/usr/local/bin'
   tasks:
-    - name: Get the Command Line Clients for OpenShift 4.3
+    - name: Get the Command Line Clients for OpenShift 4.6
       block:
-        - name: Get the OpenShift CLI for OCP 4.3
+        - name: Get the OpenShift CLI for OCP 4.6
           unarchive:
-            src: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-4.3/openshift-client-linux.tar.gz"
+            src: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-4.6/openshift-client-linux.tar.gz"
             remote_src: true
             dest: "{{ output_dir }}"
             mode: 0775
@@ -150,6 +150,11 @@
     - name: Update OAuth configuration on the cluster to add AAD
       command: >
           oc apply -f {{ output_dir }}/aad-oidc.yaml
+      when: aro_version == "4"
+
+    - name: Adding MongoDB Persistent Template (Removed in OpenShift 4.6 for some reason)
+      command: >
+          oc create -f https://raw.githubusercontent.com/openshift/origin/master/examples/db-templates/mongodb-persistent-template.json
       when: aro_version == "4"
 
     - name: Logout of the ARO cluster


### PR DESCRIPTION
##### SUMMARY

OpenShift 4.6 removed the mongodb-persistent template from the OpenShift namespace, this breaks a widely used lab called ARO Workshop which is used in both the Red Hat and Microsoft fields.

This fix readds that template to hold us over until ARO Workshop can be updated to use more modern practices like operators.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
post_software.yaml in aro config

##### ADDITIONAL INFORMATION
Also updates the OpenShift client used from from 4.3 to version 4.6.