### PR TITLE
Update sanbox-ibm role with timeout retries

### DIFF
--- a/ansible/roles-infra/sandbox-ibm/tasks/create_access.yml
+++ b/ansible/roles-infra/sandbox-ibm/tasks/create_access.yml
@@ -14,7 +14,7 @@
       grant_type: "urn:ibm:params:oauth:grant-type:apikey"
       apikey: "{{ sandbox_master_api_key }}"
   register: r_sandbox_token
-  until: r_sandbox_token == 200
+  until: r_sandbox_token.status == 200
   retries: 3
   delay: 10
 
@@ -28,7 +28,7 @@
     headers:
       Authorization: Bearer {{ auth_token }}
   register: r_sandbox_serviceids
-  until: r_sandbox_serviceid.status == 200
+  until: r_sandbox_serviceids.status == 200
   retries: 3
   delay: 10
     
@@ -97,7 +97,7 @@
     headers:
       Authorization: Bearer {{ auth_token }}
   register: r_sandbox_access_groups
-  until: r_sandbox_access_group.status == 200
+  until: r_sandbox_access_groups.status == 200
   retries: 3
   delay: 10
 

--- a/ansible/roles-infra/sandbox-ibm/tasks/create_access.yml
+++ b/ansible/roles-infra/sandbox-ibm/tasks/create_access.yml
@@ -14,6 +14,9 @@
       grant_type: "urn:ibm:params:oauth:grant-type:apikey"
       apikey: "{{ sandbox_master_api_key }}"
   register: r_sandbox_token
+  until: r_sandbox_token == 200
+  retries: 3
+  delay: 10
 
 - name: Set auth bearer token
   set_fact:
@@ -25,6 +28,9 @@
     headers:
       Authorization: Bearer {{ auth_token }}
   register: r_sandbox_serviceids
+  until: r_sandbox_serviceid.status == 200
+  retries: 3
+  delay: 10
     
 - name: Delete SID if it exists
   uri:
@@ -36,6 +42,10 @@
   loop: "{{ r_sandbox_serviceids['json']['serviceids'] | json_query(sid_query) }}"
   vars:
     sid_query: "[?name=='{{ guid }}-sid'].id"
+  register: r_sid_delete
+  until: r_sid_delete.status == 204
+  retries: 3
+  delay: 10
 
 - name: Create service ID (SID) in account
   uri:
@@ -50,6 +60,9 @@
       description: "Service ID for {{ guid }}"
       account_id: "{{ sandbox_account_id }}"
   register: r_sandbox_sid
+  until: r_sandbox_sid.status == 201
+  retries: 3
+  delay: 10
 
 - name: Set sandbox_sid_id
   set_fact:
@@ -70,6 +83,9 @@
       account_id: "{{ sandbox_account_id }}"
       store_value: false
   register: r_sandbox_sid_apikey
+  until: r_sandbox_sid_apikey.status == 201
+  retries: 3
+  delay: 10
 
 - name: Set SID API key
   set_fact:
@@ -81,6 +97,9 @@
     headers:
       Authorization: Bearer {{ auth_token }}
   register: r_sandbox_access_groups
+  until: r_sandbox_access_group.status == 200
+  retries: 3
+  delay: 10
 
 - name: Set access group ID
   set_fact: 
@@ -102,6 +121,9 @@
         - iam_id: "{{ sandbox_sid_id }}"
           type: "service"
   register: r_sid_access_group
+  until: r_sid_access_group.status == 207
+  retries: 3
+  delay: 10
 
 - name: Set access group for ROKS install
   when: ibm_roks_install
@@ -124,6 +146,10 @@
           account_role: "Member"
       access_groups:
         - "{{ sandbox_access_group }}"
+  register: r_enable_ui
+  until: r_enable_ui.status == 202
+  retries: 3
+  delay: 10
 
 - name: Enable UI access for ROKS
   when:

--- a/ansible/roles-infra/sandbox-ibm/tasks/create_roks_access_groups.yml
+++ b/ansible/roles-infra/sandbox-ibm/tasks/create_roks_access_groups.yml
@@ -51,6 +51,6 @@
         - iam_id: "{{ sandbox_sid_id }}"
           type: "service"
   register: r_sid_access_group
-  until: r_sid_access_group == 207
+  until: r_sid_access_group.status == 207
   retries: 3
   delay: 10

