### PR TITLE
remove ftl due to python module conflicts

### DIFF
--- a/ansible/configs/ocp4-disconnected-osp-lab/default_vars.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/default_vars.yml
@@ -92,7 +92,7 @@ install_k8s_modules: false
 # This var will determine if ftl-injector is installed.
 # When set to true a requirements.yml must exist in the config
 # specifying the version of ftl-injector to install
-install_ftl: true
+# install_ftl: true
 
 # FTL injector will try to install python-pip and we only have python3-pip available
 # This var will force the ftl-injector role to adapt accordingly


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

remove ftl from ocp4-disconnected-osp-lab due to python module conflicts

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-disconnected-osp-lab

<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
