### PR TITLE
Update config sandbox: enable web console access for AWS sandbox

### DIFF
--- a/ansible/configs/sandbox/default_vars_ec2.yml
+++ b/ansible/configs/sandbox/default_vars_ec2.yml
@@ -12,4 +12,4 @@ chomped_zone_internal_dns: "{{ guid }}.internal"
 
 infra_ec2_template_generate_auto_select_availability_zone: false
 
-sandbox_enable_console_access: true
+sandbox_enable_ui: true

--- a/ansible/configs/sandbox/default_vars_ec2.yml
+++ b/ansible/configs/sandbox/default_vars_ec2.yml
@@ -11,3 +11,5 @@ zone_internal_dns: "{{ guid }}.internal."
 chomped_zone_internal_dns: "{{ guid }}.internal"
 
 infra_ec2_template_generate_auto_select_availability_zone: false
+
+sandbox_enable_console_access: true

--- a/ansible/configs/sandbox/ec2_destroy_env.yml
+++ b/ansible/configs/sandbox/ec2_destroy_env.yml
@@ -1,30 +1,6 @@
 ---
 - import_playbook: ../../setup_runtime.yml
 
-- name: Backup event log of the user
-  hosts: localhost
-  connection: local
-  gather_facts: false
-  become: false
-  environment:
-    AWS_ACCESS_KEY_ID: "{{aws_access_key_id}}"
-    AWS_SECRET_ACCESS_KEY: "{{aws_secret_access_key}}"
-    AWS_DEFAULT_REGION: "{{aws_region_final|d(aws_region)}}"
-  tasks:
-    - name: Get fact for stack
-      cloudformation_facts:
-        stack_name: "{{ project_tag }}"
-      register: stack_facts
-
-    - when: project_tag in stack_facts.ansible_facts.cloudformation
-      block:
-        - name: Grab and set stack creation_time
-          set_fact:
-            stack_creation_time: >-
-              {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time }}
-            stack_status: >-
-              {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.stack_status }}
-
 - name: Build inventory
   hosts: localhost
   connection: local

--- a/ansible/configs/sandbox/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/sandbox/files/cloud_providers/ec2_cloud_template.j2
@@ -152,7 +152,7 @@ Resources:
     Type: AWS::IAM::User
     Properties:
       UserName: "{{ email | default(owner) }}-{{ guid }}"
-      {% if sandbox_enable_console_access | default(true) | bool %}
+      {% if sandbox_enable_ui | default(true) | bool %}
       LoginProfile:
         Password: "{{ student_console_password }}"
         PasswordResetRequired: False

--- a/ansible/configs/sandbox/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/sandbox/files/cloud_providers/ec2_cloud_template.j2
@@ -152,6 +152,11 @@ Resources:
     Type: AWS::IAM::User
     Properties:
       UserName: "{{ email | default(owner) }}-{{ guid }}"
+      {% if sandbox_enable_console_access | default(true) | bool %}
+      LoginProfile:
+        Password: "{{ student_console_password }}"
+        PasswordResetRequired: False
+      {% endif %}
       Policies:
         - PolicyName: AccessAll
           PolicyDocument:
@@ -168,6 +173,10 @@ Resources:
           Ref: StudentUser
 
 Outputs:
+  StudentUser:
+    Value:
+      Ref: StudentUser
+    Description: IAM Student User
   StudentUserAccessKey:
     Value:
       Ref: StudentUserAccessKey

--- a/ansible/configs/sandbox/post_infra.yml
+++ b/ansible/configs/sandbox/post_infra.yml
@@ -10,3 +10,5 @@
   tasks:
   - debug:
       msg: "Post Infrastructure - Steps starting"
+  - when: cloud_provider == 'ec2'
+    include_tasks: post_infra_ec2.yml

