### PR TITLE
Update - Fuse Foundations Part 1 - Fuse Online - Provisioning Failure Data

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_fuse_online/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_fuse_online/tasks/workload.yml
@@ -123,7 +123,7 @@
     name: amq-broker-amqp-ss
     namespace: "{{ ocp4_workload_fuse_online_project }}"
   register: r_amq_broker_ss
-  retries: 60
+  retries: 90
   delay: 10
   until:
     - r_amq_broker_ss.resources[0].status.readyReplicas is defined


### PR DESCRIPTION
##### SUMMARY
Noelia mentioned there is an intermittent error with catalog item _Fuse Foundations Part 1 - Fuse Online_. The error occurs during deployment of AMQ broker.

I added more retries during the broker deployment process.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_fuse_online

##### ADDITIONAL INFORMATION

