### PR TITLE
ODH Data Engineering: Update catalog snapshot for ODH OLM role

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_open_data_hub_olm/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_open_data_hub_olm/defaults/main.yml
@@ -14,6 +14,6 @@ ocp4_workload_open_data_hub_olm_catalogsource_name: "redhat-operators-snapshot-o
 ocp4_workload_open_data_hub_olm_automatic_install_plan_approval: false
 ocp4_workload_open_data_hub_olm_use_catalog_snapshot: true
 ocp4_workload_open_data_hub_olm_catalog_snapshot_image: "quay.io/gpte-devops-automation/olm_snapshot_community_catalog"
-ocp4_workload_open_data_hub_olm_catalog_snapshot_image_tag: "v4.7_2021_06_01"
+ocp4_workload_open_data_hub_olm_catalog_snapshot_image_tag: "v4.7_2021_07_01"
 ocp4_workload_open_data_hub_olm_install_operator_catalog: "community-operators"
 ocp4_workload_open_data_hub_olm_starting_csv: "opendatahub-operator.v1.0.10"


### PR DESCRIPTION
##### SUMMARY
FIX: Update ODH OLM role to use catalog snapshot v4.7_2021_07_01 since older snapshots are referencing image hashes that no longer exist

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
roles_ocp_workloads/ocp4_workload_open_data_hub_olm