### PR TITLE
Some fixes for Gitea 1.14 (and giteas not named 'gitea')

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/tasks/workload.yml
@@ -3,6 +3,12 @@
   debug:
     msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
 
+- name: Check Gitea Tag
+  assert:
+    that:
+    - ocp4_workload_gitea_operator_gitea_image_tag is not match('latest')
+    fail_msg: "Gitea image tag must not be set to 'latest'. Please specify the image version explicitely."
+
 - name: Install Operator
   include_role:
     name: install_operator
@@ -72,7 +78,7 @@
     kind: Pod
     namespace: "{{ ocp4_workload_gitea_operator_project }}"
     label_selectors:
-    - app = gitea
+    - app = {{ ocp4_workload_gitea_operator_name }}
   register: r_gitea_pod
 
 - name: Retrieve Gitea route
@@ -81,7 +87,7 @@
     api_version: route.openshift.io/v1
     namespace: "{{ ocp4_workload_gitea_operator_project }}"
     label_selectors:
-    - app = gitea
+    - app = {{ ocp4_workload_gitea_operator_name }}
   register: r_gitea_route
 
 - name: Configure a Gitea admin user
@@ -96,8 +102,10 @@
     register: r_giteaadmin_user
     failed_when: r_giteaadmin_user.status != 200 and r_giteaadmin_user.status != 404
 
-  - name: Create Gitea admin user
-    when: r_giteaadmin_user.status == 404
+  - name: Create Gitea admin user (before Gitea 1.14)
+    when:
+    - r_giteaadmin_user.status == 404
+    - ocp4_workload_gitea_operator_gitea_image_tag is version_compare('1.14', '<')
     command: >
       oc exec {{ r_gitea_pod.resources[0].metadata.name }}
       -n {{ ocp4_workload_gitea_operator_project }}
@@ -105,6 +113,18 @@
       --password {{ ocp4_workload_gitea_operator_admin_password }}
       --email {{ ocp4_workload_gitea_operator_admin_user }}@workshop.com
       --must-change-password=false --admin -c /home/gitea/conf/app.ini
+
+  - name: Create Gitea admin user (Gitea 1.14 and later)
+    when:
+    - r_giteaadmin_user.status == 404
+    - ocp4_workload_gitea_operator_gitea_image_tag is version_compare('1.14', '>=')
+    command: >
+      oc exec {{ r_gitea_pod.resources[0].metadata.name }}
+      -n {{ ocp4_workload_gitea_operator_project }}
+      -- /home/gitea/gitea admin user create --username {{ ocp4_workload_gitea_operator_admin_user }}
+      --password {{ ocp4_workload_gitea_operator_admin_password }}
+      --email {{ ocp4_workload_gitea_operator_admin_user }}@workshop.com
+      --must-change-password=false --admin --config /home/gitea/conf/app.ini
 
 - name: Create the users in Gitea
   when: ocp4_workload_gitea_operator_create_users | bool


### PR DESCRIPTION
##### SUMMARY

Gitea 1.14 changed the way admin users are created. Added logic to support both Gitea 1.13 and 1.14.
Also disallowing `latest` tag.
Fixed a few issues when using a name for the Gitea instance that's not "gitea".

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_gitea_operator
