### PR TITLE
Fixes for Ansible Tower Adv Lab

### DIFF
--- a/ansible/configs/ansible-automation-platform/env_vars.yml
+++ b/ansible/configs/ansible-automation-platform/env_vars.yml
@@ -536,3 +536,9 @@ default_workloads:
 #  - tower-inventory-create
 #  - tower-job-template-create
 #  - tower-babylon-job-runner
+
+### Variables to check against in the tower_validate role, they must be aligned with what you expect
+tower_expected_instances: 3            # number of instances in the cluster
+tower_expected_instance_groups: 1      # number of instance groups in the cluster
+tower_expected_licensed_min_nodes: 20  # how many managed nodes must be covered
+tower_expected_licensed_min_days: 2    # how many days there must be left on the license

--- a/ansible/configs/ansible-automation-platform/env_vars.yml
+++ b/ansible/configs/ansible-automation-platform/env_vars.yml
@@ -17,8 +17,10 @@
 ### Common Host settings
 
 repo_method: satellite # Other Options are: file, satellite and rhn
-tower_admin_password: 'changeme'
-automationcontroller_admin_password: '{{ tower_admin_password }}'
+
+# Passwords are generate in Playbook
+#tower_admin_password: 'changeme'
+#automationcontroller_admin_password: '{{ tower_admin_password }}'
 
 # tower_version: "4.0.0"  # not used by deploy_automationcontroller (yet)
 # Do you want to run a full yum update

--- a/ansible/configs/ansible-automation-platform/post_infra.yml
+++ b/ansible/configs/ansible-automation-platform/post_infra.yml
@@ -13,7 +13,7 @@
       url: "https://{{ ansible_tower_ip }}/api/v1/job_templates/{{ job_template_id }}/launch/"
       method: POST
       user: "{{tower_admin}}"
-      password: "{{ hostvars['bastion[0]']['ansible_facts'][tower_admin_password]"
+      password: "{{ hostvars['bastion[0]']['ansible_facts'][tower_admin_password] }}"
       body:
         extra_vars:
           guid: "{{guid}}"

--- a/ansible/configs/ansible-automation-platform/post_infra.yml
+++ b/ansible/configs/ansible-automation-platform/post_infra.yml
@@ -13,7 +13,7 @@
       url: "https://{{ ansible_tower_ip }}/api/v1/job_templates/{{ job_template_id }}/launch/"
       method: POST
       user: "{{tower_admin}}"
-      password: "{{tower_admin_password}}"
+      password: "{{ hostvars['bastion[0]']['ansible_facts'][tower_admin_password]"
       body:
         extra_vars:
           guid: "{{guid}}"

--- a/ansible/configs/ansible-automation-platform/post_software.yml
+++ b/ansible/configs/ansible-automation-platform/post_software.yml
@@ -113,7 +113,7 @@
           automationcontroller_url: "https://{{ tower_instance_name }}.{{ agnosticd_domain_name }}"
           automationcontroller_admin_user: "{{ automationcontroller_admin_user | default('admin') }}"
           #automationcontroller_admin_password: "{{ automationcontroller_admin_password }}"
-          automationcontroller_admin_password: "{{ hostvars['bastion[0]']['ansible_facts'][tower_admin_password] }}"
+          automationcontroller_admin_password: "{{ hostvars[bastion[0]]['tower_admin_password'] }}"
 
     - name: Set agnosticd_user_info ssh data
       agnosticd_user_info:

--- a/ansible/configs/ansible-automation-platform/post_software.yml
+++ b/ansible/configs/ansible-automation-platform/post_software.yml
@@ -111,7 +111,7 @@
           automationcontroller_url: "https://{{ tower_instance_name }}.{{ agnosticd_domain_name }}"
           automationcontroller_admin_user: "{{ automationcontroller_admin_user | default('admin') }}"
           #automationcontroller_admin_password: "{{ automationcontroller_admin_password }}"
