### PR TITLE
Update: config/ocp4-cluster (and roles) to support Tigera Calico

### DIFF
--- a/ansible/configs/ocp4-cluster/default_vars.yml
+++ b/ansible/configs/ocp4-cluster/default_vars.yml
@@ -115,10 +115,14 @@ ocp4_installer_root_url: http://d3s3zqyaz8cp2d.cloudfront.net/pub/openshift-v4/c
 
 ocp4_base_domain: "example.opentlc.com"
 
-# Network Plugin for OpenShift:
+# Red Hat Network Plugins for OpenShift:
 # - OpenshiftSDN
 # - OVNKubernetes
 # OVNKubernetes requires OCP 4.6 and newer
+#
+# Third Party Network Plugins for OpenShift
+# - Calico
+#
 ocp4_network_type: OpenshiftSDN
 
 # Install the workaround for OVN deployments. Only for 4.6+

--- a/ansible/configs/ocp4-cluster/default_vars.yml
+++ b/ansible/configs/ocp4-cluster/default_vars.yml
@@ -117,11 +117,10 @@ ocp4_base_domain: "example.opentlc.com"
 
 # Red Hat Network Plugins for OpenShift:
 # - OpenshiftSDN
-# - OVNKubernetes
-# OVNKubernetes requires OCP 4.6 and newer
+# - OVNKubernetes (requires OCP 4.6 and newer)
 #
 # Third Party Network Plugins for OpenShift
-# - Calico
+# - Calico (tested on OCP 4.7)
 #
 ocp4_network_type: OpenshiftSDN
 

--- a/ansible/configs/ocp4-cluster/default_vars_azure.yml
+++ b/ansible/configs/ocp4-cluster/default_vars_azure.yml
@@ -9,6 +9,9 @@ cloud_provider: azure
 #azure_tenant: 'bbb-aaa-ddd-ddd-aaa'
 #azure_subscription_id: 'aaa-eee-iii-ooo-uuu'
 
+# Setting the minimum OpenShift version
+ocp4_installer_version: "4.7.1"
+
 # The resource group for the DNS name
 #az_dnszone_resource_group: FROM_SECRET
 #

--- a/ansible/roles-infra/infra-azure-ssh-key/a
+++ b/ansible/roles-infra/infra-azure-ssh-key/a
@@ -1,5 +1,0 @@
-        az keyvault secret show
-        --vault-name "rhpds-guid-kv"
-        --name "vp-ocptest"
-        --query value -o tsv
-

--- a/ansible/roles/host-ocp4-installer/create-manifests.yml
+++ b/ansible/roles/host-ocp4-installer/create-manifests.yml
@@ -60,8 +60,15 @@
     - https://docs.projectcalico.org/manifests/ocp/tigera-operator/02-serviceaccount-tigera-operator.yaml
     - https://docs.projectcalico.org/manifests/ocp/tigera-operator/02-configmap-calico-resources.yaml
     - https://docs.projectcalico.org/manifests/ocp/tigera-operator/02-tigera-operator.yaml
-    - https://docs.projectcalico.org/manifests/ocp/01-cr-installation.yaml
   retries: 3
   delay: 3
   register: result
   until: result is not failed
+
+- name: Create Project Calico CR to enable VXLAN
+  when: ocp4_network_type|default("OpenshiftSDN") == "Calico"
+  template:
+    src: "templates/calico-01-cr-installation.yaml.j2"
+    dest: "/home/{{ ansible_user }}/{{ cluster_name }}/manifests/01-cr-installation.yaml"
+    owner: "{{ ansible_user }}"
+    mode: 0644

--- a/ansible/roles/host-ocp4-installer/create-manifests.yml
+++ b/ansible/roles/host-ocp4-installer/create-manifests.yml
@@ -26,3 +26,42 @@
     dest: "/home/{{ ansible_user }}/{{ cluster_name }}/manifests/99-scsi-device-detection-machineconfig.yml"
     owner: "{{ ansible_user }}"
     mode: ug=rw,o=
