### PR TITLE
Updating vars to reflect new ones in ocp4-cluster

### DIFF
--- a/ansible/roles/ocp4-workload-migration/tasks/post_workload.yml
+++ b/ansible/roles/ocp4-workload-migration/tasks/post_workload.yml
@@ -41,9 +41,9 @@
     block: |
       STUDENT={{ student_name }}
       PASSWORD={{ student_password }}
-      API_LOGIN={{ admin_user }}
-      API_PASS={{ admin_password }}
-      API_ADDRESS={{ openshift_api_url }}
+      API_LOGIN={{ ocp4_workload_authentication_admin_user }}
+      API_PASS={{ ocp4_workload_authentication_htpasswd_admin_password }}
+      API_ADDRESS={{ api_url.stdout | trim }}
       LOCAL_GUID={{ guid }}
 
 # For deployment onto a dedicated cluster (as part of the


### PR DESCRIPTION

##### SUMMARY

The variables were relying on old vars from ocp4-workshop.
We moved to ocp4-cluster, and the variables are different. 


##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
ocp4-workload-migration role

##### ADDITIONAL INFORMATION
