### PR TITLE
Export in-memory ansible inventory

### DIFF
--- a/ansible/export_inventory.yml
+++ b/ansible/export_inventory.yml
@@ -1,0 +1,10 @@
+- hosts: localhost
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: Export in-memory inventory to inventory file
+      when: agnosticd_inventory_exporter_enable | default(false) | bool
+      include_role:
+        name: agnosticd_inventory_exporter
+      vars:
+        stage: "{{ stage }}"

--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -55,6 +55,14 @@
     - post_infra
     - post_infra_tasks
 
+- import_playbook: "export_inventory.yml"
+  vars:
+    stage: post_infra
+  tags:
+    - step002
+    - post_infra
+    - post_infra_tasks
+
 ################################################################################
 ################################################################################
 ########### Step 003 Pre Software Deploy Tasks
@@ -93,6 +101,14 @@
 ################################################################################
 
 - import_playbook: "./configs/{{ env_type }}/post_software.yml"
+  tags:
+    - step005
+    - post_software
+    - post_software_tasks
+
+- import_playbook: "export_inventory.yml"
+  vars:
+    stage: post_software
   tags:
     - step005
     - post_software

--- a/ansible/roles/agnosticd_inventory_exporter/defaults/main.yaml
+++ b/ansible/roles/agnosticd_inventory_exporter/defaults/main.yaml
@@ -1,0 +1,3 @@
+---
+# The exporter is disabled by default
+agnosticd_inventory_exporter_enable: false

--- a/ansible/roles/agnosticd_inventory_exporter/tasks/main.yaml
+++ b/ansible/roles/agnosticd_inventory_exporter/tasks/main.yaml
@@ -1,0 +1,6 @@
+---
+- name: Export in-memory inventory to file
+  when: agnosticd_inventory_exporter_enable | bool
+  template:
+    dest: "{{ output_dir }}/inventory_{{ stage }}.yaml"
+    src: inventory.yaml.j2

--- a/ansible/roles/agnosticd_inventory_exporter/templates/inventory.yaml.j2
+++ b/ansible/roles/agnosticd_inventory_exporter/templates/inventory.yaml.j2
@@ -1,0 +1,17 @@
+all:
+  hosts:
+{% for host in hostvars %}
+    {{ host }}: {{ hostvars[host] | to_json }}
+{% endfor %}
+{% if groups | length > 0 %}
+  children:
+{%   for group in groups if group != 'all' %}
+    {{ group }}:
+{%     if groups[group] | length > 0 %}
+      hosts:
+{%       for host in groups[group] %}
+        {{ host }}:
+{%       endfor %}
+{%     endif %}
+{%   endfor %}
+{% endif %}


### PR DESCRIPTION
Role to export the in-memory inventory after infra and after
post_software.

The inventory file can then be used as a regular ansible inventory file
to execute ad-hoc ansible commands:

```
ansible -i /tmp/output_dir/inventory_post_infra.yaml all -m ping
```

The feature is disabled by default and can be enabled by changing the value of `agnosticd_inventory_exporter_enable` to `true`.
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request
