### PR TITLE
Fix tkn completion setup

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_pipelines/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_pipelines/tasks/workload.yml
@@ -37,9 +37,10 @@
   args:
     creates: /usr/local/bin/tkn
 
-- name: Create tkn bash completion file
+# command: does not work here - somehow the parameters don't get passed properly
+- name: Setup tkn bash completion
   become: true
-  command: /usr/local/bin/tkn completion bash >/etc/bash_completion.d/tkn
+  shell: "/usr/local/bin/tkn completion bash >/etc/bash_completion.d/tkn"
   args:
     creates: /etc/bash_completion.d/tkn
 


### PR DESCRIPTION
##### SUMMARY

Replace `command:` with `shell:` to set up completion for `tkn` in pipelines workload. Somehow command doesn't pass the parameters correctly in that instance.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_pipelines