### PR TITLE
Minor typo fix for group names in role deploy_automationcontroller

### DIFF
--- a/ansible/roles/deploy_automationcontroller/README.md
+++ b/ansible/roles/deploy_automationcontroller/README.md
@@ -31,8 +31,8 @@ ansible-playbook main.yml \
 ```
 
 1. A sample vars files defining instances in the group 
-* `ansiblecontroller`
-* `ansiblecontroller_database`
+* `automationcontroller`
+* `automationcontroller_database`
 2. Cloud secrets - get from your cluster admin
 3. Repo method secrets e.g satellite, RHN (Red hat Network), file (see the docs)
 4. See **Role Variables** below, but you must provide at a minimum


### PR DESCRIPTION
##### SUMMARY

Simple, but important, doc fix as group names had the wrong prefix in role `deploy_automationcontroller`

##### ISSUE TYPE

- Docs Pull Request


##### COMPONENT NAME

role `deploy_automationcontroller`

##### ADDITIONAL INFORMATION

