### PR TITLE
Update config ocp4-cluster: Enable On-Demand Capacity Reservation

### DIFF
--- a/ansible/action_plugins/agnosticd_odcr.py
+++ b/ansible/action_plugins/agnosticd_odcr.py
@@ -401,7 +401,7 @@ class ODCRFactory:
 
         result = {}
         az_done = set()
-        for reservation_group_name in reservation_groups:
+        for reservation_group_name in sorted(reservation_groups):
             reservation_group = reservation_groups[reservation_group_name]
             display.v("..loop2: group %s" %(reservation_group_name))
             r_ok, availability_zone, reservation_ids = self.do_reservation_group(

--- a/ansible/cloud_providers/ec2_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/ec2_infrastructure_deployment.yml
@@ -11,8 +11,10 @@
     - step001.1
     - deploy_infrastructure
   tasks:
-    - name: Run infra-aws-capacity-reservation
-      import_role:
+    # If infra-aws-capacity-reservation role was not executed, run it
+    - when: agnosticd_aws_capacity_reservation_results.reservations | default({}) | length == 0
+      name: Run infra-aws-capacity-reservation
+      include_role:
         name: infra-aws-capacity-reservation
       vars:
         ACTION: 'provision'

--- a/ansible/configs/just-a-bunch-of-nodes/default_vars_ec2.yml
+++ b/ansible/configs/just-a-bunch-of-nodes/default_vars_ec2.yml
@@ -44,3 +44,43 @@ agnosticd_aws_capacity_reservations:
     - instance_count: "{{ node_instance_count }}"
       instance_platform: "{{ node_instance_platform }}"
       instance_type: "{{ node_instance_type.ec2 }}"
+
+# To test on-demand capacity, this should try all regions and all AZ and fail:
+# agnosticd_aws_capacity_reservation_regions:
+#   - ap-southeast-1
+#   - ap-southeast-2
+#   - eu-west-1
+#   - eu-west-2
+# agnosticd_aws_capacity_reservations:
+#   az1:
+#     - instance_count: 2
+#       instance_platform: Linux/UNIX
+#       instance_type: "a1.xlarge"
+#     - instance_count: 2
+#       instance_platform: Linux/UNIX
+#       instance_type: "m5.xlarge"
+#     - instance_count: 2
+#       instance_platform: Linux/UNIX
+#       instance_type: "m5.xlarge"
+#     - instance_count: 20
+#       instance_platform: Linux/UNIX
+#       instance_type: "m5a.8xlarge"
+#   az2:
+#     - instance_count: 10
+#       instance_platform: Linux/UNIX
+#       instance_type: "m5a.4xlarge"
+#     - instance_count: 2
+#       instance_platform: Linux/UNIX
+#       instance_type: "c5.large"
+#     - instance_count: 2
+#       instance_platform: Linux/UNIX
+#       instance_type: "m4.4xlarge"
+#     - instance_count: 2
+#       instance_platform: Linux/UNIX
+#       instance_type: "m5zn.large"
+#     - instance_count: 2
+#       instance_platform: Linux/UNIX
+#       instance_type: "m6g.xlarge"
+#     - instance_count: 2
+#       instance_platform: Linux/UNIX
+#       instance_type: "m5n.large"

--- a/ansible/configs/ocp4-cluster/default_vars_ec2.yml
+++ b/ansible/configs/ocp4-cluster/default_vars_ec2.yml
@@ -73,6 +73,21 @@ ocp4_base_domain: "{{ subdomain_base }}"
 # Bastion Configuration
 bastion_instance_type: "t3a.medium"
 bastion_instance_image: RHEL82GOLD
+#bastion_instance_platform: Linux/UNIX
+# For standard (not GOLD) RHEL images:
+#bastion_instance_platform: Red Hat Enterprise Linux
+# used for on-demand capacity reservation:
+bastion_instance_platform: >-
+  {%- if 'RHEL' in bastion_instance_image -%}
+  {%-   if 'GOLD' in bastion_instance_image -%}
+  Linux/UNIX
+  {%-   else -%}
+  Red Hat Enterprise Linux
+  {%-   endif -%}
+  {%- else -%}
+  Linux/UNIX
+  {%- endif -%}
+
 # Root Filesystem Size
 bastion_rootfs_size: 30
 
@@ -131,3 +146,31 @@ instances:
   rootfs_size: "{{ bastion_rootfs_size }}"
   security_groups:
   - BastionSG
+
+# -------------------------------------------------------------------
+# AWS On-demand Capacity
+# -------------------------------------------------------------------
+# To disable ODCR entirely, just set the following variable to false:
+#agnosticd_aws_capacity_reservation_enable: false
+
+######################################
+# ocp4-cluster for workshops and labs
+######################################
+# This ODCR config is the one that has the most chances to successfully deploy.
+# It has very few constraints and the goal is to avoid Insufficient
+# Instance Capacity errors.
+#
+# - Workers are split on 2 zones, if possible. Can be a single zone.
+# - Masters are all in the same zone.
+# - Bastion has its own zone, which can also be the same as the other zones,
+#   because we don't request zones to be distinct.
+
+ocp4_cluster_pre_infra_odcr_profile: workshop
+
+############################################
+# ocp4-cluster for infra clusters, good HA.
+############################################
+# This ODCR config spread masters and workers across 3 distinct AZs.
+# If the region(s) does not have 3 AZs, it will fail 100% of the time.
+
+#ocp4_cluster_pre_infra_odcr_profile: ha

--- a/ansible/configs/ocp4-cluster/pre_infra.yml
+++ b/ansible/configs/ocp4-cluster/pre_infra.yml
@@ -56,3 +56,123 @@
       when: install_infra_ssh_key | default(false) | bool
       include_role:
         name: infra-ec2-ssh-key
+
+    # Find and set the AWS Availability Zones using on-demand capacity reservations
+    - when: ocp4_cluster_pre_infra_odcr_profile == 'workshop'
+      name: Run infra-aws-capacity-reservation
+      include_role:
+        name: infra-aws-capacity-reservation
+      vars:
+        ACTION: 'provision'
+        # Zones can be the same, not necessarly distinct.
+        agnosticd_aws_capacity_reservation_distinct: false
+        agnosticd_aws_capacity_reservations:
+          # Bastion can have its own AZ
+          az1:
+            - instance_type: "{{ bastion_instance_type }}"
+              instance_count: 1
+              instance_platform: "{{ bastion_instance_platform }}"
+
+          masters:
+            - instance_type: "{{ master_instance_type }}"
+              instance_count: 3
+              instance_platform: Linux/UNIX
+
+          # Split workers in 2 AZs if possible.  Could be the same zone.
+          workers1:
+            # Workers: half of workers
+            - instance_type: "{{ worker_instance_type }}"
+              instance_count: >-
+                {{ ( worker_instance_count | int / 2 )
+                | round(0, 'ceil')
+                | int }}
+              instance_platform: Linux/UNIX
+          workers2:
+            # Workers: half of workers + 1 in case it's odd
+            - instance_type: "{{ worker_instance_type }}"
+              instance_count: >-
+                {{ ( worker_instance_count | int / 2 )
+                | round(0, 'ceil')
+                | int }}
+              instance_platform: Linux/UNIX
+
+    - when: ocp4_cluster_pre_infra_odcr_profile == 'ha'
+      name: Run infra-aws-capacity-reservation
+      include_role:
+        name: infra-aws-capacity-reservation
+      vars:
+        ACTION: 'provision'
+        # Zones must be distinct
+        agnosticd_aws_capacity_reservation_distinct: true
+
+        agnosticd_aws_capacity_reservations:
+          az1:
+            - instance_type: "{{ bastion_instance_type }}"
+              instance_count: 1
+              instance_platform: "{{ bastion_instance_platform }}"
+            # master
+            - instance_type: "{{ master_instance_type }}"
+              instance_count: 1
+              instance_platform: Linux/UNIX
+            # Workers
+            - instance_type: "{{ worker_instance_type }}"
+              instance_count: >-
+                {{ ( worker_instance_count | int / 3 )
+                | round(0, 'ceil')
+                | int }}
+              instance_platform: Linux/UNIX
+
+          az2:
+            - instance_type: "{{ master_instance_type }}"
+              instance_count: 1
+              instance_platform: Linux/UNIX
+            # Workers
+            - instance_type: "{{ worker_instance_type }}"
+              instance_count: >-
+                {{ ( worker_instance_count | int / 3 )
+                | round(0, 'ceil')
+                | int }}
+              instance_platform: Linux/UNIX
+          az3:
+            - instance_type: "{{ master_instance_type }}"
+              instance_count: 1
+              instance_platform: Linux/UNIX
+            # Workers
+            - instance_type: "{{ worker_instance_type }}"
+              instance_count: >-
+                {{ ( worker_instance_count | int / 3 )
+                | round(0, 'ceil')
+                | int }}
+              instance_platform: Linux/UNIX
+
+    - when: agnosticd_aws_capacity_reservation_results.reservations | default({}) | length > 0
+      block:
+
+      - when: ocp4_cluster_pre_infra_odcr_profile == 'workshop'
+        name: Set availability zone for bastion, masters and workers (Workshop)
+        set_fact:
+          # Cloudformation (bastion)
+          aws_availability_zone: "{{ agnosticd_aws_capacity_reservation_results.reservations.az1.availability_zone }}"
+          # masters
+          openshift_controlplane_aws_zones_odcr:
+          - "{{ agnosticd_aws_capacity_reservation_results.reservations.masters.availability_zone }}"
+          # workers
+          openshift_machineset_aws_zones_odcr:
+          - "{{ agnosticd_aws_capacity_reservation_results.reservations.workers1.availability_zone }}"
+          - "{{ agnosticd_aws_capacity_reservation_results.reservations.workers2.availability_zone }}"
+
+      - when: ocp4_cluster_pre_infra_odcr_profile == 'ha'
+        name: Set availability zone for bastion, masters and workers (High Availability)
+        set_fact:
+          # Cloudformation (bastion)
+          aws_availability_zone: "{{ agnosticd_aws_capacity_reservation_results.reservations.az1.availability_zone }}"
+          # masters
+          openshift_controlplane_aws_zones_odcr:
+          - "{{ agnosticd_aws_capacity_reservation_results.reservations.az1.availability_zone }}"
+          - "{{ agnosticd_aws_capacity_reservation_results.reservations.az2.availability_zone }}"
+          - "{{ agnosticd_aws_capacity_reservation_results.reservations.az3.availability_zone }}"
+          # workers
+          openshift_machineset_aws_zones_odcr:
+          - "{{ agnosticd_aws_capacity_reservation_results.reservations.az1.availability_zone }}"
+          - "{{ agnosticd_aws_capacity_reservation_results.reservations.az2.availability_zone }}"
+          - "{{ agnosticd_aws_capacity_reservation_results.reservations.az3.availability_zone }}"

--- a/ansible/configs/ocp4-cluster/sample_vars/ocp4_cluster_aws_bare_bones.yml
+++ b/ansible/configs/ocp4-cluster/sample_vars/ocp4_cluster_aws_bare_bones.yml
@@ -25,7 +25,7 @@ aws_region: us-west-1
 key_name: opentlc_admin_backdoor
 
 # OpenShift Installer version to use
-ocp4_installer_version: 4.4.3
+ocp4_installer_version: 4.6.28
 
 # The Pull Secret to pull OpenShift images. Get from try.openshift.com
 ocp4_pull_secret: 'FROM_SECRET'

--- a/ansible/roles-infra/infra-aws-capacity-reservation/readme.adoc
+++ b/ansible/roles-infra/infra-aws-capacity-reservation/readme.adoc
@@ -42,8 +42,9 @@ regions:
 <2> When set to true, the module will always pick distinct zones.
 <3> For Red Hat Entreprise Linux, use `Red Hat Enterprise Linux`, for RHEL *GOLD* images, use `Linux/UNIX`. For more info, please see link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-reservations.html#capacity-reservations-platforms[upstream documentation].
 
-WARNING: reservation groups are requested alphabetically. In the above example, az1 comes first, then az2.  That is important and to be taken in consideration if you set `agnosticd_aws_capacity_reservation_distinct` to `true` because you can easily run out of Availability Zones and increase provision failures. Unless mandatory, it is not recommended to use distinct zones.
-Ideally, that variable should be configured in the `default_vars_ec2.yaml` directly in the config. For ex:
+WARNING: reservation groups are requested alphabetically. In the above example, az1 comes first, then az2.  That is important and to be taken into consideration if you set `agnosticd_aws_capacity_reservation_distinct` to `true` because you can easily run out of Availability Zones and increase provision failures. Unless mandatory, it is not recommended to use distinct zones.
+
+Ideally, `agnosticd_aws_capacity_reservations` variable should be configured in `default_vars_ec2.yaml` directly in the config or as `pre_infra` step in the config. For ex:
 [source,yaml]
 .input as part of `default_vars_ec2.yaml`
 ----

--- a/ansible/roles-infra/infra-aws-capacity-reservation/readme.adoc
+++ b/ansible/roles-infra/infra-aws-capacity-reservation/readme.adoc
@@ -17,10 +17,13 @@ agnosticd_aws_capacity_reservation_region:  # <1>
   - us-east-1
   - us-east-2
 
+# Must the zones all be distinct ?
+agnosticd_aws_capacity_reservation_distinct: false # <2>
+
 agnosticd_aws_capacity_reservations:
   az1:
     - instance_count: 1
-      instance_platform: Linux/UNIX # <2>
+      instance_platform: Linux/UNIX # <3>
       instance_type: t3a.medium
     - instance_count: 2
       instance_platform: Linux/UNIX
@@ -36,8 +39,10 @@ agnosticd_aws_capacity_reservations:
 regions:
 - "{{ aws_region }}"
 ----
-<2> For Red Hat Entreprise Linux, use `Red Hat Enterprise Linux`, for RHEL *GOLD* images, use `Linux/UNIX`. For more info, please see link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-reservations.html#capacity-reservations-platforms[upstream documentation].
+<2> When set to true, the module will always pick distinct zones.
+<3> For Red Hat Entreprise Linux, use `Red Hat Enterprise Linux`, for RHEL *GOLD* images, use `Linux/UNIX`. For more info, please see link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-reservations.html#capacity-reservations-platforms[upstream documentation].
 
+WARNING: reservation groups are requested alphabetically. In the above example, az1 comes first, then az2.  That is important and to be taken in consideration if you set `agnosticd_aws_capacity_reservation_distinct` to `true` because you can easily run out of Availability Zones and increase provision failures. Unless mandatory, it is not recommended to use distinct zones.
 Ideally, that variable should be configured in the `default_vars_ec2.yaml` directly in the config. For ex:
 [source,yaml]
 .input as part of `default_vars_ec2.yaml`

--- a/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
+++ b/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
@@ -14,6 +14,9 @@ controlPlane:
 {%   endif %}
     aws:
       type: {{ master_instance_type | to_json }}
+{%   if openshift_controlplane_aws_zones_odcr | default([]) | length > 0 %}
+      zones: {{ openshift_controlplane_aws_zones_odcr | unique | to_json }}
+{%   endif %}
       rootVolume:
         type: {{ master_storage_type | to_json }}
 {%   if master_storage_type in ['io1', 'io2'] %}
@@ -52,6 +55,8 @@ compute:
         type: {{ worker_storage_type | to_json }}
 {%   if openshift_machineset_aws_zones | default([]) | length > 0 %}
       zones: {{ openshift_machineset_aws_zones | to_json }}
+{%   elif openshift_machineset_aws_zones_odcr | default([]) | length > 0 %}
+      zones: {{ openshift_machineset_aws_zones_odcr | unique | to_json }}
 {%   endif %}
 {% endif %}
 {% if cloud_provider == 'azure' %}

--- a/tools/builds/Dockerfile-python2-aws
+++ b/tools/builds/Dockerfile-python2-aws
@@ -1,0 +1,9 @@
+FROM python:2
+
+LABEL maintainer="Guillaume Core (fridim) <gucore@redhat.com>"
+
+RUN pip install --upgrade pip
+RUN pip install ansible==2.9.15 awscli
+RUN pip install boto boto3
+
+USER ${USER_UID}


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

This change, if applied, enable the on-demand capacity reservation (ODCR) for ocp4-cluster config.

For ocp4-cluster, I created 2 profiles:

1. Workshop ODCR profile: the one that has the most chances to successfully deploy. It has very few constraints and the goal is to avoid Insufficient Capacity errors
    * Workers are split on 2 zones, if possible. Can be a single zone.
    * Masters are all in the same zone.
    * Bastion has its own zone, which can also be the same as the other zones, because we don't request zones to be distinct.
1. High availability ODCR profile: This ODCR config spread masters and workers across 3 distinct AZs. Higher risk of provision failure. Ex: If the region(s) does not have 3 AZs, it will fail 100% of the time.

In order to achieve the ha profile, as part of this change, i added a new feature to `agnosticd_odcr.py` plugin: config owner can now force zones to be *distinct*.

#### old python 2 virtualenv in prod
Since we're still using python2 in most of our provisions to aws (virtualenv `aws-ansible-2.9`) i updated `agnosticd_odcr.py` module to make it compatible with python 2.7:

* use of `six` compatibility module for some operations
* add a dockerfile for python2 testing
* fix syntax

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
* ocp4-cluster config
* agnosticd_odcr.py module
