### PR TITLE
Replaced hardcoded bastion hostname for OCP3

### DIFF
--- a/ansible/configs/ocp-workshop/post_software.yml
+++ b/ansible/configs/ocp-workshop/post_software.yml
@@ -711,9 +711,9 @@
 
     - name: Set user info for Student SSH command
       agnosticd_user_info:
-        msg: "SSH Access: ssh {{ student_name }}@bastion.{{ guid }}{{ subdomain_base_suffix }}"
+        msg: "SSH Access: ssh {{ student_name }}@{{ hostvars[groups.bastions.0].ansible_hostname }}.{{ guid }}{{ subdomain_base_suffix }}"
         data:
-          ocp_workshop_ssh_command: "ssh {{ student_name }}@bastion.{{ guid }}{{ subdomain_base_suffix }}"
+          ocp_workshop_ssh_command: "ssh {{ student_name }}@{{ hostvars[groups.bastions.0].ansible_hostname }}.{{ guid }}{{ subdomain_base_suffix }}"
 
     - name: Set user info for Student SSH password
       when: print_student_password | default(true) | bool

--- a/ansible/roles/ocp-workload-migration/tasks/pre_workload.yml
+++ b/ansible/roles/ocp-workload-migration/tasks/pre_workload.yml
@@ -34,7 +34,7 @@
 
 - wait_for:
     port: 22
-    host: "bastion.{{ guid }}.internal"
+    host: "{{ hostvars[groups.bastions.0].ansible_hostname }}.{{ guid }}.internal"
     timeout: 5
   register: status
   ignore_errors: true


### PR DESCRIPTION

##### SUMMARY

Bastion host had a 'bastion' hardcoded in the playbooks.
Since inventory is dynamically created, any changes to bastion(s) will cause failures. 
Now the bastion host part is pulled from the facts directly based on the "bastions" group. 

##### ISSUE TYPE

- Bugfix Pull Request

