### PR TITLE
Simplify include code and add Satellite pool to set-repositories

### DIFF
--- a/ansible/roles/set-repositories/defaults/main.yaml
+++ b/ansible/roles/set-repositories/defaults/main.yaml
@@ -7,6 +7,8 @@ set_repositories_satellite_ca_rpm_url: "https://{{ set_repositories_satellite_ho
 set_repositories_satellite_activationkey: "{{ satellite_activationkey | default('') }}"
 set_repositories_satellite_ca_cert: "{{ lookup('file', set_repositories_satellite_hostname ~ '.ca.crt') }}"
 set_repositories_satellite_hostname: "{{ set_repositories_satellite_url | default(satellite_url) | default('') }}"
+# pattern matching a pool name for attachment via Satellite
+#set_repositories_satellite_pool: "^$"
 
 # By default use content view mode
 use_content_view: true

--- a/ansible/roles/set-repositories/tasks/main.yml
+++ b/ansible/roles/set-repositories/tasks/main.yml
@@ -10,15 +10,5 @@
   tags:
   - set_repositories
   - packer
-  block:
-  - name: Configure Satellite Subscription
-    when: repo_method == "satellite"
-    include_tasks: ./satellite-repos.yml
-
-  - name: Configure RHN Subscription
-    when: repo_method == "rhn"
-    include_tasks: ./rhn-repos.yml
-
-  - name: Configure Repository File
-    when: repo_method == "file"
-    include_tasks: ./file-repos.yml
+  name: Configure {{ repo_method }} repositories
+  include_tasks: "{{ repo_method }}-repos.yml"

--- a/ansible/roles/set-repositories/tasks/satellite-repos.yml
+++ b/ansible/roles/set-repositories/tasks/satellite-repos.yml
@@ -117,6 +117,7 @@
     rhsm_baseurl: "https://{{ set_repositories_satellite_hostname }}/pulp/repos"
     activationkey: "{{ set_repositories_satellite_activationkey }}"
     org_id: "{{ set_repositories_satellite_org | default(satellite_org) }}"
+    pool: "{{ set_repositories_satellite_pool | default(omit) }}"
   when: set_repositories_satellite_ha is defined and set_repositories_satellite_ha|bool == True
 
 - name: Enable RHSM to manage repositories


### PR DESCRIPTION
##### SUMMARY

Two changes:

1. replace 3 include/when statements with one include <variable> statement, it removes a few useless skips and keeps the code simpler
2. add a pool option to the role to allow for custom product registration (in case the AK doesn't make it)

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
roles/set-repositories

##### ADDITIONAL INFORMATION
n/a