### PR TITLE
Update IBM RHOIC config destroy process

### DIFF
--- a/ansible/configs/ibm-rhoic/destroy_env.yml
+++ b/ansible/configs/ibm-rhoic/destroy_env.yml
@@ -71,6 +71,7 @@
       until: r_token.status != 500
       retries: 10
       delay: 6
+
     - name: Set fact for bearer token
       set_fact:
         ibm_access_token: "{{ r_token.json.access_token }}"
@@ -82,49 +83,57 @@
   gather_facts: false
   become: false
   tasks:
-    ## Processing delete for RHOIC Cluster
-    - name: Check if the cluster exists
+    # Processing delete for RHOIC Cluster
+    - name: Get a list of RHOIC clusters
       uri:
-        url: "{{ ibm_cloud_api_container_v2_url }}/getCluster?cluster=rhpds-{{ guid }}"
+        url: "{{ ibm_cloud_api_container_v2_url }}/getClusters"
         method: GET
         status_code: 200
         headers:
           Authorization: Bearer {{ ibm_access_token }}
-      register: r_does_rhoic_exist
-      tags: retrieve-rhoic
-      until: r_does_rhoic_exist.json.state is defined
-      retries: 10
-      delay: 6
+      register: r_rhoic_cluster_list
+
     - name: Delete RHOIC cluster if it exists
-      when: r_does_rhoic_exist.json.state is defined
-      uri:
-        url: "{{ ibm_cloud_api_container_v1_url }}/rhpds-{{ guid }}?{{ ibm_cloud_api_rhoic_del_uri_parameters }}"
-        method: DELETE
-        status_code: 204
-        headers:
-          Authorization: Bearer {{ ibm_access_token }}
-      tags: delete-rhoic
-      register: r_rm_rhoic
-      until: r_rm_rhoic.status == 204
-      retries: 10
-      delay: 6
-    - name: Wait 10 minutes for cluster to delete
-      when: r_rm_rhoic.status == 204
-      pause:
-        minutes: 10
-    - name: Keep checking every minute until cluster is deleted
-      when: r_rm_rhoic.status == 204
-      uri:
-        url: "{{ ibm_cloud_api_container_v2_url }}/getCluster?cluster=rhpds-{{ guid }}"
-        method: GET
-        status_code: 200
-        headers:
-          Authorization: Bearer {{ ibm_access_token }}
-      register: r_existing_rhoic
-      tags: retrieve-rhoic
-      until: r_existing_rhoic.json.code is defined and r_existing_rhoic.json.code == "G0004"
-      retries: 30
-      delay: 60
+      when: r_rhoic_cluster_list.json | json_query(_rhoic_cluster_query) | length > 0
+      block:
+        - name: Delete RHOIC cluster
+          uri:
+            url: "{{ ibm_cloud_api_container_v1_url }}/rhpds-{{ guid }}?{{ ibm_cloud_api_rhoic_del_uri_parameters }}"
+            method: DELETE
+            status_code: 204
+            headers:
+              Authorization: Bearer {{ ibm_access_token }}
+          vars:
+            _rhoic_cluster_query: "[?contains(keys(@), 'name') && name=='rhpds-{{ guid }}']"
+          tags: delete-rhoic
+          register: r_rm_rhoic
+          until: r_rm_rhoic.status == 204
+          retries: 10
+          delay: 6
+
+        - name: Wait 10 minutes for cluster to delete
+          when: 
+            - r_rm_rhoic is defined
+            - r_rm_rhoic.status == 204
+          pause:
+            minutes: 10
+
+        - name: Keep checking every minute until cluster is deleted
+          when:
+            - r_rm_rhoic is defined
+            - r_rm_rhoic.status == 204
+          uri:
+            url: "{{ ibm_cloud_api_container_v2_url }}/getCluster?cluster=rhpds-{{ guid }}"
+            method: GET
+            status_code: 200
+            headers:
+              Authorization: Bearer {{ ibm_access_token }}
+          register: r_existing_rhoic
+          tags: retrieve-rhoic
+          until: r_existing_rhoic.json.code is defined and r_existing_rhoic.json.code == "G0004"
+          retries: 30
+          delay: 60
+
     ## Processing delete for Subnet
     - name: Get a list of Subnets
       uri:
@@ -137,14 +146,17 @@
       until: r_subnets.status == 200
       retries: 10
       delay: 6
