### PR TITLE
Implement Open Environment checkbox feature (AWS)

### DIFF
--- a/ansible/cloud_providers/ec2_destroy_env.yml
+++ b/ansible/cloud_providers/ec2_destroy_env.yml
@@ -11,7 +11,14 @@
       include_role:
         name: infra-aws-capacity-reservation
       vars:
-        ACTION: 'destroy'
+        ACTION: destroy
+
+    - name: Run infra-aws-open-environment Role
+      include_role:
+        name: infra-aws-open-environment
+      vars:
+        ACTION: destroy
+      when: agnosticd_open_environment | default(false) | bool
 
     - name: Run infra-ec2-template-destroy
       include_role:

--- a/ansible/cloud_providers/ec2_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/ec2_infrastructure_deployment.yml
@@ -19,7 +19,14 @@
       include_role:
         name: infra-aws-capacity-reservation
       vars:
-        ACTION: 'provision'
+        ACTION: provision
+
+    - name: Run infra-aws-open-environment Role
+      include_role:
+        name: infra-aws-open-environment
+      vars:
+        ACTION: provision
+      when: agnosticd_open_environment | default(false) | bool
 
     - name: Run infra-ec2-template-generate Role
       import_role:

--- a/ansible/configs/ocp4-ha-lab/default_vars.yml
+++ b/ansible/configs/ocp4-ha-lab/default_vars.yml
@@ -140,8 +140,6 @@ instances:
     value: "bastions,clientvms"
   - key: "ostype"
     value: "linux"
-  - key: "Purpose"
-    value: "{{ purpose }}"
   rootfs_size: "{{ bastion_rootfs_size }}"
   security_groups:
   - BastionSG
@@ -159,8 +157,6 @@ instances:
     value: "utility"
   - key: "ostype"
     value: "linux"
-  - key: "Purpose"
-    value: "{{ purpose }}"
   - key: "user"
     value: "{{ student_name }}"
   rootfs_size: "{{ utilityvm_rootfs_size }}"

--- a/ansible/configs/ocp4-ha-lab/destroy_env.yml
+++ b/ansible/configs/ocp4-ha-lab/destroy_env.yml
@@ -347,3 +347,7 @@
         # delete stack if stack creation failed
         - stack_status is defined
         - stack_status != 'CREATE_COMPLETE'
+
+
+- name: Import default cloud provider destroy playbook
+  import_playbook: "../../cloud_providers/{{ cloud_provider }}_destroy_env.yml"

--- a/ansible/roles-infra/infra-aws-open-environment/defaults/main.yaml
+++ b/ansible/roles-infra/infra-aws-open-environment/defaults/main.yaml
@@ -1,0 +1,6 @@
+---
+admin_console_password: >-
+  {{- lookup('password', '/dev/null length=1 chars=letters') -}}
+  {{- lookup('password', '/dev/null length=10') -}}
+  {{- lookup('password', '/dev/null length=1 chars=digits') -}}
+

--- a/ansible/roles-infra/infra-aws-open-environment/tasks/create_resources.yaml
+++ b/ansible/roles-infra/infra-aws-open-environment/tasks/create_resources.yaml
@@ -1,0 +1,30 @@
+---
+- include_role:
+    name: infra-cloud-tags
+  when: cloud_tags_final is not defined
+
+- name: Launch CloudFormation template to create Open Environment
+  cloudformation:
+    aws_access_key: "{{ aws_access_key_id }}"
+    aws_secret_key: "{{ aws_secret_access_key }}"
+    stack_name: "{{ project_tag }}-open-environment"
+    state: present
+    region: "{{ aws_region_loop | d(aws_region) | d(region) | d('us-east-1')}}"
+    tags: "{{ cloud_tags_final }}"
+    template_body: "{{ lookup('template', 'open-environment.yaml.j2') }}"
+  tags:
+    - aws_infrastructure_deployment
+    - provision_cf_template
+    - open_environment
+  register: r_cloudformation_open_env
+
+- name: get AWS credentials from stack outputs
+  set_fact:
+    admin_access_key_id: >-
+      {{ r_cloudformation_open_env.stack_outputs.AdminUserAccessKey }}
+    admin_secret_access_key: >-
+      {{ r_cloudformation_open_env.stack_outputs.AdminUserSecretAccessKey }}
+    admin_console_user_name: >-
+      {{
+      r_cloudformation_open_env.stack_outputs.AdminUser
+      }}

