### PR TITLE
ODH Data Engineering: Fix url for get-a-username notebook route

### DIFF
--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/tasks/workload.yml
@@ -152,7 +152,7 @@
 - name: register cluster apps domain as a fact
   set_fact:
     f_cluster_apps_domain: "{{ r_ingress_config.resources[0].spec.domain }}"
-    f_notebook_suffix: "/notebooks/data-engineering-and-machine-learning-workshop.git/source/notebooks/hybrid-data-engineering.ipynb"
+    f_notebook_suffix: "/notebooks/data-engineering-and-machine-learning-workshop/source/notebooks/hybrid-data-engineering.ipynb"
 
 - name: search for username distribution tool
   k8s_info:


### PR DESCRIPTION
##### SUMMARY
Fix an incorrect route in the get-a-username task that would send the user to a bad jupyter notebook route

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-workload-rhte-analytics_data_ocp_workshop