+
     - name: set Subnet Name
       set_fact:
         rhoic_subnet_name: "subnet-{{ guid }}"
+
     - name: get Subnet ID
       set_fact:
         rhoic_subnet_id: "{{ item.id }}"
       with_items: "{{ r_subnets.json.subnets }}"
       when: item.name == rhoic_subnet_name
+
     - name: Delete Subnet if it exists
       when: rhoic_subnet_id is defined and rhoic_subnet_id != ""
       uri:
@@ -158,6 +170,7 @@
       retries: 30
       delay: 30
       tags: delete-subnet
+
     - name: Pausing for 10 seconds to allow the Subnet to be removed
       when: rhoic_subnet_id is defined and rhoic_subnet_id != ""
       pause:
@@ -175,14 +188,17 @@
       until: r_public_gateways.status == 200
       retries: 10
       delay: 6
+
     - name: set Public Gateway Name
       set_fact:
         rhoic_public_gateway_name: "gateway-{{ guid }}"
+
     - name: get Public Gateway ID
       set_fact:
         rhoic_public_gateway_id: "{{ item.id }}"
       with_items: "{{ r_public_gateways.json.public_gateways }}"
       when: item.name == rhoic_public_gateway_name
+
     - name: Delete Public Gateway if it exists
       when: rhoic_public_gateway_id is defined and rhoic_public_gateway_id != ""
       uri:
@@ -196,6 +212,7 @@
       until: r_existing_pg.status == 204
       retries: 30
       delay: 30
+
     - name: Pausing for 10 seconds to allow the Public Gateway to be removed
       when: rhoic_public_gateway_id is defined and rhoic_public_gateway_id != ""
       pause:
@@ -213,14 +230,17 @@
       until: r_vpcs.status == 200
       retries: 10
       delay: 6
+
     - name: set VPC Name
       set_fact:
         rhoic_vpc_name: "vpc-{{ guid }}"
+
     - name: get VPC ID
       set_fact:
         rhoic_vpc_id: "{{ item.id }}"
       with_items: "{{ r_vpcs.json.vpcs }}"
       when: item.name == rhoic_vpc_name
+
     - name: Delete VPC if it exists
       when: rhoic_vpc_id is defined and rhoic_vpc_id != ""
       uri:
@@ -234,6 +254,7 @@
       until: r_existing_vpc.status == 204
       retries: 30
       delay: 30
+
     ## Processing delete for COS
     - name: Get a list of Resource Instances
       uri:
@@ -246,14 +267,17 @@
       until: r_ris.status == 200
       retries: 10
       delay: 6
+
     - name: set Resource Instance name for the Cloud Storage Object
       set_fact:
         rhoic_cos_name: "cos-{{ guid }}"
+
     - name: get Resource Instance ID for the Cloud Storage Object
       set_fact:
         rhoic_cos_id: "{{ item.guid }}"
       with_items: "{{ r_ris.json.resources }}"
       when: item.name == rhoic_cos_name
+
     - name: Delete Resource Instances if it exists
       when: rhoic_cos_id is defined and rhoic_cos_id != ""
       uri:
@@ -267,10 +291,12 @@
       until: r_existing_cos.status == 204
       retries: 30
       delay: 30
+
     - name: Pausing for 15 seconds to allow the all removals to catch/sync up
       when: rhoic_cos_id is defined and rhoic_cos_id != ""
       pause:
         seconds: 15
+
     - debug:
         msg: "IBM-RHOIC is all cleaned up"
 

--- a/ansible/configs/ibm-rhoic/destroy_env.yml
+++ b/ansible/configs/ibm-rhoic/destroy_env.yml
@@ -95,44 +95,9 @@
 
     - name: Delete RHOIC cluster if it exists
       when: r_rhoic_cluster_list.json | json_query(_rhoic_cluster_query) | length > 0
