### PR TITLE
Add cluster-admins group for ocp4-workload-migration

### DIFF
--- a/ansible/roles/ocp4-workload-migration/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-migration/defaults/main.yml
@@ -36,3 +36,6 @@ ocs_migstorage_namespace: openshift-migration
 
 # Default to deploying bookbag with shell
 ocp4_workload_migration_deploy_bookbag: true
+
+ocp4_workload_migration_cluster_admins: >-
+  {{ ocp4_workload_authentication_admin_users | default([]) }}

--- a/ansible/roles/ocp4-workload-migration/files/cluster-admins-group.clusterrolebinding.yaml
+++ b/ansible/roles/ocp4-workload-migration/files/cluster-admins-group.clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-admin:group:cluster-admins
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: cluster-admins

--- a/ansible/roles/ocp4-workload-migration/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-migration/tasks/workload.yml
@@ -167,6 +167,15 @@
     vars:
       noobaa_s3_url: "{{ noobaa_s3_endpoint_proto }}://{{ noobaa_endpoint }}/"
 
+- when: ocp4_workload_migration_cluster_admins | length > 0
+  block:
+  - name: Create cluster-admins group
+    k8s:
+      definition: "{{ lookup('template', 'cluster-admins.group.yaml.j2') }}"
+  - name: Create cluster-admins group cluster role binding
+    k8s:
+      definition: "{{ lookup('file', 'cluster-admins-group.clusterrolebinding.yaml') }}"
+
 # Leave this as the last task in the playbook.
 - name: workload tasks complete
   debug:

--- a/ansible/roles/ocp4-workload-migration/templates/cluster-admins.group.yaml.j2
+++ b/ansible/roles/ocp4-workload-migration/templates/cluster-admins.group.yaml.j2
@@ -1,0 +1,5 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: cluster-admins
+users: {{ ocp4_workload_migration_cluster_admins | to_json }}


### PR DESCRIPTION
##### SUMMARY

Add cluster-admins group setup fro ocp4-workload-migration role.

The cluster-admins group is required for RHOCS:

https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.5/html/managing_openshift_container_storage/multicloud-object-gateway_rhocs

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Role ocp4-workload-migration