--- a/ansible/roles-infra/infra-aws-open-environment/tasks/destroy_resources.yaml
+++ b/ansible/roles-infra/infra-aws-open-environment/tasks/destroy_resources.yaml
@@ -1,0 +1,10 @@
+---
+- name: Destroy Open Environment Cloudformation stack
+  cloudformation:
+    aws_access_key: "{{ aws_access_key_id }}"
+    aws_secret_key: "{{ aws_secret_access_key }}"
+    stack_name: "{{ project_tag }}-open-environment"
+    state: absent
+    region: "{{ aws_region_loop | d(aws_region) | d(region) | d('us-east-1')}}"
+  tags:
+    - open_environment

--- a/ansible/roles-infra/infra-aws-open-environment/tasks/main.yaml
+++ b/ansible/roles-infra/infra-aws-open-environment/tasks/main.yaml
@@ -1,0 +1,12 @@
+---
+- when: ACTION == 'provision'
+  block:
+  - name: Create Open Environment resources
+    include_tasks: create_resources.yaml
+
+  - name: Print information to user
+    include_tasks: print_user_info.yaml
+
+- when: ACTION == 'destroy'
+  name: Destroy Open Environment resources
+  include_tasks: destroy_resources.yaml

--- a/ansible/roles-infra/infra-aws-open-environment/tasks/print_user_info.yaml
+++ b/ansible/roles-infra/infra-aws-open-environment/tasks/print_user_info.yaml
@@ -1,0 +1,38 @@
+---
+- name: Print Open Environment information to user
+  agnosticd_user_info:
+    msg: "{{ item }}"
+  loop:
+    - ""
+    - "Your AWS credentials are:"
+    - ""
+    - "AWS_ACCESS_KEY_ID: {{ hostvars.localhost.admin_access_key_id }}"
+    - "AWS_SECRET_ACCESS_KEY: {{ hostvars.localhost.admin_secret_access_key }}"
+    - "** Plase be very careful to not expose AWS credentials in GIT repos or anywhere else that could be public! **"
+    - ""
+    - "Top level route53 domain: {{ subdomain_base_suffix }}"
+    - "The default region is set to {{ aws_region }}"
+    - ""
+    - >-
+      {% if sandbox_enable_ui | default(true) | bool %}
+      Web Console Access: https://{{ sandbox_account_id }}.signin.aws.amazon.com/console
+      {% endif %}
+    - >-
+      {% if sandbox_enable_ui | default(true) | bool %}
+      Web Console Credentials: {{ admin_console_user_name }} / {{ admin_console_password }}
+      {% endif %}
+    - ""
+    - "Visit the following pages to learn how to use the CLI and APIs:"
+    - ""
+    - "AWS CLI Installation: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html"
+    - "AWS Config Basics: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html"
+    - "AWS API Getting Started: https://aws.amazon.com/developers/getting-started/"
+    - "Getting Started Tips - https://learning.redhat.com/course/view.php?id=2751"
+    - ""
+    - "****************************WARNING**WARNING**WARNING****************************"
+    - "** We monitor usage and we will be charging back to your cost center.          **"
+    - "** Reports from the cloud provider of misuse or account compromise will result **"
+    - "** in immediate deletion of this entire account without any warning to you.    **"
+    - "** Do not post your credentials in github/email/web pages/etc.                 **"
+    - "** NOTE: Most account compromises occur by checking credentials into github.   **"
+    - "****************************WARNING**WARNING**WARNING****************************"

