### PR TITLE
Fix Satellite services restart

### DIFF
--- a/ansible/configs/sap-smart/sat_workload.yml
+++ b/ansible/configs/sap-smart/sat_workload.yml
@@ -64,10 +64,8 @@
   run_once: true
   become: false
 
-- name: Ensure katello-service is restarted
-  service:
-    name: katello-service
-    state: restarted
+- name: Restart all Satellite services
+  command: katello-service restart
 
 - name: "Add manifest to Satellite"
   command: >


### PR DESCRIPTION
##### SUMMARY

Use katello-service to restart Satellite services

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
sap-smart


