### PR TITLE
Add role ocp4_workload_servicemesh_workshop

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/defaults/main.yml
@@ -14,7 +14,7 @@ silent: false
 ## Workshop Settings
 ocp4_workload_servicemesh_workshop_user_count: 1
 ocp4_workload_servicemesh_workshop_image_repo: quay.io/redhatgov/service-mesh-workshop-dashboard
-ocp4_workload_servicemesh_workshop_image_tag: "2.0"
+ocp4_workload_servicemesh_workshop_image_tag: "2.1"
 
 ## Operator Settings
 ocp4_workload_servicemesh_workshop_elasticsearch_channel: "4.6"

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/defaults/main.yml
@@ -11,15 +11,20 @@ silent: false
 ## into these variables. Everything you add here should be
 ## prefixed with the role name: ocp4_workload_servicemesh_workshop_*
 
+## User Settings
+ocp4_workload_servicemesh_workshop_user_count: 1
+
 ## Operator Settings
 ocp4_workload_servicemesh_workshop_elasticsearch_channel: "4.6"
 ocp4_workload_servicemesh_workshop_jaeger_channel: stable
 ocp4_workload_servicemesh_workshop_kiali_channel: stable
 ocp4_workload_servicemesh_workshop_servicemesh_channel: stable
+ocp4_workload_servicemesh_workshop_rhsso_channel: alpha
 ocp4_workload_servicemesh_workshop_elasticsearch_starting_csv: "elasticsearch-operator.4.6.0-202103010126.p0"
 ocp4_workload_servicemesh_workshop_jaeger_starting_csv: "jaeger-operator.v1.20.3"
 ocp4_workload_servicemesh_workshop_kiali_starting_csv: "kiali-operator.v1.24.7"
 ocp4_workload_servicemesh_workshop_servicemesh_starting_csv: "servicemeshoperator.v2.0.5"
+ocp4_workload_servicemesh_workshop_rhsso_starting_csv: "rhsso-operator.7.4.7"
 
 ## Operator Catalog Snapshot Settings
 ocp4_workload_servicemesh_workshop_catalogsource_name: redhat-operators-snapshot-servicemesh-workshop

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/defaults/main.yml
@@ -10,5 +10,18 @@ silent: false
 ## values the requesting user enters in the form in RHPDS
 ## into these variables. Everything you add here should be
 ## prefixed with the role name: ocp4_workload_servicemesh_workshop_*
-ocp4_workload_servicemesh_workshop_var1: val1
-ocp4_workload_servicemesh_workshop_var2: val2
+
+## Operator Settings
+ocp4_workload_servicemesh_workshop_elasticsearch_channel: "4.6"
+ocp4_workload_servicemesh_workshop_jaeger_channel: stable
+ocp4_workload_servicemesh_workshop_kiali_channel: stable
+ocp4_workload_servicemesh_workshop_servicemesh_channel: stable
+ocp4_workload_servicemesh_workshop_elasticsearch_starting_csv: "elasticsearch-operator.4.6.0-202103010126.p0"
+ocp4_workload_servicemesh_workshop_jaeger_starting_csv: "jaeger-operator.v1.20.3"
+ocp4_workload_servicemesh_workshop_kiali_starting_csv: "kiali-operator.v1.24.7"
+ocp4_workload_servicemesh_workshop_servicemesh_starting_csv: "servicemeshoperator.v2.0.5"
+
+## Operator Catalog Snapshot Settings
+ocp4_workload_servicemesh_workshop_catalogsource_name: redhat-operators-snapshot-servicemesh-workshop
+ocp4_workload_servicemesh_workshop_catalog_snapshot_image: quay.io/jakang/olm_snapshot_redhat_catalog
+ocp4_workload_servicemesh_workshop_catalog_snapshot_image_tag: "v4.6_2021_05_23"

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/defaults/main.yml
@@ -5,7 +5,7 @@ ocp_username: opentlc-mgr
 silent: false
 
 ## ADD Variables here for use in your role, if needed.
-## When you go to create a ServiceNow ticket to create 
+## When you go to create a ServiceNow ticket to create
 ## the RHPDS catalog item, you can ask the engineer to feed
 ## values the requesting user enters in the form in RHPDS
 ## into these variables. Everything you add here should be

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+## FRAMEWORK variables - do not change.
+become_override: false
+ocp_username: opentlc-mgr
+silent: false
+
+## ADD Variables here for use in your role, if needed.
+## When you go to create a ServiceNow ticket to create 
+## the RHPDS catalog item, you can ask the engineer to feed
+## values the requesting user enters in the form in RHPDS
+## into these variables. Everything you add here should be
+## prefixed with the role name: ocp4_workload_servicemesh_workshop_*
+ocp4_workload_servicemesh_workshop_var1: val1
+ocp4_workload_servicemesh_workshop_var2: val2

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/defaults/main.yml
@@ -11,8 +11,10 @@ silent: false
 ## into these variables. Everything you add here should be
 ## prefixed with the role name: ocp4_workload_servicemesh_workshop_*
 
-## User Settings
+## Workshop Settings
 ocp4_workload_servicemesh_workshop_user_count: 1
+ocp4_workload_servicemesh_workshop_image_repo: quay.io/redhatgov/service-mesh-workshop-dashboard
+ocp4_workload_servicemesh_workshop_image_tag: "2.0"
 
 ## Operator Settings
 ocp4_workload_servicemesh_workshop_elasticsearch_channel: "4.6"

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/meta/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/meta/main.yml
@@ -1,0 +1,13 @@
+---
+galaxy_info:
+  role_name: ocp4_workload_servicemesh_workshop
+  author: Chris Kang (jakang@redhat.com)
+  description: |
+    Deploy Service Mesh Workshop onto OpenShift 4
+  license: MIT
+  min_ansible_version: 2.9
+  platforms: []
+  galaxy_tags:
+  - ocp
+  - openshift
+dependencies: []

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/readme.adoc
@@ -1,4 +1,4 @@
-= ocp4-workload-sre-workshop - RedHatGov SRE Workshop
+= RedHatGov OpenShift Service Mesh Workshop
 
 == Role overview
 
@@ -7,8 +7,28 @@
  environment for the workload deployment.
 *** Debug task will print out: `pre_workload Tasks completed successfully.`
 
-** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy Shadowman Sprint
-*** This role creates a namespace (project) and deploys all the components of the demo.
+** Tasks: link:./tasks/install_elasticsearch_operator.yaml[install_elasticsearch_operator.yaml]
+*** This role installs Elastic Search (the version is locked, see the variables file)
+*** Debug task will print out: `workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/install_jaeger_operator.yaml[install_jaeger_operator.yaml]
+*** This role installs Jaeger (the version is locked, see the variables file)
+*** Debug task will print out: `workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/install_kiali_operator.yaml[install_kiali_operator.yaml]
+*** This role installs Kiali (the version is locked, see the variables file)
+*** Debug task will print out: `workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/install_servicemesh_operator.yaml[install_servicemesh_operator.yaml]
+*** This role installs Service Mesh V2 (the version is locked, see the variables file)
+*** Debug task will print out: `workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/per_user_workload.yaml[per_user_workload.yaml]
+*** This role creates a user project, service mesh project, a service mesh control plane, and attaches the user project to the user's service mesh control plane
+*** Debug task will print out: `workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/workload.yml[workload.yml]
+*** This role uses all of the above to set up the RedHatGov OSM Workshop
 *** Debug task will print out: `workload Tasks completed successfully.`
 
 ** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
@@ -18,7 +38,7 @@
 
 ** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
  delete the workload
-*** This role removes OpenShift Pipelines
+*** This role doesn't do anything here
 *** Debug task will print out: `remove_workload Tasks completed successfully.`
 
 == Review the defaults variable file
@@ -36,7 +56,7 @@ env_type: ocp-workloads
 target_host: bastion.dev4.openshift.opentlc.com
 
 ocp_workloads:
-- ocp4_workload_rhte19_shadowman
+- ocp4_workload_servicemesh_workshop
 
 #become_override: false
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/readme.adoc
@@ -1,0 +1,62 @@
+= ocp4-workload-sre-workshop - RedHatGov SRE Workshop
+
+== Role overview
+
+* This role deploys a full instance of the RedHatGov Service Mesh Workshop. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+ environment for the workload deployment.
+*** Debug task will print out: `pre_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy Shadowman Sprint
+*** This role creates a namespace (project) and deploys all the components of the demo.
+*** Debug task will print out: `workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+ configure the workload after deployment
+*** This role doesn't do anything here
+*** Debug task will print out: `post_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+ delete the workload
+*** This role removes OpenShift Pipelines
+*** Debug task will print out: `remove_workload Tasks completed successfully.`
+
+== Review the defaults variable file
+
+* This file link:./defaults/main.yml[./defaults/main.yml] contains all the variables you need to define to control the deployment of your workload.
+* The variable *ocp_username* is mandatory to assign the workload to the correct OpenShift user.
+* A variable *silent=True* can be passed to suppress debug messages.
+
+=== Deploy a Workload with the `ocp-workload` config [Mostly for testing]
+
+Create a file `workload_vars.yaml` with your variables:
+----
+cloud_provider: none
+env_type: ocp-workloads
+target_host: bastion.dev4.openshift.opentlc.com
+
+ocp_workloads:
+- ocp4_workload_rhte19_shadowman
+
+#become_override: false
+
+# If the ocp-workload supports it, you should specify the OCP user:
+ocp_username: system:admin
+
+# Usually the ocp-workloads want a GUID also:
+guid: changeme
+----
+
+From the Agnosticd/ansible directory run the playbook:
+
+----
+ansible-playbook main.yml -e @workload_vars.yml -e ACTION="create"
+----
+
+=== To Delete an environment
+
+From the Agnosticd/ansible directory run the playbook:
+
+----
+ansible-playbook main.yml -e @workload_vars.yml -e ACTION="remove"
+----

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/homeroom.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/homeroom.yaml
@@ -1,0 +1,80 @@
+---
+- name: Determine Cluster Base Domain
+  k8s_info:
+    api_version: config.openshift.io/v1
+    kind: Ingress
+    name: cluster
+  register: r_ingress_config
+
+# Example return: CLUSTER_SUBDOMAIN = apps.cluster-84d2.84d2.example.opentlc.com
+- name: Store the subdomain
+  set_fact:
+    CLUSTER_SUBDOMAIN: "{{ r_ingress_config.resources[0].spec.domain }}"
+
+- name: Create homeroom project if it doesn't exist
+  k8s:
+    state: present
+    name: homeroom
+    kind: Project
+    api_version: project.openshift.io/v1
+
+- name: Check if homeroom was already deployed
+  k8s_info:
+    api_version: apps.openshift.io/v1
+    kind: DeploymentConfig
+    name: service-mesh-workshop-spawner
+    namespace: homeroom
+  register: homeroom_deployment
+
+- name: check for the oauthclient if we're about to deploy the labguide
+  k8s_info:
+    api_version: oauth.openshift.io/v1
+    kind: OAuthClient
+    name: service-mesh-workshop-console
+  register: oauth_client
+
+- name: ensure the oauthclient is not present from an earlier run if we're about to deploy labguide
+  k8s:
+    state: absent
+    definition:
+      apiVersion: oauth.openshift.io/v1
+      kind: OAuthClient
+      metadata:
+        name: service-mesh-workshop-console
+  when:
+    - oauth_client.resources | length | int > 0
+    - homeroom_deployment.resources | length | int < 1
+
+- name: Create the homeroom template
+  command: oc apply -f https://raw.githubusercontent.com/RedHatGov/workshop-spawner/develop/templates/hosted-workshop-production.json -n homeroom
+  when: homeroom_deployment.resources | length | int < 1
+
+- name: Deploy the homeroom spawner
+  command: >-
+          oc new-app hosted-workshop-production -n homeroom \
+          -p SPAWNER_NAMESPACE=homeroom \
+          -p CLUSTER_SUBDOMAIN={{ CLUSTER_SUBDOMAIN }} \
+          -p WORKSHOP_NAME=service-mesh-workshop \
+          -p CONSOLE_IMAGE=quay.io/openshift/origin-console:4.6 \
+          -p WORKSHOP_IMAGE="{{ ocp4_workload_servicemesh_workshop_image_repo }}":"{{ ocp4_workload_servicemesh_workshop_image_tag }}"
+  when: homeroom_deployment.resources | length | int < 1
+
+- name: Check if username app was already deployed
+  k8s_info:
+    api_version: apps.openshift.io/v1
+    kind: DeploymentConfig
+    name: username-distribution
+    namespace: homeroom
+  register: username_deployment
+
+- name: Create user distribution template
+  command: oc apply -f https://raw.githubusercontent.com/redhatgov/username-distribution/master/openshift/app-ephemeral.json -n homeroom
+  when: username_deployment.resources | length | int < 1
+
+- name: Deploy user distribution app
+  command: >-
+          oc new-app username-distribution -n homeroom \
+          -p LAB_USER_PREFIX=user \
+          -p LAB_USER_COUNT="{{ ocp4_workload_servicemesh_workshop_user_count }}" \
+          -p LAB_MODULE_URLS='https://service-mesh-workshop-homeroom.{{ CLUSTER_SUBDOMAIN }};Workshop Dashboard'
+  when: username_deployment.resources | length | int < 1

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/install_elasticsearch_operator.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/install_elasticsearch_operator.yaml
@@ -1,0 +1,68 @@
+---
+- name: Create Elastic Search subscription
+  k8s:
+    state: present
+    definition: "{{ lookup('template', './templates/elasticsearch_subscription.j2' ) }}"
+
+- name: Wait until InstallPlan is created
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: InstallPlan
+    namespace: openshift-operators
+  register: r_install_plans
+  vars:
+    _query: >-
+      [?starts_with(spec.clusterServiceVersionNames[0], 'elastic')]
+  retries: 30
+  delay: 5
+  until:
+  - r_install_plans.resources | length > 0
+  - r_install_plans.resources | to_json | from_json | json_query(_query)
+
+- name: Set InstallPlan Name
+  set_fact:
+    ocp4_workload_servicemesh_workshop_elasticsearch_install_plan_name: "{{ r_install_plans.resources | to_json | from_json | json_query(query) }}"
+  vars:
+    query: >-
+      [?starts_with(spec.clusterServiceVersionNames[0], 'elastic')].metadata.name|[0]
+
+- name: Get InstallPlan
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: InstallPlan
+    name: "{{ ocp4_workload_servicemesh_workshop_elasticsearch_install_plan_name }}"
+    namespace: openshift-operators
+  register: r_install_plan
+
+- name: Approve InstallPlan if necessary
+  when: r_install_plan.resources[0].status.phase is match("RequiresApproval")
+  k8s:
+    state: present
+    definition: "{{ lookup( 'template', './templates/elasticsearch_installplan.j2' ) }}"
+
+- name: Get Installed CSV
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: Subscription
+    name: elasticsearch-operator
+    namespace: openshift-operators
+  register: r_subscription
+  retries: 30
+  delay: 5
+  until:
+  - r_subscription.resources[0].status.currentCSV is defined
+  - r_subscription.resources[0].status.currentCSV | length > 0
+
+- name: Wait until CSV is Installed
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    name: "{{ r_subscription.resources[0].status.currentCSV }}"
+    namespace: openshift-operators
+  register: r_csv
+  retries: 15
+  delay: 5
+  until:
+  - r_csv.resources[0].status.phase is defined
+  - r_csv.resources[0].status.phase | length > 0
+  - r_csv.resources[0].status.phase == "Succeeded"

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/install_jaeger_operator.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/install_jaeger_operator.yaml
@@ -1,0 +1,68 @@
+---
+- name: Create Jaeger subscription
+  k8s:
+    state: present
+    definition: "{{ lookup('template', './templates/jaeger_subscription.j2' ) }}"
+
+- name: Wait until InstallPlan is created
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: InstallPlan
+    namespace: openshift-operators
+  register: r_install_plans
+  vars:
+    _query: >-
+      [?starts_with(spec.clusterServiceVersionNames[0], 'jaeger')]
+  retries: 30
+  delay: 5
+  until:
+  - r_install_plans.resources | length > 0
+  - r_install_plans.resources | to_json | from_json | json_query(_query)
+
+- name: Set InstallPlan Name
+  set_fact:
+    ocp4_workload_servicemesh_workshop_jaeger_install_plan_name: "{{ r_install_plans.resources | to_json | from_json | json_query(query) }}"
+  vars:
+    query: >-
+      [?starts_with(spec.clusterServiceVersionNames[0], 'jaeger')].metadata.name|[0]
+
+- name: Get InstallPlan
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: InstallPlan
+    name: "{{ ocp4_workload_servicemesh_workshop_jaeger_install_plan_name }}"
+    namespace: openshift-operators
+  register: r_install_plan
+
+- name: Approve InstallPlan if necessary
+  when: r_install_plan.resources[0].status.phase is match("RequiresApproval")
+  k8s:
+    state: present
+    definition: "{{ lookup( 'template', './templates/jaeger_installplan.j2' ) }}"
+
+- name: Get Installed CSV
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: Subscription
+    name: jaeger-product
+    namespace: openshift-operators
+  register: r_subscription
+  retries: 30
+  delay: 5
+  until:
+  - r_subscription.resources[0].status.currentCSV is defined
+  - r_subscription.resources[0].status.currentCSV | length > 0
+
+- name: Wait until CSV is Installed
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    name: "{{ r_subscription.resources[0].status.currentCSV }}"
+    namespace: openshift-operators
+  register: r_csv
+  retries: 15
+  delay: 5
+  until:
+  - r_csv.resources[0].status.phase is defined
+  - r_csv.resources[0].status.phase | length > 0
+  - r_csv.resources[0].status.phase == "Succeeded"

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/install_kiali_operator.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/install_kiali_operator.yaml
@@ -1,0 +1,68 @@
+---
+- name: Create Kiali subscription
+  k8s:
+    state: present
+    definition: "{{ lookup('template', './templates/kiali_subscription.j2' ) }}"
+
+- name: Wait until InstallPlan is created
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: InstallPlan
+    namespace: openshift-operators
+  register: r_install_plans
+  vars:
+    _query: >-
+      [?starts_with(spec.clusterServiceVersionNames[0], 'kiali')]
+  retries: 30
+  delay: 5
+  until:
+  - r_install_plans.resources | length > 0
+  - r_install_plans.resources | to_json | from_json | json_query(_query)
+
+- name: Set InstallPlan Name
+  set_fact:
+    ocp4_workload_servicemesh_workshop_kiali_install_plan_name: "{{ r_install_plans.resources | to_json | from_json | json_query(query) }}"
+  vars:
+    query: >-
+      [?starts_with(spec.clusterServiceVersionNames[0], 'kiali')].metadata.name|[0]
+
+- name: Get InstallPlan
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: InstallPlan
+    name: "{{ ocp4_workload_servicemesh_workshop_kiali_install_plan_name }}"
+    namespace: openshift-operators
+  register: r_install_plan
+
+- name: Approve InstallPlan if necessary
+  when: r_install_plan.resources[0].status.phase is match("RequiresApproval")
+  k8s:
+    state: present
+    definition: "{{ lookup( 'template', './templates/kiali_installplan.j2' ) }}"
+
+- name: Get Installed CSV
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: Subscription
+    name: kiali-ossm
+    namespace: openshift-operators
+  register: r_subscription
+  retries: 30
+  delay: 5
+  until:
+  - r_subscription.resources[0].status.currentCSV is defined
+  - r_subscription.resources[0].status.currentCSV | length > 0
+
+- name: Wait until CSV is Installed
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    name: "{{ r_subscription.resources[0].status.currentCSV }}"
+    namespace: openshift-operators
+  register: r_csv
+  retries: 15
+  delay: 5
+  until:
+  - r_csv.resources[0].status.phase is defined
+  - r_csv.resources[0].status.phase | length > 0
+  - r_csv.resources[0].status.phase == "Succeeded"

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/install_servicemesh_operator.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/install_servicemesh_operator.yaml
@@ -1,0 +1,63 @@
+---
+- name: Create OpenShift Service Mesh subscription
+  k8s:
+    state: present
+    definition: "{{ lookup('template', './templates/servicemesh_subscription.j2' ) }}"
+
+- name: Wait until InstallPlan is created
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: InstallPlan
+    namespace: openshift-operators
+  register: r_install_plans
+  vars:
+    _query: >-
+      [?starts_with(spec.clusterServiceVersionNames[0], 'servicemesh')]
+  retries: 30
+  delay: 5
+  until:
+  - r_install_plans.resources | length > 0
+  - r_install_plans.resources | to_json | from_json | json_query(_query)
+
+- name: Set InstallPlan Name
+  set_fact:
+    ocp4_workload_servicemesh_workshop_servicemesh_install_plan_name: "{{ r_install_plans.resources | to_json | from_json | json_query(query) }}"
+  vars:
+    query: >-
+      [?starts_with(spec.clusterServiceVersionNames[0], 'servicemesh')].metadata.name|[0]
+
+- name: Get InstallPlan
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: InstallPlan
+    name: "{{ ocp4_workload_servicemesh_workshop_servicemesh_install_plan_name }}"
+    namespace: openshift-operators
+  register: r_install_plan
+
+- name: Approve InstallPlan if necessary
+  when: r_install_plan.resources[0].status.phase is match("RequiresApproval")
+  k8s:
+    state: present
+    definition: "{{ lookup( 'template', './templates/servicemesh_installplan.j2' ) }}"
+
+- name: Find all Service Mesh related CSVs
+  set_fact:
+    _ocp4_workload_servicemesh_csvs: "{{ r_install_plan.resources | to_json | from_json | json_query(query) }}"
+  vars:
+    query: >-
+      [?starts_with(spec.clusterServiceVersionNames[0], 'servicemeshoperator')].spec.clusterServiceVersionNames
+
+- name: Wait until all CSVs are Succeeded
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    name: "{{ item }}"
+    namespace: openshift-operators
+  register: r_csv
+  retries: 15
+  delay: 5
+  until:
+  - r_csv.resources[0].status.phase is defined
+  - r_csv.resources[0].status.phase | length > 0
+  - r_csv.resources[0].status.phase == "Succeeded"
+  loop: "{{ _ocp4_workload_servicemesh_csvs[0] }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+
+# Do not modify this file
+
+- name: Running Pre Workload Tasks
+  include_tasks:
+    file: ./pre_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload Tasks
+  include_tasks:
+    file: ./workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  include_tasks:
+    file: ./post_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload removal Tasks
+  include_tasks:
+    file: ./remove_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/per_user_workload.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/per_user_workload.yaml
@@ -1,19 +1,19 @@
 ---
 # Implement your Workload deployment tasks here
 
