### PR TITLE
Training: Change RHN to Customer Portal

### DIFF
--- a/training/02_Getting_Started/02_config_your_environment.adoc
+++ b/training/02_Getting_Started/02_config_your_environment.adoc
@@ -11,8 +11,8 @@ I’ll assume you have either self provisioned, or been provided with, an OpenSt
 
 In this document, I will use an OSP Sandbox instance as working machine, however, you can configure your own machine for this purpose. If you prefer to do so, please follow the instructions for link:https://github.com/redhat-cop/agnosticd/blob/development/training/02_Getting_Started/config_your_linux.adoc[Linux] or link:https://github.com/redhat-cop/agnosticd/blob/development/training/02_Getting_Started/configure_your_mac.adoc[Mac OS X machines].
 
-In order to request an OpenStack Sandbox instance, please go to link:https://https://rhpds.redhat.com/[https://https://rhpds.redhat.com/] and follow these steps:
-. Log in to link:https://https://rhpds.redhat.com/[https://https://rhpds.redhat.com/] using your opentlc user.
+In order to request an OpenStack Sandbox instance, please go to link:https://rhpds.redhat.com/[https://rhpds.redhat.com/] and follow these steps:
+. Log in to link:https://rhpds.redhat.com/[https://rhpds.redhat.com/] using your opentlc user.
 
 image::../images/rhpds_login.png[OPENTLC login]
 

--- a/training/02_Getting_Started/03_config_env_osp.adoc
+++ b/training/02_Getting_Started/03_config_env_osp.adoc
@@ -226,7 +226,7 @@ The variable `repo_method` in the secrets file defines the method of receiving p
 . There are three defineable options '*file*', '*rhn*', and '*satellite*'.
 .. Defining '*file*' requires a path to the repository typically in url format, that is the `own_repo_path` variable, if you dont' have access to a repo like that (should be provided by admin to a Red Hat employee) just use another method.
 
-.. Defining '*rhn*' registers systems to the Red Hat Network using subscription-manager.
+.. Defining '*rhn*' registers systems to the Red Hat Customer Portal using subscription-manager.
 
 .. Defining '*satellite*' registers systems to an existing Red Hat Satellite server.
 

--- a/training/02_Getting_Started/06_deploying_a_base_config_osp.adoc
+++ b/training/02_Getting_Started/06_deploying_a_base_config_osp.adoc
@@ -57,7 +57,7 @@ set_repositories_satellite_activationkey: CHANGEME # Activation key to register 
 ----
 And populate them with the correct values.
 
-IMPORTANT: If you don't have access to a Satellite server, you can always use your own personal activation key for your own RHN account. Please refer to this link:https://github.com/redhat-cop/agnosticd/blob/development/training/03_Infrastructure/01_Foundational/04_a_Create_an_AK.adoc[page] for guidance.
+IMPORTANT: If you don't have access to a Satellite server, you can always use your own personal activation key for your own Red Hat Customer Portal account. Please refer to this link:https://github.com/redhat-cop/agnosticd/blob/development/training/03_Infrastructure/01_Foundational/04_a_Create_an_AK.adoc[page] for guidance.
 
 == Deploy a base config
 
@@ -210,7 +210,7 @@ rhel_repos:                              # Repositories that will be available i
 update_packages: false                   # Update all packages on system after configuration. true/false
 ----
 
-Please note that available repos are linked to your RHN credentials that would have been provided on your secrets file.
+Please note that available repos are linked to your Red Hat Customer Portal credentials that would have been provided on your secrets file.
 [source,bash]
 ----
 common_packages:                         # Packages to be installed on each node

--- a/training/02_Getting_Started/07_deploying_a_base_config_aws.adoc
+++ b/training/02_Getting_Started/07_deploying_a_base_config_aws.adoc
@@ -134,7 +134,7 @@ rhel_repos:                              # Repositories that will be available i
 update_packages: false                   # Update all packages on system after configuration. true/false
 ----
 
-Please note that available repos are linked to your RHN credentials that would have been provided on your secrets file.
+Please note that available repos are linked to your Red Hat Customer Portal credentials that would have been provided on your secrets file.
 [source,bash]
 ----
 common_packages:                         # Packages to be installed on each node

--- a/training/03_Infrastructure/01_Foundational/04_Modify_a_base_config_Lab.adoc
+++ b/training/03_Infrastructure/01_Foundational/04_Modify_a_base_config_Lab.adoc
@@ -153,7 +153,7 @@ Modify a secrets file with the appropriate repository information.
 
 We are using here rhn as method, so we need to populate the variables with the appropiate values.
 
-TIP: You can simply register with your RHN credentials (user and password and a pool id). However, that is not very secure, so it's better to simply create your own activation key in link:https://access.redhat.com/[https://access.redhat.com/]. Quick instructions can be found link:https://github.com/redhat-cop/agnosticd/blob/development/training/03_Infrastructure/01_Foundational/04_a_Create_an_AK.adoc[here].
+TIP: You can simply register with your Red Hat Customer Portal credentials (user and password and a pool id). However, that is not very secure, so it's better to simply create your own activation key in link:https://access.redhat.com/[https://access.redhat.com/]. Quick instructions can be found link:https://github.com/redhat-cop/agnosticd/blob/development/training/03_Infrastructure/01_Foundational/04_a_Create_an_AK.adoc[here].
 
 [source,bash]
 ---- 

--- a/training/03_Infrastructure/01_Foundational/04_a_Create_an_AK.adoc
+++ b/training/03_Infrastructure/01_Foundational/04_a_Create_an_AK.adoc
@@ -1,8 +1,8 @@
 = Create your own Activation Key
 
