### PR TITLE
removing labels and prefix- Prometheus Operator

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_cnd_monitoring_prometheus/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cnd_monitoring_prometheus/tasks/workload.yml
@@ -12,7 +12,6 @@
     install_operator_namespace: "{{ ocp4_workload_authentication_htpasswd_user_base }}{{ project_loop_var[0] }}-{{ project_loop_var[1] }}"
     install_operator_manage_namespaces:
     - "{{ ocp4_workload_authentication_htpasswd_user_base }}{{ project_loop_var[0] }}-{{ project_loop_var[1] }}"
-    install_operator_csv_nameprefix: prometheusoperator
     install_operator_channel: "{{ ocp4_workload_cnd_monitoring_prometheus_operator_channel }}"
     install_operator_catalog: ""
     install_operator_automatic_install_plan_approval: "{{ ocp4_workload_cnd_monitoring_prometheus_automatic_install_plan_approval | default(true) }}"
@@ -34,7 +33,6 @@
   loop: "{{ users | product(ocp4_workload_cnd_monitoring_prometheus_namespace_suffixes) | list }}"
   loop_control:
     loop_var: project_loop_var
-    label: "Namespace: {{ ocp4_workload_authentication_htpasswd_user_base }}{{ project_loop_var[0] }}-{{ project_loop_var[1] }}"
 
 
 # Leave this as the last task in the playbook.


### PR DESCRIPTION
SUMMARY:

Fixing the Prometheus Operator. The operator doesn't finish the installation in several occasions. It does happens from time to time (around 8 users).

Cause:
It's preventing the Adv. CND catalog to be created.
Tested multiple times in a local environment and same issue. At some point it fails in early stages of users setup.
Removing the label once create for the namespace +  removing the prefix for the catalog source, since we don't need it.

ISSUE TYPE

Bugfix Pull Request

COMPONENT NAME
ilt-adv-cloud-native-development-prod