### PR TITLE
Add support to clean up operator objects, don't make approval manual …

### DIFF
--- a/ansible/roles/install_operator/defaults/main.yml
+++ b/ansible/roles/install_operator/defaults/main.yml
@@ -31,7 +31,6 @@ install_operator_channel: ""
 
 # Set automatic InstallPlan approval. If set to false it is also suggested
 # to set the starting_csv to pin a specific version
-# This variable has no effect when using a catalog snapshot (always true)
 install_operator_automatic_install_plan_approval: true
 
 # CSV Name. Some operators (pipelines, cough, cough) use different CSV names from

--- a/ansible/roles/install_operator/tasks/remove.yml
+++ b/ansible/roles/install_operator/tasks/remove.yml
@@ -73,3 +73,43 @@
       api_version: v1
       kind: Namespace
       name: "{{ install_operator_namespace }}"
+
+# Cleanup operator object, remove labels from CRDs
+- name: Find all CRDs with the operator label
+  k8s_info:
+    api_version: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    label_selectors:
+    - "operators.coreos.com/{{ install_operator_name }}.{{ install_operator_namespace }}="
+  register: r_crds
+
+- name: Debug
+  debug:
+    msg: "{{ item.metadata.name }}"
+  loop: "{{ r_crds.resources }}"
+
+# This doesn't work. Using command instead. :-(
+# - name: Remove operator label from any CRDs
+#   when: r_crds.resources | length > 0
+#   k8s:
+#     state: present
+#     merge_type: merge
+#     definition:
+#       apiVersion: apiextensions.k8s.io/v1
+#       kind: CustomResourceDefinition
+#       metadata:
+#         name: "{{ item.metadata.name }}"
+#         labels:
+#           "operators.coreos.com/{{ install_operator_name }}.{{ install_operator_namespace }}": null
+#   loop: "{{ r_crds.resources }}"
+- name: Remove operator label from any CRDs
+  when: r_crds.resources | length > 0
+  command: "oc label crd {{ item.metadata.name }} operators.coreos.com/{{ install_operator_name }}.{{ install_operator_namespace }}-"
+  loop: "{{ r_crds.resources }}"
+
+- name: Remove Operator
+  k8s:
+    state: absent
+    api_version: operators.coreos.com/v1
+    kind: Operator
+    name: "{{ install_operator_name }}.{{ install_operator_namespace }}"

--- a/ansible/roles/install_operator/templates/subscription.yaml.j2
+++ b/ansible/roles/install_operator/templates/subscription.yaml.j2
@@ -5,13 +5,13 @@ metadata:
   namespace: "{{ install_operator_namespace }}"
 spec:
   channel: "{{ __install_operator_channel }}"
-{% if install_operator_automatic_install_plan_approval | default(True) | bool and not install_operator_use_catalog_snapshot | default(False) | bool %}
+{% if install_operator_automatic_install_plan_approval | default(true) | bool %}
   installPlanApproval: Automatic
 {% else %}
   installPlanApproval: Manual
 {% endif %}
   name: "{{ install_operator_packagemanifest_name }}"
-{% if install_operator_use_catalog_snapshot | default(False) | bool %}
+{% if install_operator_use_catalog_snapshot | default(false) | bool %}
   source: "{{ install_operator_catalogsource_name }}"
   sourceNamespace: "{{ install_operator_catalogsource_namespace }}"
 {% else %}


### PR DESCRIPTION
…always

##### SUMMARY

Updated install_operator role to
- clean up labels on CRDs and delete Operator object when deleting an operator
- Don't make approval mandatory on Catalog Source definition.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
install_operator