### PR TITLE
Fix nsupdate 'server' param, always pass IP

### DIFF
--- a/ansible/configs/kni-osp/post_infra.yml
+++ b/ansible/configs/kni-osp/post_infra.yml
@@ -33,7 +33,11 @@
 
     - name: Add DNS entry for OpenShift API and ingress
       nsupdate:
-        server: "{{ osp_cluster_dns_server }}"
+        server: >-
+          {{ osp_cluster_dns_server
+          | ipaddr
+          | ternary(osp_cluster_dns_server, lookup('dig', osp_cluster_dns_server))
+          }}
         zone: "{{ osp_cluster_dns_zone }}"
         record: "{{ item.dns }}.{{ guid }}"
         type: A

--- a/ansible/configs/ocp4-cluster/destroy_env_osp.yml
+++ b/ansible/configs/ocp4-cluster/destroy_env_osp.yml
@@ -9,7 +9,11 @@
   tasks:
   - name: Remove DNS entry for OpenShift API and ingress
     nsupdate:
-      server: "{{ osp_cluster_dns_server }}"
+      server: >-
+        {{ osp_cluster_dns_server
+        | ipaddr
+        | ternary(osp_cluster_dns_server, lookup('dig', osp_cluster_dns_server))
+        }}
       zone: "{{ osp_cluster_dns_zone }}"
       record: "{{ item }}.cluster-{{ guid }}"
       type: A

--- a/ansible/configs/ocp4-disconnected-osp-lab/destroy_env.yml
+++ b/ansible/configs/ocp4-disconnected-osp-lab/destroy_env.yml
@@ -15,7 +15,11 @@
 
     - name: Remove DNS entry for OpenShift API and ingress
       nsupdate:
-        server: "{{ osp_cluster_dns_server }}"
+        server: >-
+          {{ osp_cluster_dns_server
+          | ipaddr
+          | ternary(osp_cluster_dns_server, lookup('dig', osp_cluster_dns_server))
+          }}
         zone: "{{ osp_cluster_dns_zone }}"
         record: "{{ item }}.cluster-{{ guid }}"
         type: A

--- a/ansible/configs/ocs4-external-implementation/destroy_env_osp.yml
+++ b/ansible/configs/ocs4-external-implementation/destroy_env_osp.yml
@@ -9,7 +9,11 @@
   tasks:
   - name: Remove DNS entry for OpenShift API and ingress
     nsupdate:
-      server: "{{ osp_cluster_dns_server }}"
+      server: >-
+        {{ osp_cluster_dns_server
+        | ipaddr
+        | ternary(osp_cluster_dns_server, lookup('dig', osp_cluster_dns_server))
+        }}
       zone: "{{ osp_cluster_dns_zone }}"
       record: "{{ item }}.cluster-{{ guid }}"
       type: A

--- a/ansible/configs/osp-migration/dns_loop.yml
+++ b/ansible/configs/osp-migration/dns_loop.yml
@@ -8,7 +8,11 @@
 
     - name: DNS entry ({{ _dns_state | default('present') }})
       nsupdate:
-        server: "{{ osp_cluster_dns_server }}"
+        server: >-
+          {{ osp_cluster_dns_server
+          | ipaddr
+          | ternary(osp_cluster_dns_server, lookup('dig', osp_cluster_dns_server))
+          }}
         zone: "{{ osp_cluster_dns_zone }}"
         #zone: rhpds.opentlc.com
         record: "{{ _dns }}"
@@ -24,7 +28,11 @@
   block:
     - name: DNS entry ({{ _dns_state | default('present') }})
       nsupdate:
-        server: "{{ osp_cluster_dns_server }}"
+        server: >-
+          {{ osp_cluster_dns_server
+          | ipaddr
+          | ternary(osp_cluster_dns_server, lookup('dig', osp_cluster_dns_server))
+          }}
         zone: "{{ osp_cluster_dns_zone }}"
         #zone: rhpds.opentlc.com
         record: "{{ _dns }}"

--- a/ansible/configs/osp-satellite-vm/dns_loop.yml
+++ b/ansible/configs/osp-satellite-vm/dns_loop.yml
@@ -8,7 +8,11 @@
 
     - name: DNS entry ({{ _dns_state | default('present') }})
       nsupdate:
