### PR TITLE
Add semantic versioning for bump_version.sh

### DIFF
--- a/tools/bump_version.sh
+++ b/tools/bump_version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 usage() {
-    echo "$0 [CONFIG] [STAGE]"
+    echo "$0 CONFIG [STAGE]"
     echo
     echo "CONFIG: ALL | ocp-workshop | ocp-demo-lab | ans-tower-lab | ..."
     echo "STAGE: test | prod | rhte"


### PR DESCRIPTION
##### SUMMARY

Add support for semantic versioning for `tools/bump_version.sh`. This PR also allows for moving to a simplified tagging scheme, removing "test" and "prod" strings.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

`tools/bump_version.sh`

##### ADDITIONAL INFORMATION

Our current tagging scheme in AgnosticD is error prone. Test tags are often skipped and when they are used we frequently find that the commit hash that is tested is not the same commit hash that is later released into production.

This PR starts us towards a new scheme where the same tags are used for test and production. The AgnosticV configuration for test should automatically use the latest tag matching a configured prefix while production should always use a fixed version tag. This will allow us to push tags and test then use pull requests to AgnosticV to govern releases to production.

The addition of semantic versioning capability will allow us to move towards being able to update versions for patch releases to fix issues with start/stop/destroy for provisioned environments while distinguishing from other code changes which may not be suitable to use on already provisioned environments.