### PR TITLE
Add generic operator install role

### DIFF
--- a/ansible/roles/install_operator/defaults/main.yml
+++ b/ansible/roles/install_operator/defaults/main.yml
@@ -1,0 +1,68 @@
+---
+become_override: false
+ocp_username: opentlc-mgr
+silent: false
+
+# Install or remove the operator
+install_operator_action: install
+# install_operator_action: remove
+
+# Name of the Operator. Must match the name of the PackageManifest
+# in the openshift-marketplace project (or wherever the custom catalogsource is installed)
+install_operator_name: openshift-pipelines
+
+# Namespace to install the operator into
+install_operator_namespace: openshift-operators
+
+# Catalog which holds the operator. Ignored when using a catalog snapshot (see below)
+install_operator_catalog: redhat-operators
+
+# PackageManifest name for the operator. 
+# Usually the same as the operator name - but sometimes (pipelines...) not
+install_operator_packagemanifest_name: "{{ install_operator_name }}"
+
+# Channel to use for the operator subscription
+# When not set (or set to "") use the default channel for the
+# OpenShift version this operator is installed on. If there is no matching
+# version use the `defaultChannel`
+install_operator_channel: ""
+# install_operator_channel: "4.7"
+
+# Set automatic InstallPlan approval. If set to false it is also suggested
+# to set the starting_csv to pin a specific version
+# This variable has no effect when using a catalog snapshot (always true)
+install_operator_automatic_install_plan_approval: true
+
+# CSV Name. Some operators (pipelines, cough, cough) use different CSV names from
+# the operator or package manifest names.
+install_operator_csv_nameprefix: "{{ install_operator_name }}"
+
+# Set a starting ClusterServiceVersion.
+# Recommended to leave empty to get latest in the channel when not using
+# a catalog snapshot.
+# Highly recommended to be set when using a catalog snapshot but can be
+# empty to get the latest available in the channel at the time when
+# the catalog snapshot got created.
+install_operator_starting_csv: ""
+
+# --------------------------------
+# Operator Catalog Snapshot Settings
+# --------------------------------
+# See https://github.com/redhat-cop/agnosticd/blob/development/docs/Operator_Catalog_Snapshots.adoc
+# for instructions on how to set up catalog snapshot images
+
+# Use a catalog snapshot
+install_operator_use_catalog_snapshot: false
+
+# Catalog Source Name when using a catalog snapshot. This should be unique
+# in the cluster to avoid clashes
+install_operator_catalogsource_name: "{{ install_operator_name }}-catalogsource"
+
+# Namespace to install the catalogsource into:
+install_operator_catalogsource_namespace: openshift-operators
+
+# Catalog snapshot image
+install_operator_catalog_snapshot_image: quay.io/gpte-devops-automation/olm_snapshot_redhat_catalog
+
+# Catalog snapshot image tag
+install_operator_catalog_snapshot_image_tag: "v4.7_2021_04_12"

--- a/ansible/roles/install_operator/meta/main.yml
+++ b/ansible/roles/install_operator/meta/main.yml
@@ -1,0 +1,18 @@
+---
+galaxy_info:
+  role_name: install_operator
+  author: Red Hat GPTE, Wolfgang Kulhanek (wkulhane@redhat.com)
+  description: |
+    Set up an Operator on OpenShift Container Platform.
+    Optionally using a Catalog Snapshot.
+    Does no operator configuration after install.
+    This is a utility role with common logic to be called
+    from other operator installation roles.
+  license: MIT
+  min_ansible_version: 2.9
+  platforms: []
+  galaxy_tags:
+  - ocp
+  - openshift
+  - operators
+dependencies: []

