### PR TITLE
removing forced subnet option for external net to default false for O…

### DIFF
--- a/ansible/roles-infra/infra-osp-project-create/defaults/main.yaml
+++ b/ansible/roles-infra/infra-osp-project-create/defaults/main.yaml
@@ -13,7 +13,7 @@ osp_create_sandbox: false
 # Set this to false if you don't want to lookup the subnet for the provider
 # network. Some OpenStack clusters have a policy that disallows setting the
 # subnet for the floating IPs.
-osp_find_public_subnet: true
+osp_find_public_subnet: false
 
 # If osp_project_create is set to yes, define those:
 # Quotas to set for new project that is created


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- FIP subnet picker for OSP heat templates

##### ADDITIONAL INFORMATION
Users are receiving the following errors in production openstack, which means something is using a full subnet (which should not happen).  The recent OSP hotfixes for OVN from Feb/Mar 2021 should remove the requirement to force a subnet.

See user error here - this is currently common for OSP provisions:
```
CREATE_FAILED  Resource CREATE failed: IpAddressGenerationFailureClient: resources.fip_bastion-4fnnv: No more IP addresses available on network e0ddc3ba-1707-44e1-a341-7c7006d60f45.",
```