### PR TITLE
Update install-config.yaml.j2

### DIFF
--- a/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
+++ b/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
@@ -74,11 +74,11 @@ compute:
   replicas: {{ worker_instance_count | int }}
 networking:
   clusterNetwork:
-  - cidr: 10.128.0.0/14
+  - cidr: {{ ocp_cluster_cidr | default('10.128.0.0/14') }}
     hostPrefix: 23
   machineCIDR: {{ ocp4_machine_cidr | default('10.0.0.0/16') | to_json }}
   serviceNetwork:
-  - 172.30.0.0/16
+  - {{ ocp_service_network | default('172.30.0.0/16') }}
 {% if ocp4_network_type | default("OpenshiftSDN") is match("OVNKubernetes") %}
   networkType: OVNKubernetes
 {% else %}


### PR DESCRIPTION
Added variable to change the default ClusterNetwork and ServiceNetwork CIDR's. This would be useful for scenario's like OCS DR which need to have two separate OCP clusters having different Cluster Network and Service Network's.

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