--- a/ansible/roles/install_operator/tasks/install.yml
+++ b/ansible/roles/install_operator/tasks/install.yml
@@ -1,0 +1,109 @@
+---
+- name: Create Catalogsource for use with catalog snapshot
+  when: install_operator_use_catalog_snapshot | bool
+  k8s:
+    state: present
+    definition: "{{ lookup('template', './templates/catalogsource.j2' ) | from_yaml }}"
+
+- name: Determine channel for the operator is no channel specified
+  when: install_operator_channel | default("") | length == 0
+  block:
+  - name: Get cluster version
+    k8s_info:
+      api_version: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+    register: r_cluster_version
+
+  - name: Get current stable channel for the operator
+    k8s_info:
+      api_version: packages.operators.coreos.com/v1
+      kind: PackageManifest
+      name: "{{ install_operator_packagemanifest_name }}"
+      namespace: openshift-marketplace
+    register: r_channel
+
+  # Set channel to the one matching the deployed cluster version.
+  # If no matching channel available set to defaultChannel from the subscription.
+  - name: Set operator channel
+    set_fact:
+      install_operator_channel: >-
+        {{ t_version_match_channel | default(r_channel.resources[0].status.defaultChannel, true) }}
+    vars:
+      t_cluster_version: >-
+        {{ r_cluster_version.resources[0].spec.channel | regex_replace('.*-(\d+\.\d+)', '\1') }}
+      t_version_match_query: "[?name=='{{ t_cluster_version }}']|[0].name"
+      t_version_match_channel: >-
+        {{ r_channel.resources[0].status.channels | json_query(t_version_match_query) }}
+
+- name: Print operator channel to be installed
+  debug:
+    msg: "Operator channel to be installed: {{ install_operator_channel }}"
+
+- name: Create operator subscription
+  k8s:
+    state: present
+    definition: "{{ lookup('template', './templates/subscription.j2' ) | from_yaml }}"
+
+- name: Wait until InstallPlan is created
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: InstallPlan
+    namespace: "{{ install_operator_namespace }}"
+  register: r_install_plans
+  vars:
+    _query: >-
+      [?starts_with(spec.clusterServiceVersionNames[0], '{{ install_operator_csv_nameprefix }}' )]
+  retries: 30
+  delay: 5
+  until:
+  - r_install_plans.resources | length > 0
+  - r_install_plans.resources | to_json | from_json | json_query(_query)
+
+- name: Set InstallPlan name
+  set_fact:
+    install_operator_install_plan_name: "{{ r_install_plans.resources | to_json | from_json | json_query(query) }}"
+  vars:
+    query: >-
+      [?starts_with(spec.clusterServiceVersionNames[0], '{{ install_operator_csv_nameprefix }}' )].metadata.name|[0]
+
+- name: Get InstallPlan
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: InstallPlan
+    name: "{{ install_operator_install_plan_name }}"
+    namespace: "{{ install_operator_namespace }}"
+  register: r_install_plan
+
+- name: Approve InstallPlan if necessary
+  when: r_install_plan.resources[0].status.phase is match("RequiresApproval")
+  k8s:
+    state: present
+    definition: "{{ lookup( 'template', './templates/installplan.j2' ) }}"
+
+- name: Get Installed CSV
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: Subscription
+    name: "{{ install_operator_name }}"
+    namespace: "{{ install_operator_namespace }}"
+  register: r_subscription
+  retries: 30
+  delay: 5
+  until:
+  - r_subscription.resources[0].status.currentCSV is defined
+  - r_subscription.resources[0].status.currentCSV | length > 0
+
+- name: Wait until CSV is Installed
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    name: "{{ r_subscription.resources[0].status.currentCSV }}"
+    namespace: "{{ install_operator_namespace }}"
+  register: r_csv
+  retries: 30
+  delay: 5
+  until:
+  - r_csv.resources[0].status.phase is defined
+  - r_csv.resources[0].status.phase | length > 0
+  - r_csv.resources[0].status.phase == "Succeeded"

--- a/ansible/roles/install_operator/tasks/main.yml
+++ b/ansible/roles/install_operator/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+# Do not modify this file
+
+- name: Install the operator
+  when: install_operator_action == "install"
+  include_tasks:
+    file: ./install.yml
+
+- name: Remove the operator
+  when: install_operator_action == "remove"
+  include_tasks:
+    file: ./remove.yml

