### PR TITLE
Add 'shortname' to OSP inventory

### DIFF
--- a/ansible/roles-infra/infra-osp-create-inventory/tasks/main.yml
+++ b/ansible/roles-infra/infra-osp-create-inventory/tasks/main.yml
@@ -35,6 +35,7 @@
   - name: Add hosts to inventory
     add_host:
       name: "{{ server | json_query(_name_selector) | default(server.name) }}"
+      shortname: "{{ server | json_query(_name_selector) | default(server.name) }}"
       original_name: "{{ server.name }}"
       groups:
       - "{{ server.metadata.ostype | default('unknowns') }}"


### PR DESCRIPTION
##### SUMMARY

Recent changes in ocp4-cluster post_software require the `shortname` to be set on the bastion server. OSP did not have that set. This PR fixes that.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
infra-osp-create-inventory
