### PR TITLE
Fix AIEdge blueprint role var reference

### DIFF
--- a/ansible/roles/ocp-workload-aiedge-computing-blueprint/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-aiedge-computing-blueprint/tasks/workload.yml
@@ -279,7 +279,7 @@
     path: "{{ item }}"
     # yamllint disable-line rule:line-length
     regexp: 'apps\.(edge-mgmt-hub\.gcp\.devcluster|staging-edge(\.gcp)?\.devcluster)\.openshift\.com'
-    replace: '{{ edge_cluster_domain_placeholder }}'
+    replace: '{{ ocp_workload_aiedge_computing_blueprint.edge_cluster_domain_placeholder }}'
   loop:
     # yamllint disable rule:line-length
     - "{{ manuela_gitops_repo_dir }}/config/instances/manuela-argocd-aggregator/hub/prometheus-route.yaml"


### PR DESCRIPTION
##### SUMMARY
Fix incorrect role var reference in role ocp-workload-aiedge-computing-blueprint. 

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
Role: ocp-workload-aiedge-computing-blueprint

##### ADDITIONAL INFORMATION
Please merge when approved