--- a/ansible/configs/sandbox/post_infra_ec2.yml
+++ b/ansible/configs/sandbox/post_infra_ec2.yml
@@ -1,0 +1,9 @@
+---
+- name: get AWS credentials from stack outputs
+  set_fact:
+    student_access_key_id: "{{ cloudformation_out_final.stack_outputs.StudentUserAccessKey }}"
+    student_secret_access_key: "{{ cloudformation_out_final.stack_outputs.StudentUserSecretAccessKey }}"
+    student_console_user_name: >-
+      {{
+      cloudformation_out_final.stack_outputs.StudentUser
+      }}

--- a/ansible/configs/sandbox/post_software.yml
+++ b/ansible/configs/sandbox/post_software.yml
@@ -9,78 +9,11 @@
 
     - name: User info for IBM Cloud
       when: cloud_provider == 'ibm'
-      block:
-        - name: Print out email body for user
-          agnosticd_user_info:
-            body: "{{ item }}"
-          loop:
-            - "<p>The information below can be used to access your IBM Cloud Sandbox environment.<br />"
-            - "<br />"
-            - "You are able to access the IBM Cloud using the CLI, APIs, or web UI.<br />"
-            - "<br />"
-            - "<strong>IBM Cloud User:</strong> {{ email }}<br />"
-            - "<strong>IBM Cloud API Key:</strong> {{ sandbox_sid_apikey }}<br />"
-            - "<strong>IBM Cloud Account ID:</strong> {{ sandbox_account_id }}<br />"
-            - "<strong>IBM Cloud Account Name:</strong> {{ sandbox_account_name }}<br />"
-            - "<br />"
-            - "To logon via the CLI:<br />"
-            - "<pre>"
-            - "export IBMCLOUD_API_KEY={{ sandbox_sid_apikey }}<br />"
-            - "ibmcloud login<br />"
-            - "</pre>"
-            - "Change your region (example):<br />"
-            - "<pre>"
-            - "ibmcloud target -r us-south<br />"
-            - "</pre></p>"
-            - "<p>To logon to the UI, visit <a href=https://cloud.ibm.com>cloud.ibm.com</a>"
-            - "</p>"
-            - "<p>Visit the following pages to learn how to use the CLI and APIs.<br />"
-            - "<br />"
-            - "IBM Cloud VPC API docs: https://cloud.ibm.com/apidocs/vpc<br />"
-            - "IBM Cloud CLI docs: https://cloud.ibm.com/docs/cli<br />"
-            - "IBM Cloud VPC SDKs: https://github.com/IBM?q=vpc&type=&language=<br /><br /></p>"
-            - "<p></p>"
-            - '<h2 style="text-align: center">'
-            - "**WARNING**WARNING**WARNING**</h2>"
-            - '<p style="text-align: center">'
-            - "We monitor usage and we will be charging back to your cost center.<br />"
-            - "Reports from the cloud provider of misuse or account compromise will result<br />"
-            - "in immediate deletion of this entire account without any warning to you.<br />"
-            - "Do not post your credentials in GitHub/email/web pages/etc.<br /><br />"
-            - '<span style="text-decoration: underline;"><strong>NOTE</strong></span>: Most account compromises occur by checking credentials into GitHub.</p>'
-            - '<h2 style="text-align: center">'
-            - "**WARNING**WARNING**WARNING**</h2>"
+      include_tasks: post_software_ibm.yml
 
     - name: User info for AWS
       when: cloud_provider == 'ec2'
-      block:
-        - name: Print connectivity info and credential location to user.info
-          agnosticd_user_info:
-            msg: "{{ item }}"
-          loop:
-            - ""
-            - "Your AWS credentials are:"
-            - ""
-            - "AWS_ACCESS_KEY_ID: {{ hostvars.localhost.student_access_key_id }}"
-            - "AWS_SECRET_ACCESS_KEY: {{ hostvars.localhost.student_secret_access_key }}"
-            - ""
-            - "Top level route53 domain: {{ subdomain_base_suffix }}"
-            - "The default region is set to {{ aws_region }}"
-            - ""
-            - "Visit the following pages to learn how to use the CLI and APIs:"
-            - ""
-            - "AWS CLI Installation: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html"
-            - "AWS Config Basics: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html"
-            - "AWS API Getting Started: https://aws.amazon.com/developers/getting-started/"
-            - "Getting Started Tips - https://learning.redhat.com/course/view.php?id=2751"
-            - ""
-            - "****************************WARNING**WARNING**WARNING****************************"
-            - "** We monitor usage and we will be charging back to your cost center.          **"
-            - "** Reports from the cloud provider of misuse or account compromise will result **"
-            - "** in immediate deletion of this entire account without any warning to you.    **"
-            - "** Do not post your credentials in github/email/web pages/etc.                 **"
-            - "** NOTE: Most account compromises occur by checking credentials into github.   **"
-            - "****************************WARNING**WARNING**WARNING****************************"
+      include_tasks: post_software_ec2.yml
 
     - debug:
         msg: "Post-Software checks completed successfully"

