### PR TITLE
Fix default vars for rhel-custom-security-content

### DIFF
--- a/ansible/configs/rhel-custom-security-content/default_vars.yml
+++ b/ansible/configs/rhel-custom-security-content/default_vars.yml
@@ -38,7 +38,8 @@ instances:
     public_dns: true
     dns_loadbalancer: false
     image: "{{ bastion_instance_image }}"
-    flavor: "{{ bastion_instance_type }}"
+    flavor:
+      ec2: "{{ bastion_instance_type }}"
     tags:
       - key: "AnsibleGroup"
         value: "bastions"


### PR DESCRIPTION
##### SUMMARY

The instance property `flavor` needs to be a dict rather than a simple string.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Config rhel-custom-security-content