### PR TITLE
Accept list msg for agnosticd_user_info

### DIFF
--- a/ansible/action_plugins/agnosticd_user_info.py
+++ b/ansible/action_plugins/agnosticd_user_info.py
@@ -63,8 +63,11 @@ class ActionModule(ActionBase):
 
         if not user and msg != None:
             # Output msg in result, prepend "user.info: " for cloudforms compatibility
-            result['msg'] = 'user.info: ' + msg
-            # Force display of result like debug
+            if isinstance(msg, list):
+                result['msg'] = ['user.info: ' + m for m in msg]
+            else:
+                result['msg'] = 'user.info: ' + msg
+                # Force display of result like debug
 
         if not user and body != None:
             # Output msg in result, prepend "user.info: " for cloudforms compatibility
@@ -95,7 +98,11 @@ class ActionModule(ActionBase):
 
             if not user and msg != None:
                 fh = open(os.path.join(output_dir, 'user-info.yaml'), 'a')
-                fh.write('- ' + json.dumps(msg) + "\n")
+                if isinstance(msg, list):
+                    for m in msg:
+                        fh.write('- ' + json.dumps(m) + "\n")
+                else:
+                    fh.write('- ' + json.dumps(msg) + "\n")
                 fh.close()
             if not user and body != None:
                 fh = open(os.path.join(output_dir, 'user-body.yaml'), 'a')
@@ -123,10 +130,11 @@ class ActionModule(ActionBase):
                         user_data_item = data
                         user_data['users'][user] = user_data_item
                     if msg:
+                        msg_str = "\n".join(msg) if isinstance(msg, list) else msg
                         if 'msg' in user_data_item:
-                            user_data_item['msg'] += "\n" + msg
+                            user_data_item['msg'] += "\n" + msg_str
                         else:
-                            user_data_item['msg'] = msg
+                            user_data_item['msg'] = msg_str
                     if body:
                         if 'body' in user_data_item:
                             user_data_item['body'] += "\n" + body


### PR DESCRIPTION
##### SUMMARY

Update agnosticd_user_info to accept a list for `msg` to match usage of `debug`. Ex:

```
- name: output workshop info guides
  agnosticd_user_info:
    msg:
    - ""
    - "URL for attendees to get a username assigned to them and links to labs:"
    - "http://get-a-username-labs-infra.{{ route_subdomain }}"
    - "You should share this URL (or a shortlink for it) -- It is all they will need to get started!"
    - ""
    - "get-a-username's admin page is https://get-a-username-labs-infra.{{ route_subdomain }}/admin"
    - "Admin login with admin/{{workshop_openshift_user_password}}"```
```

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

agnosticd_user_info