### PR TITLE
Fix role ocp4_workload_stackrox_demo_pipeline resolve display issues in Pipelines output

### DIFF
--- a/ansible/roles/ocp4_workload_stackrox_demo_pipeline/templates/config/2-rox-deployment-check-task.yml.j2
+++ b/ansible/roles/ocp4_workload_stackrox_demo_pipeline/templates/config/2-rox-deployment-check-task.yml.j2
@@ -40,6 +40,6 @@ spec:
         #!/usr/bin/env bash
         set +x
         cat /deployfile/deploy.yml
-        curl -k -L -H "Authorization: Bearer $ROX_API_TOKEN" https://$ROX_CENTRAL_ENDPOINT/api/cli/download/roxctl-linux --output ./roxctl  > /dev/null; echo "Getting roxctl"
+        curl -s -k -L -H "Authorization: Bearer $ROX_API_TOKEN" https://$ROX_CENTRAL_ENDPOINT/api/cli/download/roxctl-linux --output ./roxctl  > /dev/null
         chmod +x ./roxctl  > /dev/null
         ./roxctl deployment check --insecure-skip-tls-verify -e $ROX_CENTRAL_ENDPOINT -f /deployfile/$(params.file) 

--- a/ansible/roles/ocp4_workload_stackrox_demo_pipeline/templates/config/2-rox-image-check-task.yml.j2
+++ b/ansible/roles/ocp4_workload_stackrox_demo_pipeline/templates/config/2-rox-image-check-task.yml.j2
@@ -34,6 +34,6 @@ spec:
       script: |
         #!/usr/bin/env bash
         set +x
-        curl -k -L -H "Authorization: Bearer $ROX_API_TOKEN" https://$ROX_CENTRAL_ENDPOINT/api/cli/download/roxctl-linux --output ./roxctl  > /dev/null; echo "Getting roxctl"
+        curl -s -k -L -H "Authorization: Bearer $ROX_API_TOKEN" https://$ROX_CENTRAL_ENDPOINT/api/cli/download/roxctl-linux --output ./roxctl  > /dev/null
         chmod +x ./roxctl  > /dev/null
         ./roxctl image check --insecure-skip-tls-verify -e $ROX_CENTRAL_ENDPOINT --image $(params.image) 

--- a/ansible/roles/ocp4_workload_stackrox_demo_pipeline/templates/config/2-rox-image-scan-task.yml.j2
+++ b/ansible/roles/ocp4_workload_stackrox_demo_pipeline/templates/config/2-rox-image-scan-task.yml.j2
@@ -35,6 +35,7 @@ spec:
       script: |
         #!/usr/bin/env bash
         set +x
+        export NO_COLOR="True"
         curl -k -L -H "Authorization: Bearer $ROX_API_TOKEN" https://$ROX_CENTRAL_ENDPOINT/api/cli/download/roxctl-linux --output ./roxctl  > /dev/null; echo "Getting roxctl" 
         chmod +x ./roxctl > /dev/null
         ./roxctl image scan --insecure-skip-tls-verify -e $ROX_CENTRAL_ENDPOINT --image $(params.image) --format $(params.output_format) 

--- a/ansible/roles/ocp4_workload_stackrox_demo_pipeline/templates/config/2-rox-image-scan-task.yml.j2
+++ b/ansible/roles/ocp4_workload_stackrox_demo_pipeline/templates/config/2-rox-image-scan-task.yml.j2
@@ -36,6 +36,6 @@ spec:
         #!/usr/bin/env bash
         set +x
         export NO_COLOR="True"
-        curl -k -L -H "Authorization: Bearer $ROX_API_TOKEN" https://$ROX_CENTRAL_ENDPOINT/api/cli/download/roxctl-linux --output ./roxctl  > /dev/null; echo "Getting roxctl" 
+        curl -s -k -L -H "Authorization: Bearer $ROX_API_TOKEN" https://$ROX_CENTRAL_ENDPOINT/api/cli/download/roxctl-linux --output ./roxctl  > /dev/null
         chmod +x ./roxctl > /dev/null
         ./roxctl image scan --insecure-skip-tls-verify -e $ROX_CENTRAL_ENDPOINT --image $(params.image) --format $(params.output_format) 


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

This fixes two display issues with the Pipelines output in the OCP4/ACS demo.

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME

roles/ocp4_workload_stackrox_demo_pipeline

##### ADDITIONAL INFORMATION

The changes here are only in the templates used to create ClusterTasks in Pipelines.  There's no change in the Ansible role itself.  Tested functionality against a "OpenShift 4.7 Workshop (Training)" RHPDS cluster.
