### PR TITLE
Update config ibm-rhoic

### DIFF
--- a/ansible/configs/ibm-rhoic/destroy_env.yml
+++ b/ansible/configs/ibm-rhoic/destroy_env.yml
@@ -275,6 +275,18 @@
         ibm_rhoic_install: true
         ibm_roks_install: true
 
+    - name: Get token for sandbox-api
+      uri:
+        url: "{{ sandbox_api_url }}/token"
+        method: POST
+        body_format: json
+        body:
+          api_key: "{{ sandbox_account_db_api_key }}"
+      register: r_sandbox_account_db_api_key
+      until: r_sandbox_account_db_api_key.status != 500
+      retries: 3
+      delay: 10
+
     - name: Update account for cleanup
       uri:
         url: "{{ sandbox_api_url }}/sandbox"


### PR DESCRIPTION
##### SUMMARY

Occasionally the token we are using times out before the final API call is made, this gets a new token immediately before calling that API so that timeout will never happen.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
configs/ibm-rhoic

##### ADDITIONAL INFORMATION
If IBM Cloud is slow on removing its OpenShift cluster then the token doesn't get used before its timeout.