### PR TITLE
Add sshpass

### DIFF
--- a/ansible/roles/ocp4-workload-migration/tasks/download-content.yml
+++ b/ansible/roles/ocp4-workload-migration/tasks/download-content.yml
@@ -14,4 +14,10 @@
       dest: "/home/{{ student_name }}/{{ mig_download_content_item.target_dir }}/"
       owner: "{{ student_name }}"
       mode: "{{ mig_download_content_item.mode | default('u+rwx') }}"
+
+  - name: "Install sshpass needed for prepare_station.sh"
+    dnf:
+      name: sshpass
+      state: latest
+
   become: true


### PR DESCRIPTION
##### SUMMARY

the new env_type does not have a package installed by default (sshpass)

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

role: ocp4-workload-migration

##### ADDITIONAL INFORMATION
