### PR TITLE
Enable RHSM to manage repositories

### DIFF
--- a/ansible/roles/set-repositories/tasks/satellite-repos.yml
+++ b/ansible/roles/set-repositories/tasks/satellite-repos.yml
@@ -119,6 +119,9 @@
     org_id: "{{ set_repositories_satellite_org | default(satellite_org) }}"
   when: set_repositories_satellite_ha is defined and set_repositories_satellite_ha|bool == True
 
+- name: Enable RHSM to manage repositories
+  command: subscription-manager config --rhsm.manage_repos=1
+
 - name: Enable repos
   rhsm_repository:
     name: "*"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

Enable RHSM to manage repositories

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
set-repositories

##### ADDITIONAL INFORMATION
RHEL 8.4 in AWS seems to have manage repositories disabled in RHSM config.  This will help make sure subscription manager has repo management enabled.