### PR TITLE
Move the loop to block, not the Approve task

### DIFF
--- a/ansible/roles/ocp4-workload-migration/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-migration/tasks/workload.yml
@@ -45,9 +45,9 @@
       state: present
       definition: "{{ mtc_approved_install_plan }}"
     register: approval
-    until: approval is succeeded
-    delay: 3
-    retries: 10
+  until: approval is succeeded
+  delay: 3
+  retries: 10
 
 - name: "Wait for Migration CRDs to exist"
   k8s_info:


### PR DESCRIPTION

##### SUMMARY

The loop has to go over the whole block, repeating just the last task was a mistake


##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

role, ocp4-workload-migration

##### ADDITIONAL INFORMATION
