### PR TITLE
Change role ocp4_workload_fuse_online to use ocp4_token

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_fuse_online/templates/image-pull-secret.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_fuse_online/templates/image-pull-secret.j2
@@ -4,5 +4,5 @@ kind: Secret
 metadata:
   name: registry-credentials
 data:
-  .dockerconfigjson: "{{ ocp4_pull_secret | b64encode }}"
+  .dockerconfigjson: {{ ocp4_token | b64encode | to_json }}
 type: kubernetes.io/dockerconfigjson


### PR DESCRIPTION
##### SUMMARY

The `ocp4_pull_secret` was found to contain a dictionary rather than the
expected json string of the pull secret. This cause encoding problems.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role ocp4_workload_fuse_online