### PR TITLE
ocp4_workload_dm7_exp_elt: clusterresourcequota name cannot contain underscore

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_dm7_exp_elt/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_dm7_exp_elt/tasks/pre_workload.yml
@@ -6,6 +6,8 @@
   k8s:
     state: present
     definition: "{{ lookup('template', role_path ~ '/templates/clusterresourcequota.j2' ) | from_yaml }}"
+  vars:
+    clusterresourcequota_name: "{{ (ocp_username + '-' + guid) | replace('_','-') }}"
   when: ocp4_workload_dm7_exp_elt_ocp_user_needs_quota|default(False)|bool
 
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_dm7_exp_elt/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_dm7_exp_elt/tasks/remove_workload.yml
@@ -31,7 +31,7 @@
 - name: remove user quota - clusterresourcequota
   k8s:
     state: absent
-    name: "clusterquota-{{ ocp_username }}-{{ guid }}"
+    name: "clusterquota-{{ (ocp_username + '-' + guid) | replace('_','-') }}"
     kind: ClusterResourceQuota
     api_version: quota.openshift.io/v1
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_dm7_exp_elt/templates/clusterresourcequota.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_dm7_exp_elt/templates/clusterresourcequota.j2
@@ -2,7 +2,7 @@
 apiVersion: quota.openshift.io/v1
 kind: ClusterResourceQuota
 metadata:
-  name: clusterquota-{{ ocp_username }}-{{ guid }}
+  name: clusterquota-{{ clusterresourcequota_name }}
   labels:
     workload: ocp4-workload-dm7-exp-elt
 spec:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
role:roles_ocp_workloads/ocp4_workload_dm7_exp_elt

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
clusterresourcequota deployment fails when ocp_user has underscore in its value.
Fix: replace '_' with '-' in clusterresourcequota name.
<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