--- a/ansible/roles/install_operator/tasks/remove.yml
+++ b/ansible/roles/install_operator/tasks/remove.yml
@@ -1,0 +1,60 @@
+---
+- name: Get Installed CSV
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: Subscription
+    name: "{{ install_operator_name }}"
+    namespace: "{{ install_operator_namespace }}"
+  register: r_subscription
+
+- name: Remove CSV
+  when:
+  - r_subscription.resources | length > 0
+  - r_subscription.resources[0].status.currentCSV is defined
+  - r_subscription.resources[0].status.currentCSV | length > 0
+  k8s:
+    state: absent
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    name: "{{ r_subscription.resources[0].status.currentCSV }}"
+    namespace: "{{ install_operator_namespace }}"
+
+- name: Remove subscription
+  k8s:
+    state: absent
+    api_version: operators.coreos.com/v1alpha1
+    kind: Subscription
+    name: "{{ install_operator_name }}"
+    namespace: "{{ install_operator_namespace }}"
+
+- name: Find InstallPlan
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: InstallPlan
+    namespace: "{{ install_operator_namespace }}"
+  register: r_install_plans
+
+- name: Set InstallPlan name
+  when: r_install_plans.resources | length > 0
+  set_fact:
+    install_operator_install_plan_name: "{{ r_install_plans.resources | to_json | from_json | json_query(query) }}"
+  vars:
+    query: >-
+      [?starts_with(spec.clusterServiceVersionNames[0], '{{ install_operator_csv_nameprefix }}' )].metadata.name|[0]
+
+- name: Remove InstallPlan
+  when: install_operator_install_plan_name | default("") | length > 0
+  k8s:
+    state: absent
+    api_version: operators.coreos.com/v1alpha1
+    kind: InstallPlan
+    name: "{{ install_operator_install_plan_name }}"
+    namespace: "{{ install_operator_namespace }}"
+
+- name: Remove CatalogSource for catalog snapshot
+  k8s:
+    state: absent
+    api_version: operators.coreos.com/v1alpha1
+    kind: CatalogSource
+    name: "{{ install_operator_catalogsource_name }}"
+    namespace: "{{ install_operator_catalogsource_namespace }}"

--- a/ansible/roles/install_operator/templates/catalogsource.j2
+++ b/ansible/roles/install_operator/templates/catalogsource.j2
@@ -1,0 +1,9 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: "{{ install_operator_catalogsource_name }}"
+  namespace: "{{ install_operator_catalogsource_namespace }}"
+spec:
+  sourceType: grpc
+  image: "{{ install_operator_catalog_snapshot_image }}:{{ install_operator_catalog_snapshot_image_tag }}"
+  displayName: "{{ install_operator_catalogsource_name }}"

--- a/ansible/roles/install_operator/templates/installplan.j2
+++ b/ansible/roles/install_operator/templates/installplan.j2
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: InstallPlan
+metadata:
+  name: "{{ install_operator_install_plan_name }}"
+  namespace: "{{ install_operator_namespace }}"
+spec:
+  approved: true