-- name: Create Catalog Source for use with catalog snapshot
-  k8s:
-    state: present
-    definition: "{{ lookup('template', './templates/catalogsource.j2' ) | from_yaml }}"
-  vars:
-    namespace: "{{ t_user_project }}"
-
 - name: Make sure project "{{ t_user_project }}" is there
   k8s:
     state: present
     name: "{{ t_user_project }}"
     kind: Project
     api_version: project.openshift.io/v1
+
+- name: Create Catalog Source for use with catalog snapshot
+  k8s:
+    state: present
+    definition: "{{ lookup('template', './templates/catalogsource.j2' ) | from_yaml }}"
+  vars:
+    namespace: "{{ t_user_project }}"
 
 - name: Assign "{{ t_user }}" as admin
   k8s:

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/per_user_workload.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/per_user_workload.yaml
@@ -154,13 +154,69 @@
   - r_smmr.resources[0].spec.members is defined
   - r_smmr.resources[0].spec.members | length > 0
 
-# This is hacky, but there's no field in the Service Mesh Control Plane to modify this right now
-# We can't use set_fact either because the content we need to modify is inside a long, unformatted string
-- name: Remove DeploymentConfig from Kiali's excluded workloads
-  shell: "oc get cm kiali -n {{ t_user_servicemesh_project }} -o yaml | sed '/DeploymentConfig/d' | oc apply -n {{ t_user_servicemesh_project }} -f -"
+## This is hacky, but there's no field in the Service Mesh Control Plane to modify this easily right now
+- name: Get Kiali Config Map
+  k8s_info:
+    api_version: v1
+    kind: ConfigMap
+    name: kiali
+    namespace: "{{ t_user_servicemesh_project }}"
+  register: r_kiali_cm
 
