### PR TITLE
creating workload for the amq streams

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_amq_streams/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_amq_streams/defaults/main.yml
@@ -1,0 +1,46 @@
+---
+become_override: false
+ocp_username: opentlc-mgr
+silent: false
+
+# Defaults values below are for Red Hat Integration - AMQ Streams 1.7.0
+# Channel to use for the Red Hat Integration subscription
+# When not set (or set to "") use the default channel for the
+# OpenShift version this operator is installed on. If there is no matching
+# version use the `defaultChannel`
+ocp4_workload_amq_streams_channel: ""
+
+# Set automatic InstallPlan approval. If set to false it is also suggested
+# to set the starting_csv to pin a specific version
+# This variable has no effect when using a catalog snapshot (always true)
+ocp4_workload_amq_streams_automatic_install_plan_approval: true
+
+# Set a starting ClusterServiceVersion.
+# Recommended to leave empty to get latest in the channel when not using
+# a catalog snapshot.
+# Highly recommended to be set when using a catalog snapshot but can be
+# empty to get the latest available in the channel at the time when
+# the catalog snapshot got created.
+ocp4_workload_amq_streams_starting_csv: ""
+
+# Wait for the deployment to finish - and check that it finished successfully
+ocp4_workload_amq_streams_wait_for_deploy: true
+
+# --------------------------------
+# Operator Catalog Snapshot Settings
+# --------------------------------
+# See https://github.com/redhat-cop/agnosticd/blob/development/docs/Operator_Catalog_Snapshots.adoc
+# for instructions on how to set up catalog snapshot images
+
+# Use a catalog snapshot
+ocp4_workload_amq_streams_use_catalog_snapshot: false
+
+# Catalog Source Name when using a catalog snapshot. This should be unique
+# in the cluster to avoid clashes
+ocp4_workload_amq_streams_catalogsource_name: redhat-operators-snapshot-amq_streams
+
+# Catalog snapshot image
+ocp4_workload_amq_streams_catalog_snapshot_image: quay.io/gpte-devops-automation/olm_snapshot_redhat_catalog
+
+# Catalog snapshot image tag
+ocp4_workload_amq_streams_catalog_snapshot_image_tag: "v4.6_2020_10_28"

--- a/ansible/roles_ocp_workloads/ocp4_workload_amq_streams/meta/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_amq_streams/meta/main.yml
@@ -1,0 +1,13 @@
+---
+galaxy_info:
+  role_name: ocp4_workload_amq_streams
+  author: Red Hat GPTE, Valentina Rodriguez (vadrodrig@redhat.com)
+  description: |
+    Set up Red Hat Integration - AMQ Streams
+  license: MIT
+  min_ansible_version: 2.9
+  platforms: []
+  galaxy_tags:
+  - ocp
+  - openshift
+dependencies: []