--- a/ansible/roles-infra/sandbox-ibm/tasks/create_roks_access_groups.yml
+++ b/ansible/roles-infra/sandbox-ibm/tasks/create_roks_access_groups.yml
@@ -11,6 +11,9 @@
       name: "sandbox_ibm_roks_ag"
       description: "Access group with additional permissions for IBM ROKS"
   register: r_roks_access_group
+  until: r_roks_access_group.status == 201
+  retries: 3
+  delay: 10
 
 - name: Set ROKS access group ID
   set_fact:
@@ -22,6 +25,9 @@
     headers:
       Authorization: Bearer {{ auth_token }}
   register: r_resource_groups
+  until: r_resource_groups.status == 200
+  retries: 3
+  delay: 10
 
 - name: Set default resource group ID
   set_fact:
@@ -45,3 +51,6 @@
         - iam_id: "{{ sandbox_sid_id }}"
           type: "service"
   register: r_sid_access_group
+  until: r_sid_access_group == 207
+  retries: 3
+  delay: 10

--- a/ansible/roles-infra/sandbox-ibm/tasks/create_roks_policies.yml
+++ b/ansible/roles-infra/sandbox-ibm/tasks/create_roks_policies.yml
@@ -24,6 +24,10 @@
           - name: "serviceName"
             operator: "stringEquals"
             value: "cloud-object-storage"
+  register: r_cos_policy
+  until: r_cos_policy.status == 201
+  retries: 3
+  delay: 10
 
 - name: Create container registry policy
   uri:
@@ -50,6 +54,10 @@
           - name: "serviceName"
             operator: "stringEquals"
             value: "container-registry"
+  register: r_registry_policy
+  until: r_registry_policy.status == 201
+  retries: 3
+  delay: 10
 
 - name: Create containers-kubernetes policy
   uri:
@@ -77,6 +85,10 @@
           - name: "serviceName"
             operator: "stringEquals"
             value: "containers-kubernetes"
+  register: r_kube_policy
+  until: r_kube_policy.status == 201
+  retries: 3
+  delay: 10
 
 - name: Create is policy
   uri:
@@ -103,6 +115,10 @@
           - name: "serviceName"
             operator: "stringEquals"
             value: "is"
+  register: r_is_policy
+  until: r_is_policy.status == 201
+  retries: 3
+  delay: 10
 
 - name: Create iam-identity policy
   uri:
@@ -131,6 +147,10 @@
           - name: "serviceName"
             operator: "stringEquals"
             value: "iam-identity"
+  register: r_iam_policy
+  until: r_iam_policy.status == 201
+  retries: 3
+  delay: 10
 
 - name: Create cloudcerts policy
   uri:
@@ -158,6 +178,10 @@
           - name: "serviceName"
             operator: "stringEquals"
             value: "cloudcerts"
+  register: r_cloudcerts_policy
+  until: r_cloudcerts_policy.status == 201
+  retries: 3
+  delay: 10
 
 - name: Create global catalog policy
   uri:
@@ -184,6 +208,10 @@
           - name: "serviceName"
             operator: "stringEquals"
             value: "globalcatalog"
+  register: r_catalog_policy
+  until: r_catalog_policy.status == 201
+  retries: 3
+  delay: 10
 
 - name: Create kms policy
   uri:
@@ -212,6 +240,10 @@
           - name: "serviceName"
             operator: "stringEquals"
             value: "kms"
+  register: r_kms_policy
+  until: r_kms_policy.status == 201
+  retries: 3
+  delay: 10
 
 - name: Create default resource group policy
   uri:
@@ -241,3 +273,7 @@
           - name: "resource"
             operator: "stringEquals"
             value: "{{ sandbox_default_resource_group }}"
+  register: r_rg_policy
+  until: r_rg_policy.status == 201
+  retries: 3
+  delay: 10

--- a/ansible/roles-infra/sandbox-ibm/tasks/create_roks_ui_access.yml
+++ b/ansible/roles-infra/sandbox-ibm/tasks/create_roks_ui_access.yml
@@ -11,6 +11,9 @@
       name: "sandbox_ibm_roks_ui_ag"
       description: "Access group with additional permissions for IBM ROKS"
   register: r_roks_ui_access_group
+  until: r_roks_ui_access_group == 201
+  retries: 3
+  delay: 10
 
 - name: Set ROKS UI access group ID
   set_fact:
@@ -42,6 +45,10 @@
           - name: "serviceName"
             operator: "stringEquals"
             value: "cloud-object-storage"
+  register: r_ui_cos_policy
+  until: r_ui_cos_policy.status == 201
+  retries: 3
+  delay: 10
 
 - name: Create ROKS UI access policy
   uri:
