### PR TITLE
Add support for latest stable OCP release

### DIFF
--- a/ansible/roles/host-ocp4-installer/tasks/install_installer.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/install_installer.yml
@@ -1,4 +1,3 @@
-
 # ocp4_installer_version = 4.1.1 .. 4.99.99
 # -> specific installer version
 - name: Set URLs for OpenShift GA releases (specific version)

--- a/ansible/roles/host-ocp4-installer/tasks/install_installer.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/install_installer.yml
@@ -3,7 +3,7 @@
 - name: Set URLs for OpenShift GA releases (specific version)
   when:
   - not ocp4_installer_use_dev_preview | default(false) | bool
-  - ocp4_installer_version | string | length  > 4
+  - (ocp4_installer_version | string).split('.') | length == 3
   set_fact:
     ocp4_installer_url: >-
       {{ '{0}/ocp/{1}/openshift-install-linux-{1}.tar.gz'.format(
@@ -21,7 +21,7 @@
 - name: Set URLs for OpenShift GA releases (latest stable)
   when:
   - not ocp4_installer_use_dev_preview | default(false) | bool
-  - ocp4_installer_version | string | length <= 4
+  - (ocp4_installer_version | string).split('.') | length == 2
   set_fact:
     ocp4_installer_url: >-
       {{ '{0}/ocp/stable-{1}/openshift-install-linux.tar.gz'.format(

--- a/ansible/roles/host-ocp4-installer/tasks/install_installer.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/install_installer.yml
@@ -1,5 +1,10 @@
-- name: Set URLs for OpenShift GA releases
-  when: not ocp4_installer_use_dev_preview | default(False) | bool
+
+# ocp4_installer_version = 4.1.1 .. 4.99.99
+# -> specific installer version
+- name: Set URLs for OpenShift GA releases (specific version)
+  when:
+  - not ocp4_installer_use_dev_preview | default(false) | bool
+  - ocp4_installer_version | string | length  > 4
   set_fact:
     ocp4_installer_url: >-
       {{ '{0}/ocp/{1}/openshift-install-linux-{1}.tar.gz'.format(
@@ -8,6 +13,24 @@
       ) }}
     ocp4_client_url: >-
       {{ '{0}/ocp/{1}/openshift-client-linux-{1}.tar.gz'.format(
+        ocp4_installer_root_url | default("https://mirror.openshift.com/pub/openshift-v4/clients"),
+        ocp4_installer_version
+      ) }}
+
+# ocp4_installer_version = 4.1 .. 4.99
+# -> latest stable installer for that major version
+- name: Set URLs for OpenShift GA releases (latest stable)
+  when:
+  - not ocp4_installer_use_dev_preview | default(false) | bool
+  - ocp4_installer_version | string | length <= 4
+  set_fact:
+    ocp4_installer_url: >-
+      {{ '{0}/ocp/stable-{1}/openshift-install-linux.tar.gz'.format(
+        ocp4_installer_root_url | default("https://mirror.openshift.com/pub/openshift-v4/clients"),
+        ocp4_installer_version
+      ) }}
+    ocp4_client_url: >-
+      {{ '{0}/ocp/stable-{1}/openshift-client-linux.tar.gz'.format(
         ocp4_installer_root_url | default("https://mirror.openshift.com/pub/openshift-v4/clients"),
         ocp4_installer_version
       ) }}

--- a/ansible/roles_studentvm/studentvm_ocp4/tasks/main.yml
+++ b/ansible/roles_studentvm/studentvm_ocp4/tasks/main.yml
@@ -14,8 +14,7 @@
     block:
     # 4.1 .. 4.99 -> latest stable client for that major version
     - name: Download latest stable OpenShift CLI
-      when:
-      - studentvm_ocp4_oc_version | string | length <= 4
+      when: (studentvm_ocp4_oc_version | string).split('.') | length == 2
       unarchive:
         src: >-
           {{ ocp4_installer_root_url }}/ocp/stable-{{
@@ -30,9 +29,7 @@
 
     # 4.1.1 .. 4.99.99 -> specific client version
     - name: Download specific OpenShift CLI version
-      when:
-      - studentvm_ocp4_oc_install | bool
-      - studentvm_ocp4_oc_version | string | length > 4
+      when: (studentvm_ocp4_oc_version | string).split('.') | length == 3
       unarchive:
         src: >-
           {{ ocp4_installer_root_url }}/ocp/{{


### PR DESCRIPTION
##### SUMMARY

This PR adds support to the host-ocp4-installer role to support the latest stable release for an OpenShift major version.

ocp4_installer_version=4.7 -> Install latest stable 4.7 release (4.7.18 right now)
ocp4_installer_version=4.7.16 -> Install specific release 4.7.16

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
host-ocp4-installer

@fridim @jkupferer @klewis0928 @NonyNo3lle  FYI.