### PR TITLE
Update IBM sandbox workload with new access policies

### DIFF
--- a/ansible/roles-infra/sandbox-ibm/tasks/create_roks_access_groups.yml
+++ b/ansible/roles-infra/sandbox-ibm/tasks/create_roks_access_groups.yml
@@ -27,7 +27,7 @@
   set_fact:
     sandbox_default_resource_group: "{{ r_resource_groups.json | to_json | from_json | json_query(_rg_query) }}"
   vars:
-    _rg_query: "resources[?contains(keys(@), 'name')] | [?name=='Default'] | [0]"
+    _rg_query: "resources[?contains(keys(@), 'name')] | [?name=='Default'].id | [0]"
 
 - name: Create policies for ROKS access group
   include_tasks: create_roks_policies.yml
@@ -41,9 +41,6 @@
     body:
       access_group_id: "{{ sandbox_roks_access_group }}"
   register: r_sandbox_roks_policies
-
-- debug:
-    var: r_sandbox_roks_policies
 
 - name: Add SID to access group
   uri:

--- a/ansible/roles-infra/sandbox-ibm/tasks/create_roks_access_groups.yml
+++ b/ansible/roles-infra/sandbox-ibm/tasks/create_roks_access_groups.yml
@@ -12,12 +12,22 @@
       description: "Access group with additional permissions for IBM ROKS"
   register: r_roks_access_group
 
-- debug:
-    var: r_roks_access_group
-
 - name: Set ROKS access group ID
   set_fact:
     sandbox_roks_access_group: "{{ r_roks_access_group.json.id }}"
+
+- name: Get resource groups
+  uri:
+    url: "https://resource-controller.cloud.ibm.com/v2/resource_groups?account_id={{ sandbox_account_id }}"
+    headers:
+      Authorization: Bearer {{ auth_token }}
+  register: r_resource_groups
+
+- name: Set default resource group ID
+  set_fact:
+    sandbox_default_resource_group: "{{ r_resource_groups.json | to_json | from_json | json_query(_rg_query) }}"
+  vars:
+    _rg_query: "resources[?contains(keys(@), 'name')] | [?name=='Default'] | [0]"
 
 - name: Create policies for ROKS access group
   include_tasks: create_roks_policies.yml

--- a/ansible/roles-infra/sandbox-ibm/tasks/create_roks_policies.yml
+++ b/ansible/roles-infra/sandbox-ibm/tasks/create_roks_policies.yml
@@ -212,3 +212,29 @@
           - name: "serviceName"
             operator: "stringEquals"
             value: "kms"
+
+- name: Create default resource group policy
+  uri:
+    url: "https://iam.cloud.ibm.com/v1/policies"
+    method: POST
+    headers:
+      Authorization: Bearer {{ auth_token }}
+    status_code: 201
+    body_format: json
+    body:
+      type: "access"
+      description: "ROKS - default resource group policy"
+      subjects:
+        - attributes:
+          - name: "access_group_id"
+            value: "{{ sandbox_roks_access_group }}"
+      roles:
+        - role_id: "crn:v1:bluemix:public:iam::::role:Viewer"
+      resources:
+        - attributes:
+          - name: "accountId"
+            operator: "stringEquals"
+            value: "{{ sandbox_account_id }}"
+          - name: "resourceType"
+            operator: "stringEquals"
+            value: "{{ sandbox_default_resource_group }}"

--- a/ansible/roles-infra/sandbox-ibm/tasks/create_roks_policies.yml
+++ b/ansible/roles-infra/sandbox-ibm/tasks/create_roks_policies.yml
@@ -237,4 +237,7 @@
             value: "{{ sandbox_account_id }}"
           - name: "resourceType"
             operator: "stringEquals"
+            value: "resource-group"
+          - name: "resource"
+            operator: "stringEquals"
             value: "{{ sandbox_default_resource_group }}"


### PR DESCRIPTION
##### SUMMARY

To enable RHOIC (formerly ROKS), there was a missing access policy. This change will create that additional policy. It will be deleted as part of the cleanup.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
sanbox-ibm