### PR TITLE
Docker Image version locked

### DIFF
--- a/ansible/configs/ansible-advanced-v2/files/bind9-Dockerfile
+++ b/ansible/configs/ansible-advanced-v2/files/bind9-Dockerfile
@@ -1,5 +1,5 @@
 # bind9 dns
-FROM registry.access.redhat.com/ubi8/ubi-init:latest AS bind9-dns
+FROM registry.access.redhat.com/ubi8/ubi-init:8.3 AS bind9-dns
 
 RUN yum install -y bind 
 


### PR DESCRIPTION
##### SUMMARY
Docker ubi-init image version locked.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
bind9-Dockerfile
