### PR TITLE
Add manifest feature to the tower-license-injector role

### DIFF
--- a/ansible/roles/tower-license-injector/README.md
+++ b/ansible/roles/tower-license-injector/README.md
@@ -1,0 +1,1 @@
+CAUTION: the manifest approach works only with versions of awx.awx older than 19.2.0 (i.e. 19.1.0 or below), because the `eula_accepted` value has been removed but is required for versions of Tower 3.8 or less.

--- a/ansible/roles/tower-license-injector/defaults/main.yml
+++ b/ansible/roles/tower-license-injector/defaults/main.yml
@@ -1,0 +1,13 @@
+# define either tower_license for the old license key files, or
+# or tower_license_manifest for the new manifest based subscription.
+
+#tower_license: <JSON structure>
+
+# either use url + username + password, or use directly the content or file
+#tower_license_manifest:
+#  type: url|content|file
+#  url: <url to a file to download>
+#  username: <username to grab the url>
+#  password: <password to grab the url>
+#  content: <base64 encoded content of a manifest file>
+#  file: <path to local manifest>

--- a/ansible/roles/tower-license-injector/tasks/license.yml
+++ b/ansible/roles/tower-license-injector/tasks/license.yml
@@ -1,0 +1,12 @@
+# the old license key format until Tower 3.7
+- name: license | Copy Tower License File
+  copy:
+    content: "{{ tower_license | from_json }}"
+    dest: /root/license.txt
+  tags:
+    - tower-license-injector
+
+- name: license | Add the tower license
+  command: tower-cli setting modify LICENSE @/root/license.txt --insecure
+  tags:
+    - tower-license-injector

--- a/ansible/roles/tower-license-injector/tasks/main.yml
+++ b/ansible/roles/tower-license-injector/tasks/main.yml
@@ -1,12 +1,4 @@
 ---
-- name: Copy Tower License File
-  copy:
-    content: "{{ tower_license | from_json }}"
-    dest: /root/license.txt
-  tags:
-    - tower-license-injector
-
-- name: Add the tower license
-  command: tower-cli setting modify LICENSE @/root/license.txt --insecure
-  tags:
-    - tower-license-injector
+- name: include Tower license or manifest depending on available values
+  include_tasks:
+    file: "{{ tower_license_manifest is defined | ternary('manifest', 'license') }}.yml"

--- a/ansible/roles/tower-license-injector/tasks/man_content.yml
+++ b/ansible/roles/tower-license-injector/tasks/man_content.yml
@@ -1,0 +1,7 @@
+---
+
+- name: man-content | create tower manifest from base64 provided content
+  copy:
+    dest: "{{ __tower_license_path }}"
+    content: "{{ tower_license_manifest.content | b64decode }}"
+  when: tower_license_manifest.content is defined

--- a/ansible/roles/tower-license-injector/tasks/man_file.yml
+++ b/ansible/roles/tower-license-injector/tasks/man_file.yml
@@ -1,0 +1,7 @@
+---
+
+- name: man-file | copy tower manifest from optionally given local file
+  copy:
+    dest: "{{ __tower_license_path }}"
+    src: "{{ tower_license_manifest.file }}"
+  when: tower_license_manifest.file is defined

--- a/ansible/roles/tower-license-injector/tasks/man_url.yml
+++ b/ansible/roles/tower-license-injector/tasks/man_url.yml
@@ -1,0 +1,9 @@
+---
+
+- name: man-url | downloading tower manifest from optionally given URL
+  get_url:
+    url: "{{ tower_license_manifest.url }}"
+    dest: "{{ __tower_license_path }}"
+    username: "{{ tower_license_manifest.username | default(omit) }}"
+    password: "{{ tower_license_manifest.password | default(omit) }}"
+  when: tower_license_manifest.url is defined

--- a/ansible/roles/tower-license-injector/tasks/manifest.yml
+++ b/ansible/roles/tower-license-injector/tasks/manifest.yml
@@ -1,0 +1,14 @@
+# the new manifest based licensing since Tower 3.8+
+
+- name: manifest | include task to grab manifest according to type
+  include_tasks:
+    file: "man_{{ tower_license_manifest.type }}.yml"
+
+- name: manifest | inject tower license manifest
+  awx.awx.tower_license:
+    manifest: "{{ __tower_license_path }}"
+    force: true  # we don't really care if there was a manifest before
+    tower_host: "{{ tower_hostname }}"
+    tower_username: admin
+    tower_password: "{{tower_admin_password}}"
+    tower_verify_ssl: false

--- a/ansible/roles/tower-license-injector/tasks/manifest.yml
+++ b/ansible/roles/tower-license-injector/tasks/manifest.yml
@@ -7,7 +7,7 @@
 - name: manifest | inject tower license manifest
   awx.awx.tower_license:
     manifest: "{{ __tower_license_path }}"
-    force: true  # we don't really care if there was a manifest before
+    eula_accepted: true  # works only for Tower 3.8 / awx.awx 19.1.0
     tower_host: "{{ tower_hostname }}"
     tower_username: admin
     tower_password: "{{tower_admin_password}}"

--- a/ansible/roles/tower-license-injector/vars/main.yml
+++ b/ansible/roles/tower-license-injector/vars/main.yml
@@ -1,0 +1,2 @@
+# temporary path to the Tower manifest
+__tower_license_path: "/tmp/tower_license_manifest.zip"


### PR DESCRIPTION
##### SUMMARY

Manifest can be loaded as URL, file or base64-variable

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

roles/tower-license-injector

##### ADDITIONAL INFORMATION

The code works with Tower 3.8 and the collection awx.awx version 19.2.0