### PR TITLE
Workaround for GitOps Operator bug

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/defaults/main.yml
@@ -20,6 +20,12 @@ ocp4_workload_openshift_gitops_automatic_install_plan_approval: true
 ocp4_workload_openshift_gitops_starting_csv: ""
 # ocp4_workload_openshift_gitops_starting_csv: "openshift-gitops-operator.v1.0.1"
 
+# Install the workaround for bug https://access.redhat.com/solutions/6012601
+# Make sure to match the user_base and user_count to what has been defined for ocp4_workload_authentication
+ocp4_workload_openshift_gitops_install_workaround: false
+ocp4_workload_openshift_gitops_install_workaround_user_base: user
+ocp4_workload_openshift_gitops_install_workaround_user_count: 10
+
 # --------------------------------
 # Operator Catalog Snapshot Settings
 # --------------------------------

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/files/workaround_clusterrole.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/files/workaround_clusterrole.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: argocd-workaround993
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/remove_workload.yml
@@ -21,6 +21,22 @@
     kind: namespace
     name: openshift-gitops
 
+- name: Remove GitOps Bug Workaround
+  when: ocp4_workload_openshift_gitops_install_workaround
+  block:
+  - name: Delete ClusterRole
+    k8s:
+      state: absent
+      definition: "{{ lookup('file', 'workaround_clusterrole.yaml' ) | from_yaml }}" 
+
+  - name: Delete ClusterRoleBindings for all users
+    k8s:
+      state: absent
+      definition: "{{ lookup('template', 'workaround_clusterrolebinding.yaml.j2' ) | from_yaml }}"
+    loop: "{{ range(1, 1 + ocp4_workload_openshift_gitops_install_workaround_user_count | int) | list }}"
+    loop_control:
+      loop_var: n
+
 # Leave this as the last task in the playbook.
 - name: remove_workload tasks complete
   debug:

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/workload.yml
@@ -42,6 +42,22 @@
     install_operator_catalog_snapshot_image: "{{ ocp4_workload_openshift_gitops_catalog_snapshot_image | default('') }}"
     install_operator_catalog_snapshot_image_tag: "{{ ocp4_workload_openshift_gitops_catalog_snapshot_image_tag | default('') }}"
 
+- name: Install GitOps Bug Workaround
+  when: ocp4_workload_openshift_gitops_install_workaround
+  block:
+  - name: Set up ClusterRole
+    k8s:
+      state: present
+      definition: "{{ lookup('file', 'workaround_clusterrole.yaml' ) | from_yaml }}" 
+
+  - name: Set up ClusterRoleBindings for all users
+    k8s:
+      state: present
+      definition: "{{ lookup('template', 'workaround_clusterrolebinding.yaml.j2' ) | from_yaml }}"
+    loop: "{{ range(1, 1 + ocp4_workload_openshift_gitops_install_workaround_user_count | int) | list }}"
+    loop_control:
+      loop_var: n
+
 # Leave this as the last task in the playbook.
 - name: workload tasks complete
   debug:

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/templates/workaround_clusterrolebinding.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/templates/workaround_clusterrolebinding.yaml.j2
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: "argocd-workaround993-{{ ocp4_workload_openshift_gitops_install_workaround_user_base }}{{ n }}"
+subjects:
+- kind: ServiceAccount
+  name: argocd-argocd-application-controller
+  namespace: "{{ ocp4_workload_openshift_gitops_install_workaround_user_base }}{{ n }}-argocd"
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  name: argocd-workaround993


### PR DESCRIPTION
##### SUMMARY

Red Hat GitOps Operator has a bug preventing regular users from using ArgoCD. This PR installs the workaround as outlined in  https://access.redhat.com/solutions/6012601

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_openshift_gitops