--- a/ansible/configs/sandbox/post_software_ec2.yml
+++ b/ansible/configs/sandbox/post_software_ec2.yml
@@ -13,11 +13,11 @@
     - "The default region is set to {{ aws_region }}"
     - ""
     - >-
-      {% if sandbox_enable_console_access | default(true) | bool %}
+      {% if sandbox_enable_ui | default(true) | bool %}
       Web Console Access: https://{{ sandbox_account_id }}.signin.aws.amazon.com/console
       {% endif %}
     - >-
-      {% if sandbox_enable_console_access | default(true) | bool %}
+      {% if sandbox_enable_ui | default(true) | bool %}
       Web Console Credentials: {{ student_console_user_name }} / {{ student_console_password }}
       {% endif %}
     - ""

--- a/ansible/configs/sandbox/post_software_ec2.yml
+++ b/ansible/configs/sandbox/post_software_ec2.yml
@@ -1,0 +1,37 @@
+---
+- name: Print connectivity info and credential location to user.info
+  agnosticd_user_info:
+    msg: "{{ item }}"
+  loop:
+    - ""
+    - "Your AWS credentials are:"
+    - ""
+    - "AWS_ACCESS_KEY_ID: {{ hostvars.localhost.student_access_key_id }}"
+    - "AWS_SECRET_ACCESS_KEY: {{ hostvars.localhost.student_secret_access_key }}"
+    - ""
+    - "Top level route53 domain: {{ subdomain_base_suffix }}"
+    - "The default region is set to {{ aws_region }}"
+    - ""
+    - >-
+      {% if sandbox_enable_console_access | default(true) | bool %}
+      Web Console Access: https://{{ sandbox_account_id }}.signin.aws.amazon.com/console
+      {% endif %}
+    - >-
+      {% if sandbox_enable_console_access | default(true) | bool %}
+      Web Console Credentials: {{ student_console_user_name }} / {{ student_console_password }}
+      {% endif %}
+    - ""
+    - "Visit the following pages to learn how to use the CLI and APIs:"
+    - ""
+    - "AWS CLI Installation: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html"
+    - "AWS Config Basics: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html"
+    - "AWS API Getting Started: https://aws.amazon.com/developers/getting-started/"
+    - "Getting Started Tips - https://learning.redhat.com/course/view.php?id=2751"
+    - ""
+    - "****************************WARNING**WARNING**WARNING****************************"
+    - "** We monitor usage and we will be charging back to your cost center.          **"
+    - "** Reports from the cloud provider of misuse or account compromise will result **"
+    - "** in immediate deletion of this entire account without any warning to you.    **"
+    - "** Do not post your credentials in github/email/web pages/etc.                 **"
+    - "** NOTE: Most account compromises occur by checking credentials into github.   **"
+    - "****************************WARNING**WARNING**WARNING****************************"