-As explained, you can use your own RHN activation key that you can create at link:https://access.redhat.com/[https://access.redhat.com/].
+As explained, you can use your own Red Hat Customer Portal activation key that you can create at link:https://access.redhat.com/[https://access.redhat.com/].
 
-The process is very simple, just log into link:https://access.redhat.com/[https://access.redhat.com/] with your RHN account.
+The process is very simple, just log into link:https://access.redhat.com/[https://access.redhat.com/] with your Red Hat Customer Portal account.
 
 Click on Subscriptions and on the Subscriptions tab you can see all the subscriptions you have available on your account (please note numbers have been obfuscated)
 

--- a/training/03_Infrastructure/02_Advanced/02_Variables_deep_dive.adoc
+++ b/training/03_Infrastructure/02_Advanced/02_Variables_deep_dive.adoc
@@ -93,13 +93,13 @@ These are the variables that allow you to connect to other services, a typical c
 
 *1. file:* Defining 'file' requires a path to the repository typically in url format. own_repo_path explaination,if no access use other methods.
 
-*2. rhn:* Defining 'rhn' registers systems to the Red Hat Network using subscription-manager. Define only ONE of the 2 options, credentials and activation key. Defining both, will result in failure.
+*2. rhn:* Defining 'rhn' registers systems to the Red Hat Customer Portal using subscription-manager. Define only ONE of the 2 options, credentials and activation key. Defining both, will result in failure.
 
-    - *Option 1*, using your RHN account credentials.
+    - *Option 1*, using your Red Hat Customer Portal account credentials.
 
-        - *rhel_subscription_user*: Your RHN user account login.
+        - *rhel_subscription_user*: Your Red Hat Customer Portal user account login.
 
-        - *rhel_subscription_pass*: Your RHN user account password.
+        - *rhel_subscription_pass*: Your Red Hat Customer Portal user account password.
 
         - *rhsm_pool_ids*: Your chosen pool ID.
 

--- a/training/03_Infrastructure/02_Advanced/04_Adding_Versions_RHEL.adoc
+++ b/training/03_Infrastructure/02_Advanced/04_Adding_Versions_RHEL.adoc
@@ -41,11 +41,11 @@ email: example@example.com               # User info for notifications
 
 == Setting the repo method
 
-In order to deploy separate versions of RHEL with specified repos, there are two options, either with RHN or using a Satellite server. 
+In order to deploy separate versions of RHEL with specified repos, there are two options, either with Red Hat Customer Portal or using a Satellite server. 
 
 * When using Satellite you can define an activation key associated with a content-view that will automatically handle repos for each major version of RHEL. 
 
-* When registering to RHN you can define separate repo dictionaries for both RHEL 7 and 8. 
+* When registering to Red Hat Customer Portal you can define separate repo dictionaries for both RHEL 7 and 8. 
 
 *NOTE*: Content view creation is out of the scope of this training.
 
@@ -116,7 +116,7 @@ Satellite is populated using the following tasks file `roles/set-repositories/ta
 
 From the above example we see that when using an activationkey and content-view the role automatically enables all available repos. The Satellite server automatically parses major versions of the RHEL systems and assigns the repos accordingly.
 
-RHN is populated using the following tasks file `roles/set-repositories/tasks/rhn-repos.yml` and it populates repos in this way:
+When registering to the Red Hat Customer Portal, the repositories to enable are defined in the following tasks file `roles/set-repositories/tasks/rhn-repos.yml`:
 
 [source,bash]
 ----
@@ -147,7 +147,7 @@ RHN is populated using the following tasks file `roles/set-repositories/tasks/rh
     state: enabled
 ----
 
-Last, we need to add the environment configuration variables, in this case we are going to use a Satellite sever and an activation key, but we could as well use our own activation key (or even a pool id) in our personal RHN account. As explained in the Foundational Level of this training, we need to add this to our `secrets.yaml` file:
+Last, we need to add the environment configuration variables, in this case we are going to use a Satellite sever and an activation key, but we could as well use our own activation key (or even a pool id) from our personal Red Hat Customer Portal account. As explained in the Foundational Level of this training, we need to add this to our `secrets.yaml` file:
 
 [source,bash]
 ----
@@ -177,7 +177,7 @@ use_content_view: true    # Repo dictionary can contain both rhel 7 and 8 if usi
 # See roles/set-repositories/tasks/satellite-repos.yml
 ----
 
-IMPORTANT: If you don't have access to a Satellite server, you can always use your own personal activation key for your own RHN account. Please refer to this link:https://github.com/redhat-cop/agnosticd/blob/development/training/03_Infrastructure/01_Foundational/04_a_Create_an_AK.adoc[page] for guidance.
+IMPORTANT: If you don't have access to a Satellite server, you can always use your own personal activation key for your own Red Hat Customer Portal account. Please refer to this link:https://github.com/redhat-cop/agnosticd/blob/development/training/03_Infrastructure/01_Foundational/04_a_Create_an_AK.adoc[page] for guidance.
 
 In this example you can see that we use the two *rhel_repos_el7* and *rhel_repos_el8* lists to enable repositories on different versions of RHEL based on the Ansible facts of the systems.
 


### PR DESCRIPTION
##### SUMMARY

RHN has been decomissioned and the term is not being used anymore. The term used now is Red Hat Subscription Management (RHSM) which one can use to register a system to Red Hat Customer Portal (or Red Hat Satellite).

See [Red Hat Subscription Management Migration FAQ](https://access.redhat.com/articles/2979901) for more info.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
AgnosticD training adoc files.