### PR TITLE
Fix some glitches in the first OSP walkthrough documentation

### DIFF
--- a/docs/First_OSP_Env_walkthrough.adoc
+++ b/docs/First_OSP_Env_walkthrough.adoc
@@ -5,13 +5,14 @@ In this document we will explain how one could setup their laptop for AgnosticD 
 
 If you are a Red Hatter, you can use link:labs.opentlc.com[labs.opentlc.com] to request access to our OpenStack cluster.
 . Log in to link:https://labs.opentlc.com[https://labs.opentlc.com] using your opentlc user.
-. Go to *Services* -> *Catalogs* -> *Novello testing* -> *DEV OSP Sandbox*.
+. Go to *Services* -> *Catalogs* -> *Novello Testing* -> *OSP Sandbox AgD Training* (all Red Hat employees should see it, make sure you are in the right group).
 . Click *Order* -> *Submit*
 
 NOTE: You will receive three emails indicating the status of the environment and instructions for accessing the environment.
 In the third email you receive all information you need to login to the client machine that would have the rest of required information.
 
-NOTE: You can use the VM as your ansible host or copy the files over to your laptop and work locally.
+NOTE: You can use the bastion VM as your ansible host or copy the files over to your laptop and work locally.
+Most steps are only necessary on your laptop as the bastion host is already pre-configured.
 
 
 === Configure your environment for running OpenStack Ansible
@@ -67,15 +68,6 @@ $ pip3 install -r https://raw.githubusercontent.com/redhat-cop/agnosticd/develop
 ----
 (ansible2.9-python3.6) $ pip3 install -r https://raw.githubusercontent.com/redhat-cop/agnosticd/development/tools/virtualenvs/ansible2.9-python3.6.txt
 ----
-----
-
-----
-# Install python modules needed by ansible
-sudo pip install openstacksdk
-
-# Install openstack CLIs
-sudo pip install python-openstackclient python-heatclient
-----
 
 === Getting your OpenStack Credentials
 
@@ -125,7 +117,8 @@ $ openstack --os-cloud=GUID-project server list
 +--------------------------------------+-----------+--------+------------------------------------------------+-------+---------+
 ----
 
-. Try to login to OpenStack UI: link:http://horizon.red.osp.opentlc.com/dashboard/auth/login/[]. You must use the credentials from `.config/openstack/clouds.yaml` to login to the UI.
+. Try to login to OpenStack UI using the auth_url from the `clouds.yaml` _without_ port and path, i.e. something like: https://api.xxx.infra.opentlc.com/.
+  You must use username and password from `.config/openstack/clouds.yaml` to login to the UI (the domain can be ignored as long as it is 'Default').
 
 === Setting up AgnosticD and your development environment
 
@@ -136,7 +129,7 @@ $ openstack --os-cloud=GUID-project server list
 git clone https://github.com/redhat-cop/agnosticd
 ----
 
-. Create your `secret.yml` file *oustide the repository*, and edit it using the correct credentials based on your `clouds.yml` file:
+. Create your `secret.yml` file *outside the repository*, and edit it using the correct credentials based on your `clouds.yml` file:
 
 +
 [source,bash]


### PR DESCRIPTION
##### SUMMARY

- service to use has changed
- the format was borked within the instructions to install Python modules
- few more cosmetic changes

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

docs/First_OSP_Env_walkthrough.adoc

##### ADDITIONAL INFORMATION

n/a