### PR TITLE
aws sandbox: Make sure keypair is always created

### DIFF
--- a/ansible/roles-infra/infra-aws-sandbox/tasks/main.yml
+++ b/ansible/roles-infra/infra-aws-sandbox/tasks/main.yml
@@ -18,7 +18,7 @@
 - import_tasks: user.yml
 - import_tasks: route53.yml
 - include_tasks: keypair.yml
-  when: operation == 'CREATE'
+  when: operation in ['CREATE', 'RESET']
   tags: keypair
 - include_tasks: ipa.yml
   when:


### PR DESCRIPTION
When cleaning up the sandbox, also recreated the keypair if needed.
