### PR TITLE
ODCR: fix EndDate TZ, use UTC

### DIFF
--- a/ansible/action_plugins/agnosticd_odcr.py
+++ b/ansible/action_plugins/agnosticd_odcr.py
@@ -257,7 +257,7 @@ class ODCRFactory:
 
             response = self.clients[region].create_capacity_reservation(
                 AvailabilityZone=availability_zone,
-                EndDate=datetime.datetime.now() + duration,
+                EndDate=datetime.datetime.utcnow() + duration,
                 EndDateType='limited',
                 InstanceMatchCriteria='open',
                 TagSpecifications=tag_spec,


### PR DESCRIPTION
fix the following error:

```
TASK [infra-aws-capacity-reservation : Create on-demand capacity reservations and save result] ***
Monday 10 May 2021  04:36:44 -0400 (0:00:00.109)       0:00:12.494 ************
 [ERROR]: ClientError(u'An error occurred (InvalidParameterValue) when calling
the CreateCapacityReservation operation: The specified EndDate has already
passed. Specify an EndDate in the future.',)
fatal: [localhost]: FAILED! => {"changed": false, "error": "Client Error while creating reservation."}
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
- agnosticd_odcr.py

##### ADDITIONAL INFORMATION
tested with python2 and python3
