### PR TITLE
Fix role ocp-workload-aiedge-computing-blueprint

### DIFF
--- a/ansible/roles/ocp-workload-aiedge-computing-blueprint/defaults/main.yml
+++ b/ansible/roles/ocp-workload-aiedge-computing-blueprint/defaults/main.yml
@@ -34,3 +34,4 @@ ocp_workload_aiedge_computing_blueprint_defaults:
   dockerconfigjson_template: '{"auths":{"INTERNAL_REGISTRY_URL": { "auth": "INTERNAL_REGISTRY_AUTH_TOKEN" }}}'
   image_registry_auth_user: "admin"
   pipeline_namespace: "manuela-ci"
+  edge_cluster_domain_placeholder: "{EDGE_CLUSTER_DOMAIN}"

--- a/ansible/roles/ocp-workload-aiedge-computing-blueprint/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-aiedge-computing-blueprint/tasks/workload.yml
@@ -193,6 +193,7 @@
     - "{{ hub_repo_dir }}/base/02_cluster-addons/07_tekton/configmaps/environment.yaml"
     - "{{ hub_repo_dir }}/base/03_services/argocd-operator-subs/channel.yaml"
     - "{{ hub_repo_dir }}/base/03_services/manuela-central/argocd-hub-centraldatacenter.yaml"
+    - "{{ hub_repo_dir }}/base/03_services/manuela-factory-subs/channel.yaml"
     - "{{ hub_repo_dir }}/base/03_services/manuela-ml-workspace/kustomization.yaml"
     - "{{ hub_repo_dir }}/sites/edge-mgmt-hub.gcp.devcluster.openshift.com/00_install-config/kustomization.yaml"
     - "{{ hub_repo_dir }}/sites/edge-mgmt-hub.gcp.devcluster.openshift.com/README.md"
@@ -259,12 +260,26 @@
     - "{{ manuela_dev_repo_dir }}"
   ignore_errors: yes
 
-- name: Update all references to the route for edge-mgmt-hub.gcp.devcluster domain
+- name: Update all manuela-tst references to the route for edge-mgmt-hub.gcp.devcluster domain
   replace:
     path: "{{ item }}"
     # yamllint disable-line rule:line-length
     regexp: 'apps\.(edge-mgmt-hub\.gcp\.devcluster|staging-edge(\.gcp)?\.devcluster)\.openshift\.com'
     replace: '{{ core_cluster_wildcard_domain }}'
+  loop:
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-tst/line-dashboard-configmap-config.json"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-tst/line-dashboard-route.yaml"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-tst/machine-sensor-1-configmap.properties"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-tst/machine-sensor-2-configmap.properties"
+    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-tst/messaging-route.yaml"
+    # yamllint disable rule:line-length
+
+- name: Update all factory and line references to the route for edge cluster placeholder
+  replace:
+    path: "{{ item }}"
+    # yamllint disable-line rule:line-length
+    regexp: 'apps\.(edge-mgmt-hub\.gcp\.devcluster|staging-edge(\.gcp)?\.devcluster)\.openshift\.com'
+    replace: '{{ edge_cluster_domain_placeholder }}'
   loop:
     # yamllint disable rule:line-length
     - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-argocd-aggregator/hub/prometheus-route.yaml"
@@ -285,11 +300,6 @@
     - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-stormshift-staging-gcp/machine-sensor/machine-sensor-1-configmap.properties"
     - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-stormshift-staging-gcp/machine-sensor/machine-sensor-2-configmap.properties"
     - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-stormshift-staging-gcp/messaging/route.yaml"
-    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-tst/line-dashboard-configmap-config.json"
-    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-tst/line-dashboard-route.yaml"
-    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-tst/machine-sensor-1-configmap.properties"
-    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-tst/machine-sensor-2-configmap.properties"
-    - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-tst/messaging-route.yaml"
     # yamllint enable rule:line-length
 
 - name: Commit changes to the gitops routes
@@ -360,6 +370,29 @@
     # yamllint disable-line rule:line-length
     cmd: "oc apply -f '{{ hub_repo_dir }}/base/02_cluster-addons/06_opendatahub/subscription.yaml'"
 
+- name: Get list of InstallPlans in openshift-operators that require manual approval
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: InstallPlan
+    namespace: openshift-operators
+  register: openshift_operators_installplan
+  # Using a json_query filter with JMESPath to selec the installPlans that are pending approval
+  # JMESPath Examples - https://jmespath.org/examples.html
+  until: "openshift_operators_installplan.resources | json_query('[?status.phase==`RequiresApproval`]')"
+  retries: 10
+  delay: 30
+
+- name: Approve pending InstallPlans in openshift-operators
+  k8s:
+    state: present
+    api_version: operators.coreos.com/v1alpha1
+    kind: InstallPlan
+    name: "{{ item.metadata.name }}"
+    namespace: openshift-operators
+    definition:
+      spec:
+        approved: true
+  loop: "{{ openshift_operators_installplan.resources }}"
 ###################################################################################################
 # Create Image Registry auth info
 ###################################################################################################
@@ -500,7 +533,7 @@
   register: result
   until: result.resources|length > 0
   retries: 10
-  delay: 20
+  delay: 60
 
 - name: Create tekton pipelines
   command:
@@ -532,18 +565,17 @@
   command:
     cmd: "oc apply -f '{{ hub_repo_dir }}/base/03_services/argocd-operator-subs/placementrule-labels.yaml'"
 
-- name: Create the ACM gitops subscription
+- name: Create the ACM subscription for ArgoCD operator
   command:
     cmd: "oc apply -f '{{ hub_repo_dir }}/base/03_services/argocd-operator-subs/subscription-labels.yaml'"
+
+- name: Create the ACM subscription for MANUela factory
+  command:
+    cmd: "oc apply -f '{{ hub_repo_dir }}/base/03_services/manuela-factory-subs/subscription-labels-devcluster-factory.yaml'"
 
 - name: Create the Manuela centraldatacenter argocd application
   command:
     cmd: "oc apply -f '{{ hub_repo_dir }}/base/03_services/manuela-central/argocd-hub-centraldatacenter.yaml'"
-
-- name: Create the Manuela factorydatacenter argocd application
-  command:
-    cmd: "oc apply -f '{{ edge_repo_dir }}/sites/staging-edge.devcluster.openshift.com/03_services/argocd-gitops-factory/argocd-staging-aws-factorydatacenter.yaml'"
-    # yamllint enable rule:line-length
 
 - name: Create the Manuela ML workspace
   k8s:


### PR DESCRIPTION
##### SUMMARY
Fix role `ocp-workload-aiedge-computing-blueprint` to approve operator installs that require manual approval & use ACM cluster labels to manage the install of ArgoCD operator and application on managed clusters

* Add check for any operator installs that require manual approval
* Use ACM cluster labels to control the install of ArgoCD on specific clusters
* Use ACM subscriptions to managed the creation of MANUela factory+line
ArgoCD applications
* Add manuela-factory-subs/channel to the list of replaced git repo
* Use placeholder test for the edge cluster domain

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ROLE: `ocp-workload-aiedge-computing-blueprint`

##### ADDITIONAL INFORMATION
N/A