-- name: Restart Kiali to take effect
-  shell: "oc rollout restart deployment kiali -n {{ t_user_servicemesh_project }}"
+- name: Remove DeploymentConfig from excluded workloads
+  set_fact:
+    r_kiali_cm_config: "{{ r_kiali_cm.resources[0].data['config.yaml'] | replace('- DeploymentConfig\n', '') }}"
+
+- name: Create new Kiali Config Map
+  set_fact:
+    r_kiali_cm_new: {'apiVersion': 'v1', 'kind': 'ConfigMap', 'metadata': "{{ r_kiali_cm.resources[0].metadata }}", 'data': {'config.yaml': "{{ r_kiali_cm_config}}"}}
+
+- name: Apply new Config Map
+  k8s:
+    state: present
+    definition: "{{ r_kiali_cm_new | to_yaml }}"
+
+- name: Scale Kiali down
+  k8s_scale:
+    api_version: v1
+    kind: Deployment
+    name: kiali
+    namespace: "{{ t_user_servicemesh_project }}"
+    replicas: 0
+    wait: no
+
+- name: Wait for scale down
+  k8s_info:
+    api_version: v1
+    kind: Deployment
+    name: kiali
+    namespace: "{{ t_user_servicemesh_project }}"
+  register: r_kiali_deployment
+  retries: 15
+  delay: 5
+  until:
+  - r_kiali_deployment.resources | json_query('[*].status.conditions[?type==`Available`][].status') | select ('match','True') | list | length == 1
+
+- name: Restart Kiali for config map change to take effect
+  k8s_scale:
+    api_version: v1
+    kind: Deployment
+    name: kiali
+    namespace: "{{ t_user_servicemesh_project }}"
+    replicas: 1
+    wait: no
+
+- name: Wait for scale up
+  k8s_info:
+    api_version: v1
+    kind: Deployment
+    name: kiali
+    namespace: "{{ t_user_servicemesh_project }}"
+  register: r_kiali_deployment
+  retries: 15
+  delay: 5
+  until:
+  - r_kiali_deployment.resources | json_query('[*].status.conditions[?type==`Available`][].status') | select ('match','True') | list | length == 1
 
 # Leave this as the last task in the playbook.
 - name: workload tasks complete

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/per_user_workload.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/per_user_workload.yaml
@@ -172,14 +172,17 @@
   set_fact:
     r_kiali_cm_config: "{{ r_kiali_cm.resources[0].data['config.yaml'] | replace('- DeploymentConfig\n', '') }}"
 
