### PR TITLE
AWS Sandbox cleanup of S3 Access points

### DIFF
--- a/ansible/roles-infra/infra-aws-sandbox/tasks/manual_cleanup.yml
+++ b/ansible/roles-infra/infra-aws-sandbox/tasks/manual_cleanup.yml
@@ -84,3 +84,28 @@
 
         - set_fact:
             run_aws_nuke_again: true
+
+    # Access Points
+    - name: List all Access points
+      command: >-
+        aws s3control list-access-points
+        --account {{ account_id | quote }}
+        --region {{ _region | quote }}
+      register: r_access_points
+
+    - when: >-
+        (r_access_points.stdout | from_json).AccessPointList
+        | default([])  | length > 0
+      block:
+        - name: Delete all access points
+          loop: >-
+            {{ (r_access_points.stdout | from_json).AccessPointList
+            | default([]) }}
+          command: >-
+            aws s3control delete-access-point
+            --account-id {{ account_id | quote }}
+            --name {{ item.Name | quote }}
+            --region {{ _region | quote }}
+
+        - set_fact:
+            run_aws_nuke_again: true


### PR DESCRIPTION
Until https://github.com/rebuy-de/aws-nuke/issues/660  is fixed upstream
in aws-nuke, manually cleanup all the S3 Access Points

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
