### PR TITLE
remove double quotes from AWS IAM password

### DIFF
--- a/ansible/configs/sandbox/pre_infra_ec2.yml
+++ b/ansible/configs/sandbox/pre_infra_ec2.yml
@@ -2,7 +2,7 @@
 - name: Set student Console password
   set_fact:
     student_console_password: >-
-      {{ lookup('password', '/dev/null length=12 chars=ascii_letters,digits,punctuation') }}
+      {{ lookup('password', '/dev/null length=12 chars=ascii_letters,digits,punctuation') | replace('"', 'q') }}
 
 - name: Get the current caller identity information
   environment:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

remove double quotes from AWS IAM password

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

sandbox

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
