### PR TITLE
UPDATE: config/aro

### DIFF
--- a/ansible/configs/aro/post_software.yml
+++ b/ansible/configs/aro/post_software.yml
@@ -155,11 +155,6 @@
           oc apply -f {{ output_dir }}/aad-oidc.yaml
       when: aro_version == "4"
 
-    - name: Adding MongoDB Persistent Template (Removed in OpenShift 4.6 for some reason)
-      command: >
-          oc create -f https://raw.githubusercontent.com/openshift/origin/master/examples/db-templates/mongodb-persistent-template.json
-      when: aro_version == "4"
-
     - name: Logout of the ARO cluster
       command: >
           oc logout


### PR DESCRIPTION
##### SUMMARY

We introduced this task to add the template in ARO 4.6 to ease the transition as OpenShift dropped it in 4.6. Now that OpenShift 4.8 is about to be released and ARO is now on 4.7, it doesn't work anymore and causes the deploy to fail on the last step.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
config/aro

##### ADDITIONAL INFORMATION
N/A