### PR TITLE
Adding ownership change on file copy to student

### DIFF
--- a/ansible/roles/ocp4-workload-migration/tasks/post_workload.yml
+++ b/ansible/roles/ocp4-workload-migration/tasks/post_workload.yml
@@ -15,6 +15,7 @@
 - when: student_name is defined
   name: "Saving OCP4 cluster info for bookbag deployment"
   copy:
+    owner: {{ student_name }}
     content: |
       [OCP4]
       guid={{ guid }}

--- a/ansible/roles/ocp4-workload-migration/tasks/post_workload.yml
+++ b/ansible/roles/ocp4-workload-migration/tasks/post_workload.yml
@@ -15,7 +15,7 @@
 - when: student_name is defined
   name: "Saving OCP4 cluster info for bookbag deployment"
   copy:
-    owner: {{ student_name }}
+    owner: "{{ student_name }}"
     content: |
       [OCP4]
       guid={{ guid }}


### PR DESCRIPTION
##### SUMMARY

Created files in the user directory are owned by root, and not the lab user. 
That makes it difficult to work with. 
Added student user ownership at copy time

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
role, ocp4_workload_migration, post workload scritps.

##### ADDITIONAL INFORMATION