--- a/ansible/roles-infra/infra-aws-open-environment/templates/open-environment.yaml.j2
+++ b/ansible/roles-infra/infra-aws-open-environment/templates/open-environment.yaml.j2
@@ -1,0 +1,39 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  AdminUser:
+    Type: AWS::IAM::User
+    Properties:
+      UserName: "{{ email | default(owner) | default('open-environment') }}-{{ guid }}-admin"
+      LoginProfile:
+        Password: {{ admin_console_password | to_json }}
+        PasswordResetRequired: False
+      Policies:
+        - PolicyName: AccessAll
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action: "*"
+                Resource: "*"
+
+  AdminUserAccessKey:
+      DependsOn: AdminUser
+      Type: AWS::IAM::AccessKey
+      Properties:
+        UserName:
+          Ref: AdminUser
+Outputs:
+  AdminUser:
+    Value:
+      Ref: AdminUser
+    Description: IAM Admin User
+  AdminUserAccessKey:
+    Value:
+      Ref: AdminUserAccessKey
+    Description: IAM access key for Admin
+  AdminUserSecretAccessKey:
+    Value:
+      Fn::GetAtt:
+        - AdminUserAccessKey
+        - SecretAccessKey
+    Description: IAM User access key for admin

--- a/ansible/roles-infra/infra-cloud-tags/defaults/main.yaml
+++ b/ansible/roles-infra/infra-cloud-tags/defaults/main.yaml
@@ -1,0 +1,10 @@
+---
+default_cloud_tags:
+  Stack: "project {{ project_tag }}"
+  owner: "{{ email | default(user) | default('unknown') }}"
+  env_type: "{{ env_type }}"
+  guid: "{{ guid }}"
+  uuid: "{{ uuid | default('none') }}"
+
+# custom additional tags :
+cloud_tags: {}

--- a/ansible/roles-infra/infra-cloud-tags/tasks/main.yaml
+++ b/ansible/roles-infra/infra-cloud-tags/tasks/main.yaml
@@ -1,0 +1,11 @@
+---
+- name: Set cloud_tags_final (string)
+  set_fact:
+    cloud_tags_final: >-
+      {{ default_cloud_tags | combine( cloud_tags | from_json ) }}
+  when: cloud_tags is string
+
+- name: Set cloud_tags_final (dictionary)
+  set_fact:
+    cloud_tags_final: "{{ default_cloud_tags | combine( cloud_tags | d({}) ) }}"
+  when: cloud_tags is not string

--- a/ansible/roles-infra/infra-ec2-template-create/tasks/main.yml
+++ b/ansible/roles-infra/infra-ec2-template-create/tasks/main.yml
@@ -4,16 +4,12 @@
 # and this role will run everytime.
 - when: stack_deployed is not defined or stack_deployed == false
   block:
-    - set_fact:
-        cloud_tags_final: "{{ cloud_tags | from_json }}"
-      when: cloud_tags is string
+
+    - include_role:
+        name: infra-cloud-tags
+      when: cloud_tags_final is not defined
 
     - set_fact:
-        cloud_tags_final: "{{ cloud_tags | d({}) }}"
-      when: cloud_tags is not string
-
-    - set_fact:
-        cf_tags_final: "{{ cf_tags | combine(cloud_tags_final)}}"
         cloudformation_template: "{{output_dir}}/{{ env_type }}.{{ guid }}.{{cloud_provider}}_cloud_template"
 
     - name: Wait a bit for the previous stack and child resources to be deleted
@@ -62,7 +58,7 @@
         region: "{{ aws_region_loop | d(aws_region) | d(region) | d('us-east-1')}}"
         # rollback is unreliable, it can make this task hang forever.
         disable_rollback: true
-        tags: "{{ cf_tags | combine(cloud_tags_final)}}"
+        tags: "{{ cloud_tags_final }}"
       args: "{{ cloudform_args }}"
       tags:
         - aws_infrastructure_deployment


### PR DESCRIPTION
This change, if applied, adds a new role to AgnosticD to
enable or disable Open Environment full access for any catalog item.

The variable is the boolean `agnosticd_open_environment`.
If `true`, the role `infra-aws-open-environment` is executed during the infra step.
It creates an admin user with programmatic and Web Console access.
It then prints the credentials to the user as user.info.

Also:

- create an infra-cloud-tags role to define in one place the
  default cloud tags and reuse them in several other roles or configs.

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request
- New role Pull Request

##### COMPONENT NAME
- infra-aws-open-environment role
- ec2 cloud-provider