+
+# Tigera Calico is an alternative CNI to OpenShiftSDN or OVNKubernetes
+# This downloads all the extra manifests which are maintained by Tigera
+- name: Download Project Calico Manifests
+  when: ocp4_network_type|default("OpenshiftSDN") == "Calico"
+  get_url:
+    url: "{{ item }}"
+    dest: "/home/{{ ansible_user }}/{{ cluster_name }}/manifests/"
+    mode: 0644
+  loop:
+    - https://docs.projectcalico.org/manifests/ocp/crds/01-crd-installation.yaml
+    - https://docs.projectcalico.org/manifests/ocp/crds/01-crd-imageset.yaml
+    - https://docs.projectcalico.org/manifests/ocp/crds/01-crd-tigerastatus.yaml
+    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_bgpconfigurations.yaml
+    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_bgppeers.yaml
+    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_blockaffinities.yaml
+    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_clusterinformations.yaml
+    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_felixconfigurations.yaml
+    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_globalnetworkpolicies.yaml
+    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_globalnetworksets.yaml
+    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_hostendpoints.yaml
+    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_ipamblocks.yaml
+    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_ipamconfigs.yaml
+    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_ipamhandles.yaml
+    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_ippools.yaml
+    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_kubecontrollersconfigurations.yaml
+    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_networkpolicies.yaml
+    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_networksets.yaml
+    - https://docs.projectcalico.org/manifests/ocp/tigera-operator/00-namespace-tigera-operator.yaml
+    - https://docs.projectcalico.org/manifests/ocp/tigera-operator/02-rolebinding-tigera-operator.yaml
+    - https://docs.projectcalico.org/manifests/ocp/tigera-operator/02-role-tigera-operator.yaml
+    - https://docs.projectcalico.org/manifests/ocp/tigera-operator/02-serviceaccount-tigera-operator.yaml
+    - https://docs.projectcalico.org/manifests/ocp/tigera-operator/02-configmap-calico-resources.yaml
+    - https://docs.projectcalico.org/manifests/ocp/tigera-operator/02-tigera-operator.yaml
+    - https://docs.projectcalico.org/manifests/ocp/01-cr-installation.yaml
+  retries: 3
+  delay: 3
+  register: result
+  until: result is not failed

--- a/ansible/roles/host-ocp4-installer/templates/calico-01-cr-installation.yaml.j2
+++ b/ansible/roles/host-ocp4-installer/templates/calico-01-cr-installation.yaml.j2
@@ -1,0 +1,14 @@
+apiVersion: operator.tigera.io/v1
+kind: Installation
+metadata:
+  name: default
+spec:
+  variant: Calico
+  calicoNetwork:
+    bgp: Disabled
+    ipPools:
+    - blockSize: 26
+      cidr: 10.128.0.0/14
+      encapsulation: VXLAN
+      natOutgoing: Enabled
+      nodeSelector: all()

--- a/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
+++ b/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
@@ -86,6 +86,8 @@ networking:
   - {{ ocp_service_network | default('172.30.0.0/16') }}
 {% if ocp4_network_type | default("OpenshiftSDN") is match("OVNKubernetes") %}
   networkType: OVNKubernetes
+{% elif ocp4_network_type | default("OpenshiftSDN") is match("Calico") %}
+  networkType: Calico
 {% else %}
   networkType: OpenshiftSDN
 {% endif %}

--- a/ansible/roles/host_virtualenv/lookup_plugins/host_virtualenv_combined_requirements.py
+++ b/ansible/roles/host_virtualenv/lookup_plugins/host_virtualenv_combined_requirements.py
@@ -47,7 +47,7 @@ class LookupModule(LookupBase):
                 self.__add_requirement(line, requirements)
 
     def __add_requirement(self, reqspec, requirements):
-        m = re.match(r'^(-?)([\w\-.]+)(,?(<|>|<=|>=|==|!=|~=)[0-9.]*\*?)*$', reqspec)
+        m = re.match(r'^(-?)([\w\-.]+)(,?(<|>|<=|>=|==|!=|~=)[a-z0-9.]*\*?)*$', reqspec)
         if m:
             exclude, name, versionspec = (m.group(1), m.group(2), m.group(3))
             if exclude == '-':

--- a/ansible/roles_ocp_workloads/ocp4_workload_tigera_calico/.yamllint
+++ b/ansible/roles_ocp_workloads/ocp4_workload_tigera_calico/.yamllint
@@ -1,0 +1,16 @@
+---
+extends: default
+
+rules:
+  comments:
+    require-starting-space: false
+    min-spaces-from-content: 1
+  comments-indentation: disable
+  indentation:
+    indent-sequences: consistent
+  line-length:
+    max: 120
+    allow-non-breakable-inline-mappings: true
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 1

