### PR TITLE
Fix config ocp4-cluster, lifecycle start hook: add all missing cloud providers

### DIFF
--- a/ansible/configs/ocp4-cluster/lifecycle_hook_post_start.yml
+++ b/ansible/configs/ocp4-cluster/lifecycle_hook_post_start.yml
@@ -8,15 +8,24 @@
   become: false
   tasks:
   - when: cloud_provider == 'ec2'
-    block:
-    - name: Run infra-ec2-create-inventory Role
-      include_role:
-        name: infra-ec2-create-inventory
+    name: Run infra-ec2-create-inventory Role
+    include_role:
+      name: infra-ec2-create-inventory
 
-    - name: Run Common SSH Config Generator Role
-      include_role:
-        name: infra-common-ssh-config-generate
-      when: "'bastions' in groups"
+  - when: cloud_provider == 'osp'
+    name: Run infra-osp-create-inventory Role
+    include_role:
+      name: infra-osp-create-inventory
+
+  - when: cloud_provider == 'azure'
+    name: Run infra-azure-create-inventory Role
+    include_role:
+      name: infra-azure-create-inventory
+
+  - name: Run Common SSH Config Generator Role
+    include_role:
+      name: infra-common-ssh-config-generate
+    when: "'bastions' in groups"
 
 - name: Set ansible_ssh_extra_args
   hosts:


### PR DESCRIPTION
When the cloud provider is different than ec2, the inventory is not built, and the CSR are not approved resulting in a broken cluster.

This change, if applied, add includes to build the inventory for OSP and Azure so the certificates are all approved there too.

##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
- ocp4-cluster config