### PR TITLE
Deployment should go good with novello tag on DEV config.

### DIFF
--- a/ansible/configs/osp-migration/pull_repo.yml
+++ b/ansible/configs/osp-migration/pull_repo.yml
@@ -44,7 +44,7 @@
   ansible.builtin.debug:
     msg:
      - "Repository {{ heat_templates_private_repo }}"
-     - "Tag {{ heat_templates_private_repo_tag }}"
+     - "Tag "{{ heat_templates_private_repo_tag | default('master') }}""
 
 - name: Download the templates from the private repository
   git:

--- a/ansible/configs/osp-migration/pull_repo.yml
+++ b/ansible/configs/osp-migration/pull_repo.yml
@@ -44,7 +44,7 @@
   ansible.builtin.debug:
     msg:
      - "Repository {{ heat_templates_private_repo }}"
-     - "Tag "{{ heat_templates_private_repo_tag | default('master') }}""
+     - "Tag {{ heat_templates_private_repo_tag | default('master') }}"
 
 - name: Download the templates from the private repository
   git:

--- a/ansible/configs/osp-migration/pull_repo.yml
+++ b/ansible/configs/osp-migration/pull_repo.yml
@@ -43,8 +43,8 @@
 - name: Display the private repository and tag
   ansible.builtin.debug:
     msg:
-     - "Repository {{ heat_templates_private_repo }}"
-     - "Tag {{ heat_templates_private_repo_tag | default('master') }}"
+    - "Repository {{ heat_templates_private_repo }}"
+    - "Tag {{ heat_templates_private_repo_tag | default('master') }}"
 
 - name: Download the templates from the private repository
   git:


### PR DESCRIPTION
##### SUMMARY
This is related to https://github.com/redhat-cop/agnosticd/pull/3894. With this commit deployment always expecting a tag whereas all DEV developments don’t have a tag as it always use master branch of novello-template repo. This PR is intened to fix that. It will display what tag is selected. IF no tag is selected by default it will select master in next TASK namely **Download the templates from the private repository**. So I added same condition here

##### ISSUE TYPE
- Bugfix Pull Request
- 
##### COMPONENT NAME
All Novello deployment affected.