-- name: Create new Kiali Config Map
-  set_fact:
-    r_kiali_cm_new: {'apiVersion': 'v1', 'kind': 'ConfigMap', 'metadata': "{{ r_kiali_cm.resources[0].metadata }}", 'data': {'config.yaml': "{{ r_kiali_cm_config}}"}}
-
 - name: Apply new Config Map
   k8s:
     state: present
-    definition: "{{ r_kiali_cm_new | to_yaml }}"
+    definition:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: kiali
+        namespace: "{{ t_user_servicemesh_project}}"
+      data:
+        'config.yaml': "{{ r_kiali_cm_config }}"
 
 - name: Scale Kiali down
   k8s_scale:

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/per_user_workload.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/per_user_workload.yaml
@@ -8,12 +8,20 @@
   vars:
     namespace: "{{ t_user_project }}"
 
-- name: Make sure project {{ t_user_project }} is there
+- name: Make sure project "{{ t_user_project }}" is there
   k8s:
     state: present
     name: "{{ t_user_project }}"
     kind: Project
     api_version: project.openshift.io/v1
+
+- name: Assign "{{ t_user }}" as admin
+  k8s:
+    state: present
+    definition: "{{ lookup('template', './templates/rbac.j2' ) }}"
+  vars:
+    name: "{{ t_user }}"
+    namespace: "{{ t_user_project }}"
 
 - name: Install RH SSO operator in {{ t_user_project }}
   k8s:
@@ -82,6 +90,27 @@
   - r_csv.resources[0].status.phase is defined
   - r_csv.resources[0].status.phase | length > 0
   - r_csv.resources[0].status.phase == "Succeeded"
