### PR TITLE
Fix missing GUID. Closes #3548

### DIFF
--- a/ansible/roles/bastion/tasks/main.yml
+++ b/ansible/roles/bastion/tasks/main.yml
@@ -188,8 +188,8 @@
     - install_bash_customization
 
 - name: Install .bash_profile
-  copy:
-    src: ../files/bash_profile
+  template:
+    src: ../templates/bash_profile.j2
     dest: "{{ item.directory }}/.bash_profile"
     mode: 0644
     owner: "{{ item.user }}"

--- a/ansible/roles/bastion/templates/bash_profile.j2
+++ b/ansible/roles/bastion/templates/bash_profile.j2
@@ -8,4 +8,4 @@ fi
 # User specific environment and startup programs
 
 export PATH=$PATH:$HOME/bin:/usr/local/bin:/usr/local/maven/bin
-export GUID=`hostname | awk -F. '{print $2}'`
+export GUID={{ guid }}


### PR DESCRIPTION
##### SUMMARY

Replace "hostname" logic in .bashrc with just a {{ guid }}. Fixes issue #3548 

FYI: @prakhar1985 (OpenShift environments have mostly switched to bastion-lite instead of bastion - guess that's why nobody noticed until now.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Role: bastion
