### PR TITLE
Add a few check_mode:false to allow for the --check mode a bit longer

### DIFF
--- a/ansible/cloud_providers/ec2_pre_checks.yml
+++ b/ansible/cloud_providers/ec2_pre_checks.yml
@@ -13,6 +13,7 @@
       shell: command -v aws
       failed_when: false
       changed_when: false
+      check_mode: false
       register: raws
 
     - name: Fail if AWS command CLI if not available

--- a/ansible/roles-infra/infra-ec2-template-generate/tasks/locate_availability_zones.yml
+++ b/ansible/roles-infra/infra-ec2-template-generate/tasks/locate_availability_zones.yml
@@ -28,6 +28,7 @@
   command: aws ec2 describe-instance-type-offerings help
   failed_when: false
   changed_when: false
+  check_mode: false
   register: r_aws_type_offerings
 
 # Some config use instances[].subnet(s) to define in what subnet each instance goes.

--- a/ansible/roles-infra/infra-ec2-template-generate/tasks/locate_availability_zones_tasks.yml
+++ b/ansible/roles-infra/infra-ec2-template-generate/tasks/locate_availability_zones_tasks.yml
@@ -14,6 +14,7 @@
     --query "InstanceTypeOfferings[].Location"
     --output json
   changed_when: false
+  check_mode: false
   register: r_possible_azs
 
 - debug:


### PR DESCRIPTION
##### SUMMARY

I added a few `check_mode: false` to some command tasks checking for information, allowing the provisioning to work a bit longer in check mode without modifying anything in the environment.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
cloud_providers
roles-infra/infra-ec2-template-generate

##### ADDITIONAL INFORMATION
The main.yml playbook still can't run fully in check mode and will probably never run through, but it helps to check quickly if some configuration is completely awry.