### PR TITLE
UPDATE:  roles_ocp_workloads/ocp4_workload_cyberark_dap

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_cyberark_dap/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cyberark_dap/tasks/workload.yml
@@ -19,6 +19,10 @@
     remote_src: true
     owner: "{{ ansible_user }}"
     group: users
+  register: unarchive_result
+  until: unarchive_result is not failed
+  retries: 5
+  delay: 3
 
 - name: Set random password for dap
   set_fact:


### PR DESCRIPTION
##### SUMMARY

Extremely rare network timeouts happen when getting file to unarchive, this will work around them.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
roles_ocp_workloads/ocp4_workload_cyberark_dap

##### ADDITIONAL INFORMATION
N/A