-      block:
-        - name: Delete RHOIC cluster
-          uri:
-            url: "{{ ibm_cloud_api_container_v1_url }}/rhpds-{{ guid }}?{{ ibm_cloud_api_rhoic_del_uri_parameters }}"
-            method: DELETE
-            status_code: 204
-            headers:
-              Authorization: Bearer {{ ibm_access_token }}
-          vars:
-            _rhoic_cluster_query: "[?contains(keys(@), 'name') && name=='rhpds-{{ guid }}']"
-          tags: delete-rhoic
-          register: r_rm_rhoic
-          until: r_rm_rhoic.status == 204
-          retries: 10
-          delay: 6
-
-        - name: Wait 10 minutes for cluster to delete
-          when: 
-            - r_rm_rhoic is defined
-            - r_rm_rhoic.status == 204
-          pause:
-            minutes: 10
-
-        - name: Keep checking every minute until cluster is deleted
-          when:
-            - r_rm_rhoic is defined
-            - r_rm_rhoic.status == 204
-          uri:
-            url: "{{ ibm_cloud_api_container_v2_url }}/getCluster?cluster=rhpds-{{ guid }}"
-            method: GET
-            status_code: 200
-            headers:
-              Authorization: Bearer {{ ibm_access_token }}
-          register: r_existing_rhoic
-          tags: retrieve-rhoic
-          until: r_existing_rhoic.json.code is defined and r_existing_rhoic.json.code == "G0004"
-          retries: 30
-          delay: 60
+      include_tasks: destroy_rhoic_cluster.yml
+      vars:
+        _rhoic_cluster_query: "[?contains(keys(@), 'name') && name=='rhpds-{{ guid }}']"
 
     ## Processing delete for Subnet
     - name: Get a list of Subnets

--- a/ansible/configs/ibm-rhoic/destroy_env.yml
+++ b/ansible/configs/ibm-rhoic/destroy_env.yml
@@ -92,6 +92,9 @@
         headers:
           Authorization: Bearer {{ ibm_access_token }}
       register: r_rhoic_cluster_list
+      until: r_rhoic_cluster_list.status == 200
+      retries: 10
+      delay: 6
 
     - name: Delete RHOIC cluster if it exists
       when: r_rhoic_cluster_list.json | json_query(_rhoic_cluster_query) | length > 0

--- a/ansible/configs/ibm-rhoic/destroy_rhoic_cluster.yml
+++ b/ansible/configs/ibm-rhoic/destroy_rhoic_cluster.yml
@@ -15,7 +15,7 @@
   delay: 6
 
 - name: Wait 10 minutes for cluster to delete
-  when: 
+  when:
     - r_rm_rhoic is defined
     - r_rm_rhoic.status == 204
   pause:

--- a/ansible/configs/ibm-rhoic/destroy_rhoic_cluster.yml
+++ b/ansible/configs/ibm-rhoic/destroy_rhoic_cluster.yml
@@ -26,13 +26,15 @@
     - r_rm_rhoic is defined
     - r_rm_rhoic.status == 204
   uri:
-    url: "{{ ibm_cloud_api_container_v2_url }}/getCluster?cluster=rhpds-{{ guid }}"
+    url: "{{ ibm_cloud_api_container_v2_url }}/getClusters"
     method: GET
     status_code: 200
     headers:
       Authorization: Bearer {{ ibm_access_token }}
   register: r_existing_rhoic
   tags: retrieve-rhoic
-  until: r_existing_rhoic.json.code is defined and r_existing_rhoic.json.code == "G0004"
+  until: r_existing_rhoic.json | json_query(_rhoic_cluster_query) | length == 0
   retries: 30
   delay: 60
+  vars:
+    _rhoic_cluster_query: "[?contains(keys(@), 'name') && name=='rhpds-{{ guid }}']"

--- a/ansible/configs/ibm-rhoic/destroy_rhoic_cluster.yml
+++ b/ansible/configs/ibm-rhoic/destroy_rhoic_cluster.yml
@@ -1,0 +1,38 @@
+---
+- name: Delete RHOIC cluster
+  uri:
+    url: "{{ ibm_cloud_api_container_v1_url }}/rhpds-{{ guid }}?{{ ibm_cloud_api_rhoic_del_uri_parameters }}"
+    method: DELETE
+    status_code: 204
+    headers:
+      Authorization: Bearer {{ ibm_access_token }}
+  vars:
+    _rhoic_cluster_query: "[?contains(keys(@), 'name') && name=='rhpds-{{ guid }}']"
+  tags: delete-rhoic
+  register: r_rm_rhoic
+  until: r_rm_rhoic.status == 204
+  retries: 10
+  delay: 6
+
+- name: Wait 10 minutes for cluster to delete
+  when: 
+    - r_rm_rhoic is defined
+    - r_rm_rhoic.status == 204
+  pause:
+    minutes: 10
+
+- name: Keep checking every minute until cluster is deleted
+  when:
+    - r_rm_rhoic is defined
+    - r_rm_rhoic.status == 204
+  uri:
+    url: "{{ ibm_cloud_api_container_v2_url }}/getCluster?cluster=rhpds-{{ guid }}"
+    method: GET
+    status_code: 200
+    headers:
+      Authorization: Bearer {{ ibm_access_token }}
+  register: r_existing_rhoic
+  tags: retrieve-rhoic
+  until: r_existing_rhoic.json.code is defined and r_existing_rhoic.json.code == "G0004"
+  retries: 30
+  delay: 60

