### PR TITLE
Add reasonable default for studentvm_ocp4_user_name

### DIFF
--- a/ansible/roles_studentvm/studentvm_ocp4/defaults/main.yml
+++ b/ansible/roles_studentvm/studentvm_ocp4/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
-  # User Name to install odo bash completion for
-studentvm_ocp4_user_name: ""
+# User Name to install odo bash completion for
+studentvm_ocp4_user_name: "{{ student_name | default(ansible_user) }}"
 # Where to install all the executables
 studentvm_ocp4_bin_path: /usr/local/bin
 

--- a/ansible/roles_studentvm/studentvm_ocp4/tasks/main.yml
+++ b/ansible/roles_studentvm/studentvm_ocp4/tasks/main.yml
@@ -149,7 +149,7 @@
 
   - name: Install Bash Completion for odo
     blockinfile:
-      dest: "/home/{{ studentvm_ocp4_user_name }}/.bashrc"
+      dest: "~{{ studentvm_ocp4_user_name }}/.bashrc"
       insertafter: EOF
       marker: "# <!-- {mark} ANSIBLE MANAGED BLOCK (odo) -->"
       block: |


### PR DESCRIPTION
##### SUMMARY

The role studentvm_ocp4 current fails if the user name is not set. A reasonable default is to use `student_name` if available and otherwise fall back to `ansible_user`.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Role studentvm_ocp4