### PR TITLE
Update OCP4 MTC to 1.4.5

### DIFF
--- a/ansible/roles/ocp-workload-migration/templates/operator.yml.j2
+++ b/ansible/roles/ocp-workload-migration/templates/operator.yml.j2
@@ -288,7 +288,7 @@ spec:
       serviceAccountName: migration-operator
       containers:
       - name: operator
-        image: registry.redhat.io/rhmtc/{{ mig_migration_namespace }}-rhel7-operator:v1.4.2
+        image: registry.redhat.io/rhmtc/{{ mig_migration_namespace }}-rhel7-operator:v1.4.5-4
         imagePullPolicy: Always
         volumeMounts:
         - mountPath: /tmp/ansible-operator/runner
@@ -309,53 +309,53 @@ spec:
         - name: PROJECT
           value: rhmtc
         - name: RSYNC_TRANSFER_REPO
-          value: {{ mig_migration_namespace }}-rsync-transfer-rhel8@sha256
+          value: {{ mig_migration_namespace }}-rsync-transfer-rhel8
         - name: RSYNC_TRANSFER_TAG
-          value: a30f13c8b55824401c98ae2f9f40cc85b3b3ac9e43ad8f538fcc94715190c1e0
+          value: v1.4.5-2
         - name: HOOK_RUNNER_REPO
-          value: {{ mig_migration_namespace }}-hook-runner-rhel7@sha256
+          value: {{ mig_migration_namespace }}-hook-runner-rhel7
         - name: HOOK_RUNNER_TAG
-          value: bf69cc3957504e0bfc28f2a401790d8ca1ac67c295d3567c51b7d84831bf9239
+          value: v1.4.5-2
         - name: MIG_CONTROLLER_REPO
-          value: {{ mig_migration_namespace }}-controller-rhel8@sha256
-        - name: MIG_UI_REPO
-          value: {{ mig_migration_namespace }}-ui-rhel8@sha256
-        - name: MIG_LOG_READER_REPO
-          value: {{ mig_migration_namespace }}-log-reader-rhel8@sha256
-        - name: MIGRATION_REGISTRY_REPO
-          value: {{ mig_migration_namespace }}-registry-rhel8@sha256
-        - name: MIGRATION_REGISTRY_TAG
-          value: 78e0cdca846377254eee0d571fbf897416843947b744a53bdd81758b0b5c5377
-        - name: VELERO_REPO
-          value: {{ mig_migration_namespace }}-velero-rhel8@sha256
-        - name: VELERO_PLUGIN_REPO
-          value: openshift-velero-plugin-rhel8@sha256
-        - name: VELERO_RESTIC_RESTORE_HELPER_REPO
-          value: {{ mig_migration_namespace }}-velero-restic-restore-helper-rhel8@sha256
-        - name: VELERO_AWS_PLUGIN_REPO
-          value: {{ mig_migration_namespace }}-velero-plugin-for-aws-rhel8@sha256
-        - name: VELERO_GCP_PLUGIN_REPO
-          value: {{ mig_migration_namespace }}-velero-plugin-for-gcp-rhel8@sha256
-        - name: VELERO_AZURE_PLUGIN_REPO
-          value: {{ mig_migration_namespace }}-velero-plugin-for-microsoft-azure-rhel8@sha256
-        - name: VELERO_TAG
-          value: 29cfe7d13fea468a43f48e43e4f25e4d5ee168311543e612b9e6f14186c32d28
-        - name: VELERO_RESTIC_RESTORE_HELPER_TAG
-          value: b1d09e559f07f132cec7a487515be8817331a6812e9b6112280ef8450bde340f
-        - name: VELERO_PLUGIN_TAG
-          value: 2e59ff364e31b936f7b0e7d82a5424b387d99dbc01441563cb9d98a000c384a4
-        - name: VELERO_AWS_PLUGIN_TAG
-          value: 7fa461a1c70d9440921fa0a985752f4cd792138b1da3186a9e7a2978b64c0d2b
-        - name: VELERO_GCP_PLUGIN_TAG
-          value: 664b0108e0646a96bbc4aca4a8bfded8a96d19c04746f781e2a8cdf4841aad78
-        - name: VELERO_AZURE_PLUGIN_TAG
-          value: 54edc07003bb9f38006cfad81991c2e30d255047f4bd8214d93b65e4e68ece00
-        - name: MIG_UI_TAG
-          value: 83f4b7bcc386e22163852b5a0468329c54f5881dcc7cfd041e8d153355652de7
+          value: {{ mig_migration_namespace }}-controller-rhel8
         - name: MIG_CONTROLLER_TAG
-          value: 1555fb0a34359a384fabab72566db2008c877f1f85c3e9cecc2ec336d544b293
+          value: v1.4.5-2
+        - name: MIG_UI_REPO
+          value: {{ mig_migration_namespace }}-ui-rhel8
+        - name: MIG_UI_TAG
+          value: v1.4.5-2
+        - name: MIG_LOG_READER_REPO
+          value: {{ mig_migration_namespace }}-log-reader-rhel8
         - name: MIG_LOG_READER_TAG
-          value: ffbcecbc4f5818616a41feaed4ae23dd0d1d7a3301f634e89f8781c6ba7cffc9
+          value: v1.4.5-2
+        - name: MIGRATION_REGISTRY_REPO
+          value: {{ mig_migration_namespace }}-registry-rhel8
+        - name: MIGRATION_REGISTRY_TAG
+          value: v1.4.5-2
+        - name: VELERO_REPO
+          value: {{ mig_migration_namespace }}-velero-rhel8
+        - name: VELERO_TAG
+          value: v1.4.5-2
+        - name: VELERO_PLUGIN_REPO
+          value: openshift-velero-plugin-rhel8
+        - name: VELERO_PLUGIN_TAG
+          value: v1.4.5-2
+        - name: VELERO_RESTIC_RESTORE_HELPER_REPO
+          value: {{ mig_migration_namespace }}-velero-restic-restore-helper-rhel8
+        - name: VELERO_RESTIC_RESTORE_HELPER_TAG
+          value: v1.4.5-2
+        - name: VELERO_AWS_PLUGIN_REPO
+          value: {{ mig_migration_namespace }}-velero-plugin-for-aws-rhel8
+        - name: VELERO_AWS_PLUGIN_TAG
+          value: v1.4.5-2
+        - name: VELERO_GCP_PLUGIN_REPO
+          value: {{ mig_migration_namespace }}-velero-plugin-for-gcp-rhel8
+        - name: VELERO_GCP_PLUGIN_TAG
+          value: v1.4.5-2
+        - name: VELERO_AZURE_PLUGIN_REPO
+          value: {{ mig_migration_namespace }}-velero-plugin-for-microsoft-azure-rhel8
+        - name: VELERO_AZURE_PLUGIN_TAG
+          value: v1.4.5-2
       volumes:
         - name: runner
           emptyDir: {}

--- a/ansible/roles/ocp4-workload-migration/templates/mig-operator-subscription-downstream.yml.j2
+++ b/ansible/roles/ocp4-workload-migration/templates/mig-operator-subscription-downstream.yml.j2
@@ -6,7 +6,7 @@ metadata:
 spec:
   channel: release-v1.4
   installPlanApproval: Manual
-  startingCSV: mtc-operator.v1.4.2
+  startingCSV: mtc-operator.v1.4.5
   name: mtc-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION

##### SUMMARY

Updating the OCP3 and OCP4 versions of MTC tooling to the newest GA. 

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ocp4-workload-migration
ocp-workload-migration