+
+- name: Make sure project "{{ t_user_servicemesh_project }}"" is there
+  k8s:
+    state: present
+    name: "{{ t_user_servicemesh_project }}"
+    kind: Project
+    api_version: project.openshift.io/v1
+
+- name: Assign "{{ t_user }}" as admin
+  k8s:
+    state: present
+    definition: "{{ lookup('template', './templates/rbac.j2' ) }}"
+  vars:
+    name: "{{ t_user }}"
+    namespace: "{{ t_user_servicemesh_project}}"
+
+- name: Make sure to delete any limit ranges in {{ t_user_servicemesh_project }}
+  k8s:
+    state: absent
+    name: "{{ t_user_servicemesh_project }}"
+    kind: LimitRange
 
 # Leave this as the last task in the playbook.
 - name: workload tasks complete

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/per_user_workload.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/per_user_workload.yaml
@@ -1,0 +1,90 @@
+---
+# Implement your Workload deployment tasks here
+
+- name: Create Catalog Source for use with catalog snapshot
+  k8s:
+    state: present
+    definition: "{{ lookup('template', './templates/catalogsource.j2' ) | from_yaml }}"
+  vars:
+    namespace: "{{ t_user_project }}"
+
+- name: Make sure project {{ t_user_project }} is there
+  k8s:
+    state: present
+    name: "{{ t_user_project }}"
+    kind: Project
+    api_version: project.openshift.io/v1
+
+- name: Install RH SSO operator in {{ t_user_project }}
+  k8s:
+    state: present
+    definition: "{{ lookup('template', './templates/rhsso_operator.j2' ) }}"
+
+- name: Wait until InstallPlan is created
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: InstallPlan
+    namespace: "{{ t_user_project }}"
+  register: r_install_plans
+  vars:
+    _query: >-
+      [?starts_with(spec.clusterServiceVersionNames[0], 'rhsso')]
+  retries: 30
+  delay: 5
+  until:
+  - r_install_plans.resources | length > 0
+  - r_install_plans.resources | to_json | from_json | json_query(_query)
+
+- name: Set InstallPlan Name
+  set_fact:
+    ocp4_workload_servicemesh_workshop_rhsso_install_plan_name: "{{ r_install_plans.resources | to_json | from_json | json_query(query) }}"
+  vars:
+    query: >-
+      [?starts_with(spec.clusterServiceVersionNames[0], 'rhsso')].metadata.name|[0]
+
+- name: Get InstallPlan
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: InstallPlan
+    name: "{{ ocp4_workload_servicemesh_workshop_rhsso_install_plan_name }}"
+    namespace: "{{ t_user_project }}"
+  register: r_install_plan
+
+- name: Approve InstallPlan if necessary
+  when: r_install_plan.resources[0].status.phase is match("RequiresApproval")
+  k8s:
+    state: present
+    definition: "{{ lookup( 'template', './templates/rhsso_installplan.j2' ) }}"
+
+- name: Get Installed CSV
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: Subscription
+    name: rhsso-operator
+    namespace: "{{ t_user_project }}"
+  register: r_subscription
+  retries: 30
+  delay: 5
+  until:
+  - r_subscription.resources[0].status.currentCSV is defined
+  - r_subscription.resources[0].status.currentCSV | length > 0
+
+- name: Wait until CSV is Installed
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    name: "{{ r_subscription.resources[0].status.currentCSV }}"
+    namespace: "{{ t_user_project }}"
+  register: r_csv
+  retries: 15
+  delay: 5
+  until:
+  - r_csv.resources[0].status.phase is defined
+  - r_csv.resources[0].status.phase | length > 0
+  - r_csv.resources[0].status.phase == "Succeeded"
+
+# Leave this as the last task in the playbook.
+- name: workload tasks complete
+  debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent | bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/per_user_workload.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/per_user_workload.yaml
@@ -154,6 +154,14 @@
   - r_smmr.resources[0].spec.members is defined
   - r_smmr.resources[0].spec.members | length > 0
 
+# This is hacky, but there's no field in the Service Mesh Control Plane to modify this right now
+# We can't use set_fact either because the content we need to modify is inside a long, unformatted string
+- name: Remove DeploymentConfig from Kiali's excluded workloads
+  shell: "oc get cm kiali -n {{ t_user_servicemesh_project }} -o yaml | sed '/DeploymentConfig/d' | oc apply -n {{ t_user_servicemesh_project }} -f -"
+
+- name: Restart Kiali to take effect
+  shell: "oc rollout restart deployment kiali -n {{ t_user_servicemesh_project }}"
+
 # Leave this as the last task in the playbook.
 - name: workload tasks complete
   debug:

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/per_user_workload.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/per_user_workload.yaml
@@ -112,6 +112,48 @@
     name: "{{ t_user_servicemesh_project }}"
     kind: LimitRange
 
+- name: Create service mesh control plane in {{ t_user_servicemesh_project }}
+  k8s:
+    state: present
+    definition: "{{ lookup('template', './templates/servicemesh_controlplane.j2' ) }}"
+  vars:
+    namespace: "{{ t_user_servicemesh_project}}"
+
+- name: Wait for Service Mesh Control Plane to finish installation
+  k8s_info:
+    api_version: maistra.io/v2
+    kind: ServiceMeshControlPlane
+    name: workshop-install
+    namespace: "{{ t_user_servicemesh_project }}"
+  register: r_smcp
+  retries: 40
+  delay: 10
+  until:
+  - r_smcp.resources[0].status.readiness.components is defined
+  - r_smcp.resources[0].status.readiness.components.pending | length == 0
+  - r_smcp.resources[0].status.readiness.components.unready | length == 0
+
+- name: Add {{ t_user_project }} as a member to its corresponding service mesh project
+  k8s:
+    state: present
+    definition: "{{ lookup('template', './templates/servicemesh_memberroll.j2' ) }}"
+  vars:
+    namespace: "{{ t_user_servicemesh_project}}"
+    user_namespace: "{{ t_user_project }}"
+
+- name: Wait for Service Mesh Member Roll to configure completely
+  k8s_info:
+    api_version: maistra.io/v1
+    kind: ServiceMeshMemberRoll
+    name: default
+    namespace: "{{ t_user_servicemesh_project }}"
+  register: r_smmr
+  retries: 15
+  delay: 5
+  until:
+  - r_smmr.resources[0].spec.members is defined
+  - r_smmr.resources[0].spec.members | length > 0
+
 # Leave this as the last task in the playbook.
 - name: workload tasks complete
   debug:

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/per_user_workload.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/per_user_workload.yaml
@@ -154,6 +154,11 @@
   - r_smmr.resources[0].spec.members is defined
   - r_smmr.resources[0].spec.members | length > 0
 
+- name: Create network policy to allow traffic into {{ t_user_project }}
+  k8s:
+    state: present
+    definition: "{{ lookup('template', './templates/netpol.j2' ) }}"
+
 ## This is hacky, but there's no field in the Service Mesh Control Plane to modify this easily right now
 - name: Get Kiali Config Map
   k8s_info:

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/post_workload.yml
@@ -1,0 +1,32 @@
+---
+
+- name: Print user info
+  agnosticd_user_info:
+    msg: "{{ item }}"
+  loop:
+  - ""
+  - "Presenter's Guide available here: https://github.com/RedHatGov/service-mesh-workshop-dashboard#openshift-service-mesh-workshop"
+
+
+# Leave these as the last tasks in the playbook
+# ---------------------------------------------
+
+# For deployment onto a dedicated cluster (as part of the
+# cluster deployment) set workload_shared_deployment to False
+# This is the default so it does not have to be set explicitely
+- name: post_workload tasks complete
+  debug:
+    msg: "Post-Workload tasks completed successfully."
+  when:
+  - not silent|bool
+  - not workload_shared_deployment|default(False)
+
+# For RHPDS deployment (onto a shared cluster) set
+# workload_shared_deployment to True
+# (in the deploy script or AgnosticV configuration)
+- name: post_workload tasks complete
+  debug:
+    msg: "Post-Software checks completed successfully"
+  when:
+  - not silent|bool
+  - workload_shared_deployment|default(False)

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/pre_workload.yml
@@ -1,0 +1,8 @@
+---
+# Implement your Pre Workload deployment tasks here
+
+# Leave this as the last task in the playbook.
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/remove_workload.yml
@@ -1,0 +1,12 @@
+---
+# Implement your workload removal tasks here
+# ------------------------------------------
+
+
+# Leave this as the last task in the playbook.
+# --------------------------------------------
+
+- name: remove_workload tasks complete
+  debug:
+    msg: "Remove Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/workload.yml
@@ -1,0 +1,16 @@
+---
+- name: Setting up workload for user
+  debug:
+    msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
+
+### BEGIN WORKSHOP SETUP ###
+
+
+### END WORKSHOP SETUP
+
+# Leave this as the last task in the playbook.
+# --------------------------------------------
+- name: workload tasks complete
+  debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/workload.yml
@@ -33,6 +33,7 @@
   loop_control:
     loop_var: t_user_num
   vars:
