### PR TITLE
implement AWS on-demand capacity reservation (ODCR)

### DIFF
--- a/ansible/action_plugins/agnosticd_odcr.py
+++ b/ansible/action_plugins/agnosticd_odcr.py
@@ -56,6 +56,9 @@ _raw:
 display = Display()
 pp = pprint.PrettyPrinter(indent=2)
 
+class InvalidDuration(Exception):
+    """Exception for parse_duration."""
+
 def parse_duration(time_str):
     """Parse duration (str) and return timedelta
 
@@ -75,9 +78,11 @@ def parse_duration(time_str):
         r'^((?P<days>\d+?)[dD])? *((?P<hours>\d+?)[hH])? *((?P<minutes>\d+?)m)? *((?P<seconds>\d+?)s?)?$'
     )
 
+    if not time_str or not isinstance(time_str, str):
+        raise InvalidDuration("'%s' is not a valid duration" %(time_str))
     parts = regex.match(time_str.strip())
     if not parts:
-        return 0
+        raise InvalidDuration("'%s' is not a valid duration" %(time_str))
     parts = parts.groupdict()
     time_params = {}
     for (name, param) in iter(parts.items()):

--- a/ansible/action_plugins/test_agnosticd_odcr.py
+++ b/ansible/action_plugins/test_agnosticd_odcr.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+import pytest
+import agnosticd_odcr
+import datetime
+
+def test_parse_duration():
+
+    testcases = [
+        ['3d', datetime.timedelta(days=3)],
+        [' 3d', datetime.timedelta(days=3)],
+        [' 3d ', datetime.timedelta(days=3)],
+        [' 3d   ', datetime.timedelta(days=3)],
+        [' 3d \t  ', datetime.timedelta(days=3)],
+        [' 3d \t \n ', datetime.timedelta(days=3)],
+        ['8D', datetime.timedelta(days=8)],
+        ['1h', datetime.timedelta(hours=1)],
+        ['0h', datetime.timedelta(0)],
+        ['0', datetime.timedelta(0)],
+        ['0s', datetime.timedelta(0)],
+        ['3600', datetime.timedelta(hours=1)],
+        ['1d12h', datetime.timedelta(days=1, hours=12)],
+        ['3d 12h 6m', datetime.timedelta(days=3, hours=12, minutes=6)],
+        ['1d 12h', datetime.timedelta(days=1, hours=12)],
+    ]
+    for tc in testcases:
+        assert(agnosticd_odcr.parse_duration(tc[0]) == tc[1])

--- a/ansible/action_plugins/test_agnosticd_odcr.py
+++ b/ansible/action_plugins/test_agnosticd_odcr.py
@@ -17,6 +17,8 @@ def test_parse_duration():
         ['1h', datetime.timedelta(hours=1)],
         ['0h', datetime.timedelta(0)],
         ['0', datetime.timedelta(0)],
+        ['0d0m0s', datetime.timedelta(0)],
+        ['1d0m0s', datetime.timedelta(days=1)],
         ['0s', datetime.timedelta(0)],
         ['3600', datetime.timedelta(hours=1)],
         ['1d12h', datetime.timedelta(days=1, hours=12)],
@@ -25,3 +27,23 @@ def test_parse_duration():
     ]
     for tc in testcases:
         assert(agnosticd_odcr.parse_duration(tc[0]) == tc[1])
+
+    error_testcases = [
+        '3 days',
+        'INVALID',
+        'duration in the middle 3d of a sentence',
+        '2.3d',
+        '2.3m',
+        'd',
+        'm',
+        's',
+        '',
+        None,
+        {},
+        [],
+        ["nonemptylist"],
+    ]
+
+    for tc in error_testcases:
+        with pytest.raises(agnosticd_odcr.InvalidDuration):
+            agnosticd_odcr.parse_duration(tc)

--- a/ansible/cloud_providers/ec2_destroy_env.yml
+++ b/ansible/cloud_providers/ec2_destroy_env.yml
@@ -7,6 +7,12 @@
   gather_facts: False
   become: no
   tasks:
+    - name: Run infra-aws-capacity-reservation
+      include_role:
+        name: infra-aws-capacity-reservation
+      vars:
+        ACTION: destroy
+
     - name: Run infra-ec2-template-destroy
       include_role:
         name: infra-ec2-template-destroy

--- a/ansible/cloud_providers/ec2_destroy_env.yml
+++ b/ansible/cloud_providers/ec2_destroy_env.yml
@@ -11,7 +11,7 @@
       include_role:
         name: infra-aws-capacity-reservation
       vars:
-        ACTION: destroy
+        ACTION: 'destroy'
 
     - name: Run infra-ec2-template-destroy
       include_role:

--- a/ansible/cloud_providers/ec2_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/ec2_infrastructure_deployment.yml
@@ -14,6 +14,8 @@
     - name: Run infra-aws-capacity-reservation
       import_role:
         name: infra-aws-capacity-reservation
+      vars:
+        ACTION: provision
 
     - name: Run infra-ec2-template-generate Role
       import_role:

--- a/ansible/cloud_providers/ec2_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/ec2_infrastructure_deployment.yml
@@ -11,6 +11,10 @@
     - step001.1
     - deploy_infrastructure
   tasks:
+    - name: Run infra-aws-capacity-reservation
+      import_role:
+        name: infra-aws-capacity-reservation
+
     - name: Run infra-ec2-template-generate Role
       import_role:
         name: infra-ec2-template-generate

--- a/ansible/cloud_providers/ec2_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/ec2_infrastructure_deployment.yml
@@ -15,7 +15,7 @@
       import_role:
         name: infra-aws-capacity-reservation
       vars:
-        ACTION: provision
+        ACTION: 'provision'
 
     - name: Run infra-ec2-template-generate Role
       import_role:

--- a/ansible/configs/just-a-bunch-of-nodes/default_vars_ec2.yml
+++ b/ansible/configs/just-a-bunch-of-nodes/default_vars_ec2.yml
@@ -31,6 +31,10 @@ node_instance_platform: Linux/UNIX
 agnosticd_aws_capacity_reservation:
   regions:
   - "{{ aws_region }}"
+  - ap-southeast-1
+  - ap-southeast-2
+  - eu-west-1
+  - eu-west-2
   reservations:
     az1:
       - instance_count: 1

--- a/ansible/configs/just-a-bunch-of-nodes/default_vars_ec2.yml
+++ b/ansible/configs/just-a-bunch-of-nodes/default_vars_ec2.yml
@@ -24,8 +24,10 @@ aws_region: ap-southeast-2
 # you are provisioning from.
 #key_name: "default_key_name"
 
-bastion_instance_platform: Linux/UNIX
-node_instance_platform: Linux/UNIX
+bastion_instance_platform: Red Hat Enterprise Linux
+node_instance_platform: Red Hat Enterprise Linux
+#bastion_instance_platform: Linux/UNIX
+#node_instance_platform: Linux/UNIX
 
 # AWS on-demand capacity reservation
 agnosticd_aws_capacity_reservation:

--- a/ansible/configs/just-a-bunch-of-nodes/default_vars_ec2.yml
+++ b/ansible/configs/just-a-bunch-of-nodes/default_vars_ec2.yml
@@ -23,3 +23,19 @@ aws_region: ap-southeast-2
 # exist in your aws account and the private key should exist on the local machine
 # you are provisioning from.
 #key_name: "default_key_name"
+
+bastion_instance_platform: Linux/UNIX
+node_instance_platform: Linux/UNIX
+
+# AWS on-demand capacity reservation
+agnosticd_aws_capacity_reservation:
+  regions:
+  - "{{ aws_region }}"
+  reservations:
+    az1:
+      - instance_count: 1
+        instance_platform: "{{ bastion_instance_platform }}"
+        instance_type: "{{ bastion_instance_type.ec2 }}"
+      - instance_count: "{{ node_instance_count }}"
+        instance_platform: "{{ node_instance_platform }}"
+        instance_type: "{{ node_instance_type.ec2 }}"

--- a/ansible/configs/just-a-bunch-of-nodes/default_vars_ec2.yml
+++ b/ansible/configs/just-a-bunch-of-nodes/default_vars_ec2.yml
@@ -30,18 +30,17 @@ node_instance_platform: Red Hat Enterprise Linux
 #node_instance_platform: Linux/UNIX
 
 # AWS on-demand capacity reservation
-agnosticd_aws_capacity_reservation:
-  regions:
+agnosticd_aws_capacity_reservation_regions:
   - "{{ aws_region }}"
   - ap-southeast-1
   - ap-southeast-2
   - eu-west-1
   - eu-west-2
-  reservations:
-    az1:
-      - instance_count: 1
-        instance_platform: "{{ bastion_instance_platform }}"
-        instance_type: "{{ bastion_instance_type.ec2 }}"
-      - instance_count: "{{ node_instance_count }}"
-        instance_platform: "{{ node_instance_platform }}"
-        instance_type: "{{ node_instance_type.ec2 }}"
+agnosticd_aws_capacity_reservations:
+  az1:
+    - instance_count: 1
+      instance_platform: "{{ bastion_instance_platform }}"
+      instance_type: "{{ bastion_instance_type.ec2 }}"
+    - instance_count: "{{ node_instance_count }}"
+      instance_platform: "{{ node_instance_platform }}"
+      instance_type: "{{ node_instance_type.ec2 }}"

--- a/ansible/configs/just-a-bunch-of-nodes/sample_vars.yml
+++ b/ansible/configs/just-a-bunch-of-nodes/sample_vars.yml
@@ -8,6 +8,7 @@
 env_type: just-a-bunch-of-nodes       # Name of config to deploy
 output_dir: /tmp/workdir                # Writable working scratch directory
 node_instance_count: 2                  # Number of nodes to deploy
+node_instance_type: m5.xlarge           # instance type
 email: name@example.com                 # User info for notifications
 
 guid: guid02                             # Unique string used in FQDN
@@ -26,4 +27,46 @@ key_name: ocpkey                        # Keyname must exist in AWS
 # AWS Credentials. These are required (don't sync them to your fork)
 # aws_access_key_id:
 # aws_secret_access_key:
+#
+
+# AWS on-demand capacity reservation
+agnosticd_aws_capacity_reservation:
+  regions:
+  - "ap-southeast-1"
+  - "us-east-2"
+  - "{{ aws_region }}"
+  - "eu-west-2"
+  reservations:
+    az1:
+      - instance_count: "{{ node_instance_count }}"
+        instance_platform: Linux/UNIX
+        instance_type: "a1.xlarge"
+      - instance_count: "{{ node_instance_count }}"
+        instance_platform: Linux/UNIX
+        instance_type: "{{ node_instance_type }}"
+      - instance_count: "{{ node_instance_count }}"
+        instance_platform: Linux/UNIX
+        instance_type: "m5.xlarge"
+      - instance_count: 20
+        instance_platform: Linux/UNIX
+        instance_type: "m5a.8xlarge"
+    az2:
+      - instance_count: 10
+        instance_platform: Linux/UNIX
+        instance_type: "m5a.4xlarge"
+      - instance_count: "{{ node_instance_count }}"
+        instance_platform: Linux/UNIX
+        instance_type: "c5.large"
+      - instance_count: "{{ node_instance_count }}"
+        instance_platform: Linux/UNIX
+        instance_type: "m4.4xlarge"
+      - instance_count: "{{ node_instance_count }}"
+        instance_platform: Linux/UNIX
+        instance_type: "m5zn.large"
+      - instance_count: 2
+        instance_platform: Linux/UNIX
+        instance_type: "m6g.xlarge"
+      - instance_count: 2
+        instance_platform: Linux/UNIX
+        instance_type: "m5n.large"
 ...

--- a/ansible/configs/just-a-bunch-of-nodes/sample_vars.yml
+++ b/ansible/configs/just-a-bunch-of-nodes/sample_vars.yml
@@ -8,7 +8,8 @@
 env_type: just-a-bunch-of-nodes       # Name of config to deploy
 output_dir: /tmp/workdir                # Writable working scratch directory
 node_instance_count: 2                  # Number of nodes to deploy
-node_instance_type: m5.xlarge           # instance type
+node_instance_type:
+  ec2: m5.xlarge                        # instance type
 email: name@example.com                 # User info for notifications
 
 guid: guid02                             # Unique string used in FQDN
@@ -22,51 +23,10 @@ own_repo_path: http://admin.example.com/repos/version
 cloud_provider: ec2                     # Which AgnosticD Cloud Provider to use
 aws_region: us-east-1                   # AWS Region to deploy in
 HostedZoneId: Z3IHLWJZOU9SRT            # You will need to change this
-key_name: ocpkey                        # Keyname must exist in AWS
+key_name: opentlc_admin_backdoor        # Keyname must exist in AWS
 
 # AWS Credentials. These are required (don't sync them to your fork)
 # aws_access_key_id:
 # aws_secret_access_key:
 #
-
-# AWS on-demand capacity reservation
-agnosticd_aws_capacity_reservation:
-  regions:
-  - "ap-southeast-1"
-  - "us-east-2"
-  - "{{ aws_region }}"
-  - "eu-west-2"
-  reservations:
-    az1:
-      - instance_count: "{{ node_instance_count }}"
-        instance_platform: Linux/UNIX
-        instance_type: "a1.xlarge"
-      - instance_count: "{{ node_instance_count }}"
-        instance_platform: Linux/UNIX
-        instance_type: "{{ node_instance_type }}"
-      - instance_count: "{{ node_instance_count }}"
-        instance_platform: Linux/UNIX
-        instance_type: "m5.xlarge"
-      - instance_count: 20
-        instance_platform: Linux/UNIX
-        instance_type: "m5a.8xlarge"
-    az2:
-      - instance_count: 10
-        instance_platform: Linux/UNIX
-        instance_type: "m5a.4xlarge"
-      - instance_count: "{{ node_instance_count }}"
-        instance_platform: Linux/UNIX
-        instance_type: "c5.large"
-      - instance_count: "{{ node_instance_count }}"
-        instance_platform: Linux/UNIX
-        instance_type: "m4.4xlarge"
-      - instance_count: "{{ node_instance_count }}"
-        instance_platform: Linux/UNIX
-        instance_type: "m5zn.large"
-      - instance_count: 2
-        instance_platform: Linux/UNIX
-        instance_type: "m6g.xlarge"
-      - instance_count: 2
-        instance_platform: Linux/UNIX
-        instance_type: "m5n.large"
 ...

--- a/ansible/roles-infra/infra-aws-capacity-reservation/defaults/main.yaml
+++ b/ansible/roles-infra/infra-aws-capacity-reservation/defaults/main.yaml
@@ -1,0 +1,3 @@
+---
+agnosticd_aws_capacity_reservation_enable: true
+agnosticd_aws_capacity_reservation_ttl: 1h

--- a/ansible/roles-infra/infra-aws-capacity-reservation/defaults/main.yaml
+++ b/ansible/roles-infra/infra-aws-capacity-reservation/defaults/main.yaml
@@ -1,3 +1,5 @@
 ---
 agnosticd_aws_capacity_reservation_enable: true
 agnosticd_aws_capacity_reservation_ttl: 1h
+agnosticd_aws_capacity_reservation_regions:
+  - "{{ aws_region }}"

--- a/ansible/roles-infra/infra-aws-capacity-reservation/lookup_plugins/agnosticd_aws_create_capacity_reservations.py
+++ b/ansible/roles-infra/infra-aws-capacity-reservation/lookup_plugins/agnosticd_aws_create_capacity_reservations.py
@@ -1,0 +1,386 @@
+from __future__ import (absolute_import, division, print_function)
+import datetime
+import os
+import re
+import pprint
+from ansible.errors import AnsibleError
+from ansible.plugins.lookup import LookupBase
+from ansible.utils.display import Display
+
+import boto3
+import botocore.exceptions
+__metaclass__ = type
+
+DOCUMENTATION = """
+        lookup: agnosticd_aws_create_capacity_reservations
+        author: Guillaume Core <gucore@redhat.com>
+        version_added: "2.9"
+        short_description: Create AWS on-demand Capacity Reservations
+        description:
+            - Create reservations and return Regions / AZs / Ids
+        options:
+          _terms:
+            description: reservations to create
+            required: True
+          ttl:
+            description: The TTL to set in the reservations
+            required: False
+            type: int
+            default: 1h
+"""
+
+EXAMPLES = """
+- name: Create reservations and save result
+  vars:
+    odcr:
+      regions:
+      - us-east-1
+      - us-east-2
+      reservations:
+        az1:
+          - instance_count: 3
+            instance_platform: Linux/UNIX
+            instance_type: "m5.xlarge"
+  set_fact:
+    _capacity_reservations: >-
+      {{
+      lookup(
+      'agnosticd_aws_create_capacity_reservations',
+      odcr,
+      ttl='1h'
+      )
+      }}
+
+
+"""
+
+RETURN = """
+_raw:
+   description: Reservations
+   type: list
+"""
+
+display = Display()
+pp = pprint.PrettyPrinter(indent=2)
+
+regex = re.compile(
+    r'((?P<days>\d+?)d)?((?P<hours>\d+?)h)?((?P<minutes>\d+?)m)?((?P<seconds>\d+?)s)?'
+)
+
+def parse_time(time_str):
+    parts = regex.match(time_str)
+    if not parts:
+        return
+    parts = parts.groupdict()
+    time_params = {}
+    for (name, param) in iter(parts.items()):
+        if param:
+            time_params[name] = int(param)
+    return datetime.timedelta(**time_params)
+
+def translate_to_api_names(key_str):
+    """Return the corresponding names to use with AWS Apis and python functions"""
+    entries = {
+        'instance_count': 'InstanceCount',
+        'instance_platform': 'InstancePlatform',
+        'instance_type': 'InstanceType',
+        'instance_match_criteria': 'InstanceMatchCriteria',
+        'tenancy': 'Tenancy',
+    }
+
+    if key_str in entries:
+        return entries[key_str]
+    else:
+        raise AnsibleError("Key {} is not supported in a reservation.".format(key_str))
+
+
+def tag_match(tags1, tags2):
+    """All tags1 are in tags2"""
+    for t1 in tags1:
+        if t1 in tags2:
+            continue
+
+        return False
+
+    return True
+
+def check_response(response):
+    """Check HTTPStatusCode"""
+    try:
+        if response['ResponseMetadata']['HTTPStatusCode'] != 200:
+            display.error(pp.pformat(response))
+            raise AnsibleError("Error requesting EC2 offerings.")
+    except:
+        display.error(pp.pformat(response))
+        raise AnsibleError("Error requesting EC2 offerings.")
+
+class LookupModule(LookupBase):
+
+    def get_azs(self):
+        """Return all availability zones for a region"""
+
+        response = self.client.describe_availability_zones()
+
+        return list(
+            map(
+                lambda elem: elem['ZoneName'],
+                filter(
+                    lambda elem: elem['State'] == 'available',
+                    response['AvailabilityZones']
+                )
+            )
+        )
+
+    def filter_azs(self, azs, instance_types):
+        """Return the intersection of possible AZs for a list of instance types.
+
+        args: 1) set of all AZs
+              2) set of all instance types
+
+        return:  set of AZs for which there is an offering for all instance types
+        """
+        response = self.client.describe_instance_type_offerings(
+            LocationType='availability-zone',
+            Filters=[
+                {
+                    'Name': 'instance-type',
+                    'Values': list(instance_types),
+                },
+            ],
+        )
+
+        check_response(response)
+
+        display.vvv(pp.pformat(response['InstanceTypeOfferings']))
+
+        result = azs
+
+        # Get the intersection of all AZs
+        for instance_type in instance_types:
+            result = result & set(map(lambda elem: elem['Location'],
+                                      list(filter(lambda elem: elem['InstanceType'] == instance_type,
+                                                  response['InstanceTypeOfferings']))))
+
+        return result
+
+
+    def create_reservation(self, ttl, reservation, tags=[], az=''):
+        """Create an on-demand reservation
+
+        returns ...
+        """
+        reservation_translated = {
+            translate_to_api_names(k): v for k, v in reservation.items()
+        }
+
+        try:
+            duration = parse_time(ttl)
+        except:
+            raise AnsibleError("could not parse duration {}".format(ttl))
+
+        if len(tags) > 0:
+            tag_spec =[{
+                'ResourceType': 'capacity-reservation',
+                'Tags':tags,
+            }]
+        else:
+            tag_spec = []
+
+        response = self.client.create_capacity_reservation(
+            **reservation_translated,
+            AvailabilityZone=az,
+            EndDate=datetime.datetime.now() + duration,
+            EndDateType='limited',
+            InstanceMatchCriteria='open',
+            TagSpecifications=tag_spec,
+        )
+
+        check_response(response)
+
+        display.vvvv("response: %s" % pp.pformat(response))
+        return response
+
+    def describe_reservations(self, tags=[], az='*'):
+        """Filter reservations by tag and return Ids"""
+
+        filters = [{'Name':'state', 'Values':['active','pending']}]
+        if az != None and az != '*' and az != '':
+            filters.append({'Name': 'availability-zone', 'Values': [az]})
+
+        response = self.client.describe_capacity_reservations(
+            Filters=filters,
+        )
+
+        check_response(response)
+
+        display.vvvvv(pp.pformat(response))
+        result = list(
+            filter(lambda elem: tag_match(tags, elem['Tags']),
+                   response['CapacityReservations']))
+
+        return [i['CapacityReservationId'] for i in result]
+
+    def cancel_reservation(self, reservation_id, context):
+        """Cancel a reservation by ID"""
+
+        response = self.client.cancel_capacity_reservation(
+            CapacityReservationId=reservation_id,
+        )
+        display.vvvv(pp.pformat(response))
+
+        check_response(response)
+
+        display.display("Reservation canceled: %s  (%s)" %(reservation_id, context))
+
+    def cancel_all_reservations(tags, context):
+        """Cancel all reservations matching tags"""
+        reservation_ids = self.describe_reservations(tags=tags)
+        for r_id in reservation_ids:
+            self.cancel_reservation(r_id, context)
+
+    def run(self, terms, variables=None, **kwargs):
+        ttl = kwargs.get('ttl', '1h')
+
+        aws_key = variables['aws_access_key_id']
+        aws_secret = variables['aws_secret_access_key']
+
+        tags = []
+        if 'uuid' in variables:
+            tags.append({'Key': 'uuid', 'Value': variables['uuid']})
+
+        tags.append({'Key': 'guid', 'Value': variables['guid']})
+        tags.append({'Key': 'created-by', 'Value': 'agnosticd'})
+
+
+        ret = []
+        for term in terms:
+            display.v("# input\n%s" % pp.pformat(term))
+            display.v("ttl: %s" % ttl)
+            regions = term['regions']
+
+            for region in regions:
+                self.client = boto3.client('ec2',
+                                        aws_access_key_id=aws_key,
+                                        aws_secret_access_key=aws_secret,
+                                        region_name=region,
+                                        )
+                self.cleanup_all_reservations(tags, context=region)
+
+
+            loop1_break = False
+            for region in regions:
+                display.v(".loop1: Trying region %s" % (region))
+
+                self.client = boto3.client('ec2',
+                                        aws_access_key_id=aws_key,
+                                        aws_secret_access_key=aws_secret,
+                                        region_name=region,
+                                        )
+
+                all_azs = set(self.get_azs())
+                display.v(".loop1: available AZs: %s" % all_azs)
+
+                loop2_break = False
+                for reservation_group in term['reservations']:
+                    display.v("..loop2: reservation_group: %s" % (pp.pformat(reservation_group)))
+
+                    all_instance_types = set(
+                        i['instance_type'] for i in term['reservations'][reservation_group]
+                    )
+                    all_possible_azs = self.filter_azs(all_azs, all_instance_types)
+                    display.v(
+                        "..loop2: AZs with matching offerings for group %s: %s" %
+                        (reservation_group, pp.pformat(all_possible_azs)))
+
+                    loop3_break = False
+                    for az in all_possible_azs:
+                        created_reservations = []
+                        display.v("...loop3: trying az %s" %(az))
+
+                        for reservation in term['reservations'][reservation_group]:
+                            # TODO: remove DRYRUN or replace with action=destroy
+                            if 'DRYRUN' in variables and variables['DRYRUN']:
+                                continue
+                            try:
+                                response = self.create_reservation(
+                                    ttl=ttl,
+                                    reservation=reservation,
+                                    az=az,
+                                    tags=tags)
+                            except botocore.exceptions.ClientError as err:
+                                if 'InstanceLimitExceeded' in str(err):
+                                    display.display("InstanceLimitExceeded %s - %d * %s"
+                                                    %(az, reservation['instance_count'], reservation['instance_type']))
+                                    display.display(
+                                        "Reservation could not be created in %s, trying next AZ."
+                                        %(az)
+                                    )
+                                    for r_id in created_reservations:
+                                        self.cancel_reservation(r_id, context=az)
+                                    break
+
+                                if 'InsufficientInstanceCapacity' in str(err):
+                                    display.display("InsufficientInstanceCapacity %s - %d * %s"
+                                                    %(az, reservation['instance_count'],
+                                                      reservation['instance_type']))
+
+                                    display.display(
+                                        "Reservation could not be created in %s, trying next AZ."
+                                        %(az)
+                                    )
+                                    for r_id in created_reservations:
+                                        self.cancel_reservation(r_id, context=az)
+                                    break
+
+                                display.error(pp.pformat(err))
+                                raise AnsibleError(
+                                    "Client Error while creating reservation."
+                                ) from err
+
+                            if response['ResponseMetadata']['HTTPStatusCode'] == 200:
+                                # if success, continue
+                                r_id = response['CapacityReservation']['CapacityReservationId']
+                                display.display("Reservation created: %s (%s)" %(r_id, az))
+                                created_reservations.append(r_id)
+                                continue
+
+                            display.v(pp.pformat(r))
+                            display.display(
+                                "Reservation could not be created in %s, trying next AZ."
+                                %(az)
+                            )
+                            for r_id in created_reservations:
+                                self.cancel_reservation(r_id, context=az)
+                            break
+                        else:
+                            # All reservations of the reservation group (az) are created
+                            break
+                        if loop3_break:
+                            break
+                    else:
+                        # All AZ were tried for that reservation group
+                        display.display(
+                            "Reservations could not be created in %s, trying next region."
+                            %(region)
+                        )
+                        # cancel all reservations made in that region
+                        self.cleanup_all_reservations(tags, context=region)
+
+                        break
+                    if loop2_break:
+                        break
+                else:
+                    # All reservation groups (az) are done
+                    break
+                if loop1_break:
+                    break
+
+        # TODO: testing (aws api down, etc)
+        # TODO: return value
+        ret_i = {}
+        ret_i['azs'] = {}
+        ret_i['ids'] = {}
+        ret_i['region'] = "us-east-1"
+        ret.append(ret_i)
+        display.vvv("result: %s" % ret)
+        return ret

--- a/ansible/roles-infra/infra-aws-capacity-reservation/readme.adoc
+++ b/ansible/roles-infra/infra-aws-capacity-reservation/readme.adoc
@@ -1,0 +1,142 @@
+This role implements link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-reservations.html[on-demand capacity reservation] in agnosticd.
+
+== Core role `agnosticd_aws_capacity_reservation` ==
+
+The goal of the role is to provide a mean for us to make sure the capacity is reserved in the early stages of agnosticd (pre_infra), instead of failing later when it tries to create the instances.
+
+
+input:
+
+[source,yaml]
+.In agnosticv
+----
+# credentials must be set
+aws_access_key_id: ...
+aws_secret_access_key: ...
+
+agnosticd_aws_capacity_reservation:
+  regions: # <1>
+  - us-east-1
+  - us-east-2
+  reservations:
+    az1:
+      - instance_count: 1
+        instance_platform: Linux/UNIX
+        instance_type: t3a.medium
+      - instance_count: 2
+        instance_platform: Linux/UNIX
+        instance_type: m5a.4xlarge
+    az2:
+      - instance_count: 3
+        instance_platform: Linux/UNIX
+        instance_type: m5a.2xlarge
+----
+<1> for mono-region provisioning, here we can use `aws_region` passed from cloudforms:
++
+----
+regions:
+- "{{ aws_region }}"
+----
+
+Ideally, that variable should be configured in the `default_vars_ec2.yaml` directly in the config. For ex:
+[source,yaml]
+.input as part of `default_vars_ec2.yaml`
+----
+agnosticd_aws_capacity_reservation:
+  regions:
+  - "{{ aws_region }}"
+  reservations:
+    az1:
+      - instance_count: 1
+        instance_platform: Linux/UNIX
+        instance_type: "{{ bastion_instance_type }}"
+      - instance_count: "{{ worker_instance_count }}"
+        instance_platform: Linux/UNIX
+        instance_type: "{{ worker_instance_type }}"
+    az2:
+      - instance_count: "{{ master_instance_count }}"
+        instance_platform: Linux/UNIX
+        instance_type: "{{ master_instance_type }}"
+----
+
+The role will set the following variables, that can be used in later stages in agnosticd:
+
+[source,yaml]
+.output
+----
+aws_region: us-east-1
+
+aws_availability_zones:
+  az1: us-east-1a
+  az2: us-east-1b
+----
+
+az1 and az2 keys must be chosen carefully and must make sense in the agnosticd config which must support the use of the `aws_availability_zones` dictionary.
+
+NOTE: az1 and az2 found by the role are not necessarly different, they can be the same. The goal of the role is to provide capacity. Later we could add an option to ensure it's spread across AZs and that all the AZ are different. But that's not part of initial implementation.
+
+If there is only one AZ key in the `agnosticd_aws_capacity_reservation` dictionary (all instances are in the same availability zone), then the role also sets the variable `aws_availability_zone`:
+
+[source,yaml]
+.With only one AZ
+----
+aws_region: us-east-1
+aws_availability_zones:
+  az1: us-east-1a
+aws_availability_zone: us-east-1a
+----
+
+=== How ? ===
+
+The role will iterate on all the regions asked, and then for each reservation group, will try to create the capacity reservations in the available AZs.
+
+NOTE: During that process, if a reservation for an instance type fails, the role will delete previous capacity reservations made on that AZ for the other instances types and continue with the next AZ on the list, until an AZ that can host all instances types of the reservation group is found. We shoud probably implement that *in python* and not in ansible, because that kind of tasks are difficult to approach and hard to maintain in ansible.
+
+The capacity reservation will be created with a *TTL of 1h*. That should give plenty of time for agnosticd to create the infra.
+
+When several instance types are under the same AZ group, only an AZ that can host all of them will be selected.
+
+WARNING: Keep in mind that if `aws_region` or `aws_availability_zone` are defined as extra-vars (agnosticV or simply passed to ansible), then the role will not be able to override them.
+
+[source,yaml]
+.reservation properties
+----
+  - instance_count: Integer
+    instance_match_criteria: open | targeted # <1>
+    instance_platform: String # (usually  Linux/UNIX)
+    instance_type: String  # ex: m5a.4xlarge
+    tenancy: default | dedicated # <2>
+----
+<1> default: open, in case of targeted, aws_capacity_reservation_ids is set (in order)
+<2>  shared or dedicated hardware. You probably want to keep the default. For more info see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/dedicated-instance.html
+
+For more info, see link:https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-tagspecifications[AWS doc].
+
+When `instance_match_criteria` is set to `targeted`, the role will also set the `aws_capacity_reservation_ids` var:
+
+[source,yaml]
+.output
+----
+aws_capacity_reservation_ids:
+  az1: cr-123456789
+  az2: cr-123456789
+----
+
+If `instance_match_criteria` is set to `targeted`, the agnosticd config must support it and the ids must be used in the config, otherwise the reservation will not be used for the instances.
+
+=== Should i use open or targeted ? ===
+
+When you're in sandboxes, you can use `open`, and should not really care about `targeted`, as the only thing running in the sandbox will be the current provision.
+
+When in a shared account (ex: GPTE prod account 'gpe'), `targeted` must be used, otherwise there no guarantee which instances will be part of the reservation. Already running instances could match the criteria of the reservation.
+
+At first we would probably use this feature only as `open`, in AWS sandboxes.
+
+WARNING: If you use `targeted`, keep in mind to adjust the TTL properly. Instances targeting a capacity reservation cannot be easily stopped/started. The instances can no longer launch if the target capacity reservation has expired or was canceled.
+
+=== When ? ===
+
+The role would be executed if:
+
+* `agnosticd_aws_capacity_reservation` is defined and not empty
+* `agnosticd_aws_capacity_reservation_enable` is true (default is true)

--- a/ansible/roles-infra/infra-aws-capacity-reservation/readme.adoc
+++ b/ansible/roles-infra/infra-aws-capacity-reservation/readme.adoc
@@ -13,7 +13,6 @@ input:
 # credentials must be set
 aws_access_key_id: ...
 aws_secret_access_key: ...
-
 agnosticd_aws_capacity_reservation:
   regions: # <1>
   - us-east-1
@@ -61,28 +60,44 @@ agnosticd_aws_capacity_reservation:
 
 The role will set the following variables, that can be used in later stages in agnosticd:
 
-[source,yaml]
 .output
+[source,yaml]
 ----
 aws_region: us-east-1
 
-aws_availability_zones:
-  az1: us-east-1a
-  az2: us-east-1b
+agnosticd_aws_capacity_reservation_results:
+  region: us-east-1
+  az1:
+    availability_zone: us-east-1a
+    reservations_ids:
+      - cr-03ede0234dabf424e
+      - cr-08daa70b36405528d
+  az2:
+    availability_zone: us-east-1b
+    reservations_ids:
+      - cr-07d8ae35483fe8c98
 ----
 
-az1 and az2 keys must be chosen carefully and must make sense in the agnosticd config which must support the use of the `aws_availability_zones` dictionary.
+az1 and az2 keys must be chosen carefully and must make sense in the agnosticd config which must support the use of the `agnosticd_aws_capacity_reservation_results` dictionary.
+:
 
 NOTE: az1 and az2 found by the role are not necessarly different, they can be the same. The goal of the role is to provide capacity. Later we could add an option to ensure it's spread across AZs and that all the AZ are different. But that's not part of initial implementation.
 
-If there is only one AZ key in the `agnosticd_aws_capacity_reservation` dictionary (all instances are in the same availability zone), then the role also sets the variable `aws_availability_zone`:
+If there is only one AZ key in the `agnosticd_aws_capacity_reservation` dictionary (all instances are in the same availability zone), then the role also automatically sets the variable `aws_availability_zone`:
 
 [source,yaml]
-.With only one AZ
+.Output with only one AZ
 ----
+agnosticd_aws_capacity_reservation_results:
+  region: us-east-1
+  single_availability_zone: us-east-1a
+  az1:
+    availability_zone: us-east-1a
+    reservations_ids:
+      - cr-03ede0234dabf424e
+      - cr-08daa70b36405528d
+
 aws_region: us-east-1
-aws_availability_zones:
-  az1: us-east-1a
 aws_availability_zone: us-east-1a
 ----
 
@@ -140,3 +155,10 @@ The role would be executed if:
 
 * `agnosticd_aws_capacity_reservation` is defined and not empty
 * `agnosticd_aws_capacity_reservation_enable` is true (default is true)
+
+
+== How to use ODCR in agnosticd config ? ==
+
+The best way is to define the `agnosticd_aws_capacity_reservation` in default vars `default_vars_ec2.yaml` file.
+
+Then, use the

--- a/ansible/roles-infra/infra-aws-capacity-reservation/readme.adoc
+++ b/ansible/roles-infra/infra-aws-capacity-reservation/readme.adoc
@@ -13,22 +13,22 @@ input:
 # credentials must be set
 aws_access_key_id: ...
 aws_secret_access_key: ...
-agnosticd_aws_capacity_reservation:
-  regions: # <1>
+agnosticd_aws_capacity_reservation_region:  # <1>
   - us-east-1
   - us-east-2
-  reservations:
-    az1:
-      - instance_count: 1
-        instance_platform: Linux/UNIX # <2>
-        instance_type: t3a.medium
-      - instance_count: 2
-        instance_platform: Linux/UNIX
-        instance_type: m5a.4xlarge
-    az2:
-      - instance_count: 3
-        instance_platform: Linux/UNIX
-        instance_type: m5a.2xlarge
+
+agnosticd_aws_capacity_reservations:
+  az1:
+    - instance_count: 1
+      instance_platform: Linux/UNIX # <2>
+      instance_type: t3a.medium
+    - instance_count: 2
+      instance_platform: Linux/UNIX
+      instance_type: m5a.4xlarge
+  az2:
+    - instance_count: 3
+      instance_platform: Linux/UNIX
+      instance_type: m5a.2xlarge
 ----
 <1> for mono-region provisioning, here we can use `aws_region` passed from cloudforms:
 +
@@ -42,24 +42,23 @@ Ideally, that variable should be configured in the `default_vars_ec2.yaml` direc
 [source,yaml]
 .input as part of `default_vars_ec2.yaml`
 ----
-agnosticd_aws_capacity_reservation:
-  regions:
+agnosticd_aws_capacity_reservation_regions:
   - "{{ aws_region }}"
-  reservations:
-    az1:
-      - instance_count: 1
-        instance_platform: Linux/UNIX
-        instance_type: "{{ bastion_instance_type }}"
-      - instance_count: "{{ worker_instance_count }}"
-        instance_platform: Linux/UNIX
-        instance_type: "{{ worker_instance_type }}"
-    az2:
-      - instance_count: "{{ master_instance_count }}"
-        instance_platform: Linux/UNIX
-        instance_type: "{{ master_instance_type }}"
+agnosticd_aws_capacity_reservations:
+  az1:
+    - instance_count: 1
+      instance_platform: Linux/UNIX
+      instance_type: "{{ bastion_instance_type }}"
+    - instance_count: "{{ worker_instance_count }}"
+      instance_platform: Linux/UNIX
+      instance_type: "{{ worker_instance_type }}"
+  az2:
+    - instance_count: "{{ master_instance_count }}"
+      instance_platform: Linux/UNIX
+      instance_type: "{{ master_instance_type }}"
 ----
 
-WARNING: Make sure not to pass `aws_region` as extra-vars if you set several regions in `agnosticd_aws_capacity_reservation.regions`. If it's set as extra-vars, it will take precedence regardless of what's set by the role and provision will fail.
+WARNING: Make sure not to pass `aws_region` as extra-vars if you set several regions in `agnosticd_aws_capacity_reservation_regions`. If it's set as extra-vars, it will take precedence regardless of what's set by the role and provision will fail.
 
 The role sets the following variables, that can be used in later stages in agnosticd:
 
@@ -70,15 +69,16 @@ aws_region: us-east-1
 
 agnosticd_aws_capacity_reservation_results:
   region: us-east-1
-  az1:
-    availability_zone: us-east-1a
-    reservations_ids:
-      - cr-03ede0234dabf424e
-      - cr-08daa70b36405528d
-  az2:
-    availability_zone: us-east-1b
-    reservations_ids:
-      - cr-07d8ae35483fe8c98
+  reservations:
+    az1:
+      availability_zone: us-east-1a
+      reservations_ids:
+        - cr-03ede0234dabf424e
+        - cr-08daa70b36405528d
+    az2:
+      availability_zone: us-east-1b
+      reservations_ids:
+        - cr-07d8ae35483fe8c98
 ----
 
 az1 and az2 keys must be chosen carefully and must make sense in the agnosticd config which must support the use of the `agnosticd_aws_capacity_reservation_results` dictionary.
@@ -86,7 +86,7 @@ az1 and az2 keys must be chosen carefully and must make sense in the agnosticd c
 
 NOTE: az1 and az2 found by the role are not necessarly different, they can be the same. The goal of the role is to provide capacity. Later we could add an option to ensure it's spread across AZs and that all the AZ are different. But that's not part of initial implementation.
 
-If there is only one AZ key in the `agnosticd_aws_capacity_reservation` dictionary (all instances are in the same availability zone), then the role also automatically sets the variable `aws_availability_zone`:
+If there is only one AZ key in the `agnosticd_aws_capacity_reservations` dictionary (all instances are in the same availability zone), then the role also automatically sets the variable `aws_availability_zone`:
 
 [source,yaml]
 .Output with only one AZ
@@ -94,11 +94,12 @@ If there is only one AZ key in the `agnosticd_aws_capacity_reservation` dictiona
 agnosticd_aws_capacity_reservation_results:
   region: us-east-1
   single_availability_zone: us-east-1a
-  az1:
-    availability_zone: us-east-1a
-    reservations_ids:
-      - cr-03ede0234dabf424e
-      - cr-08daa70b36405528d
+  reservations:
+    az1:
+      availability_zone: us-east-1a
+      reservations_ids:
+        - cr-03ede0234dabf424e
+        - cr-08daa70b36405528d
 
 aws_region: us-east-1
 aws_availability_zone: us-east-1a
@@ -125,7 +126,7 @@ WARNING: Keep in mind that if `aws_region` or `aws_availability_zone` are define
     instance_type: String  # ex: m5a.4xlarge
     tenancy: default | dedicated # <2>
 ----
-<1> default: open, in case of targeted, aws_capacity_reservation_ids is set (in order)
+<1> default: open, in case of targeted, the revervation IDs must be used in the config
 <2>  shared or dedicated hardware. You probably want to keep the default. For more info see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/dedicated-instance.html
 
 For more info, see link:https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-tagspecifications[AWS doc].
@@ -151,5 +152,5 @@ agnosticd_aws_capacity_reservation_ttl: 1h
 
 The role would be executed if:
 
-* `agnosticd_aws_capacity_reservation` is defined and not empty
+* `agnosticd_aws_capacity_reservations` is defined and not empty
 * `agnosticd_aws_capacity_reservation_enable` is true (default is true)

--- a/ansible/roles-infra/infra-aws-capacity-reservation/readme.adoc
+++ b/ansible/roles-infra/infra-aws-capacity-reservation/readme.adoc
@@ -2,7 +2,7 @@ This role implements link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec
 
 == Core role `agnosticd_aws_capacity_reservation` ==
 
-The goal of the role is to provide a mean for us to make sure the capacity is reserved in the early stages of agnosticd (pre_infra), instead of failing later when it tries to create the instances.
+The goal of the role is to provide a way to make sure the capacity is reserved in the early stages of agnosticd (pre_infra), instead of failing later when it tries to create the instances.
 
 
 input:
@@ -20,7 +20,7 @@ agnosticd_aws_capacity_reservation:
   reservations:
     az1:
       - instance_count: 1
-        instance_platform: Linux/UNIX
+        instance_platform: Linux/UNIX # <2>
         instance_type: t3a.medium
       - instance_count: 2
         instance_platform: Linux/UNIX
@@ -36,6 +36,7 @@ agnosticd_aws_capacity_reservation:
 regions:
 - "{{ aws_region }}"
 ----
+<2> For Red Hat Entreprise Linux, use `Red Hat Enterprise Linux`, for RHEL *GOLD* images, use `Linux/UNIX`. For more info, please see link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-reservations.html#capacity-reservations-platforms[upstream documentation].
 
 Ideally, that variable should be configured in the `default_vars_ec2.yaml` directly in the config. For ex:
 [source,yaml]
@@ -58,7 +59,9 @@ agnosticd_aws_capacity_reservation:
         instance_type: "{{ master_instance_type }}"
 ----
 
-The role will set the following variables, that can be used in later stages in agnosticd:
+WARNING: Make sure not to pass `aws_region` as extra-vars if you set several regions in `agnosticd_aws_capacity_reservation.regions`. If it's set as extra-vars, it will take precedence regardless of what's set by the role and provision will fail.
+
+The role sets the following variables, that can be used in later stages in agnosticd:
 
 .output
 [source,yaml]
@@ -103,15 +106,15 @@ aws_availability_zone: us-east-1a
 
 === How ? ===
 
-The role will iterate on all the regions asked, and then for each reservation group, will try to create the capacity reservations in the available AZs.
+The role iterates on all the regions asked, and then for each reservation group, tries to create the capacity reservations in the available AZs.
 
-NOTE: During that process, if a reservation for an instance type fails, the role will delete previous capacity reservations made on that AZ for the other instances types and continue with the next AZ on the list, until an AZ that can host all instances types of the reservation group is found. We shoud probably implement that *in python* and not in ansible, because that kind of tasks are difficult to approach and hard to maintain in ansible.
+NOTE: During that process, if a reservation for an instance type fails, the role deletes previous capacity reservations made on that AZ for the other instances types and continues with the next AZ on the list, until an AZ that can host all instances types of the reservation group is found. The role rely on an action plugin, link:../../action_plugins/agnosticd_odcr.py[agnosticd_odcr.py]. The logic is implemented there in python since those kinds of task are difficult to approach and hard to maintain in ansible.
 
-The capacity reservation will be created with a *TTL of 1h*. That should give plenty of time for agnosticd to create the infra.
+The capacity reservation is created with a *TTL of 1h*. That should give plenty of time for agnosticd to create the infra.
 
 When several instance types are under the same AZ group, only an AZ that can host all of them will be selected.
 
-WARNING: Keep in mind that if `aws_region` or `aws_availability_zone` are defined as extra-vars (agnosticV or simply passed to ansible), then the role will not be able to override them.
+WARNING: Keep in mind that if `aws_region` or `aws_availability_zone` are defined as extra-vars (agnosticV or simply passed to ansible), then the role does not override them, and provision is likely to fail if they differ.
 
 [source,yaml]
 .reservation properties
@@ -127,27 +130,22 @@ WARNING: Keep in mind that if `aws_region` or `aws_availability_zone` are define
 
 For more info, see link:https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-tagspecifications[AWS doc].
 
-When `instance_match_criteria` is set to `targeted`, the role will also set the `aws_capacity_reservation_ids` var:
-
-[source,yaml]
-.output
-----
-aws_capacity_reservation_ids:
-  az1: cr-123456789
-  az2: cr-123456789
-----
-
-If `instance_match_criteria` is set to `targeted`, the agnosticd config must support it and the ids must be used in the config, otherwise the reservation will not be used for the instances.
+When `instance_match_criteria` is set to `targeted`, the agnosticd config must support it and the ids must be used in the config, otherwise the reservation will not be used by the instances.
 
 === Should i use open or targeted ? ===
 
 When you're in sandboxes, you can use `open`, and should not really care about `targeted`, as the only thing running in the sandbox will be the current provision.
 
-When in a shared account (ex: GPTE prod account 'gpe'), `targeted` must be used, otherwise there no guarantee which instances will be part of the reservation. Already running instances could match the criteria of the reservation.
+When in a shared account (ex: GPTE prod account 'gpe'), `targeted` should be used, otherwise there is no guarantee which instances will be part of the reservation. Already running instances could match the criteria of the reservation.
 
 At first we would probably use this feature only as `open`, in AWS sandboxes.
 
 WARNING: If you use `targeted`, keep in mind to adjust the TTL properly. Instances targeting a capacity reservation cannot be easily stopped/started. The instances can no longer launch if the target capacity reservation has expired or was canceled.
+
+[source,yaml]
+----
+agnosticd_aws_capacity_reservation_ttl: 1h
+----
 
 === When ? ===
 
@@ -155,10 +153,3 @@ The role would be executed if:
 
 * `agnosticd_aws_capacity_reservation` is defined and not empty
 * `agnosticd_aws_capacity_reservation_enable` is true (default is true)
-
-
-== How to use ODCR in agnosticd config ? ==
-
-The best way is to define the `agnosticd_aws_capacity_reservation` in default vars `default_vars_ec2.yaml` file.
-
-Then, use the

--- a/ansible/roles-infra/infra-aws-capacity-reservation/tasks/create.yaml
+++ b/ansible/roles-infra/infra-aws-capacity-reservation/tasks/create.yaml
@@ -3,14 +3,15 @@
 
 - name: Create on-demand capacity reservations and save result
   agnosticd_odcr:
-    data: "{{ agnosticd_aws_capacity_reservation }}"
+    reservations: "{{ agnosticd_aws_capacity_reservations }}"
+    regions: "{{ agnosticd_aws_capacity_reservation_regions }}"
     aws_access_key_id: "{{ aws_access_key_id }}"
     aws_secret_access_key: "{{ aws_secret_access_key }}"
   register: r_odcr
 
 - name: Set fact agnosticd_aws_capacity_reservation_results
   set_fact:
-    agnosticd_aws_capacity_reservation_results: "{{ r_odcr.data }}"
+    agnosticd_aws_capacity_reservation_results: "{{ r_odcr }}"
 
 - name: Set AZ and region
   set_fact:

--- a/ansible/roles-infra/infra-aws-capacity-reservation/tasks/create.yaml
+++ b/ansible/roles-infra/infra-aws-capacity-reservation/tasks/create.yaml
@@ -7,11 +7,7 @@
     regions: "{{ agnosticd_aws_capacity_reservation_regions }}"
     aws_access_key_id: "{{ aws_access_key_id }}"
     aws_secret_access_key: "{{ aws_secret_access_key }}"
-  register: r_odcr
-
-- name: Set fact agnosticd_aws_capacity_reservation_results
-  set_fact:
-    agnosticd_aws_capacity_reservation_results: "{{ r_odcr }}"
+  register: agnosticd_aws_capacity_reservation_results
 
 - name: Set AZ and region
   set_fact:

--- a/ansible/roles-infra/infra-aws-capacity-reservation/tasks/create.yaml
+++ b/ansible/roles-infra/infra-aws-capacity-reservation/tasks/create.yaml
@@ -1,0 +1,25 @@
+---
+# TODO: test DryRun capacity reservation
+
+- name: Create on-demand capacity reservations and save result
+  set_fact:
+    _capacity_reservations: >-
+      {{ lookup(
+      'agnosticd_aws_create_capacity_reservations',
+      agnosticd_aws_capacity_reservation,
+      ttl=agnosticd_aws_capacity_reservation_ttl
+      )
+      }}
+
+- name: Set AZ and region
+  set_fact:
+    aws_region: "{{ _capacity_reservations.region }}"
+    aws_availability_zones: "{{ _capacity_reservations.azs }}"
+
+- name: Set capacity reservation IDs if any
+  when: _capacity_reservations.ids | default([]) | length > 0
+  set_fact:
+    aws_capacity_reservation_ids: "{{ _capacity_reservations.ids }}"
+
+# TODO: Remove
+- fail:

--- a/ansible/roles-infra/infra-aws-capacity-reservation/tasks/create.yaml
+++ b/ansible/roles-infra/infra-aws-capacity-reservation/tasks/create.yaml
@@ -3,23 +3,31 @@
 
 - name: Create on-demand capacity reservations and save result
   set_fact:
-    _capacity_reservations: >-
+    agnosticd_aws_capacity_reservation_results: >-
       {{ lookup(
       'agnosticd_aws_create_capacity_reservations',
       agnosticd_aws_capacity_reservation,
       ttl=agnosticd_aws_capacity_reservation_ttl
       )
       }}
+  changed_when: true
+
+- debug:
+    var: agnosticd_aws_capacity_reservation_results
 
 - name: Set AZ and region
   set_fact:
-    aws_region: "{{ _capacity_reservations.region }}"
-    aws_availability_zones: "{{ _capacity_reservations.azs }}"
+    aws_region: "{{ agnosticd_aws_capacity_reservation_results.region }}"
 
-- name: Set capacity reservation IDs if any
-  when: _capacity_reservations.ids | default([]) | length > 0
+- name: Ensure aws_region is not passed as extra vars and different
+  assert:
+    that: aws_region == agnosticd_aws_capacity_reservation_results.region
+    msg: >-
+      If you want to use on-demand capacity reservations, do not set
+      aws_region as extra-vars.
+
+- name: Set default aws_availability_zone (single AZ)
+  when: agnosticd_aws_capacity_reservation_results.single_availability_zone | default('') != ''
   set_fact:
-    aws_capacity_reservation_ids: "{{ _capacity_reservations.ids }}"
+    aws_availability_zone: "{{ agnosticd_aws_capacity_reservation_results.single_availability_zone }}"
 
-# TODO: Remove
-- fail:

--- a/ansible/roles-infra/infra-aws-capacity-reservation/tasks/create.yaml
+++ b/ansible/roles-infra/infra-aws-capacity-reservation/tasks/create.yaml
@@ -2,18 +2,15 @@
 # TODO: test DryRun capacity reservation
 
 - name: Create on-demand capacity reservations and save result
-  set_fact:
-    agnosticd_aws_capacity_reservation_results: >-
-      {{ lookup(
-      'agnosticd_aws_create_capacity_reservations',
-      agnosticd_aws_capacity_reservation,
-      ttl=agnosticd_aws_capacity_reservation_ttl
-      )
-      }}
-  changed_when: true
+  agnosticd_odcr:
+    data: "{{ agnosticd_aws_capacity_reservation }}"
+    aws_access_key_id: "{{ aws_access_key_id }}"
+    aws_secret_access_key: "{{ aws_secret_access_key }}"
+  register: r_odcr
 
-- debug:
-    var: agnosticd_aws_capacity_reservation_results
+- name: Set fact agnosticd_aws_capacity_reservation_results
+  set_fact:
+    agnosticd_aws_capacity_reservation_results: "{{ r_odcr.data }}"
 
 - name: Set AZ and region
   set_fact:

--- a/ansible/roles-infra/infra-aws-capacity-reservation/tasks/destroy.yaml
+++ b/ansible/roles-infra/infra-aws-capacity-reservation/tasks/destroy.yaml
@@ -1,0 +1,15 @@
+
+---
+- name: Delete on-demand capacity reservations and save result
+  set_fact:
+    agnosticd_aws_capacity_reservation_results: >-
+      {{ lookup(
+      'agnosticd_aws_create_capacity_reservations',
+      agnosticd_aws_capacity_reservation,
+      ttl=agnosticd_aws_capacity_reservation_ttl
+      ACTION='destroy',
+      )
+      }}
+
+- debug:
+    var: agnosticd_aws_capacity_reservation_results

--- a/ansible/roles-infra/infra-aws-capacity-reservation/tasks/destroy.yaml
+++ b/ansible/roles-infra/infra-aws-capacity-reservation/tasks/destroy.yaml
@@ -1,7 +1,8 @@
 ---
-- name: Cancel on-demand capacity reservations and save result
+- name: Cancel on-demand capacity reservations
   agnosticd_odcr:
-    data: "{{ agnosticd_aws_capacity_reservation }}"
+    regions: "{{ agnosticd_aws_capacity_reservation_regions }}"
+    reservations: "{{ agnosticd_aws_capacity_reservations }}"
     aws_access_key_id: "{{ aws_access_key_id }}"
     aws_secret_access_key: "{{ aws_secret_access_key }}"
     state: absent
@@ -9,4 +10,4 @@
 
 - name: Set fallback_regions (for deletion in the right region using aws_region_final)
   set_fact:
-    fallback_regions: "{{ agnosticd_aws_capacity_reservation.regions }}"
+    fallback_regions: "{{ agnosticd_aws_capacity_reservation_regions }}"

--- a/ansible/roles-infra/infra-aws-capacity-reservation/tasks/destroy.yaml
+++ b/ansible/roles-infra/infra-aws-capacity-reservation/tasks/destroy.yaml
@@ -6,3 +6,7 @@
     aws_secret_access_key: "{{ aws_secret_access_key }}"
     state: absent
   register: r_odcr
+
+- name: Set fallback_regions (for deletion in the right region using aws_region_final)
+  set_fact:
+    fallback_regions: "{{ agnosticd_aws_capacity_reservation.regions }}"

--- a/ansible/roles-infra/infra-aws-capacity-reservation/tasks/destroy.yaml
+++ b/ansible/roles-infra/infra-aws-capacity-reservation/tasks/destroy.yaml
@@ -1,15 +1,8 @@
-
 ---
-- name: Delete on-demand capacity reservations and save result
-  set_fact:
-    agnosticd_aws_capacity_reservation_results: >-
-      {{ lookup(
-      'agnosticd_aws_create_capacity_reservations',
-      agnosticd_aws_capacity_reservation,
-      ttl=agnosticd_aws_capacity_reservation_ttl
-      ACTION='destroy',
-      )
-      }}
-
-- debug:
-    var: agnosticd_aws_capacity_reservation_results
+- name: Cancel on-demand capacity reservations and save result
+  agnosticd_odcr:
+    data: "{{ agnosticd_aws_capacity_reservation }}"
+    aws_access_key_id: "{{ aws_access_key_id }}"
+    aws_secret_access_key: "{{ aws_secret_access_key }}"
+    state: absent
+  register: r_odcr

--- a/ansible/roles-infra/infra-aws-capacity-reservation/tasks/main.yaml
+++ b/ansible/roles-infra/infra-aws-capacity-reservation/tasks/main.yaml
@@ -5,6 +5,6 @@
   block:
     - include_tasks: pre_checks.yaml
     - include_tasks: create.yaml
-      when: ACTION == provision
+      when: ACTION == 'provision'
     - include_tasks: destroy.yaml
-      when: ACTION == destroy
+      when: ACTION == 'destroy'

--- a/ansible/roles-infra/infra-aws-capacity-reservation/tasks/main.yaml
+++ b/ansible/roles-infra/infra-aws-capacity-reservation/tasks/main.yaml
@@ -5,3 +5,6 @@
   block:
     - include_tasks: pre_checks.yaml
     - include_tasks: create.yaml
+      when: ACTION == provision
+    - include_tasks: destroy.yaml
+      when: ACTION == destroy

--- a/ansible/roles-infra/infra-aws-capacity-reservation/tasks/main.yaml
+++ b/ansible/roles-infra/infra-aws-capacity-reservation/tasks/main.yaml
@@ -1,0 +1,7 @@
+---
+- when:
+    - agnosticd_aws_capacity_reservation is defined
+    - agnosticd_aws_capacity_reservation_enable | bool
+  block:
+    - include_tasks: pre_checks.yaml
+    - include_tasks: create.yaml

--- a/ansible/roles-infra/infra-aws-capacity-reservation/tasks/main.yaml
+++ b/ansible/roles-infra/infra-aws-capacity-reservation/tasks/main.yaml
@@ -1,6 +1,6 @@
 ---
 - when:
-    - agnosticd_aws_capacity_reservation is defined
+    - agnosticd_aws_capacity_reservations is defined
     - agnosticd_aws_capacity_reservation_enable | bool
   block:
     - include_tasks: pre_checks.yaml

--- a/ansible/roles-infra/infra-aws-capacity-reservation/tasks/pre_checks.yaml
+++ b/ansible/roles-infra/infra-aws-capacity-reservation/tasks/pre_checks.yaml
@@ -8,8 +8,8 @@
     loop_var: check
     label: "{{ check.msg }}"
   loop:
-    - msg: reservations are missing in agnosticd_aws_capacity_reservation dictionary
-      that: agnosticd_aws_capacity_reservation.reservations | default([]) | length > 0
+    - msg: agnosticd_aws_capacity_reservations dictionary is empty
+      that: agnosticd_aws_capacity_reservations | default({}) | length > 0
 
-    - msg: regions are missing in agnosticd_aws_capacity_reservation dictionary
-      that: agnosticd_aws_capacity_reservation.regions | default([]) | length > 0
+    - msg: agnosticd_aws_capacity_reservation_regions list is empty
+      that: agnosticd_aws_capacity_reservation_regions | default([]) | length > 0

--- a/ansible/roles-infra/infra-aws-capacity-reservation/tasks/pre_checks.yaml
+++ b/ansible/roles-infra/infra-aws-capacity-reservation/tasks/pre_checks.yaml
@@ -1,0 +1,15 @@
+---
+- name: Ensure mandatory variables are set
+  assert:
+    that: "{{ check.that }}"
+    fail_msg: "{{ check.msg }}"
+    quiet: true
+  loop_control:
+    loop_var: check
+    label: "{{ check.msg }}"
+  loop:
+    - msg: reservations are missing in agnosticd_aws_capacity_reservation dictionary
+      that: agnosticd_aws_capacity_reservation.reservations | default([]) | length > 0
+
+    - msg: regions are missing in agnosticd_aws_capacity_reservation dictionary
+      that: agnosticd_aws_capacity_reservation.regions | default([]) | length > 0

--- a/ansible/roles-infra/infra-ec2-template-destroy/tasks/ec2_detect_region_tasks.yml
+++ b/ansible/roles-infra/infra-ec2-template-destroy/tasks/ec2_detect_region_tasks.yml
@@ -10,16 +10,16 @@
         aws cloudformation describe-stacks
         --stack-name {{project_tag}} --region {{item}}
       register: cloudformation_detect
-      with_items: "{{ [aws_region] + fallback_regions|d([]) }}"
+      loop: "{{ [aws_region] + fallback_regions|d([]) }}"
       changed_when: false
       failed_when: false
 
     - name: Set aws_region_final
       set_fact:
-        aws_region_final: "{{item._ansible_item_label}}"
-      with_items: "{{cloudformation_detect.results}}"
+        aws_region_final: "{{item.item}}"
+      loop: "{{cloudformation_detect.results}}"
       loop_control:
-        label: "{{item._ansible_item_label|d('unknown')}}"
+        label: "{{item.item|d('unknown')}}"
       when: item.rc == 0
 
 # else just set as the provided aws_region

--- a/tools/builds/Dockerfile-aws
+++ b/tools/builds/Dockerfile-aws
@@ -3,7 +3,7 @@ FROM python:3
 LABEL maintainer="Guillaume Core (fridim) <gucore@redhat.com>"
 
 RUN pip install --upgrade pip
-RUN pip install ansible awscli
+RUN pip install ansible==2.9.15 awscli
 RUN pip install boto boto3
 
 USER ${USER_UID}


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

Implement on-demand capacity reservations in agnosticd.

A certain % of our provisions are failing because of *InstanceInsufficientCapacity* error in AWS.

This change implements the creation of capacity reservations as described here:
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-reservations.html

In a nutshell, if ODCR is wanted and supported by the config:
1. role  determines the AZs with matching instance-type offerings
2. role creates the capacity reservations
3. if it fails, move to next AZ
4. if it fails again, move to next region


Input vars and output Vars are described in the readme of the role.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request


##### COMPONENT NAME
- ansible/action_plugins/agnosticd_odcr.py 
- ansible/roles-infra/infra-aws-capacity-reservation

##### ADDITIONAL INFORMATION

To heavily test that feature the following setting can be used:

```yaml
# AWS on-demand capacity reservation
agnosticd_aws_capacity_reservation:
  regions:
  - "ap-southeast-1"
  - "ap-southeast-2"
  - "eu-west-2"
  - "us-east-2"
  reservations:
    az1:
      - instance_count: 2
        instance_platform: Linux/UNIX
        instance_type: "a1.xlarge"
      - instance_count: 2
        instance_platform: Linux/UNIX
        instance_type: "m5.xlarge"
      - instance_count: 2
        instance_platform: Linux/UNIX
        instance_type: "m5.xlarge"
      - instance_count: 20
        instance_platform: Linux/UNIX
        instance_type: "m5a.8xlarge"
    az2:
      - instance_count: 10
        instance_platform: Linux/UNIX
        instance_type: "m5a.4xlarge"
      - instance_count: 2
        instance_platform: Linux/UNIX
        instance_type: "c5.large"
      - instance_count: 2
        instance_platform: Linux/UNIX
        instance_type: "m4.4xlarge"
      - instance_count: 2
        instance_platform: Linux/UNIX
        instance_type: "m5zn.large"
      - instance_count: 2
        instance_platform: Linux/UNIX
        instance_type: "m6g.xlarge"
      - instance_count: 2
        instance_platform: Linux/UNIX
        instance_type: "m5n.large"

```

Example output with the above input:

```
TASK [infra-aws-capacity-reservation : Create on-demand capacity reservations and save result] ************
Thursday 25 March 2021  21:56:10 +0000 (0:00:00.099)       0:00:04.904 ********
Reservation created: cr-00774fde905632bc9 (ap-southeast-1a)
Reservation created: cr-0e6113bfb628434da (ap-southeast-1a)
Reservation created: cr-0a5e0e734cc808edb (ap-southeast-1a)
InsufficientInstanceCapacity ap-southeast-1a - 20 * m5a.8xlarge
reservation could not be created in ap-southeast-1a, trying next AZ.
Reservation canceled: cr-00774fde905632bc9  (ap-southeast-1)
Reservation canceled: cr-0e6113bfb628434da  (ap-southeast-1)
Reservation canceled: cr-0a5e0e734cc808edb  (ap-southeast-1)
Reservation created: cr-0df74dfb39a778905 (ap-southeast-1b)
Reservation created: cr-06184b7180c95857f (ap-southeast-1b)
Reservation created: cr-07f0f01206c886099 (ap-southeast-1b)
InsufficientInstanceCapacity ap-southeast-1b - 20 * m5a.8xlarge
reservation could not be created in ap-southeast-1b, trying next AZ.
Reservation canceled: cr-0df74dfb39a778905  (ap-southeast-1)
Reservation canceled: cr-06184b7180c95857f  (ap-southeast-1)
Reservation canceled: cr-07f0f01206c886099  (ap-southeast-1)
Reservations could not be created in ap-southeast-1, trying next region.
Reservation created: cr-02f6406c408d1e75d (ap-southeast-2b)
Reservation created: cr-074477b9c268b0652 (ap-southeast-2b)
Reservation created: cr-08287568be4415009 (ap-southeast-2b)
InsufficientInstanceCapacity ap-southeast-2b - 20 * m5a.8xlarge
reservation could not be created in ap-southeast-2b, trying next AZ.
Reservation canceled: cr-02f6406c408d1e75d  (ap-southeast-2)
Reservation canceled: cr-074477b9c268b0652  (ap-southeast-2)
Reservation canceled: cr-08287568be4415009  (ap-southeast-2)
Reservation created: cr-06c1637156e702982 (ap-southeast-2c)
Reservation created: cr-097d0056ac5a02c4b (ap-southeast-2c)
Reservation created: cr-041507431748ec134 (ap-southeast-2c)
InsufficientInstanceCapacity ap-southeast-2c - 20 * m5a.8xlarge
reservation could not be created in ap-southeast-2c, trying next AZ.
Reservation canceled: cr-06c1637156e702982  (ap-southeast-2)
Reservation canceled: cr-097d0056ac5a02c4b  (ap-southeast-2)
Reservation canceled: cr-041507431748ec134  (ap-southeast-2)
Reservations could not be created in ap-southeast-2, trying next region.
Reservations could not be created in eu-west-2, trying next region.
Reservation created: cr-0adb932601680a55c (us-east-2a)
Reservation created: cr-06209579e1c9ada76 (us-east-2a)
Reservation created: cr-0e7fbbfd75a48f4d8 (us-east-2a)
InstanceLimitExceeded us-east-2a - 20 * m5a.8xlarge
Reservation could not be created in us-east-2a, trying next AZ.
reservation could not be created in us-east-2a, trying next AZ.
Reservation canceled: cr-0adb932601680a55c  (us-east-2)
Reservation canceled: cr-06209579e1c9ada76  (us-east-2)
Reservation canceled: cr-0e7fbbfd75a48f4d8  (us-east-2)
Reservation created: cr-07b5f5e68ad8529ae (us-east-2b)
Reservation created: cr-02d2334cb4d04cd48 (us-east-2b)
Reservation created: cr-08544d614d8787c15 (us-east-2b)
InsufficientInstanceCapacity us-east-2b - 20 * m5a.8xlarge
reservation could not be created in us-east-2b, trying next AZ.
Reservation canceled: cr-07b5f5e68ad8529ae  (us-east-2)
Reservation canceled: cr-02d2334cb4d04cd48  (us-east-2)
Reservation canceled: cr-08544d614d8787c15  (us-east-2)
Reservations could not be created in us-east-2, trying next region.
Reservation created: cr-00168f2be46bbe716 (us-east-1c)
Reservation created: cr-0a5e77bf4dc6e5fb0 (us-east-1c)
Reservation created: cr-0fa16b79ad9cc68cf (us-east-1c)
Reservation created: cr-00949d6f32ebfa838 (us-east-1c)
Reservation created: cr-074f838673e2e28d7 (us-east-1f)
Reservation created: cr-02abf3540d412f6ee (us-east-1f)
Reservation created: cr-06fa198103aa6b5eb (us-east-1f)
Reservation created: cr-0e264b79e08d481ec (us-east-1f)
Reservation created: cr-08021a2c39f3375fb (us-east-1f)
Reservation created: cr-0ccea54a010ec4c4e (us-east-1f)
changed: [localhost]
```

As you can see in that example, it tries all AZs of a region, cancels all reservations if one failed before moving to the next region.