### PR TITLE
Remove root owner from script

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_adv_app_deploy_ilt_final_lab/tasks/gitea_setup_repo.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_adv_app_deploy_ilt_final_lab/tasks/gitea_setup_repo.yml
@@ -57,8 +57,6 @@
       src: update_repo.sh.j2
       dest: /tmp/update_repo.sh
       mode: 0775
-      owner: root
-      group: root
 
   - name: Execute the upate repo script
     command: /tmp/update_repo.sh


### PR DESCRIPTION
##### SUMMARY

Playbook tried to set owner/group as root:root - which is a) not allowed and b) should not be necessary. Removing.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_adv_app_deploy_ilt_final_lab