--- a/ansible/roles/install_operator/templates/subscription.j2
+++ b/ansible/roles/install_operator/templates/subscription.j2
@@ -1,0 +1,23 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: "{{ install_operator_name }}"
+  namespace: "{{ install_operator_namespace }}"
+spec:
+  channel: "{{ install_operator_channel }}"
+{% if install_operator_automatic_install_plan_approval | default(True) | bool and not install_operator_use_catalog_snapshot | default(False) | bool %}
+  installPlanApproval: Automatic
+{% else %}
+  installPlanApproval: Manual
+{% endif %}
+  name: "{{ install_operator_packagemanifest_name }}"
+{% if install_operator_use_catalog_snapshot | default(False) | bool %}
+  source: "{{ install_operator_catalogsource_name }}"
+  sourceNamespace: "{{ install_operator_catalogsource_namespace }}"
+{% else %}
+  source: "{{ install_operator_catalog }}"
+  sourceNamespace: openshift-marketplace
+{% endif %}
+{% if install_operator_starting_csv | default("") | length > 0 %}
+  startingCSV: "{{ install_operator_starting_csv }}"
+{% endif %}

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/defaults/main.yml
@@ -1,0 +1,40 @@
+---
+become_override: false
+ocp_username: opentlc-mgr
+silent: false
+
+# Channel to use for the OpenShift GitOps subscription
+ocp4_workload_openshift_gitops_channel: preview
+
+# Set automatic InstallPlan approval. If set to false it is also suggested
+# to set the starting_csv to pin a specific version
+# This variable has no effect when using a catalog snapshot (always true)
+ocp4_workload_openshift_gitops_automatic_install_plan_approval: true
+
+# Set a starting ClusterServiceVersion.
+# Recommended to leave empty to get latest in the channel when not using
+# a catalog snapshot.
+# Highly recommended to be set when using a catalog snapshot but can be
+# empty to get the latest available in the channel at the time when
+# the catalog snapshot got created.
+ocp4_workload_openshift_gitops_starting_csv: ""
+# ocp4_workload_openshift_gitops_starting_csv: "openshift-gitops-operator.v1.0.1"
+
+# --------------------------------
+# Operator Catalog Snapshot Settings
+# --------------------------------
+# See https://github.com/redhat-cop/agnosticd/blob/development/docs/Operator_Catalog_Snapshots.adoc
+# for instructions on how to set up catalog snapshot images
+
+# Use a catalog snapshot
+ocp4_workload_openshift_gitops_use_catalog_snapshot: false
+
+# Catalog Source Name when using a catalog snapshot. This should be unique
+# in the cluster to avoid clashes
+ocp4_workload_openshift_gitops_catalogsource_name: redhat-operators-snapshot-gitops
+
+# Catalog snapshot image
+ocp4_workload_openshift_gitops_catalog_snapshot_image: quay.io/gpte-devops-automation/olm_snapshot_redhat_catalog
+
+# Catalog snapshot image tag
+ocp4_workload_openshift_gitops_catalog_snapshot_image_tag: v4.7_2021_04_12

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/meta/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/meta/main.yml
@@ -1,0 +1,14 @@
+---
+galaxy_info:
+  role_name: ocp4_workload_openshift_gitops
+  author: Red Hat GPTE, Wolfgang Kulhanek (wkulhane@redhat.com)
+  description: |
+    Set up OpenShift GitOps (Operator).
+  license: MIT
+  min_ansible_version: 2.9
+  platforms: []
+  galaxy_tags:
+  - ocp
+  - openshift
+  - gitops
+dependencies: []

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/readme.adoc
@@ -1,0 +1,66 @@
+= ocp4_workload_gitops - Deploy OpenShift GitOps to an OpenShift Cluster
+
+[WARNING]
+This role is dependent on the OpenShift Pipelines Operator. Make sure to install the pipelines operator *BEFORE* installing this one.
+
+== Role overview
+
+* This role installs OpenShift GitOps into an OpenShift Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+ environment for the workload deployment.
+*** Debug task will print out: `pre_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy OpenShift GitOps
+*** This role creates a namespace (project) and deploys the operator.
+*** Debug task will print out: `workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+ configure the workload after deployment
+*** This role doesn't do anything here
+*** Debug task will print out: `post_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+ delete the workload
+*** This role removes OpenShift GitOps. Note that it *does not remove the pipelines operator*.
+*** Debug task will print out: `remove_workload Tasks completed successfully.`
+
+== Review the defaults variable file
+
+* This file link:./defaults/main.yml[./defaults/main.yml] contains all the variables you need to define to control the deployment of your workload.
+* The variable *ocp_username* is mandatory to assign the workload to the correct OpenShift user.
+* A variable *silent=True* can be passed to suppress debug messages.
+
+
+=== Deploy a Workload with the `ocp-workload` config [Mostly for testing]
+
+Create a file `workload_vars.yaml` with your variables:
+----
+cloud_provider: none
+env_type: ocp-workloads
+target_host: bastion.dev4.openshift.opentlc.com
+
+ocp_workloads:
+- ocp4_workload_gitops
+
+#become_override: false
+
+# If the ocp-workload supports it, you should specify the OCP user:
+ocp_username: system:admin
+
+# Usually the ocp-workloads want a GUID also:
+guid: changeme
+----
+
+From the Agnosticd/ansible directory run the playbook:
+
+----
+ansible-playbook main.yml -e @workload_vars.yml -e ACTION="create"
+----
+
+=== To Delete an environment
+
+From the Agnosticd/ansible directory run the playbook:
+
+----
+ansible-playbook main.yml -e @workload_vars.yml -e ACTION="remove"
+----

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+
+# Do not modify this file
+
+- name: Running Pre Workload Tasks
+  include_tasks:
+    file: ./pre_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload Tasks
+  include_tasks:
+    file: ./workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  include_tasks:
+    file: ./post_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload removal Tasks
+  include_tasks:
+    file: ./remove_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/post_workload.yml
@@ -1,0 +1,9 @@
+---
+# Implement your Post Workload deployment tasks here
+
+
+# Leave this as the last task in the playbook.
+- name: post_workload tasks complete
+  debug:
+    msg: "Post-Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/pre_workload.yml
@@ -1,0 +1,8 @@
+---
+# Implement your Pre Workload deployment tasks here
+
+# Leave this as the last task in the playbook.
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/remove_workload.yml
@@ -1,0 +1,28 @@
+---
+# Implement your Workload removal tasks here
+
+- name: Install OpenShift GitOps operator
+  include_role:
+    name: install_operator
+  vars:
+    install_operator_action: remove
+    install_operator_name: openshift-gitops-operator
+    install_operator_namespace: openshift-operators
+    install_operator_channel: preview
+    install_operator_catalog: redhat-operators
+    install_operator_use_catalog_snapshot: "{{ ocp4_workload_openshift_gitops_use_catalog_snapshot }}"
+    install_operator_catalog_snapshot_image: "{{ ocp4_workload_openshift_gitops_catalog_snapshot_image | default('') }}"
+    install_operator_catalog_snapshot_image_tag: "{{ ocp4_workload_openshift_gitops_catalog_snapshot_image_tag }}"
+
+- name: Remove openshift-gitops namespace
+  k8s:
+    state: absent
+    api_version: v1
+    kind: namespace
+    name: openshift-gitops
+
+# Leave this as the last task in the playbook.
+- name: remove_workload tasks complete
+  debug:
+    msg: "Remove Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/workload.yml
@@ -1,0 +1,49 @@
+---
+# Implement your Workload deployment tasks here
+
+- name: Setting up workload for user
+  debug:
+    msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
+
+- name: Check that OpenShift Pipelines are installed
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    namespace: openshift-operators
+  register: r_csvs
+
+- name: Set Pipelines CSV name
+  set_fact:
+    __ocp4_workload_openshift_gitops_pipelines_csv_name: "{{ r_csvs.resources | to_json | from_json | json_query(query) }}"
+  vars:
+    query: >-
+      [?starts_with(metadata.name, 'redhat-openshift-pipelines' )].metadata.name
+
+- name: Assert that a CSV has been found
+  assert:
+    that:
+      __ocp4_workload_openshift_gitops_pipelines_csv_name | length > 0
+    success_msg: "Found OpenShift Pipelines operator."
+    fail_msg: "OpenShift Pipelines operator needs to be installed before the OpenShift GitOps operator."
+    
+- name: Install Operator
+  include_role:
+    name: install_operator
+  vars:
+    install_operator_action: install
+    install_operator_name: openshift-gitops-operator
+    install_operator_namespace: openshift-operators
+    install_operator_channel: "{{ ocp4_workload_openshift_gitops_channel }}"
+    install_operator_catalog: redhat-operators
+    install_operator_automatic_install_plan_approval: "{{ ocp4_workload_openshift_gitops_automatic_install_plan_approval | default(true) }}"
+    install_operator_starting_csv: "{{ ocp4_workload_openshift_gitops_starting_csv }}"
+    install_operator_use_catalog_snapshot: "{{ ocp4_workload_openshift_gitops_use_catalog_snapshot | default(false)}}"
+    install_operator_catalogsource_name: "{{ ocp4_workload_openshift_gitops_catalogsource_name | default('') }}"
+    install_operator_catalog_snapshot_image: "{{ ocp4_workload_openshift_gitops_catalog_snapshot_image | default('') }}"
+    install_operator_catalog_snapshot_image_tag: "{{ ocp4_workload_openshift_gitops_catalog_snapshot_image_tag | default('') }}"
+
+# Leave this as the last task in the playbook.
+- name: workload tasks complete
+  debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/workload.yml
@@ -25,7 +25,7 @@
       __ocp4_workload_openshift_gitops_pipelines_csv_name | length > 0
     success_msg: "Found OpenShift Pipelines operator."
     fail_msg: "OpenShift Pipelines operator needs to be installed before the OpenShift GitOps operator."
-    
+
 - name: Install Operator
   include_role:
     name: install_operator


### PR DESCRIPTION
##### SUMMARY

Added a generic role, *install_operator* that installs an Operator into an OpenShift Cluster. It supports all the usual features like manual approval or using a catalog source.

Also added a workload, *ocp4_workload_openshift_gitops* using that generic role as a first example. Workloads will be updated to use the generic role as they are being updated periodically.

@thoraxe FYI.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
install_operator
ocp4_workload_openshift_gitops

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