--- a/ansible/configs/ibm-rhoic/infra.yml
+++ b/ansible/configs/ibm-rhoic/infra.yml
@@ -31,10 +31,12 @@
       until: r_token.status == 200
       retries: 10
       delay: 6
+
     - name: Set fact for bearer token
       set_fact:
         ibm_access_token: "{{ r_token.json.access_token }}"
       tags: store-token
+
     ## Getting Resource Group ID
     - name: Get a list of Resource Groups
       uri:
@@ -47,10 +49,12 @@
       until: r_rgs.status == 200
       retries: 10
       delay: 6
+
     - name: set Resource Group name
       debug:
         var: r_rgs
         verbosity: 2
+
     - name: get Resource Group ID
       set_fact:
         rhoic_rg_id: "{{ item.id }}"
@@ -75,6 +79,7 @@
       until: r_vpcs.status == 200
       retries: 10
       delay: 6
+
     - name: Create VPC if it does not exist
       when: r_vpcs.json.vpcs | json_query(vpc_query) | length == 0
       uri:
@@ -94,22 +99,27 @@
       until: r_new_vpc.status == 201
       retries: 10
       delay: 6
+
     - name: Fail if variable not defined
       fail:
         msg: "Infrastructure components under {{ guid }} already exist -- clean up first"
       when: r_new_vpc.json.id is not defined
       tags: fail-because-something-exists
+
     - name: Set fact for VPC ID
       set_fact:
         rhoic_vpc_id: "{{ r_new_vpc.json.id }}"
       tags: store-vpc-id
+
     - name: Set fact for Security Group ID
       set_fact:
         rhoic_sg_id: "{{ r_new_vpc.json.default_security_group.id }}"
       tags: store-sg-id
+
     - name: Pausing for 15s to allow the VPC to build
       pause:
         seconds: 15
+
     ## Starting Public Gateway Section
     - name: Get a list of Public Gateways
       uri:
@@ -122,6 +132,7 @@
       until: r_public_gateways.status == 200
       retries: 10
       delay: 6
+
     - name: Create Public Gateway if it does not exist
       when: r_public_gateways.json.public_gateways | json_query(public_gateway_query) | length == 0
       uri:
@@ -145,15 +156,18 @@
       until: r_new_public_gateway.status == 201
       retries: 10
       delay: 6
+
     - name: Fail if variable not defined
       fail:
         msg: "Infrastructure components under {{ guid }} already exist -- clean up first"
       when: r_new_public_gateway.json.id is not defined
       tags: fail-because-something-exists
+
     - name: Set fact for Public Gateway ID
       set_fact:
         rhoic_public_gateway_id: "{{ r_new_public_gateway.json.id }}"
       tags: store-public-gateway-id
+
     ## Starting Subnet Section
     - name: Get a list of Subnets
       uri:
@@ -166,11 +180,13 @@
       until: r_subnets.status == 200
       retries: 10
       delay: 6
+
     - name: Picking proper IP range based on region and zone
       set_fact:
         rhoic_cidr: "{{ item.cidr }}"
       when: item.zone == rhoic_zone
       loop: "{{ ibm_cloud_zones_default_ip }}"
+
     - name: Create Subnet if it does not exist
       when: r_subnets.json.subnets | json_query(subnet_query) | length == 0
       uri:
@@ -196,19 +212,23 @@
       until: r_new_subnet.status == 201
       retries: 10
       delay: 6
+
     - name: Fail if variable not defined
       fail:
         msg: "Infrastructure components under {{ guid }} already exist -- clean up first"
       when: r_new_subnet.json.id is not defined
       tags: fail-because-something-exists
+
     - name: Set fact for Subnet ID
       set_fact:
         rhoic_subnet_id: "{{ r_new_subnet.json.id }}"
       tags: store-subnet-id
+
     ## Connect Public Gateway to Subnet
     - name: Pausing for 15s to allow the Subnet and Public Gateway to finish
       pause:
         seconds: 15