+    t_user: user{{ t_user_num }}
     t_user_project: user{{ t_user_num }}
     t_user_servicemesh_project: user{{ t_user_num }}-istio
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/workload.yml
@@ -37,6 +37,17 @@
     t_user_project: user{{ t_user_num }}
     t_user_servicemesh_project: user{{ t_user_num }}-istio
 
+- name: Allow inbound traffic to non-servicemesh routes
+  k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-ingress
+        labels: 
+          'network.openshift.io/policy-group': ingress
+
 ### END WORKSHOP SETUP
 
 # Leave this as the last task in the playbook.

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/workload.yml
@@ -48,6 +48,9 @@
         labels: 
           'network.openshift.io/policy-group': ingress
 
+- name: Set up Homeroom for workshop users
+  include_tasks: ./homeroom.yaml
+
 ### END WORKSHOP SETUP
 
 # Leave this as the last task in the playbook.

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/workload.yml
@@ -1,10 +1,22 @@
 ---
-- name: Setting up workload for user
-  debug:
-    msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
 
 ### BEGIN WORKSHOP SETUP ###
+- name: Create Catalog Source for use with catalog snapshot
+  k8s:
+    state: present
+    definition: "{{ lookup('template', './templates/catalogsource.j2' ) | from_yaml }}"
 
+- name: Install Elastic Search Operator
+  include_tasks: ./install_elasticsearch_operator.yaml
+
+- name: Install Jaeger Operator
+  include_tasks: ./install_jaeger_operator.yaml  
+
+- name: Install Kiali Operator
+  include_tasks: ./install_kiali_operator.yaml
+
+- name: Install Service Mesh Operator
+  include_tasks: ./install_servicemesh_operator.yaml
 
 ### END WORKSHOP SETUP
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/workload.yml
@@ -16,7 +16,7 @@
   include_tasks: ./install_elasticsearch_operator.yaml
 
 - name: Install Jaeger Operator
-  include_tasks: ./install_jaeger_operator.yaml  
+  include_tasks: ./install_jaeger_operator.yaml
 
 - name: Install Kiali Operator
   include_tasks: ./install_kiali_operator.yaml
@@ -45,7 +45,7 @@
       kind: Namespace
       metadata:
         name: openshift-ingress
-        labels: 
+        labels:
           'network.openshift.io/policy-group': ingress
 
 - name: Set up Homeroom for workshop users

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/workload.yml
@@ -1,10 +1,16 @@
 ---
 
 ### BEGIN WORKSHOP SETUP ###
+- fail:
+    msg: User count ({{ user_count }}) < 1
+  when: ocp4_workload_servicemesh_workshop_user_count| int < 1
+
 - name: Create Catalog Source for use with catalog snapshot
   k8s:
     state: present
     definition: "{{ lookup('template', './templates/catalogsource.j2' ) | from_yaml }}"
+  vars:
+    namespace: openshift-operators
 
 - name: Install Elastic Search Operator
   include_tasks: ./install_elasticsearch_operator.yaml
@@ -17,6 +23,18 @@
 
 - name: Install Service Mesh Operator
   include_tasks: ./install_servicemesh_operator.yaml
+
+- name: Setting up workload for user
+  debug:
+    msg: "Setting up workload for {{ ocp4_workload_servicemesh_workshop_user_count }} users"
+
+- include_tasks: per_user_workload.yaml
+  loop: "{{ range(1, 1 + (ocp4_workload_servicemesh_workshop_user_count | int)) | list }}"
+  loop_control:
+    loop_var: t_user_num
+  vars:
+    t_user_project: user{{ t_user_num }}
+    t_user_servicemesh_project: user{{ t_user_num }}-istio
 
 ### END WORKSHOP SETUP
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/catalogsource.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/catalogsource.j2
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
   name: "{{ ocp4_workload_servicemesh_workshop_catalogsource_name }}"
-  namespace: openshift-operators
+  namespace: "{{ namespace }}"
 spec:
   sourceType: grpc
   image: "{{ ocp4_workload_servicemesh_workshop_catalog_snapshot_image }}:{{ ocp4_workload_servicemesh_workshop_catalog_snapshot_image_tag }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/catalogsource.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/catalogsource.j2