@@ -69,6 +76,10 @@
           - name: "serviceName"
             operator: "stringEquals"
             value: "containers-kubernetes"
+  register: r_ui_policy
+  until: r_ui_policy.status == 201
+  retries: 3
+  delay: 10
 
 - name: Enable UI access for ROKS
   uri:
@@ -85,3 +96,7 @@
       access_groups:
         - "{{ sandbox_access_group }}"
         - "{{ sandbox_roks_ui_access_group }}"
+  register: r_ui_access
+  until: r_ui_access.status == 202
+  retries: 3
+  delay: 10

--- a/ansible/roles-infra/sandbox-ibm/tasks/create_roks_ui_access.yml
+++ b/ansible/roles-infra/sandbox-ibm/tasks/create_roks_ui_access.yml
@@ -11,7 +11,7 @@
       name: "sandbox_ibm_roks_ui_ag"
       description: "Access group with additional permissions for IBM ROKS"
   register: r_roks_ui_access_group
-  until: r_roks_ui_access_group == 201
+  until: r_roks_ui_access_group.status == 201
   retries: 3
   delay: 10
 

--- a/ansible/roles-infra/sandbox-ibm/tasks/remove_access.yml
+++ b/ansible/roles-infra/sandbox-ibm/tasks/remove_access.yml
@@ -14,7 +14,7 @@
       grant_type: "urn:ibm:params:oauth:grant-type:apikey"
       apikey: "{{ sandbox_master_api_key }}"
   register: r_sandbox_token
-  until: r_sandbox_token == 200
+  until: r_sandbox_token.status == 200
   retries: 3
   delay: 10
 
@@ -28,7 +28,7 @@
     headers:
       Authorization: Bearer {{ auth_token }}
   register: r_sandbox_serviceids
-  until: r_sandbox_serviceids == 200
+  until: r_sandbox_serviceids.status == 200
   retries: 3
   delay: 10
     

--- a/ansible/roles-infra/sandbox-ibm/tasks/remove_access.yml
+++ b/ansible/roles-infra/sandbox-ibm/tasks/remove_access.yml
@@ -14,6 +14,9 @@
       grant_type: "urn:ibm:params:oauth:grant-type:apikey"
       apikey: "{{ sandbox_master_api_key }}"
   register: r_sandbox_token
+  until: r_sandbox_token == 200
+  retries: 3
+  delay: 10
 
 - name: Set auth bearer token
   set_fact:
@@ -25,6 +28,9 @@
     headers:
       Authorization: Bearer {{ auth_token }}
   register: r_sandbox_serviceids
+  until: r_sandbox_serviceids == 200
+  retries: 3
+  delay: 10
     
 - name: Delete all SIDs
   uri:
@@ -34,6 +40,10 @@
     headers:
       Authorization: Bearer {{ auth_token }}
   loop: "{{ r_sandbox_serviceids['json']['serviceids'] }}"
+  register: r_sid_delete
+  until: r_sid_delete.status == 204
+  retries: 3
+  delay: 10
 
 - name: Clean up IBM ROKS policies and access groups
   when: ibm_roks_install

--- a/ansible/roles-infra/sandbox-ibm/tasks/remove_roks_access.yml
+++ b/ansible/roles-infra/sandbox-ibm/tasks/remove_roks_access.yml
@@ -5,7 +5,7 @@
     headers:
       Authorization: Bearer {{ auth_token }}
   register: r_sandbox_access_groups
-  until: r_sandbox_access_groups == 200
+  until: r_sandbox_access_groups.status == 200
   retries: 3
   delay: 10
 

--- a/ansible/roles-infra/sandbox-ibm/tasks/remove_roks_access.yml
+++ b/ansible/roles-infra/sandbox-ibm/tasks/remove_roks_access.yml
@@ -5,6 +5,9 @@
     headers:
       Authorization: Bearer {{ auth_token }}
   register: r_sandbox_access_groups
+  until: r_sandbox_access_groups == 200
+  retries: 3
+  delay: 10
 
 - name: Set ROKS service account access group ID
   set_fact: 
@@ -13,12 +16,6 @@
   vars:
     ag_query: "[?name=='sandbox_ibm_roks_ag'].id | [0]"
     ag_ui_query: "[?name=='sandbox_ibm_roks_ui_ag'].id | [0]"
