### PR TITLE
Add student user option to default CFN template

### DIFF
--- a/ansible/roles-infra/infra-ec2-template-generate/templates/cloud_template.j2
+++ b/ansible/roles-infra/infra-ec2-template-generate/templates/cloud_template.j2
@@ -364,7 +364,10 @@ Resources:
           Ref: Route53User
 {% endif %}
 
-{% if sandbox_student_user %}
+{% if sandbox_student_user 
+   and (agnosticv_meta.sandboxed | bool
+   or __meta__.aws_sandboxed | bool) 
+%}
   StudentUser:
     Type: AWS::IAM::User
     Properties:
@@ -407,7 +410,10 @@ Outputs:
     Description: IAM User for Route53 (Let's Encrypt)
 {% endif %}
 
-{% if sandbox_student_user %}
+{% if sandbox_student_user 
+   and (agnosticv_meta.sandboxed | bool
+   or __meta__.aws_sandboxed | bool) 
+%}
   StudentUser:
     Value:
       Ref: StudentUser

--- a/ansible/roles-infra/infra-ec2-template-generate/templates/cloud_template.j2
+++ b/ansible/roles-infra/infra-ec2-template-generate/templates/cloud_template.j2
@@ -364,6 +364,27 @@ Resources:
           Ref: Route53User
 {% endif %}
 
+{% if sandbox_student_user %}
+  StudentUser:
+    Type: AWS::IAM::User
+    Properties:
+      UserName: "{{ email | default(owner) }}-{{ guid }}"
+      Policies:
+        - PolicyName: AccessAll
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action: "*"
+                Resource: "*"
+
+  StudentUserAccessKey:
+      DependsOn: StudentUser
+      Type: AWS::IAM::AccessKey
+      Properties:
+        UserName:
+          Ref: StudentUser
+{% endif %}
+
 Outputs:
   Route53internalzoneOutput:
     Description: The ID of the internal route 53 zone
@@ -384,4 +405,23 @@ Outputs:
         - Route53UserAccessKey
         - SecretAccessKey
     Description: IAM User for Route53 (Let's Encrypt)
+{% endif %}
+
+{% if sandbox_student_user %}
+  StudentUser:
+    Value:
+      Ref: StudentUser
+    Description: IAM User for Student
+
+  StudentUserAccessKey:
+    Value:
+      Ref: StudentUserAccessKey
+    Description: IAM access key for Student
+
+  StudentUserSecretAccessKey:
+    Value:
+      Fn::GetAtt:
+        - StudentUserAccessKey
+        - SecretAccessKey
+    Description: IAM secret access key for student
 {% endif %}


### PR DESCRIPTION
##### SUMMARY

This adds the option to enable a new set of credentials to the default CFN template. This can be used when there is a need for an environment provisioned in a sandbox account to interact directly with an AWS service.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
infra-ec2-template-generate