### PR TITLE
Add parameters for Slack binding to avoid rate limits

### DIFF
--- a/ansible/configs/sap-integration/files/k8s/kamelet_slack_source.j2
+++ b/ansible/configs/sap-integration/files/k8s/kamelet_slack_source.j2
@@ -39,6 +39,9 @@ spec:
       uri: "slack:{{channel}}"
       parameters:
         token: "{{token}}"
+        lazyStartProducer: true
+        delay: 10000
+        initialDelay: 30000
 {% endraw %}
       steps:
       - marshal:


### PR DESCRIPTION

##### SUMMARY

Slack is complaining about API rate limits when running multiple instances of the lab. This will prevent that

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
sap-integration


