### PR TITLE
Update roles stackrox for increase retries

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_stackrox_central/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_stackrox_central/tasks/workload.yml
@@ -20,7 +20,7 @@
     namespace: stackrox
     name: central
   register: r_stackrox_central_route
-  retries: 5
+  retries: 10
   delay: 20
 
 - name: Store central route as a fact
@@ -44,5 +44,5 @@
     validate_certs: no
   register: result
   until: result.status == 200
-  retries: 8
+  retries: 15
   delay: 20

--- a/ansible/roles_ocp_workloads/ocp4_workload_stackrox_sensor/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_stackrox_sensor/tasks/workload.yml
@@ -32,7 +32,7 @@
     - r_stackrox_sensor_deployment.resources[0].status.readyReplicas is defined
     - r_stackrox_sensor_deployment.resources[0].status.readyReplicas | int >= 1
   delay: 20
-  retries: 6
+  retries: 15
 
 - name: Determine number of collectors
   kubernetes.core.k8s_info:
@@ -55,4 +55,4 @@
 # yamllint disable-line rule:line-length
     - r_stackrox_collector_daemonset.resources[0].status.numberReady | int == r_stackrox_collector_daemonset.resources[0].status.desiredNumberScheduled | int
   delay: 20
-  retries: 6
+  retries: 15


### PR DESCRIPTION
##### SUMMARY

Increasing the retries to wait for ready replicas. Should not be a problem, but this just adds some more buffer since we ran into a few issues.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_stackrox_central
ocp4_workload_stackrox_sensor