-        server: "{{ osp_cluster_dns_server }}"
+        server: >-
+          {{ osp_cluster_dns_server
+          | ipaddr
+          | ternary(osp_cluster_dns_server, lookup('dig', osp_cluster_dns_server))
+          }}
         zone: "{{ osp_cluster_dns_zone }}"
         #zone: rhpds.opentlc.com
         record: "{{ _dns }}"
@@ -24,7 +28,11 @@
   block:
     - name: DNS entry ({{ _dns_state | default('present') }})
       nsupdate:
-        server: "{{ osp_cluster_dns_server }}"
+        server: >-
+          {{ osp_cluster_dns_server
+          | ipaddr
+          | ternary(osp_cluster_dns_server, lookup('dig', osp_cluster_dns_server))
+          }}
         zone: "{{ osp_cluster_dns_zone }}"
         #zone: rhpds.opentlc.com
         record: "{{ _dns }}"

--- a/ansible/configs/sap-integration/destroy_env_osp.yml
+++ b/ansible/configs/sap-integration/destroy_env_osp.yml
@@ -18,7 +18,11 @@
 
     - name: Remove DNS entry for OpenShift API and ingress
       nsupdate:
-        server: "{{ osp_cluster_dns_server }}"
+        server: >-
+          {{ osp_cluster_dns_server
+          | ipaddr
+          | ternary(osp_cluster_dns_server, lookup('dig', osp_cluster_dns_server))
+          }}
         zone: "{{ osp_cluster_dns_zone }}"
         record: "{{ item }}.{{ guid }}"
         type: A

--- a/ansible/roles-infra/infra-osp-dns/tasks/nested_loop.yml
+++ b/ansible/roles-infra/infra-osp-dns/tasks/nested_loop.yml
@@ -13,7 +13,11 @@
 
     - name: DNS entry ({{ _dns_state | default('present') }})
       nsupdate:
-        server: "{{ osp_cluster_dns_server }}"
+        server: >-
+          {{ osp_cluster_dns_server
+          | ipaddr
+          | ternary(osp_cluster_dns_server, lookup('dig', osp_cluster_dns_server))
+          }}
         zone: "{{ osp_cluster_dns_zone }}"
         record: "{{ _instance_name }}.{{ guid }}"
         type: A
@@ -29,7 +33,11 @@
   block:
     - name: DNS entry ({{ _dns_state | default('present') }})
       nsupdate:
-        server: "{{ osp_cluster_dns_server }}"
+        server: >-
+          {{ osp_cluster_dns_server
+          | ipaddr
+          | ternary(osp_cluster_dns_server, lookup('dig', osp_cluster_dns_server))
+          }}
         zone: "{{ osp_cluster_dns_zone }}"
         record: "{{ _instance_name }}.{{ guid }}"
         type: A

--- a/ansible/roles/ocp-infra-osp-fip/tasks/main.yml
+++ b/ansible/roles/ocp-infra-osp-fip/tasks/main.yml
@@ -24,7 +24,11 @@
 
 - name: Add DNS entry for OpenShift API and ingress
   nsupdate:
-    server: "{{ osp_cluster_dns_server }}"
+    server: >-
+      {{ osp_cluster_dns_server
+      | ipaddr
+      | ternary(osp_cluster_dns_server, lookup('dig', osp_cluster_dns_server))
+      }}
     zone: "{{ osp_cluster_dns_zone }}"
     record: "{{ item.dns }}.cluster-{{ guid }}"
     type: A


### PR DESCRIPTION
This change, if applied, fixes all 'nsupdate' invocations and makes sure the IP
address is used, not the dns name.

This change fixes the following error that happens with some recent versions of ansible:

> dns.exception.SyntaxError: Text input is malformed.

Co-authored-by: Eric L <ericzolf@users.noreply.github.com>

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Bugfix Pull Request



##### ADDITIONAL INFORMATION
I tested the following playbook with:

```yaml
- hosts: localhost
  gather_facts: false
  tasks:
    - debug:
        msg: "{{ myvar | ipaddr | ternary(myvar, lookup('dig', myvar)) }}"
      vars:
        myvar: ddns01.opentlc.com
    - debug:
        msg: "{{ myvar | ipaddr | ternary(myvar, lookup('dig', myvar)) }}"
      vars:
        myvar: 169.45.246.132
```

* ansible 2.11
* ansible 2.9
* ansible 2.7
* openstack-ansible-2.9 virtualenv
* ansible system on admin host
* aws-ansible-2.9 virtualenv