--- a/ansible/roles_ocp_workloads/ocp4_workload_tigera_calico/README.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_tigera_calico/README.adoc
@@ -1,0 +1,67 @@
+= ocp4_workload_tigera_calico - Deploys the Tigera Calico operator and client config
+
+== Role overview
+
+* This role installs the Tigera Calico operator and client configuration into an OpenShift Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment.
+*** Debug task will print out: `pre_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy Calico
+*** This role deploys the Tigera Calico operator and client configation
+*** Debug task will print out: `workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+ configure the workload after deployment
+*** This role doesn't do anything here
+*** Debug task will print out: `post_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+ delete the workload
+*** This role uninstalls the Calico operator and client config
+*** Debug task will print out: `remove_workload Tasks completed successfully.`
+
+== Review the defaults variable file
+
+* This file link:./defaults/main.yml[./defaults/main.yml] contains all the variables you need to define to control the deployment of your workload.
+
+* You can modify any of these default values by adding `-e "variable_name=variable_value"` to the command line
+
+=== Deploy a Workload with the `ocp-workload` playbook [Mostly for testing]
+
+----
+TARGET_HOST="bastion.guid.example.opentlc.com"
+OCP_USERNAME="vpower-redhat.com"
+WORKLOAD="ocp4_workload_tigera_calico"
+GUID="1234"
+ANSIBLE_USER="$OCP_USERNAME"
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=${ANSIBLE_USER}" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"silent=False" \
+    -e"guid=${GUID}" \
+    -e"ACTION=create"
+----
+
+=== To Delete an environment
+
+----
+TARGET_HOST="bastion.guid.example.opentlc.com"
+OCP_USERNAME="vpower-redhat.com"
+WORKLOAD="ocp4_workload_tigera_calico"
+GUID="1234"
+ANSIBLE_USER="$OCP_USERNAME"
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=${ANSIBLE_USER}" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"silent=False" \
+    -e"guid=${GUID}" \
+    -e"ACTION=remove"
+----

--- a/ansible/roles_ocp_workloads/ocp4_workload_tigera_calico/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_tigera_calico/defaults/main.yml
@@ -18,7 +18,7 @@ sub_spec_install_plan: Manual
 sub_spec_name: tigera-operator
 sub_spec_source: certified-operators
 sub_spec_source_namespace: openshift-marketplace
-sub_spec_starting_csv: tigera-operator.v1.17.3
+sub_spec_starting_csv: tigera-operator.v1.17.4
 
 # Calico client configuration URL
-calico_client_manifest_url: https://docs.projectcalico.org/manifests/calicoctl.yaml
+calico_client_manifest_url: "https://docs.projectcalico.org/manifests/calicoctl.yaml"

--- a/ansible/roles_ocp_workloads/ocp4_workload_tigera_calico/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_tigera_calico/defaults/main.yml
@@ -13,7 +13,7 @@ og_metadata_name: tigera-operator
 
 # Subscription template variables
 sub_metadata_name: tigera-operator-subscription
-sub_spec_channel: stable
+sub_spec_channel: release-v1.17
 sub_spec_install_plan: Manual
 sub_spec_name: tigera-operator
 sub_spec_source: certified-operators

--- a/ansible/roles_ocp_workloads/ocp4_workload_tigera_calico/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_tigera_calico/defaults/main.yml
@@ -1,0 +1,24 @@
+---
+become_override: false
+ocp_username: opentlc-mgr
+silent: false
+
+num_users: "100"
+
+# Establish the namespace to target
+target_namespace: tigera-operator
+
+# OperatorGroup template variables
+og_metadata_name: tigera-operator
+
+# Subscription template variables
+sub_metadata_name: tigera-operator-subscription
+sub_spec_channel: stable
+sub_spec_install_plan: Manual
+sub_spec_name: tigera-operator
+sub_spec_source: certified-operators
+sub_spec_source_namespace: openshift-marketplace
+sub_spec_starting_csv: tigera-operator.v1.17.3
+
+# Calico client configuration URL
+calico_client_manifest_url: https://docs.projectcalico.org/manifests/calicoctl.yaml

--- a/ansible/roles_ocp_workloads/ocp4_workload_tigera_calico/meta/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_tigera_calico/meta/main.yml
@@ -1,0 +1,15 @@
+---
+galaxy_info:
+  role_name: ocp4_workload_couchbase_cluster
+  author: Vince Power (vpower@redhat.com)
+  description: |
+    Set up Tigera Calico operator and client on OpenShift 4.
+  license: MIT
+  min_ansible_version: 2.9
+  platforms: []
+  galaxy_tags:
+  - ocp
+  - openshift
+  - tigera
+  - calico
+dependencies: []

--- a/ansible/roles_ocp_workloads/ocp4_workload_tigera_calico/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_tigera_calico/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: Running Pre Workload Tasks
+  import_tasks: ./pre_workload.yml
+  become: false
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload Tasks
+  import_tasks: ./workload.yml
+  become: false
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  import_tasks: ./post_workload.yml
+  become: false
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload removal Tasks
+  import_tasks: ./remove_workload.yml
+  become: false
+  when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles_ocp_workloads/ocp4_workload_tigera_calico/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_tigera_calico/tasks/post_workload.yml
@@ -1,0 +1,4 @@
+---
+- name: post_workload Tasks Complete
+  debug:
+    msg: "Post-Software checks completed successfully"

--- a/ansible/roles_ocp_workloads/ocp4_workload_tigera_calico/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_tigera_calico/tasks/pre_workload.yml
@@ -1,0 +1,12 @@
+---
+# Create Namespace
+- name: "Creating namespace"
+  k8s:
+    name: "{{ target_namespace }}"
+    api_version: v1
+    kind: Namespace
+    state: present
+
+- name: pre_workload Tasks Complete
+  debug:
+    msg: "Pre-Software checks completed successfully"

--- a/ansible/roles_ocp_workloads/ocp4_workload_tigera_calico/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_tigera_calico/tasks/remove_workload.yml
@@ -19,21 +19,10 @@
     kind: Namespace
     state: absent
 
-# download client configuration
-- name: "Download yaml for client configuration"
-  get_url:
-    url: "{{ calico_client_manifest_url }}"
-    dest: "/home/{{ ansible_user }}/{{ guid }}_calico_client_manifest.yaml"
-    mode: 0644
-
 # delete client configuration
-- name: "Deleting client configuration"
-  k8s:
-    state: absent
-    src: "/home/{{ ansible_user }}/{{ guid }}_calico_client_manifest.yaml"
-
-# delete client configuration
-- name: "Delete yaml for client configuration"
-  file:
-    path: "/home/{{ ansible_user }}/{{ guid }}_calico_client_manifest.yaml"
-    state: absent
+- name: "Create client configuration"
+  shell: "oc delete -f {{ calico_client_manifest_url }}"
+  register: result
+  until: result is not failed
+  delay: 3
+  retries: 3

--- a/ansible/roles_ocp_workloads/ocp4_workload_tigera_calico/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_tigera_calico/tasks/remove_workload.yml
@@ -1,10 +1,11 @@
 ---
-# verify there are no ceph PVCs in use
+# delete subscription yaml
 - name: "Delete Subscription"
   k8s:
     state: absent
     definition: "{{ lookup('template', 'subscription.yml.j2') }}"
 
+# delete operatorgroup yaml
 - name: "Delete OperatorGroup"
   k8s:
     state: absent
@@ -18,8 +19,21 @@
     kind: Namespace
     state: absent
 
+# download client configuration
+- name: "Download yaml for client configuration"
+  get_url:
+    url: "{{ calico_client_manifest_url }}"
+    dest: "/home/{{ ansible_user }}/{{ guid }}_calico_client_manifest.yaml"
+    mode: 0644
+
 # delete client configuration
 - name: "Deleting client configuration"
   k8s:
     state: absent
-    src: "{{ calico_client_manifest_url }}"
+    src: "/home/{{ ansible_user }}/{{ guid }}_calico_client_manifest.yaml"
+
+# delete client configuration
+- name: "Delete yaml for client configuration"
+  file:
+    path: "/home/{{ ansible_user }}/{{ guid }}_calico_client_manifest.yaml"
+    state: absent

--- a/ansible/roles_ocp_workloads/ocp4_workload_tigera_calico/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_tigera_calico/tasks/remove_workload.yml
@@ -1,0 +1,25 @@
+---
+# verify there are no ceph PVCs in use
+- name: "Delete Subscription"
+  k8s:
+    state: absent
+    definition: "{{ lookup('template', 'subscription.yml.j2') }}"
+
+- name: "Delete OperatorGroup"
+  k8s:
+    state: absent
+    definition: "{{ lookup('template', 'operatorgroup.yml.j2') }}"
+
+# delete namespace
+- name: "Deleting namespace"
+  k8s:
+    name: "{{ target_namespace }}"
+    api_version: v1
+    kind: Namespace
+    state: absent
+
+# delete client configuration
+- name: "Deleting client configuration"
+  k8s:
+    state: absent
+    src: "{{ calico_client_manifest_url }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_tigera_calico/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_tigera_calico/tasks/workload.yml
@@ -11,18 +11,13 @@
     state: present
     definition: "{{ lookup('template', 'subscription.yml.j2') }}"
 
-# download client configuration
-- name: "Download yaml for client configuration"
-  get_url:
-    url: "{{ calico_client_manifest_url }}"
-    dest: "/home/{{ ansible_user }}/{{ guid }}_calico_client_manifest.yaml"
-    mode: 0644
-
 # apply client configuration
 - name: "Create client configuration"
-  k8s:
-    state: present
-    src: "/home/{{ ansible_user }}/{{ guid }}_calico_client_manifest.yaml"
+  shell: "oc create -f {{ calico_client_manifest_url }}"
+  register: result
+  until: result is not failed
+  delay: 3
+  retries: 3
 
 - name: workload Tasks Complete
   debug:

--- a/ansible/roles_ocp_workloads/ocp4_workload_tigera_calico/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_tigera_calico/tasks/workload.yml
@@ -1,0 +1,20 @@
+---
+- name: "Create OperatorGroup"
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'operatorgroup.yml.j2') }}"
+
+- name: "Create Subscription"
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'subscription.yml.j2') }}"
+
+# delete client configuration
+- name: "Create Client Configuration"
+  k8s:
+    state: present
+    src: "{{ calico_client_manifest_url }}"
+
+- name: workload Tasks Complete
+  debug:
+    msg: workload Tasks Complete

--- a/ansible/roles_ocp_workloads/ocp4_workload_tigera_calico/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_tigera_calico/tasks/workload.yml
@@ -1,19 +1,28 @@
 ---
+# apply operatorgroup yaml
 - name: "Create OperatorGroup"
   k8s:
     state: present
     definition: "{{ lookup('template', 'operatorgroup.yml.j2') }}"
 
+# apply subscription yaml
 - name: "Create Subscription"
   k8s:
     state: present
     definition: "{{ lookup('template', 'subscription.yml.j2') }}"
 
-# delete client configuration
-- name: "Create Client Configuration"
+# download client configuration
+- name: "Download yaml for client configuration"
+  get_url:
+    url: "{{ calico_client_manifest_url }}"
+    dest: "/home/{{ ansible_user }}/{{ guid }}_calico_client_manifest.yaml"
+    mode: 0644
+
+# apply client configuration
+- name: "Create client configuration"
   k8s:
     state: present
-    src: "{{ calico_client_manifest_url }}"
+    src: "/home/{{ ansible_user }}/{{ guid }}_calico_client_manifest.yaml"
 
 - name: workload Tasks Complete
   debug:

--- a/ansible/roles_ocp_workloads/ocp4_workload_tigera_calico/templates/operatorgroup.yml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_tigera_calico/templates/operatorgroup.yml.j2
@@ -1,0 +1,9 @@
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: {{og_metadata_name}}
+  namespace: {{target_namespace}}
+spec:
+  targetNamespaces:
+  - {{target_namespace}}

--- a/ansible/roles_ocp_workloads/ocp4_workload_tigera_calico/templates/subscription.yml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_tigera_calico/templates/subscription.yml.j2
@@ -1,0 +1,13 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: {{sub_metadata_name}}
+  namespace: {{target_namespace}}
+spec:
+  channel: {{sub_spec_channel}}
+  installPlanApproval: {{sub_spec_install_plan}}
+  name: {{sub_spec_name}}
+  source: {{sub_spec_source}}
+  sourceNamespace: {{sub_spec_source_namespace}}
+  startingCSV: {{sub_spec_starting_csv}}


### PR DESCRIPTION
##### SUMMARY

To support running demos in RHPDS which use Calico as the default CNI in OpenShift, I needed to update the ocp4-cluster config, the ocp4 installer role, and add a new role to install the operator post-installation.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Updated:
 - configs/ocp4-cluster
 - roles/host-ocp4-installer

 Created:
- roles_ocp_workloads/ocp4_workload_tigera_calico

Defects found:
- roles-infra/infra-azure-ssh-key
- roles/host_virtualenv

##### ADDITIONAL INFORMATION

These were found when testing on Azure:
 - Removed the file ansible/roles-infra/infra-azure-ssh-key/a because I accidentally added it a while ago
 - Updated the regex is ansible/roles/host_virtualenv/lookup_plugins/host_virtualenv_combined_requirements.py to allow for alphabetic characters in pip version numbers