+
     - name: Attach the Public Gateway to the Subnet if they both exist
       when: rhoic_sg_id is defined and rhoic_public_gateway_id is defined
       uri:
@@ -225,6 +245,7 @@
       until: r_map_pg.status == 201
       retries: 10
       delay: 6
+
     ## Starting Security Groups Section
     - name: Update Security Group to add NodePort tcp ports
       when: r_vpcs.json.vpcs | json_query(vpc_query) | length == 0
@@ -248,6 +269,7 @@
       until: r_update_sg1.status == 201
       retries: 10
       delay: 6
+
     - name: Update Security Group to add NodePort tcp ports
       when: r_vpcs.json.vpcs | json_query(vpc_query) | length == 0
       uri:
@@ -270,6 +292,7 @@
       until: r_update_sg2.status == 201
       retries: 10
       delay: 6
+
     ## Starting Cloud Object Storage Section
     - name: Create Cloud Object Storage resource if it does not exist
       uri:
@@ -289,10 +312,12 @@
       until: r_new_cos.status == 201
       retries: 10
       delay: 6
+
     - name: Set fact for COS CRN
       set_fact:
         rhoic_cos_id: "{{ r_new_cos.json.id }}"
       tags: store-cos-id
+
     - name: Pausing for 15s to allow the COS to build
       pause:
         seconds: 15

--- a/ansible/configs/ibm-rhoic/software.yml
+++ b/ansible/configs/ibm-rhoic/software.yml
@@ -30,23 +30,28 @@
       until: r_openshift_version_list.status == 200
       retries: 10
       delay: 6
+
     - debug:
         var: r_openshift_version_list.json.openshift
         verbosity: 2
       tags: get-versions
+
     - name: Set fact for RHOIC patch version
       set_fact:
         rhoic_openshift_version_patch: "{{  r_openshift_version_list.json.openshift | json_query(jmesquery) }}"
       vars:
         jmesquery: "[?major==`{{ rhoic_openshift_version_major }}` && minor==`{{ rhoic_openshift_version_minor }}`].patch"
       tags: get-versions
+
     - name: Set fact for RHOIC version
       set_fact:
         rhoic_openshift_version: "{{ rhoic_openshift_version_major }}.{{ rhoic_openshift_version_minor }}.{{ rhoic_openshift_version_patch[0] }}_openshift"
       tags: get-versions
+
     - debug:
         var: rhoic_openshift_version
       tags: get-versions
+
     ## Cluster Creation
     - name: Create RHOIC cluster
       uri:
@@ -80,16 +85,20 @@
       until: r_new_rhoic.status == 201
       retries: 10
       delay: 6
+
     - debug:
         var: r_new_rhoic
         verbosity: 2
+
     - name: Set fact for RHOIC Cluster ID
       set_fact:
         rhoic_cluster_id: "{{ r_new_rhoic.json.clusterID }}"
       tags: store-rhoic-id
+
     - name: Pausing for 45 minutes to allow the RHOIC cluster to build
       pause:
         minutes: 45
+
     ## Re-Authenticating because token only good for 60 minutes
     ## and we don't want it to expire
     - name: Authorize to get bearer token for REST calls
@@ -103,13 +112,16 @@
       until: r_token.status == 200
       retries: 10
       delay: 6
+
     - name: Set fact for bearer token
       set_fact:
         ibm_access_token: "{{ r_token.json.access_token }}"
       tags: store-token
+
     ## Now let us wait for the cluster to come alive (2 minutes between checks)
     - pause:
         seconds: 15
+
     - name: Wait for the RHOIC cluster to finish deploying
       uri:
         url: "{{ ibm_cloud_api_container_v2_url }}/getCluster?cluster={{ rhoic_cluster_id }}"
@@ -122,10 +134,12 @@
       until: r_existing_rhoic.json.state is defined and r_existing_rhoic.json.state == "normal"
       retries: 30
       delay: 120
+
     - name: Displaying RHOIC cluster details
       debug:
         var: r_existing_rhoic
         verbosity: 2
+
     ## Sending details of the cluster to the client
     - name: Passing along the cluster info
       agnosticd_user_info:


### PR DESCRIPTION

##### SUMMARY

The current destroy process is failing when a RHOIC cluster doesn't actually exist. This will change the process to pull a whole list of existing RHOIC clusters and delete it if it exists. The current process looks for a specific cluster and fails when it doesn't find it.

Also, line spacing.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ibm-rhoic