### PR TITLE
Remove broken task from rhel-security config.

### DIFF
--- a/ansible/configs/rhel-security/post_infra.yml
+++ b/ansible/configs/rhel-security/post_infra.yml
@@ -6,11 +6,3 @@
   tasks:
     - debug:
         msg: "Step 002 Post Infrastructure"
-
-- name: install SSH key to RHEL 8 all hosts
-  hosts: all
-  tasks:
-    - copy:
-        src: ~/.ssh/id_rsa
-        dest: ~/.ssh/id_rsa
-        mode: u=rw,go=


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
Removes a broken unnecessary task from the rhel-security config

`
fatal: [bastion.blv8z.internal]: FAILED! => {"changed": false, "msg": "Could not find or access '~/.ssh/id_rsa' on the Ansible Controller.\nIf you are using a module and expect the file to exist on the remote, see the remote_src option"}
`

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
rhel-security

