### PR TITLE
pass IP address of osp_cluster_dns_server to nsupdate

### DIFF
--- a/ansible/configs/kni-osp/post_infra.yml
+++ b/ansible/configs/kni-osp/post_infra.yml
@@ -33,7 +33,7 @@
 
     - name: Add DNS entry for OpenShift API and ingress
       nsupdate:
-        server: "{{ osp_cluster_dns_server }}"
+        server: "{{ lookup('dig', osp_cluster_dns_server) }}"
         zone: "{{ osp_cluster_dns_zone }}"
         record: "{{ item.dns }}.{{ guid }}"
         type: A

--- a/ansible/configs/ocp4-cluster/destroy_env_osp.yml
+++ b/ansible/configs/ocp4-cluster/destroy_env_osp.yml
@@ -9,7 +9,7 @@
   tasks:
   - name: Remove DNS entry for OpenShift API and ingress
     nsupdate:
-      server: "{{ osp_cluster_dns_server }}"
+      server: "{{ lookup('dig', osp_cluster_dns_server) }}"
       zone: "{{ osp_cluster_dns_zone }}"
       record: "{{ item }}.cluster-{{ guid }}"
       type: A

--- a/ansible/configs/ocp4-disconnected-osp-lab/destroy_env.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/destroy_env.yml
@@ -15,7 +15,7 @@
 
     - name: Remove DNS entry for OpenShift API and ingress
       nsupdate:
-        server: "{{ osp_cluster_dns_server }}"
+        server: "{{ lookup('dig', osp_cluster_dns_server) }}"
         zone: "{{ osp_cluster_dns_zone }}"
         record: "{{ item }}.cluster-{{ guid }}"
         type: A

--- a/ansible/configs/ocs4-external-implementation/destroy_env_osp.yml
+++ b/ansible/configs/ocs4-external-implementation/destroy_env_osp.yml
@@ -9,7 +9,7 @@
   tasks:
   - name: Remove DNS entry for OpenShift API and ingress
     nsupdate:
-      server: "{{ osp_cluster_dns_server }}"
+      server: "{{ lookup('dig', osp_cluster_dns_server) }}"
       zone: "{{ osp_cluster_dns_zone }}"
       record: "{{ item }}.cluster-{{ guid }}"
       type: A

--- a/ansible/configs/osp-migration/dns_loop.yml
+++ b/ansible/configs/osp-migration/dns_loop.yml
@@ -8,7 +8,7 @@
 
     - name: DNS entry ({{ _dns_state | default('present') }})
       nsupdate:
-        server: "{{ osp_cluster_dns_server }}"
+        server: "{{ lookup('dig', osp_cluster_dns_server) }}"
         zone: "{{ osp_cluster_dns_zone }}"
         #zone: rhpds.opentlc.com
         record: "{{ _dns }}"
@@ -24,7 +24,7 @@
   block:
     - name: DNS entry ({{ _dns_state | default('present') }})
       nsupdate:
-        server: "{{ osp_cluster_dns_server }}"
+        server: "{{ lookup('dig', osp_cluster_dns_server) }}"
         zone: "{{ osp_cluster_dns_zone }}"
         #zone: rhpds.opentlc.com
         record: "{{ _dns }}"

--- a/ansible/configs/osp-satellite-vm/dns_loop.yml
+++ b/ansible/configs/osp-satellite-vm/dns_loop.yml
@@ -8,7 +8,7 @@
 
     - name: DNS entry ({{ _dns_state | default('present') }})
       nsupdate:
-        server: "{{ osp_cluster_dns_server }}"
+        server: "{{ lookup('dig', osp_cluster_dns_server) }}"
         zone: "{{ osp_cluster_dns_zone }}"
         #zone: rhpds.opentlc.com
         record: "{{ _dns }}"
@@ -24,7 +24,7 @@
   block:
     - name: DNS entry ({{ _dns_state | default('present') }})
       nsupdate:
-        server: "{{ osp_cluster_dns_server }}"
+        server: "{{ lookup('dig', osp_cluster_dns_server) }}"
         zone: "{{ osp_cluster_dns_zone }}"
         #zone: rhpds.opentlc.com
         record: "{{ _dns }}"

--- a/ansible/configs/sap-integration/destroy_env_osp.yml
+++ b/ansible/configs/sap-integration/destroy_env_osp.yml
@@ -18,7 +18,7 @@
 
     - name: Remove DNS entry for OpenShift API and ingress
       nsupdate:
-        server: "{{ osp_cluster_dns_server }}"
+        server: "{{ lookup('dig', osp_cluster_dns_server) }}"
         zone: "{{ osp_cluster_dns_zone }}"
         record: "{{ item }}.{{ guid }}"
         type: A

--- a/ansible/roles-infra/infra-osp-dns/tasks/nested_loop.yml
+++ b/ansible/roles-infra/infra-osp-dns/tasks/nested_loop.yml
@@ -13,7 +13,7 @@
 
     - name: DNS entry ({{ _dns_state | default('present') }})
       nsupdate:
-        server: "{{ osp_cluster_dns_server }}"
+        server: "{{ lookup('dig', osp_cluster_dns_server) }}"
         zone: "{{ osp_cluster_dns_zone }}"
         record: "{{ _instance_name }}.{{ guid }}"
         type: A
@@ -29,7 +29,7 @@
   block:
     - name: DNS entry ({{ _dns_state | default('present') }})
       nsupdate:
-        server: "{{ osp_cluster_dns_server }}"
+        server: "{{ lookup('dig', osp_cluster_dns_server) }}"
         zone: "{{ osp_cluster_dns_zone }}"
         record: "{{ _instance_name }}.{{ guid }}"
         type: A

--- a/ansible/roles/ocp-infra-osp-fip/tasks/main.yml
+++ b/ansible/roles/ocp-infra-osp-fip/tasks/main.yml
@@ -24,7 +24,7 @@
 
 - name: Add DNS entry for OpenShift API and ingress
   nsupdate:
-    server: "{{ osp_cluster_dns_server }}"
+    server: "{{ lookup('dig', osp_cluster_dns_server) }}"
     zone: "{{ osp_cluster_dns_zone }}"
     record: "{{ item.dns }}.cluster-{{ guid }}"
     type: A


### PR DESCRIPTION
##### SUMMARY

The `nsupdate` module expects the `server` to be an IP address, not a
hostname (see [1]), but osp_cluster_dns_server is a hostname.
Use the `dig` lookup to convert that to a real IP address.

If you pass a hostname to the `server` parameter, the Python DNS module
raises an error:

    dns.exception.SyntaxError: Text input is malformed.

[1] https://docs.ansible.com/ansible/latest/collections/community/general/nsupdate_module.html#parameter-server

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below
ansible 2.9.18
  config file = /home/evgeni/Devel/agnosticd/ansible/ansible.cfg
  configured module search path = ['/home/evgeni/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.9/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.9.4 (default, Apr  6 2021, 00:00:00) [GCC 10.2.1 20201125 (Red Hat 10.2.1-9)]
```