@@ -1,0 +1,9 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: "{{ ocp4_workload_servicemesh_workshop_catalogsource_name }}"
+  namespace: openshift-operators
+spec:
+  sourceType: grpc
+  image: "{{ ocp4_workload_servicemesh_workshop_catalog_snapshot_image }}:{{ ocp4_workload_servicemesh_workshop_catalog_snapshot_image_tag }}"
+  displayName: "{{ ocp4_workload_servicemesh_workshop_catalogsource_name }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/elasticsearch_installplan.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/elasticsearch_installplan.j2
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: InstallPlan
+metadata:
+  name: "{{ ocp4_workload_servicemesh_workshop_elasticsearch_install_plan_name }}"
+  namespace: openshift-operators
+spec:
+  approved: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/elasticsearch_subscription.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/elasticsearch_subscription.j2
@@ -1,0 +1,12 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: elasticsearch-operator
+  namespace: openshift-operators
+spec:
+  channel: "{{ ocp4_workload_servicemesh_workshop_elasticsearch_channel }}"
+  installPlanApproval: Manual
+  name: elasticsearch-operator
+  source: "{{ ocp4_workload_servicemesh_workshop_catalogsource_name }}"
+  sourceNamespace: openshift-operators
+  startingCSV: "{{ ocp4_workload_servicemesh_workshop_elasticsearch_starting_csv }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/jaeger_installplan.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/jaeger_installplan.j2
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: InstallPlan
+metadata:
+  name: "{{ ocp4_workload_servicemesh_workshop_jaeger_install_plan_name }}"
+  namespace: openshift-operators
+spec:
+  approved: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/jaeger_subscription.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/jaeger_subscription.j2
@@ -1,0 +1,12 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: jaeger-product
+  namespace: openshift-operators
+spec:
+  channel: "{{ ocp4_workload_servicemesh_workshop_jaeger_channel }}"
+  installPlanApproval: Manual
+  name: jaeger-product
+  source: "{{ ocp4_workload_servicemesh_workshop_catalogsource_name }}"
+  sourceNamespace: openshift-operators
+  startingCSV: "{{ ocp4_workload_servicemesh_workshop_jaeger_starting_csv }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/kiali_installplan.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/kiali_installplan.j2
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: InstallPlan
+metadata:
+  name: "{{ ocp4_workload_servicemesh_workshop_kiali_install_plan_name }}"
+  namespace: openshift-operators
+spec:
+  approved: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/kiali_subscription.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/kiali_subscription.j2
@@ -1,0 +1,12 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: kiali-ossm
+  namespace: openshift-operators
+spec:
+  channel: "{{ ocp4_workload_servicemesh_workshop_kiali_channel }}"
+  installPlanApproval: Manual
+  name: kiali-ossm
+  source: "{{ ocp4_workload_servicemesh_workshop_catalogsource_name }}"
+  sourceNamespace: openshift-operators
+  startingCSV: "{{ ocp4_workload_servicemesh_workshop_kiali_starting_csv }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/netpol.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/netpol.j2
@@ -1,0 +1,12 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: istio-mesh-workshop-all
+  namespace: {{ t_user_project }}
+spec:
+  ingress:
+  - from:
+    - namespaceSelector: {}
+  podSelector: {}
+  policyTypes:
+  - Ingress

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/rbac.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/rbac.j2
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "{{ name }}"
+  namespace: "{{ namespace }}"
+subjects:
+- kind: User
+  name: "{{ name }}"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/rhsso_installplan.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/rhsso_installplan.j2
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: InstallPlan
+metadata:
+  name: "{{ ocp4_workload_servicemesh_workshop_rhsso_install_plan_name }}"
+  namespace: "{{ t_user_project }}"
+spec:
+  approved: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/rhsso_operator.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/rhsso_operator.j2
@@ -1,0 +1,21 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: my-group
+  namespace: "{{ t_user_project }}"
+spec:
+  targetNamespaces:
+  - "{{ t_user_project }}"
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: rhsso-operator
+  namespace: "{{ t_user_project }}"
+spec:
+  channel: "{{ ocp4_workload_servicemesh_workshop_rhsso_channel }}"
+  installPlanApproval: Manual
+  name: rhsso-operator
+  source: "{{ ocp4_workload_servicemesh_workshop_catalogsource_name }}"
+  sourceNamespace: "{{ t_user_project }}"
+  startingCSV: "{{ ocp4_workload_servicemesh_workshop_rhsso_starting_csv }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/servicemesh_controlplane.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/servicemesh_controlplane.j2
@@ -11,7 +11,7 @@ spec:
           policy: REGISTRY_ONLY
   tracing:
     type: Jaeger
-    sampling: 25
+    sampling: 10000
   addons:
     jaeger:
       name: jaeger

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/servicemesh_controlplane.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/servicemesh_controlplane.j2
@@ -1,0 +1,24 @@
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+metadata:
+  name: workshop-install
+  namespace: {{ namespace }}
+spec:
+  proxy:
+    networking:
+      trafficControl:
+        outbound:
+          policy: REGISTRY_ONLY
+  tracing:
+    type: Jaeger
+    sampling: 25
+  addons:
+    jaeger:
+      name: jaeger
+    grafana:
+      enabled: true
+    kiali:
+      name: kiali
+      enabled: true
+    prometheus:
+      enabled: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/servicemesh_installplan.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/servicemesh_installplan.j2
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: InstallPlan
+metadata:
+  name: "{{ ocp4_workload_servicemesh_workshop_servicemesh_install_plan_name }}"
+  namespace: openshift-operators
+spec:
+  approved: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/servicemesh_memberroll.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/servicemesh_memberroll.j2
@@ -1,0 +1,8 @@
+apiVersion: maistra.io/v1
+kind: ServiceMeshMemberRoll
+metadata:
+  name: default
+  namespace: {{ namespace }}
+spec:
+  members:
+    - {{ user_namespace }}

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/servicemesh_subscription.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/servicemesh_subscription.j2
@@ -1,0 +1,12 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: servicemeshoperator
+  namespace: openshift-operators
+spec:
+  channel: "{{ ocp4_workload_servicemesh_workshop_servicemesh_channel }}"
+  installPlanApproval: Manual
+  name: servicemeshoperator
+  source: "{{ ocp4_workload_servicemesh_workshop_catalogsource_name }}"
+  sourceNamespace: openshift-operators
+  startingCSV: "{{ ocp4_workload_servicemesh_workshop_servicemesh_starting_csv }}"


### PR DESCRIPTION
##### SUMMARY
Adds an agnosticd OCP4 workload role that deploys the RedHatGov OpenShift Service Mesh Workshop

##### ISSUE TYPE
- New role Pull Request

##### COMPONENT NAME
ocp4_workload_servicemesh_workshop

##### ADDITIONAL INFORMATION
This is agnosticd OCP4 workload role that deploys RedHatGov's OSM workshop.  The workshop content is delivered via homeroom (https://github.com/RedHatGov/service-mesh-workshop-dashboard), and the code used by the workshop participants is here (https://github.com/RedHatGov/service-mesh-workshop-code).  After adding this role, we will file a ticket to add this workshop to RHPDS.

The `ocp4_workload_servicemesh_workshop` role was tested on an RHPDS OpenShift 4.7 Cluster.