-          automationcontroller_admin_password: "{{ hostvars[bastion[0]]['tower_admin_password'] }}"
+          automationcontroller_admin_password: "{{ hostvars[groups['bastions'][0]]['tower_admin_password'] }}"
 
     - name: Set agnosticd_user_info ssh data
       agnosticd_user_info:

--- a/ansible/configs/ansible-automation-platform/post_software.yml
+++ b/ansible/configs/ansible-automation-platform/post_software.yml
@@ -85,20 +85,18 @@
     - name: Output user_info for osp or ec2 based deploys
       agnosticd_user_info:
         msg: |
-          {% if install_vscode_server is true %}
             To Access VScode UI via browser:
-            VScode UI URL: https://{{ groups['bastions'][0] | regex_replace('\\..*$') }}.{{ agnosticd_domain_name }}
-            VScode UI Password: {{ vscode_user_password | default('password_not_set') }}
+            VScode UI URL: https://bastion.{{ agnosticd_domain_name }}
+            VScode UI Password: {{ hostvars[groups['bastions'][0]]['tower_admin_password'] }}
 
-          {% endif %}
             To Access Ansible controller console via browser:
             Automation controller URL: https://{{ tower_instance_name }}.{{ agnosticd_domain_name }}
             Automation controller Username: {{ automationcontroller_admin_user | default('admin') }}
-            Automation controller Admin Password: {{ automationcontroller_admin_password }}
+            Automation controller Admin Password: {{ hostvars[groups['bastions'][0]]['tower_admin_password'] }}
 
-          To Access Control node via SSH:
-          ssh {{ student_name }}@{{ groups['bastions'][0] | regex_replace('\\..*$') }}.{{ agnosticd_domain_name }}
-          Enter ssh password when prompted: {{ student_password }}
+            To Access Control node via SSH:
+            ssh {{ student_name }}@bastion.{{ agnosticd_domain_name }}
+            Enter ssh password when prompted: {{ student_password }}
 
     - name: Set visual studio code agnosticd_user_info data
       when: install_vscode_server | default(false) | bool

--- a/ansible/configs/ansible-automation-platform/post_software.yml
+++ b/ansible/configs/ansible-automation-platform/post_software.yml
@@ -7,39 +7,39 @@
     - debug:
         msg: "Post-Software tasks Started"
 
-- name: Step lab post software deployment
-  hosts: bastions
-  gather_facts: false
-  become: true
-  tags:
-    - opentlc_bastion_tasks
-  pre_tasks:
-    - name: create SSH key for user {{ ansible_user }}
-      user:
-        name: "{{ ansible_user }}"
-        generate_ssh_key: true
-    - name: fetch locally the newly created SSH key for later usage in git-server-ssh
-      fetch:
-        src: /home/{{ ansible_user }}/.ssh/id_rsa.pub
-        dest: "{{ output_dir }}/{{ guid }}_{{ ansible_user }}_id_rsa.pub"
-        flat: true
-    - name: install some additional convenience software on the bastion
-      package:
-        name:
-          - tree
-        state: present
-  roles:
-    - role: git-server-ssh
-      vars:
-        git_user: git
-        git_project: structured-content
-        git_authorized_keys: "{{ output_dir }}/{{ guid }}_{{ ansible_user }}_id_rsa.pub"
-  post_tasks:
-    - name: add user {{ ansible_user }} to {{ git_user }} group
-      user:
-        name: "{{ ansible_user }}"
-        groups: "{{ git_user }}"  # it has been created by the git-server-ssh role
-        append: true
+# - name: Step lab post software deployment
+#   hosts: bastions
+#   gather_facts: false
+#   become: true
+#   tags:
+#     - opentlc_bastion_tasks
+#   pre_tasks:
+#     - name: create SSH key for user {{ ansible_user }}
+#       user:
+#         name: "{{ ansible_user }}"
+#         generate_ssh_key: true
+#     - name: fetch locally the newly created SSH key for later usage in git-server-ssh
+#       fetch:
+#         src: /home/{{ ansible_user }}/.ssh/id_rsa.pub
+#         dest: "{{ output_dir }}/{{ guid }}_{{ ansible_user }}_id_rsa.pub"
+#         flat: true
+#     - name: install some additional convenience software on the bastion
+#       package:
+#         name:
+#           - tree
+#         state: present
+#   roles:
+#     - role: git-server-ssh
+#       vars:
+#         git_user: git
+#         git_project: structured-content
+#         git_authorized_keys: "{{ output_dir }}/{{ guid }}_{{ ansible_user }}_id_rsa.pub"
+#   post_tasks:
+#     - name: add user {{ ansible_user }} to {{ git_user }} group
+#       user:
+#         name: "{{ ansible_user }}"
+#         groups: "{{ git_user }}"  # it has been created by the git-server-ssh role
+#         append: true
 
 - name: PostSoftware flight-check
   hosts: bastions

