### PR TITLE
Add warning to not check AWS credentials into GIT

### DIFF
--- a/ansible/configs/sandbox/post_software_ec2.yml
+++ b/ansible/configs/sandbox/post_software_ec2.yml
@@ -8,6 +8,7 @@
     - ""
     - "AWS_ACCESS_KEY_ID: {{ hostvars.localhost.student_access_key_id }}"
     - "AWS_SECRET_ACCESS_KEY: {{ hostvars.localhost.student_secret_access_key }}"
+    - "** Plase be very careful to not expose AWS credentials in GIT repos or anywhere else that could be public! **"
     - ""
     - "Top level route53 domain: {{ subdomain_base_suffix }}"
     - "The default region is set to {{ aws_region }}"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

Add warning to not check AWS credentials into GIT

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
sandbox

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