--- a/ansible/configs/sandbox/post_software_ibm.yml
+++ b/ansible/configs/sandbox/post_software_ibm.yml
@@ -1,0 +1,41 @@
+---
+- name: Print out email body for user
+  agnosticd_user_info:
+    body: "{{ item }}"
+  loop:
+    - "<p>The information below can be used to access your IBM Cloud Sandbox environment.<br />"
+    - "<br />"
+    - "You are able to access the IBM Cloud using the CLI, APIs, or web UI.<br />"
+    - "<br />"
+    - "<strong>IBM Cloud User:</strong> {{ email }}<br />"
+    - "<strong>IBM Cloud API Key:</strong> {{ sandbox_sid_apikey }}<br />"
+    - "<strong>IBM Cloud Account ID:</strong> {{ sandbox_account_id }}<br />"
+    - "<strong>IBM Cloud Account Name:</strong> {{ sandbox_account_name }}<br />"
+    - "<br />"
+    - "To logon via the CLI:<br />"
+    - "<pre>"
+    - "export IBMCLOUD_API_KEY={{ sandbox_sid_apikey }}<br />"
+    - "ibmcloud login<br />"
+    - "</pre>"
+    - "Change your region (example):<br />"
+    - "<pre>"
+    - "ibmcloud target -r us-south<br />"
+    - "</pre></p>"
+    - "<p>To logon to the UI, visit <a href=https://cloud.ibm.com>cloud.ibm.com</a>"
+    - "</p>"
+    - "<p>Visit the following pages to learn how to use the CLI and APIs.<br />"
+    - "<br />"
+    - "IBM Cloud VPC API docs: https://cloud.ibm.com/apidocs/vpc<br />"
+    - "IBM Cloud CLI docs: https://cloud.ibm.com/docs/cli<br />"
+    - "IBM Cloud VPC SDKs: https://github.com/IBM?q=vpc&type=&language=<br /><br /></p>"
+    - "<p></p>"
+    - '<h2 style="text-align: center">'
+    - "**WARNING**WARNING**WARNING**</h2>"
+    - '<p style="text-align: center">'
+    - "We monitor usage and we will be charging back to your cost center.<br />"
+    - "Reports from the cloud provider of misuse or account compromise will result<br />"
+    - "in immediate deletion of this entire account without any warning to you.<br />"
+    - "Do not post your credentials in GitHub/email/web pages/etc.<br /><br />"
+    - '<span style="text-decoration: underline;"><strong>NOTE</strong></span>: Most account compromises occur by checking credentials into GitHub.</p>'
+    - '<h2 style="text-align: center">'
+    - "**WARNING**WARNING**WARNING**</h2>"

--- a/ansible/configs/sandbox/pre_infra.yml
+++ b/ansible/configs/sandbox/pre_infra.yml
@@ -11,48 +11,9 @@
     - debug:
         msg: "Step 000 Pre Infrastructure - Starting"
 
+    - when: cloud_provider == 'ec2'
+      include_tasks: pre_infra_ec2.yml
+
     - name: Get sandbox account credentials
       when: cloud_provider == 'ibm'
-      block:
-        - name: Get token for sandbox-api
-          uri:
-            url: "{{ sandbox_api_url }}/token"
-            method: POST
-            body_format: json
-            body:
-              api_key: "{{ sandbox_account_db_api_key }}"
-          register: r_sandbox_account_db_api_key
-
-        - name: Assign available sandbox account
-          uri:
-            url: "{{ sandbox_api_url }}/sandbox"
-            method: POST
-            headers:
-              Authorization: Bearer {{ r_sandbox_account_db_api_key['json']['access_token'] }}
-            body_format: json
-            body:
-              guid: "{{ guid }}"
-              owner_name: "{{ student_name }}"
-              env_type: "{{ env_type | default('') }}"
-              owner_email: "{{ email }}"
-              note: "{{ sandbox_note | default('') }}"
-              cloud_provider: "{{ cloud_provider }}"
-          register: r_sandbox_account
-
-        - name: Set IBM Cloud account_id
-          set_fact:
-            sandbox_account_id: "{{ r_sandbox_account['json']['account_id']['S'] }}"
-
-        - name: Set IBM Cloud account_name
-          set_fact:
-            sandbox_account_name: "{{ r_sandbox_account['json']['account_name']['S'] }}"
-
-        - name: Set account master API key
-          set_fact:
-            sandbox_master_api_key: "{{ r_sandbox_account['json']['master_api_key']['S'] }}"
-
-        - name: Create the sandbox account access
-          include_role:
-            name: sandbox-ibm
-          vars:
-            action: "create"
+      include_tasks: pre_infra_ibm.yml

