### PR TITLE
Fix password generation in sandbox open env

### DIFF
--- a/ansible/configs/sandbox/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/sandbox/files/cloud_providers/ec2_cloud_template.j2
@@ -154,7 +154,7 @@ Resources:
       UserName: "{{ email | default(owner) }}-{{ guid }}"
       {% if sandbox_enable_ui | default(true) | bool %}
       LoginProfile:
-        Password: "{{ student_console_password }}"
+        Password: {{ student_console_password | to_json }}
         PasswordResetRequired: False
       {% endif %}
       Policies:

--- a/ansible/configs/sandbox/pre_infra_ec2.yml
+++ b/ansible/configs/sandbox/pre_infra_ec2.yml
@@ -2,7 +2,8 @@
 - name: Set student Console password
   set_fact:
     student_console_password: >-
-      {{ lookup('password', '/dev/null length=12 chars=ascii_letters,digits,punctuation') | regex_replace('["{}]', 'q') }}
+      {{ lookup('password', '/dev/null length=12') -}}
+      {{- lookup('password', '/dev/null length=1 chars=digits') }}
 
 - name: Get the current caller identity information
   environment:


### PR DESCRIPTION
Use ansible default chars for the generation of passwords:

> By default generated passwords contain a random mix of upper and lowercase ASCII letters, the numbers 0-9 and punctuation (". , : - _").

Plus adds a number at the end to pass AWS password policy:

> Password should meet 1 more of the following requirements: Password should have at least one number, Password should have at least one symbol

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