--- a/ansible/configs/ansible-automation-platform/post_software.yml
+++ b/ansible/configs/ansible-automation-platform/post_software.yml
@@ -90,7 +90,7 @@
             VScode UI Password: {{ hostvars[groups['bastions'][0]]['tower_admin_password'] }}
 
             To Access Ansible controller console via browser:
-            Automation controller URL: https://{{ tower_instance_name }}.{{ agnosticd_domain_name }}
+            Automation controller URL: https://{{ tower_instance_name }}1.{{ agnosticd_domain_name }}
             Automation controller Username: {{ automationcontroller_admin_user | default('admin') }}
             Automation controller Admin Password: {{ hostvars[groups['bastions'][0]]['tower_admin_password'] }}
 

--- a/ansible/configs/ansible-automation-platform/post_software.yml
+++ b/ansible/configs/ansible-automation-platform/post_software.yml
@@ -112,13 +112,14 @@
         data:
           automationcontroller_url: "https://{{ tower_instance_name }}.{{ agnosticd_domain_name }}"
           automationcontroller_admin_user: "{{ automationcontroller_admin_user | default('admin') }}"
-          automationcontroller_admin_password: "{{ automationcontroller_admin_password }}"
+          #automationcontroller_admin_password: "{{ automationcontroller_admin_password }}"
+          automationcontroller_admin_password: "{{ hostvars['bastion[0]']['ansible_facts'][tower_admin_password] }}"
 
     - name: Set agnosticd_user_info ssh data
       agnosticd_user_info:
         data:
           ssh_command: >-
-            ssh {{ student_name }}@{{ groups['bastions'][0] | regex_replace('\\..*$') }}.{{ agnosticd_domain_name }}
+            ssh {{ student_name }}@bastion.{{ agnosticd_domain_name }}
           ssh_password: "{{ student_password }}"
 
     - name: Deploy Bookbag

--- a/ansible/configs/ansible-automation-platform/pre_software.yml
+++ b/ansible/configs/ansible-automation-platform/pre_software.yml
@@ -14,7 +14,7 @@
         creates: "{{ output_dir }}/{{ env_authorized_key }}"
       when: set_env_authorized_key
 
- - name: Configure all hosts with Repositories, Common Files and Set environment key
+- name: Configure all hosts with Repositories, Common Files and Set environment key
   hosts:
     - all:!windows
   become: true

--- a/ansible/configs/ansible-automation-platform/pre_software.yml
+++ b/ansible/configs/ansible-automation-platform/pre_software.yml
@@ -14,6 +14,9 @@
         creates: "{{ output_dir }}/{{ env_authorized_key }}"
       when: set_env_authorized_key
 
+    - name: Debug vars
+      debug:
+        var: "{{ hostvars['bastion[0]']['ansible_facts'][tower_admin_password]"
 
 - name: Configure all hosts with Repositories, Common Files and Set environment key
   hosts:

