### PR TITLE
Bump google-auth in k8s virtualenv for ocp4-workshop

### DIFF
--- a/ansible/configs/ocp4-workshop/files/requirements_k8s.txt
+++ b/ansible/configs/ocp4-workshop/files/requirements_k8s.txt
@@ -14,7 +14,7 @@ cryptography==3.2
 dictdiffer==0.8.1
 distro==1.4.0
 docutils==0.15.2
-google-auth==1.10.2
+google-auth==1.29.0
 idna==2.8
 Jinja2==2.10.3
 jmespath==0.9.4


### PR DESCRIPTION
##### SUMMARY

Fix k8s virtualenv definition for ocp4-workshop by bumping version of google-auth module.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Config ocp4-workshop