### PR TITLE
pntae-vilt-bastion: new security group to enable https port 443

### DIFF
--- a/ansible/configs/pntae-vilt-bastion/default_vars.yml
+++ b/ansible/configs/pntae-vilt-bastion/default_vars.yml
@@ -46,6 +46,7 @@ instances:
         size: 20
     security_groups:
       - BastionSG
+      - pntaeSG
 
   - name: "node"
     count: "{{node_instance_count}}"

--- a/ansible/configs/pntae-vilt-bastion/default_vars_osp.yml
+++ b/ansible/configs/pntae-vilt-bastion/default_vars_osp.yml
@@ -3,3 +3,17 @@ ansible_user: cloud-user
 remote_user: cloud-user
 
 chomped_zone_internal_dns: "example.com"
+
+##### Security Groups ###
+security_groups:
+
+  - name: pntaeSG
+    rules:
+      - name: HTTPsSG
+        protocol: tcp
+        description: "HTTPS Public"
+        from_port: 443
+        to_port: 443
+        cidr: 0.0.0.0/0
+        rule_type: Ingress
+


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
config pntae-vilt-bastion needs port 443 access on bastion

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