--- a/ansible/configs/ansible-automation-platform/pre_software.yml
+++ b/ansible/configs/ansible-automation-platform/pre_software.yml
@@ -14,11 +14,7 @@
         creates: "{{ output_dir }}/{{ env_authorized_key }}"
       when: set_env_authorized_key
 
-    - name: Debug vars
-      debug:
-        var: "{{ hostvars['bastion[0]']['ansible_facts'][tower_admin_password]"
-
-- name: Configure all hosts with Repositories, Common Files and Set environment key
+ - name: Configure all hosts with Repositories, Common Files and Set environment key
   hosts:
     - all:!windows
   become: true

--- a/ansible/configs/ansible-automation-platform/requirements.yml
+++ b/ansible/configs/ansible-automation-platform/requirements.yml
@@ -7,4 +7,4 @@ roles:
 
 collections:
 - name: awx.awx
-  version: '19.1.0'  # last version to offer eula_accepted parameter
+  version: '19.2.0'  # last version to offer eula_accepted parameter

--- a/ansible/configs/ansible-automation-platform/sample_vars.yml
+++ b/ansible/configs/ansible-automation-platform/sample_vars.yml
@@ -27,6 +27,12 @@ set_repositories_satellite_ha: true
 use_content_view: true
 set_repositories_satellite_pool: "^Ansible Automation .*"
 
+# Install license from URL
+tower_license_manifest:
+  type: url
+  url: <url to a file to download>
+  username: <username to grab the url>
+  password: <password to grab the url>
 
 # Cloud specfic settings - example given here for AWS
 # Follow those steps to find out the correct parameters:
@@ -71,8 +77,10 @@ target_regions:
 
 # CHANGEME (secrets)
 # e.g. http://example.com/ansible-automation-platform-setup-bundle-latest.tar.gz"
-deploy_automationcontroller_installer_url: ""
-deploy_automationcontroller_manifest_path: "~/secrets/automationcontroller_manifest.zip"
+deploy_automationcontroller_installer_url: "" 
+
+# not used with license injector role
+#deploy_automationcontroller_manifest_path: "~/secrets/automationcontroller_manifest.zip"
 
 #infra_workloads:
 #  - tower-copy-ssh                  ;;; specific to dark-tower

--- a/ansible/configs/ansible-automation-platform/software.yml
+++ b/ansible/configs/ansible-automation-platform/software.yml
@@ -37,6 +37,10 @@
       set_fact:
         automationcontroller_admin_password: "{{ tower_admin_password }}"
 
+    - name: Set vscode password to tower_admin_password
+      set_fact:
+        vscode_user_password: "{{ tower_admin_password }}"
+
     - name: Install Ansible automation controller
       include_role:
         name: deploy_automationcontroller

--- a/ansible/configs/ansible-automation-platform/software.yml
+++ b/ansible/configs/ansible-automation-platform/software.yml
@@ -25,10 +25,6 @@
 
   tasks:
 
-    - name: Install code-server
-      include_role:
-        name: vscode-server
-
     - name: create strong password for Tower and VScode
       set_fact:
         tower_admin_password: "{{ lookup('password', '/dev/null length=12 chars=ascii_letters,digits') }}"
@@ -40,6 +36,10 @@
     - name: Set vscode password to tower_admin_password
       set_fact:
         vscode_user_password: "{{ tower_admin_password }}"
+
+    - name: Install code-server
+      include_role:
+        name: vscode-server
 
     - name: Install Ansible automation controller
       include_role:

--- a/ansible/configs/ansible-automation-platform/software.yml
+++ b/ansible/configs/ansible-automation-platform/software.yml
@@ -33,14 +33,19 @@
       include_role:
         name: deploy_automationcontroller
 
-- name: Issue and install certs on autoctl's
+- name: Install license and LE certs on autoctl nodes
   hosts: automationcontroller
   gather_facts: false
   become: true
 
   tasks:
 
