### PR TITLE
Remove broken bash completion task for istioctl in role studentvm_ocp4

### DIFF
--- a/ansible/roles_studentvm/studentvm_ocp4/tasks/main.yml
+++ b/ansible/roles_studentvm/studentvm_ocp4/tasks/main.yml
@@ -164,11 +164,6 @@
       args:
         creates: "{{ studentvm_ocp4_bin_path }}/istioctl"
 
-    - name: Bash Completions - istioctl
-      shell: "{{ studentvm_ocp4_bin_path }}/istioctl completion bash >/etc/bash_completion.d/istioctl"
-      args:
-        creates: "/etc/bash_completion.d/istioctl"
-
   - name: S2I
     when: studentvm_ocp4_s2i_install | bool
     block:


### PR DESCRIPTION
##### SUMMARY

Remove broken task which attempts to setup bash completion for istioctl. The logic in the task is not how istioctl bash completion functions and produces the error:

```
$ ./istioctl completion bash
Error: unknown command "completion" for "istioctl"
Run 'istioctl --help' for usage.
```

A future feature PR could implement bash completion for istioctl following documentation here:

https://istio.io/latest/docs/ops/diagnostic-tools/istioctl/#enabling-auto-completion

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role studentvm_ocp4