### PR TITLE
Operator is not finishing the installation - changing the catalog source name.

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_cnd_monitoring_prometheus/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cnd_monitoring_prometheus/tasks/remove_workload.yml
@@ -18,7 +18,7 @@
     install_operator_automatic_install_plan_approval: "{{ ocp4_workload_cnd_monitoring_prometheus_automatic_install_plan_approval | default(true) }}"
     install_operator_starting_csv: "{{ ocp4_workload_cnd_monitoring_prometheus_starting_csv }}"
     install_operator_catalogsource_setup: "{{ ocp4_workload_cnd_monitoring_prometheus_use_catalog_snapshot }}"
-    install_operator_catalogsource_name: "{{ ocp4_workload_authentication_htpasswd_user_base }}{{ project_loop_var[0] }}-{{ project_loop_var[1] }}"
+    install_operator_catalogsource_name: "{{ ocp4_workload_cnd_monitoring_prometheus_catalogsource_name }}"
     install_operator_catalogsource_image: "{{ ocp4_workload_cnd_monitoring_prometheus_catalog_snapshot_image }}"
     install_operator_catalogsource_image_tag: "{{ ocp4_workload_cnd_monitoring_prometheus_catalog_snapshot_image_tag }}"
   loop: "{{ users | product(ocp4_workload_cnd_monitoring_prometheus_namespace_suffixes) | list }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_cnd_monitoring_prometheus/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cnd_monitoring_prometheus/tasks/workload.yml
@@ -18,7 +18,7 @@
     install_operator_automatic_install_plan_approval: "{{ ocp4_workload_cnd_monitoring_prometheus_automatic_install_plan_approval | default(true) }}"
     install_operator_starting_csv: "{{ ocp4_workload_cnd_monitoring_prometheus_starting_csv }}"
     install_operator_catalogsource_setup: "{{ ocp4_workload_cnd_monitoring_prometheus_use_catalog_snapshot }}"
-    install_operator_catalogsource_name: "{{ ocp4_workload_authentication_htpasswd_user_base }}{{ project_loop_var[0] }}-{{ project_loop_var[1] }}"
+    install_operator_catalogsource_name: "{{ ocp4_workload_cnd_monitoring_prometheus_catalogsource_name }}"
     install_operator_catalogsource_image: "{{ ocp4_workload_cnd_monitoring_prometheus_catalog_snapshot_image }}"
     install_operator_catalogsource_image_tag: "{{ ocp4_workload_cnd_monitoring_prometheus_catalog_snapshot_image_tag }}"
   loop: "{{ users | product(ocp4_workload_cnd_monitoring_prometheus_namespace_suffixes) | list }}"


### PR DESCRIPTION
SUMMARY:

Fixing the Prometheus Operator. The operator doesn't finish the installation in several occasions. It does happens from time to time (around 3-4 users). 

Cause:
It's preventing the Adv. CND catalog to be created. 
Tested multiple times in a local environment and same issue. At some point it fails in early stages of users setup.
Making the catalog source name fixed is avoiding this issue and have all the namespaces per 20 users with the operators created.

ISSUE TYPE

Bugfix Pull Request

COMPONENT NAME
ilt-adv-cloud-native-development-prod