### PR TITLE
Fix ocp4-workload-ccnrd-cuttingedge to update links

### DIFF
--- a/ansible/roles/ocp4-workload-ccnrd-cuttingedge/templates/devfile.json.j2
+++ b/ansible/roles/ocp4-workload-ccnrd-cuttingedge/templates/devfile.json.j2
@@ -28,7 +28,7 @@
     {
       "alias": "mta-ide-plugin",
       "type": "chePlugin",
-      "reference": "https://raw.githubusercontent.com/redhat-cop/agnosticd/development/ansible/roles/ocp4-workload-ccnrd/files/cheplugin-meta.yaml",
+      "reference": "https://raw.githubusercontent.com/redhat-cop/agnosticd/development/ansible/roles/ocp4-workload-ccnrd-cuttingedge/files/cheplugin-meta.yaml",
       "memoryLimit": "1500M"
     }
   ],


### PR DESCRIPTION
…ccnrd-cuttingedge role

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Fix ocp4-workload-ccnrd-cuttingedge to update links for ccnrd-cuttingedge role
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