--- a/ansible/configs/sandbox/pre_infra_ec2.yml
+++ b/ansible/configs/sandbox/pre_infra_ec2.yml
@@ -1,0 +1,17 @@
+---
+- name: Set student Console password
+  set_fact:
+    student_console_password: >-
+      {{ lookup('password', '/dev/null length=12 chars=ascii_letters,digits') }}
+
+- name: Get the current caller identity information
+  environment:
+    AWS_ACCESS_KEY_ID: "{{aws_access_key_id}}"
+    AWS_SECRET_ACCESS_KEY: "{{aws_secret_access_key}}"
+    AWS_DEFAULT_REGION: "{{aws_region_final|d(aws_region)}}"
+  aws_caller_info:
+  register: _caller_info
+
+- name: Set  account ID
+  set_fact:
+    sandbox_account_id: "{{ _caller_info.account }}"

--- a/ansible/configs/sandbox/pre_infra_ibm.yml
+++ b/ansible/configs/sandbox/pre_infra_ibm.yml
@@ -1,0 +1,43 @@
+---
+- name: Get token for sandbox-api
+  uri:
+    url: "{{ sandbox_api_url }}/token"
+    method: POST
+    body_format: json
+    body:
+      api_key: "{{ sandbox_account_db_api_key }}"
+  register: r_sandbox_account_db_api_key
+
+- name: Assign available sandbox account
+  uri:
+    url: "{{ sandbox_api_url }}/sandbox"
+    method: POST
+    headers:
+      Authorization: Bearer {{ r_sandbox_account_db_api_key['json']['access_token'] }}
+    body_format: json
+    body:
+      guid: "{{ guid }}"
+      owner_name: "{{ student_name }}"
+      env_type: "{{ env_type | default('') }}"
+      owner_email: "{{ email }}"
+      note: "{{ sandbox_note | default('') }}"
+      cloud_provider: "{{ cloud_provider }}"
+  register: r_sandbox_account
+
+- name: Set IBM Cloud account_id
+  set_fact:
+    sandbox_account_id: "{{ r_sandbox_account['json']['account_id']['S'] }}"
+
+- name: Set IBM Cloud account_name
+  set_fact:
+    sandbox_account_name: "{{ r_sandbox_account['json']['account_name']['S'] }}"
+
+- name: Set account master API key
+  set_fact:
+    sandbox_master_api_key: "{{ r_sandbox_account['json']['master_api_key']['S'] }}"
+
+- name: Create the sandbox account access
+  include_role:
+    name: sandbox-ibm
+  vars:
+    action: "create"

--- a/ansible/configs/sandbox/pre_software.yml
+++ b/ansible/configs/sandbox/pre_software.yml
@@ -5,13 +5,5 @@
   gather_facts: false
   become: false
   tasks:
-  - name: Get AWS credentials
-    when: cloud_provider == 'ec2'
-    block:
-    - name: get AWS credentials from stack outputs
-      set_fact:
-        student_access_key_id: "{{ cloudformation_out_final.stack_outputs.StudentUserAccessKey }}"
-        student_secret_access_key: "{{ cloudformation_out_final.stack_outputs.StudentUserSecretAccessKey }}"
-
   - debug:
       msg: "Pre-Software checks completed successfully"


### PR DESCRIPTION
This commit, if applied, adds a new feature to the 'sandbox' config to
enable access to the AWS Web console to students.

- introduce new boolean variable sandbox_enable_console_access (default: true)
- Remove useless tasks in ec2_destroy_env.yml
- Enable LoginProfile for the student user in the cloudformation template
- use include_tasks to dynamically load either ibm  or ec2 tasks:
  when provisioning for ec2, we don't want to display IBM tasks and vice versa.
- Display access in user.info

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
- sandbox config
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->


