### PR TITLE
Add ability to not lookup public subnet for OpenStack provider

### DIFF
--- a/ansible/roles-infra/infra-osp-project-create/defaults/main.yaml
+++ b/ansible/roles-infra/infra-osp-project-create/defaults/main.yaml
@@ -10,6 +10,11 @@ osp_project_create: true
 # password as the regular user.
 osp_create_sandbox: false
 
+# Set this to false if you don't want to lookup the subnet for the provider
+# network. Some OpenStack clusters have a policy that disallows setting the
+# subnet for the floating IPs.
+osp_find_public_subnet: true
+
 # If osp_project_create is set to yes, define those:
 # Quotas to set for new project that is created
 quota_num_instances: 15

--- a/ansible/roles-infra/infra-osp-project-create/tasks/main.yml
+++ b/ansible/roles-infra/infra-osp-project-create/tasks/main.yml
@@ -32,7 +32,8 @@
     block:
     - name: Get public subnet to use
       shell: |
-        openstack ip availability show {{ provider_network }} -f json | jq -r '.subnet_ip_availability | min_by(.used_ips) | .subnet_id'
+        openstack ip availability show {{ provider_network }} -f json \
+        | jq -r '.subnet_ip_availability | min_by(.used_ips) | .subnet_id'
       register: r_floating_subnet
     - name: Set fact for public subnet
       set_fact:
@@ -54,7 +55,8 @@
     block:
     - name: Get public subnet to use
       shell: |
-        openstack ip availability show {{ provider_network }} -f json | jq -r '.subnet_ip_availability | min_by(.used_ips) | .subnet_id'
+        openstack ip availability show {{ provider_network }} -f json \
+        | jq -r '.subnet_ip_availability | min_by(.used_ips) | .subnet_id'
       register: r_floating_subnet
     - name: Set fact for public subnet
       set_fact:

--- a/ansible/roles-infra/infra-osp-project-create/tasks/main.yml
+++ b/ansible/roles-infra/infra-osp-project-create/tasks/main.yml
@@ -35,6 +35,7 @@
         openstack ip availability show {{ provider_network }} -f json \
         | jq -r '.subnet_ip_availability | min_by(.used_ips) | .subnet_id'
       register: r_floating_subnet
+      changed_when: false
     - name: Set fact for public subnet
       set_fact:
         osp_public_subnet: "{{ r_floating_subnet.stdout }}"
@@ -58,6 +59,7 @@
         openstack ip availability show {{ provider_network }} -f json \
         | jq -r '.subnet_ip_availability | min_by(.used_ips) | .subnet_id'
       register: r_floating_subnet
+      changed_when: false
     - name: Set fact for public subnet
       set_fact:
         osp_public_subnet: "{{ r_floating_subnet.stdout }}"

--- a/ansible/roles-infra/infra-osp-project-create/tasks/main.yml
+++ b/ansible/roles-infra/infra-osp-project-create/tasks/main.yml
@@ -28,13 +28,15 @@
     OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
     OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"
   block:
-  - name: Get public subnet to use
-    shell: |
-      openstack ip availability show external -f json | jq -r '.subnet_ip_availability | min_by(.used_ips) | .subnet_id'
-    register: r_floating_subnet
-  - name: Set fact for public subnet
-    set_fact:
-      osp_public_subnet: "{{ r_floating_subnet.stdout }}"
+  - when: osp_find_public_subnet | bool
+    block:
+    - name: Get public subnet to use
+      shell: |
+        openstack ip availability show {{ provider_network }} -f json | jq -r '.subnet_ip_availability | min_by(.used_ips) | .subnet_id'
+      register: r_floating_subnet
+    - name: Set fact for public subnet
+      set_fact:
+        osp_public_subnet: "{{ r_floating_subnet.stdout }}"
 
 - when: >-
     osp_project_create | bool
@@ -48,13 +50,15 @@
     OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
     OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"
   block:
