### PR TITLE
Adding yamllint to ansible/cloud_providers

### DIFF
--- a/ansible/cloud_providers/.yamllint
+++ b/ansible/cloud_providers/.yamllint
@@ -1,0 +1,13 @@
+---
+extends: default
+
+rules:
+  comments:
+    require-starting-space: false
+    min-spaces-from-content: 1
+  comments-indentation: disable
+  indentation:
+    indent-sequences: consistent
+  line-length:
+    max: 160
+    allow-non-breakable-inline-mappings: true

--- a/ansible/cloud_providers/ec2_destroy_env.yml
+++ b/ansible/cloud_providers/ec2_destroy_env.yml
@@ -4,8 +4,8 @@
 - name: Delete Infrastructure
   hosts: localhost
   connection: local
-  gather_facts: False
-  become: no
+  gather_facts: false
+  become: false
   tasks:
     - name: Run infra-aws-capacity-reservation
       include_role:

--- a/ansible/cloud_providers/ibm_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/ibm_infrastructure_deployment.yml
@@ -9,5 +9,5 @@
     - step001.1
     - deploy_infrastructure
   tasks:
-  - debug:
-      msg: "Placeholder for future infra deployment in IBM Cloud"
+    - debug:
+        msg: "Placeholder for future infra deployment in IBM Cloud"

--- a/ansible/cloud_providers/osp_destroy_env.yml
+++ b/ansible/cloud_providers/osp_destroy_env.yml
@@ -4,8 +4,8 @@
 - name: Delete Infrastructure
   hosts: localhost
   connection: local
-  gather_facts: False
-  become: no
+  gather_facts: false
+  become: false
   tasks:
     - name: Run infra-osp-dns
       include_role:

--- a/ansible/cloud_providers/test_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/test_infrastructure_deployment.yml
@@ -1,10 +1,10 @@
 ---
 
 - name: Step 001.1 Deploy Infrastructure
-  hosts:        localhost
-  connection:   local
+  hosts: localhost
+  connection: local
   gather_facts: false
-  become:       false
+  become: false
 
   tags:
     - step001


### PR DESCRIPTION
##### SUMMARY

We had a situation with a previous commit where someone updated a file in cloud_providers which broke the syntax and caused other things in DEV to fail. This change will ensure that at least the syntax is correct in cloud_providers before merging is allowed.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible/cloud_providers

##### ADDITIONAL INFORMATION
This is the change that happened to azure_infrastructure which I want to avoid in the future
https://github.com/redhat-cop/agnosticd/commit/b91cd0f571b31093061d83570528f4af013eb448#diff-e68e040cbbe52d399e9f255a9e8896dd3d73c745b3a54285f3c88287837717b1