-    - name: call issue_cert role
+    - name: License autoctl nodes
+      include_role:
+        name: tower-license-injector
+      run_once: true
+
+    - name: Issue LE certs on autoctl nodes
       include_role:
         name: automation_controller_issue_cert
 

--- a/ansible/configs/ansible-automation-platform/software.yml
+++ b/ansible/configs/ansible-automation-platform/software.yml
@@ -29,6 +29,14 @@
       include_role:
         name: vscode-server
 
+    - name: create strong password for Tower and VScode
+      set_fact:
+        tower_admin_password: "{{ lookup('password', '/dev/null length=12 chars=ascii_letters,digits') }}"
+
+    - name: New deploy_automationcontroller role needs password under different name
+      set_fact:
+        automationcontroller_admin_password: "{{ tower_admin_password }}"
+
     - name: Install Ansible automation controller
       include_role:
         name: deploy_automationcontroller

--- a/ansible/roles/automation_controller_issue_cert/tasks/main.yml
+++ b/ansible/roles/automation_controller_issue_cert/tasks/main.yml
@@ -43,7 +43,7 @@
             tower_verify_ssl: false
             tower_host: https://localhost/
             tower_username: admin
-            tower_password: "{{ hostvars['bastion[0]']['ansible_facts'][tower_admin_password] }}"
+            tower_password: "{{ hostvars[bastion[0]]['tower_admin_password'] }}"
           register: change_base_url
           until: change_base_url is not failed
           # tower may not be fully up yet, wait for it gratuitously

--- a/ansible/roles/automation_controller_issue_cert/tasks/main.yml
+++ b/ansible/roles/automation_controller_issue_cert/tasks/main.yml
@@ -25,7 +25,7 @@
     - &tower-pinger-block
       block:
         - name: check Tower status
-          shell: "curl --user 'admin:{{ tower_admin_password }}' -vkL -XGET https://localhost/api/v2/ping/"
+          shell: "curl --user 'admin:{{ hostvars['bastion[0]']['ansible_facts'][tower_admin_password]' -vkL -XGET https://localhost/api/v2/ping/"
           register: check2
         - name: Display /api/v2/ping results (stdout)
           debug:
@@ -43,7 +43,7 @@
             tower_verify_ssl: false
             tower_host: https://localhost/
             tower_username: admin
-            tower_password: "{{ tower_admin_password }}"
+            tower_password: "{{ hostvars['bastion[0]']['ansible_facts'][tower_admin_password]"
           register: change_base_url
           until: change_base_url is not failed
           # tower may not be fully up yet, wait for it gratuitously

--- a/ansible/roles/automation_controller_issue_cert/tasks/main.yml
+++ b/ansible/roles/automation_controller_issue_cert/tasks/main.yml
@@ -43,7 +43,7 @@
             tower_verify_ssl: false
             tower_host: https://localhost/
             tower_username: admin
-            tower_password: "{{ hostvars['bastion[0]']['ansible_facts'][tower_admin_password]"
+            tower_password: "{{ hostvars['bastion[0]']['ansible_facts'][tower_admin_password] }}"
           register: change_base_url
           until: change_base_url is not failed
           # tower may not be fully up yet, wait for it gratuitously

--- a/ansible/roles/automation_controller_issue_cert/tasks/main.yml
+++ b/ansible/roles/automation_controller_issue_cert/tasks/main.yml
@@ -25,7 +25,7 @@
     - &tower-pinger-block
       block:
         - name: check Tower status
-          shell: "curl --user 'admin:{{ hostvars['bastion[0]']['ansible_facts'][tower_admin_password]' -vkL -XGET https://localhost/api/v2/ping/"
+          shell: "curl --user 'admin:{{ hostvars[bastion[0]]['tower_admin_password']' -vkL -XGET https://localhost/api/v2/ping/"
           register: check2
         - name: Display /api/v2/ping results (stdout)
           debug:

--- a/ansible/roles/automation_controller_issue_cert/tasks/main.yml
+++ b/ansible/roles/automation_controller_issue_cert/tasks/main.yml
@@ -25,7 +25,7 @@
     - &tower-pinger-block
       block:
         - name: check Tower status