-  - name: Get public subnet to use
-    shell: |
-      openstack ip availability show external -f json | jq -r '.subnet_ip_availability | min_by(.used_ips) | .subnet_id'
-    register: r_floating_subnet
-  - name: Set fact for public subnet
-    set_fact:
-      osp_public_subnet: "{{ r_floating_subnet.stdout }}"
+  - when: osp_find_public_subnet | bool
+    block:
+    - name: Get public subnet to use
+      shell: |
+        openstack ip availability show {{ provider_network }} -f json | jq -r '.subnet_ip_availability | min_by(.used_ips) | .subnet_id'
+      register: r_floating_subnet
+    - name: Set fact for public subnet
+      set_fact:
+        osp_public_subnet: "{{ r_floating_subnet.stdout }}"
   - name: Create project and quota
     when: osp_project_create
     block:

--- a/ansible/roles-infra/infra-osp-template-generate/templates/cloud_template_master.j2
+++ b/ansible/roles-infra/infra-osp-template-generate/templates/cloud_template_master.j2
@@ -45,8 +45,10 @@ resources:
       name: "{{ guid }}-{{ network['name'] }}-router"
       external_gateway_info:
         network: "{{ provider_network }}"
+{% if osp_public_subnet is defined %}
         external_fixed_ips:
         - subnet: "{{ osp_public_subnet }}"
+{% endif %}
 
   {{ network['name'] }}-router_private_interface:
     type: OS::Neutron::RouterInterface
@@ -134,7 +136,9 @@ resources:
     type: OS::Neutron::FloatingIP
     properties:
       floating_network: {{ provider_network }}
+{% if osp_public_subnet is defined %}
       floating_subnet: "{{ osp_public_subnet }}"
+{% endif %}
 
   fip_association_{{ iname }}:
     type: OS::Neutron::FloatingIPAssociation
@@ -215,7 +219,9 @@ resources:
     type: OS::Neutron::FloatingIP
     properties:
       floating_network: "{{ additional_fips[fipname].network }}"
+{% if osp_public_subnet is defined %}
       floating_subnet: "{{ osp_public_subnet }}"
+{% endif %}
 {%     if additional_fips[fipname].description is defined %}
       value_specs:
         description: "{{ additional_fips[fipname].description }}"

--- a/ansible/roles-infra/infra-osp-template-generate/templates/nested_version/cloud_template_master.j2
+++ b/ansible/roles-infra/infra-osp-template-generate/templates/nested_version/cloud_template_master.j2
@@ -59,8 +59,10 @@ resources:
       name: "{{ guid }}-{{ network['name'] }}-router"
       external_gateway_info:
         network: "{{ provider_network }}"
+{% if osp_public_subnet is defined %}
         external_fixed_ips:
         - subnet: "{{ osp_public_subnet }}"
+{% endif %}
 
   {{ network['name'] }}-router_private_interface:
     type: OS::Neutron::RouterInterface
@@ -194,7 +196,9 @@ resources:
     type: OS::Neutron::FloatingIP
     properties:
       floating_network: "{{ additional_fips[fipname].network }}"
+{% if osp_public_subnet is defined %}
       floating_subnet: "{{ osp_public_subnet }}"
+{% endif %}
 {%     if additional_fips[fipname].description is defined %}
       value_specs:
         description: {{ additional_fips[fipname].description }}

--- a/ansible/roles-infra/infra-osp-template-generate/templates/nested_version/cloud_template_nested.j2
+++ b/ansible/roles-infra/infra-osp-template-generate/templates/nested_version/cloud_template_nested.j2
@@ -76,7 +76,9 @@ resources:
     condition: create_fip
     properties:
       floating_network: { get_param: provider_network }
+{% if osp_public_subnet is defined %}
       floating_subnet: "{{ osp_public_subnet }}"
+{% endif %}
 
   fip_association:
     type: OS::Neutron::FloatingIPAssociation


### PR DESCRIPTION
##### SUMMARY

When deploying to OpenStack, the router external IP address floating IP addresses are created on the provider network specified by the user via `provider_network`. If the provider network has more than one subnet, the logic is to pick the one with the least used IP addresses. This is done with `openstack ip availability` but it lookups a hard coded `external` network. This pull request replaces it with the `provider_network`.

And some clusters have a policy that forbids to specify the subnet when creating a router or floating IP. The pull request adds a boolean variable named `osp_find_public_subnet` that will enable lookup when set to true. Its default value is `true` to be backward compatible with the current behavior.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
roles-infra/infra-osp-project-create
roles-infra/infra-osp-template-generate