-
-- debug:
-    var: sandbox_roks_access_group
-
-- debug:
-    var: sandbox_roks_ui_access_group
 
 - name: Remove ROKS access groups and policies
   when: sandbox_roks_access_group | length > 0

--- a/ansible/roles-infra/sandbox-ibm/tasks/remove_roks_access_groups.yml
+++ b/ansible/roles-infra/sandbox-ibm/tasks/remove_roks_access_groups.yml
@@ -5,6 +5,9 @@
     headers:
       Authorization: Bearer {{ auth_token }}
   register: r_sandbox_roks_policies
+  until: r_sandbox_roks_policies.status == 200
+  retries: 3
+  delay: 10
 
 - name: Delete ROKS access policies
   when: r_sandbox_roks_policies | length > 0
@@ -17,6 +20,10 @@
   loop: "{{ r_sandbox_roks_policies.json | to_json | from_json | json_query(_policy_query) }}"
   vars:
     _policy_query: "policies[?contains(keys(@), 'description') && starts_with(description, 'ROKS')].id"
+  register: r_policy_delete
+  until: r_policy_delete.status == 204
+  retries: 3
+  delay: 10
 
 - name: Delete ROKS access group
   when: sandbox_roks_access_group | length > 0
@@ -26,3 +33,7 @@
     headers:
       Authorization: Bearer {{ auth_token }}
     status_code: 204
+  register: r_ag_delete
+  until: r_ag_delete.status == 204
+  retries: 3
+  delay: 10

--- a/ansible/roles-infra/sandbox-ibm/tasks/remove_roks_ui_access_groups.yml
+++ b/ansible/roles-infra/sandbox-ibm/tasks/remove_roks_ui_access_groups.yml
@@ -5,6 +5,9 @@
     headers:
       Authorization: Bearer {{ auth_token }}
   register: r_sandbox_roks_ui_policies
+  until: r_sandbox_roks_ui_policies.status == 200
+  retries: 3
+  delay: 10
 
 - name: Delete ROKS UI access policies
   when: r_sandbox_roks_ui_policies | length > 0
@@ -17,6 +20,10 @@
   loop: "{{ r_sandbox_roks_ui_policies.json | to_json | from_json | json_query(_policy_query) }}"
   vars:
     _policy_query: "policies[?contains(keys(@), 'description') && starts_with(description, 'ROKS')].id"
+  register: r_ui_policy_delete
+  until: r_ui_policy_delete.status == 204
+  retries: 3
+  delay: 10
 
 - name: Get a list of members in ROKS UI access group
   uri:
@@ -24,6 +31,9 @@
     headers:
       Authorization: Bearer {{ auth_token }}
   register: r_sandbox_roks_ui_access_group_users
+  until: r_sandbox_roks_ui_access_group_users.status == 200
+  retries: 3
+  delay: 10
 
 - name: Delete members from ROKS UI access group
   when: r_sandbox_roks_ui_access_group_users | length > 0
@@ -36,6 +46,10 @@
   loop: "{{ r_sandbox_roks_ui_access_group_users.json | to_json | from_json | json_query(_membership_query) }}"
   vars:
     _membership_query: "members[].iam_id"
+  register: r_ui_member_delete
+  until: r_ui_member_delete.status == 204
+  retries: 3
+  delay: 10
 
 - name: Delete ROKS UI access group
   uri:
@@ -44,3 +58,7 @@
     headers:
       Authorization: Bearer {{ auth_token }}
     status_code: 204
+  register: r_ui_ag_delete
+  until: r_ui_ag_delete.status == 204
+  retries: 3
+  delay: 10

--- a/ansible/roles-infra/sandbox-ibm/tasks/remove_ui_access.yml
+++ b/ansible/roles-infra/sandbox-ibm/tasks/remove_ui_access.yml
@@ -5,6 +5,9 @@
     headers:
       Authorization: Bearer {{ auth_token }}
   register: r_sandbox_users
+  until: r_sandbox_users.status == 200
+  retries: 3
+  delay: 10
 
 - name: Remove user from account
   uri:
@@ -18,3 +21,7 @@
   vars:
     # user_query: "[?user_id=='{{ email }}'].iam_id"
     user_query: "[?user_id!='{{ sandbox_account_admin }}'].iam_id"
+  register: r_remove_user
+  until: r_remove_user.status == 204
+  retries: 3
+  delay: 10


### PR DESCRIPTION
##### SUMMARY

The IBM Cloud APIs timeout more than we can tolerate. This adds retries to all of the API calls to avoid failures due to brief failures of the API.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
sandbox-ibm