### PR TITLE
Mtc version bump and approval check

### DIFF
--- a/ansible/roles/ocp4-workload-migration/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-migration/tasks/workload.yml
@@ -44,6 +44,10 @@
     k8s:
       state: present
       definition: "{{ mtc_approved_install_plan }}"
+    register: approval
+    until: approval is succeeded
+    delay: 3
+    retries: 10
 
 - name: "Wait for Migration CRDs to exist"
   k8s_info:

--- a/ansible/roles/ocp4-workload-migration/templates/mig-operator-subscription-downstream.yml.j2
+++ b/ansible/roles/ocp4-workload-migration/templates/mig-operator-subscription-downstream.yml.j2
@@ -6,7 +6,7 @@ metadata:
 spec:
   channel: release-v1.4
   installPlanApproval: Manual
-  startingCSV: mtc-operator.v1.4.0
+  startingCSV: mtc-operator.v1.4.2
   name: mtc-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION

##### SUMMARY
Updated MTC to 1.4.2

In the  new MTC  we are trying to approve the plan but the OLM is also adding some status fields to the same install plan and changing the observedGeneration of the object. 
We need to try and retry.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

role: ocp4-workload-migration

##### ADDITIONAL INFORMATION
