### PR TITLE
Display private repo and tag for osp-migration configs

### DIFF
--- a/ansible/configs/osp-migration/pull_repo.yml
+++ b/ansible/configs/osp-migration/pull_repo.yml
@@ -40,6 +40,12 @@
     mode: 0400
   when: platform != "babylon"
 
+- name: Display the private repository and tag
+  ansible.builtin.debug:
+    msg:
+     - "Repository {{ heat_templates_private_repo }}"
+     - "Tag {{ heat_templates_private_repo_tag }}"
+
 - name: Download the templates from the private repository
   git:
     repo: "{{ heat_templates_private_repo }}"


### PR DESCRIPTION

##### SUMMARY

Added debug task to display the private repo and tag used in the osp-migration config


