### PR TITLE
Add lxml python lib to ocp4-cluster k8s virtualenv

### DIFF
--- a/ansible/configs/ocp4-cluster/files/requirements_k8s.txt
+++ b/ansible/configs/ocp4-cluster/files/requirements_k8s.txt
@@ -19,6 +19,7 @@ idna==2.8
 Jinja2==2.10.3
 jmespath==0.9.4
 kubernetes==11.0.0
+lxml==4.6.3
 MarkupSafe==1.1.1
 oauthlib==3.1.0
 openshift==0.11.2


### PR DESCRIPTION
##### SUMMARY

Add lxml to k8s virtualenv required by 3scale demo workload, which uses the `xml` ansible module.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Config ocp4-cluster