-          shell: "curl --user 'admin:{{ hostvars[bastion[0]]['tower_admin_password']' -vkL -XGET https://localhost/api/v2/ping/"
+          shell: "curl --user 'admin:{{ hostvars[groups['bastions'][0]]['tower_admin_password'] }}' -vkL -XGET https://localhost/api/v2/ping/"
           register: check2
         - name: Display /api/v2/ping results (stdout)
           debug:
@@ -43,7 +43,7 @@
             tower_verify_ssl: false
             tower_host: https://localhost/
             tower_username: admin
-            tower_password: "{{ hostvars[bastion[0]]['tower_admin_password'] }}"
+            tower_password: "{{ hostvars[groups['bastions'][0]]['tower_admin_password'] }}"
           register: change_base_url
           until: change_base_url is not failed
           # tower may not be fully up yet, wait for it gratuitously

--- a/ansible/roles/deploy_automationcontroller/tasks/main.yml
+++ b/ansible/roles/deploy_automationcontroller/tasks/main.yml
@@ -79,25 +79,25 @@
   debug:
     msg: '{{ r_automationcontroller_ping.json }}'
 
-- name: License Ansible controller via manifest block
-  block:
+# - name: License Ansible controller via manifest block
+#   block:
 
-    - name: Load manifest into register
-      local_action:
-        module: slurp
-        src: "{{ deploy_automationcontroller_manifest_path }}"
-      register: r_automationcontroller_manifest_file
-      become: false
+#     - name: Load manifest into register
+#       local_action:
+#         module: slurp
+#         src: "{{ deploy_automationcontroller_manifest_path }}"
+#       register: r_automationcontroller_manifest_file
+#       become: false
 
-    - name: Insert Ansible controller License via manifest
-      uri:
-        url: "https://{{groups['automationcontroller'][0] }}/api/v2/config/"
-        method: POST
-        user: "{{ deploy_automationcontroller_admin_user | default('admin') }}"
-        password: "{{ deploy_automationcontroller_admin_password }}"
-        body: '{ "eula_accepted": true, "manifest": "{{ r_automationcontroller_manifest_file.content }}" }'
-        body_format: json
-        validate_certs: false
-        force_basic_auth: true
+#     - name: Insert Ansible controller License via manifest
+#       uri:
+#         url: "https://{{groups['automationcontroller'][0] }}/api/v2/config/"
+#         method: POST
+#         user: "{{ deploy_automationcontroller_admin_user | default('admin') }}"
+#         password: "{{ deploy_automationcontroller_admin_password }}"
+#         body: '{ "eula_accepted": true, "manifest": "{{ r_automationcontroller_manifest_file.content }}" }'
+#         body_format: json
+#         validate_certs: false
+#         force_basic_auth: true
 
 ...

--- a/ansible/roles/deploy_automationcontroller/tasks/main.yml
+++ b/ansible/roles/deploy_automationcontroller/tasks/main.yml
@@ -79,6 +79,7 @@
   debug:
     msg: '{{ r_automationcontroller_ping.json }}'
 
+# Replaced by tower-license-injector role...
 # - name: License Ansible controller via manifest block
 #   block:
 

--- a/ansible/roles/tower-license-injector/tasks/manifest.yml
+++ b/ansible/roles/tower-license-injector/tasks/manifest.yml
@@ -10,5 +10,5 @@
     #eula_accepted: true  # works only for Tower 3.8 / awx.awx 19.1.0
     tower_host: "https://localhost/"
     tower_username: admin
-    tower_password: "{{ hostvars['bastion[0]']['ansible_facts'][tower_admin_password]"
+    tower_password: "{{ hostvars['bastion[0]']['ansible_facts'][tower_admin_password] }}"
     tower_verify_ssl: false

