### PR TITLE
Remove version pin which causes continual upgrade and OLM race condit…

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhte19_shadowman/templates/amq-streams.yml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhte19_shadowman/templates/amq-streams.yml.j2
@@ -20,4 +20,3 @@
     name: amq-streams
     source: redhat-operators
     sourceNamespace: openshift-marketplace
-    startingCSV: amqstreams.v1.5.3

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhte19_shadowman/templates/datagrid.yml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhte19_shadowman/templates/datagrid.yml.j2
@@ -20,4 +20,3 @@
     name: datagrid
     source: redhat-operators
     sourceNamespace: openshift-marketplace
-    startingCSV: datagrid-operator.v8.1.0


### PR DESCRIPTION
…ions

##### SUMMARY

The Catalog Item for the OpenShift 4 Shadowman Sprint Demo has been failing for awhile since updates were released to the DataGrid and AMQ Streams operators. We originally pinned our `Subscription` specs with a `startingCSV`, and since the `updatePolicy: Automatic`, creation of the `Subscription` results in a series of updates, which continually replaces the `Infinispan` and `KafkaCluster` CRDs.

Removal of the `startingCSV` should simply install the latest available version, resolving the issue.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_rhte19_shadowman

##### ADDITIONAL INFORMATION
Error output: 
```bash
TASK [ocp4_workload_rhte19_shadowman : Create Infinispan CR] *******************
Tuesday 06 April 2021  14:11:26 -0400 (0:00:02.429)       0:55:12.556 ********* 
FAILED - RETRYING: Create Infinispan CR (10 retries left).
...
FAILED - RETRYING: Create Infinispan CR (1 retries left).
fatal: [bastion.test-7351.internal]: FAILED! => {"attempts": 10, "changed": false, "msg": "Failed to find exact match for infinispan.org/v1.Infinispan by [kind, name, singularName, shortNames]"}

NO MORE HOSTS LEFT *************************************************************

PLAY RECAP *********************************************************************
bastion.test-7351.internal : ok=199  changed=97   unreachable=0    failed=1    skipped=89   rescued=0    ignored=0   
localhost                  : ok=66   changed=11   unreachable=0    failed=0    skipped=56   rescued=0    ignored=0
```

After changes:
```bash
...
TASK [ocp4_workload_rhte19_shadowman : Running Workload removal Tasks] *************************************************************
Monday 12 April 2021  15:08:04 -0400 (0:00:00.040)       0:01:16.473 ********** 
skipping: [127.0.0.1]

TASK [Run multiple workloads] ******************************************************************************************************
Monday 12 April 2021  15:08:04 -0400 (0:00:00.031)       0:01:16.505 ********** 
skipping: [127.0.0.1]

PLAY RECAP *************************************************************************************************************************
127.0.0.1                  : ok=23   changed=9    unreachable=0    failed=0    skipped=4    rescued=0    ignored=0   

```