--- a/ansible/roles_ocp_workloads/ocp4_workload_amq_streams/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_amq_streams/readme.adoc
@@ -1,0 +1,64 @@
+= ocp4_workload_amq_streams - Red Hat Integration - AMQ Streams to OpenShift
+
+== Role overview
+
+* This role installs Red Hat Integration - AMQ Streams into an OpenShift Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+ environment for the workload deployment.
+*** Debug task will print out: `pre_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy Red Hat Integration - AMQ Streams
+*** Debug task will print out: `workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+ configure the workload after deployment
+*** This role doesn't do anything here
+*** Debug task will print out: `post_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+ delete the workload
+*** This role removes the Red Hat Integration - AMQ Streams operator.
+*** Debug task will print out: `remove_workload Tasks completed successfully.`
+
+== Review the defaults variable file
+
+* This file link:./defaults/main.yml[./defaults/main.yml] contains all the variables you need to define to control the deployment of your workload.
+* The variable *ocp_username* is mandatory to assign the workload to the correct OpenShift user.
+* A variable *silent=True* can be passed to suppress debug messages.
+
+=== Deploy a Workload with the `ocp-workload` playbook [Mostly for testing]
+
+----
+TARGET_HOST="bastion.ocp43.openshift.opentlc.com"
+OCP_USERNAME="varodrig-redhat.com"
+WORKLOAD="ocp4_workload_amq_streams"
+GUID=1001
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=ec2-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"silent=False" \
+    -e"guid=${GUID}" \
+    -e"ACTION=create"
+----
+
+=== To Delete an environment
+
+----
+TARGET_HOST="bastion.ocp43.openshift.opentlc.com"
+OCP_USERNAME="varodrig-redhat.com"
+WORKLOAD="ocp4_workload_amq_streams"
+GUID=1002
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=ec2-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"guid=${GUID}" \
+    -e"ACTION=remove"
+----

--- a/ansible/roles_ocp_workloads/ocp4_workload_amq_streams/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_amq_streams/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+# Do not modify this file
+
+- name: Running Pre Workload Tasks
+  include_tasks:
+    file: ./pre_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload Tasks
+  include_tasks:
+    file: ./workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  include_tasks:
+    file: ./post_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload removal Tasks
+  include_tasks:
+    file: ./remove_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles_ocp_workloads/ocp4_workload_amq_streams/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_amq_streams/tasks/post_workload.yml
@@ -1,0 +1,9 @@
+---
+# Implement your Post Workload deployment tasks here
+
+
+# Leave this as the last task in the playbook.
+- name: post_workload tasks complete
+  debug:
+    msg: "Post-Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_amq_streams/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_amq_streams/tasks/pre_workload.yml
@@ -1,0 +1,8 @@
+---
+# Implement your Pre Workload deployment tasks here
+
+# Leave this as the last task in the playbook.
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_amq_streams/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_amq_streams/tasks/remove_workload.yml
@@ -1,0 +1,22 @@
+
+- name: Remove Operator
+  include_role:
+    name: install_operator
+  vars:
+    install_operator_action: remove
+    install_operator_name: amq-streams-operator
+    install_operator_namespace: openshift-operators
+    install_operator_channel: "{{ ocp4_workload_amq_streams_channel }}"
+    install_operator_catalog: redhat-operators
+    install_operator_automatic_install_plan_approval: "{{ ocp4_workload_amq_streams_automatic_install_plan_approval | default(true) }}"
+    install_operator_starting_csv: "{{ ocp4_workload_amq_streams_starting_csv }}"
+    install_operator_use_catalog_snapshot: "{{ ocp4_workload_amq_streams_use_catalog_snapshot | default(false)}}"
+    install_operator_catalogsource_name: "{{ ocp4_workload_amq_streams_catalogsource_name | default('') }}"
+    install_operator_catalog_snapshot_image: "{{ ocp4_workload_amq_streams_catalog_snapshot_image | default('') }}"
+    install_operator_catalog_snapshot_image_tag: "{{ ocp4_workload_amq_streams_catalog_snapshot_image_tag | default('') }}"
+
+# Leave this as the last task in the playbook.
+- name: remove_workload tasks complete
+  debug:
+    msg: "Remove Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_amq_streams/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_amq_streams/tasks/workload.yml
@@ -1,0 +1,28 @@
+---
+# Implement your Workload deployment tasks here
+- name: Setting up workload for user
+  debug:
+    msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
+
+- name: Install Operator
+  include_role:
+    name: install_operator
+  vars:
+    install_operator_action: install
+    install_operator_name: amq_streams-operator
+    install_operator_namespace: openshift-operators
+    install_operator_channel: "{{ ocp4_workload_amq_streams_channel }}"
+    install_operator_catalog: redhat-operators
+    install_operator_automatic_install_plan_approval: "{{ ocp4_workload_amq_streams_automatic_install_plan_approval | default(true) }}"
+    install_operator_starting_csv: "{{ ocp4_workload_amq_streams_starting_csv }}"
+    install_operator_use_catalog_snapshot: "{{ ocp4_workload_amq_streams_use_catalog_snapshot | default(false)}}"
+    install_operator_catalogsource_name: "{{ ocp4_workload_amq_streams_catalogsource_name | default('') }}"
+    install_operator_catalog_snapshot_image: "{{ ocp4_workload_amq_streams_catalog_snapshot_image | default('') }}"
+    install_operator_catalog_snapshot_image_tag: "{{ ocp4_workload_amq_streams_catalog_snapshot_image_tag | default('') }}"
+
+
+# Leave this as the last task in the playbook.
+- name: workload tasks complete
+  debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_amq_streams/templates/catalogsource.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_amq_streams/templates/catalogsource.j2
@@ -1,0 +1,9 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: "{{ ocp4_workload_amq_streams_catalogsource_name }}"
+  namespace: openshift-operators
+spec:
+  sourceType: grpc
+  image: "{{ ocp4_workload_amq_streams_catalog_snapshot_image }}:{{ ocp4_workload_amq_streams_catalog_snapshot_image_tag }}"
+  displayName: "{{ ocp4_workload_amq_streams_catalogsource_name }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_amq_streams/templates/installplan.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_amq_streams/templates/installplan.j2
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: InstallPlan
+metadata:
+  name: "{{ ocp4_workload_amq_streams_install_plan_name }}"
+  namespace: openshift-operators
+spec:
+  approved: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_amq_streams/templates/subscription.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_amq_streams/templates/subscription.j2
@@ -1,0 +1,23 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: amq_streams-operator
+  namespace: openshift-operators
+spec:
+  channel: "{{ ocp4_workload_amq_streams_channel }}"
+{% if ocp4_workload_amq_streams_automatic_install_plan_approval | default(True) | bool and not ocp4_workload_amq_streams_use_catalog_snapshot | default(False) | bool %}
+  installPlanApproval: Automatic
+{% else %}
+  installPlanApproval: Manual
+{% endif %}
+  name: amq_streams-operator
+{% if ocp4_workload_amq_streams_use_catalog_snapshot | default(False) | bool %}
+  source: "{{ ocp4_workload_amq_streams_catalogsource_name }}"
+  sourceNamespace: openshift-operators
+{% else %}
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+{% endif %}
+{% if ocp4_workload_amq_streams_starting_csv | default("") | length > 0 %}
+  startingCSV: "{{ ocp4_workload_amq_streams_starting_csv }}"
+{% endif %}


### PR DESCRIPTION
SUMMARY:


This is a generic workload to be used for amq streams. For now it'll be used in the Adv. CND VILT, but can be used by any catalog.


ISSUE TYPE
- New config Pull Request

COMPONENT NAME
ilt-adv-cloud-native-development-prod

```
