### PR TITLE
ocp4-workload-rhte-analytics_data_ocp_workshop: Set kfdef to use ODH manifests v1.0.10

### DIFF
--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/templates/data-engineering-kfdef.yaml.j2
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/templates/data-engineering-kfdef.yaml.j2
@@ -63,5 +63,5 @@ spec:
       name: odh-dashboard
   repos:
     - name: manifests
-      uri: https://github.com/opendatahub-io/odh-manifests/tarball/v1.0.5
+      uri: https://github.com/opendatahub-io/odh-manifests/tarball/v1.0.10
   version: master


### PR DESCRIPTION
##### SUMMARY
Updates `ocp4-workload-rhte-analytics_data_ocp_workshop` KfDef to pull kustomize components from ODH manifests v1.0.10.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`ocp4-workload-rhte-analytics_data_ocp_workshop`