--- a/ansible/roles/tower-license-injector/tasks/manifest.yml
+++ b/ansible/roles/tower-license-injector/tasks/manifest.yml
@@ -10,5 +10,5 @@
     #eula_accepted: true  # works only for Tower 3.8 / awx.awx 19.1.0
     tower_host: "https://localhost/"
     tower_username: admin
-    tower_password: "{{ hostvars['bastion[0]']['ansible_facts'][tower_admin_password] }}"
+    tower_password: "{{ hostvars[bastion[0]]['tower_admin_password'] }}"
     tower_verify_ssl: false

--- a/ansible/roles/tower-license-injector/tasks/manifest.yml
+++ b/ansible/roles/tower-license-injector/tasks/manifest.yml
@@ -10,5 +10,5 @@
     #eula_accepted: true  # works only for Tower 3.8 / awx.awx 19.1.0
     tower_host: "https://localhost/"
     tower_username: admin
-    tower_password: "{{ tower_admin_password }}"
+    tower_password: "{{ hostvars['bastion[0]']['ansible_facts'][tower_admin_password]"
     tower_verify_ssl: false

--- a/ansible/roles/tower-license-injector/tasks/manifest.yml
+++ b/ansible/roles/tower-license-injector/tasks/manifest.yml
@@ -10,5 +10,5 @@
     #eula_accepted: true  # works only for Tower 3.8 / awx.awx 19.1.0
     tower_host: "https://localhost/"
     tower_username: admin
-    tower_password: "{{ hostvars[bastion[0]]['tower_admin_password'] }}"
+    tower_password: "{{ hostvars[groups['bastions'][0]]['tower_admin_password'] }}"
     tower_verify_ssl: false

--- a/ansible/roles/tower-license-injector/tasks/manifest.yml
+++ b/ansible/roles/tower-license-injector/tasks/manifest.yml
@@ -7,8 +7,8 @@
 - name: manifest | inject tower license manifest
   awx.awx.tower_license:
     manifest: "{{ __tower_license_path }}"
-    eula_accepted: true  # works only for Tower 3.8 / awx.awx 19.1.0
-    tower_host: "{{ tower_hostname }}"
+    #eula_accepted: true  # works only for Tower 3.8 / awx.awx 19.1.0
+    tower_host: "https://localhost/"
     tower_username: admin
-    tower_password: "{{tower_admin_password}}"
+    tower_password: "{{ tower_admin_password }}"
     tower_verify_ssl: false

--- a/ansible/roles/tower-license-injector/templates/tower_cli.j2
+++ b/ansible/roles/tower-license-injector/templates/tower_cli.j2
@@ -1,5 +1,5 @@
 [general]
 host = "{{ tower_hostname }}"
 username = admin
-password = {{tower_admin_password}}
+password = {{"{{ hostvars['bastion[0]']['ansible_facts'][tower_admin_password]"}}
 verify_ssl = False

--- a/ansible/roles/tower-license-injector/templates/tower_cli.j2
+++ b/ansible/roles/tower-license-injector/templates/tower_cli.j2
@@ -1,5 +1,5 @@
 [general]
 host = "{{ tower_hostname }}"
 username = admin
-password = {{"{{ hostvars['bastion[0]']['ansible_facts'][tower_admin_password]"}}
+password = "{{ hostvars[groups['bastions'][0]]['tower_admin_password'] }}"
 verify_ssl = False


### PR DESCRIPTION
##### SUMMARY

This deploys okay from BEUI with our common.yaml and dev.yaml.

Agnosticd/Bookbag User Info needs some polish and the callback at the end didn't work. But apart from this looks good.

This:
- deploys an Automation Controller cluster with LE certs and vscode-server
- uses Tower manifest access credentials from a secret to grab it (Josh)
- Creates a strong password in a Playbook and passes it to deploy-automation-controller role, vscode-server role, tower-license-injector role and automation_controller_issue_cert role.
- For manifest injection we use Eric's role

@rhjcd @tonykay @ericzolf 