### PR TITLE
new workload: ocp4_workload_vertical_pod_autoscaler

### DIFF
--- a/ansible/roles-infra/infra-ec2-template-create/tasks/main.yml
+++ b/ansible/roles-infra/infra-ec2-template-create/tasks/main.yml
@@ -51,6 +51,10 @@
 
     - name: Launch CloudFormation template ({{ cloudform_location }})
       cloudformation:
+        capabilities:
+          - CAPABILITY_IAM
+          - CAPABILITY_NAMED_IAM
+          - CAPABILITY_AUTO_EXPAND
         aws_access_key: "{{ aws_access_key_id }}"
         aws_secret_key: "{{ aws_secret_access_key }}"
         stack_name: "{{ project_tag }}"

--- a/ansible/roles/ocp4-workload-pipelines/templates/subscription.j2
+++ b/ansible/roles/ocp4-workload-pipelines/templates/subscription.j2
@@ -11,7 +11,7 @@ spec:
   installPlanApproval: Manual
 {% endif %}
   name: openshift-pipelines-operator
-  source: community-operators
+  source: redhat-operators
   sourceNamespace: openshift-marketplace
 {% if ocp4_workload_pipelines.starting_csv | d("") | length > 0 %}
   startingCSV: "openshift-pipelines-operator.{{ ocp4_workload_pipelines.starting_csv }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/defaults/main.yml
@@ -1,0 +1,41 @@
+---
+become_override: false
+ocp_username: opentlc-mgr
+silent: false
+
+
+# Channel to use for the OpenShift vertical_pod_autoscaler subscription
+ocp4_workload_vertical_pod_autoscaler_channel: '4.8'
+
+# Set automatic InstallPlan approval. If set to false it is also suggested
+# to set the starting_csv to pin a specific version
+# This variable has no effect when using a catalog snapshot (always true)
+ocp4_workload_vertical_pod_autoscaler_automatic_install_plan_approval: true
+
+# Set a starting ClusterServiceVersion.
+# Recommended to leave empty to get latest in the channel when not using
+# a catalog snapshot.
+# Highly recommended to be set when using a catalog snapshot but can be
+# empty to get the latest available in the channel at the time when
+# the catalog snapshot got created.
+ocp4_workload_vertical_pod_autoscaler_starting_csv: ""
+
+# --------------------------------
+# Operator Catalog Snapshot Settings
+# --------------------------------
+# See https://github.com/redhat-cop/agnosticd/blob/development/docs/Operator_Catalog_Snapshots.adoc
+# for instructions on how to set up catalog snapshot images
+
+# Use a catalog snapshot
+ocp4_workload_vertical_pod_autoscaler_use_catalog_snapshot: false
+
+# Catalog Source Name when using a catalog snapshot. This should be unique
+# in the cluster to avoid clashes
+ocp4_workload_vertical_pod_autoscaler_catalogsource_name: redhat-operators-snapshot-vertical_pod_autoscaler
+
+# Catalog snapshot image
+ocp4_workload_vertical_pod_autoscaler_catalog_snapshot_image: quay.io/gpte-devops-automation/olm_snapshot_redhat_catalog
+
+# Catalog snapshot image tag
+ocp4_workload_vertical_pod_autoscaler_catalog_snapshot_image_tag: v4.7_2021_2_240
+

--- a/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/defaults/main.yml
@@ -3,7 +3,6 @@ become_override: false
 ocp_username: opentlc-mgr
 silent: false
 
-
 # Channel to use for the OpenShift vertical_pod_autoscaler subscription
 ocp4_workload_vertical_pod_autoscaler_channel: '4.8'
 
@@ -38,4 +37,3 @@ ocp4_workload_vertical_pod_autoscaler_catalog_snapshot_image: quay.io/gpte-devop
 
 # Catalog snapshot image tag
 ocp4_workload_vertical_pod_autoscaler_catalog_snapshot_image_tag: v4.7_2021_2_240
-

--- a/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/meta/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/meta/main.yml
@@ -1,0 +1,13 @@
+---
+galaxy_info:
+  role_name: ocp4_workload_pipelines
+  author: Red Hat GPTE, Judd Maltin (jmaltin@redhat.com)
+  description: |
+    Set up OpenShift Vertical Pod Autoscaler (Operator).
+  license: MIT
+  min_ansible_version: 2.9
+  platforms: []
+  galaxy_tags:
+  - ocp
+  - openshift
+dependencies: []

--- a/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/readme.adoc
@@ -1,0 +1,63 @@
+= ocp4_workload_vertical_pod_autoscaler - Deploy OpenShift Vertical Pod Autoscaler to an OpenShift Cluster
+
+== Role overview
+
+* This role installs OpenShift Vertical Pod Autoscaler into an OpenShift Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+ environment for the workload deployment.
+*** Debug task will print out: `pre_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy OpenShift Vertical Pod Autoscaler
+*** This role creates the Vertical Pod Autoscaler Install object that deploys the controllers etc.
+*** Debug task will print out: `workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+ configure the workload after deployment
+*** This role doesn't do anything here
+*** Debug task will print out: `post_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+ delete the workload
+*** This role removes OpenShift Pipelines
+*** Debug task will print out: `remove_workload Tasks completed successfully.`
+
+== Review the defaults variable file
+
+* This file link:./defaults/main.yml[./defaults/main.yml] contains all the variables you need to define to control the deployment of your workload.
+* The variable *ocp_username* is mandatory to assign the workload to the correct OpenShift user.
+* A variable *silent=True* can be passed to suppress debug messages.
+
+
+=== Deploy a Workload with the `ocp-workload` config [Mostly for testing]
+
+Create a file `workload_vars.yaml` with your variables:
+----
+cloud_provider: none
+env_type: ocp-workloads
+target_host: bastion.dev4.openshift.opentlc.com
+
+ocp_workloads:
+- ocp4_workload_vertical_pod_autoscaler
+
+#become_override: false
+
+# If the ocp-workload supports it, you should specify the OCP user:
+ocp_username: system:admin
+
+# Usually the ocp-workloads want a GUID also:
+guid: changeme
+----
+
+From the Agnosticd/ansible directory run the playbook:
+
+----
+ansible-playbook main.yml -e @workload_vars.yml -e ACTION="create"
+----
+
+=== To Delete an environment
+
+From the Agnosticd/ansible directory run the playbook:
+
+----
+ansible-playbook main.yml -e @workload_vars.yml -e ACTION="remove"
+----

--- a/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+
+# Do not modify this file
+
+- name: Running Pre Workload Tasks
+  include_tasks:
+    file: ./pre_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload Tasks
+  include_tasks:
+    file: ./workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  include_tasks:
+    file: ./post_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload removal Tasks
+  include_tasks:
+    file: ./remove_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/tasks/post_workload.yml
@@ -1,0 +1,9 @@
+---
+# Implement your Post Workload deployment tasks here
+
+
+# Leave this as the last task in the playbook.
+- name: post_workload tasks complete
+  debug:
+    msg: "Post-Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/tasks/pre_workload.yml
@@ -1,0 +1,8 @@
+---
+# Implement your Pre Workload deployment tasks here
+
+# Leave this as the last task in the playbook.
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/tasks/remove_workload.yml
@@ -1,0 +1,84 @@
+---
+# Implement your Workload removal tasks here
+
+# Old Pipelines operator
+- name: Remove TektonConfig (old)
+  k8s:
+    state: absent
+    api_version: operator.tekton.dev/v1alpha1
+    kind: config
+    name: cluster
+  ignore_errors: true
+
+# New Pipelines operator
+- name: Remove TektonConfig (new)
+  k8s:
+    state: absent
+    api_version: operator.tekton.dev/v1alpha1
+    kind: TektonConfig
+    name: config
+  ignore_errors: true
+
+- name: Wait until all OpenShift pipelines pods have been removed
+  k8s_info:
+    api_version: v1
+    kind: Pod
+    namespace: openshift-pipelines
+  register: r_pipelines_pods
+  retries: 20
+  delay: 5
+  until: r_pipelines_pods.resources | length == 0
+  ignore_errors: true
+
+- name: Remove Pipelines operator
+  include_role:
+    name: install_operator
+  vars:
+    install_operator_action: remove
+    install_operator_name: openshift-pipelines-operator
+    install_operator_namespace: openshift-operators
+    install_operator_channel: "{{ ocp4_workload_pipelines_channel }}"
+    install_operator_catalog: redhat-operators
+    install_operator_automatic_install_plan_approval: "{{ ocp4_workload_pipelines_automatic_install_plan_approval }}"
+    install_operator_csv_nameprefix: "redhat-openshift-pipelines"
+    install_operator_starting_csv: "{{ ocp4_workload_pipelines_starting_csv }}"
+    install_operator_catalogsource_setup: "{{ ocp4_workload_pipelines_use_catalog_snapshot }}"
+    install_operator_catalogsource_name: "{{ ocp4_workload_pipelines_catalogsource_name }}"
+    install_operator_catalogsource_namespace: openshift-operators
+    install_operator_catalogsource_image: "{{ ocp4_workload_pipelines_catalog_snapshot_image | default('') }}"
+    install_operator_catalogsource_image_tag: "{{ ocp4_workload_pipelines_catalog_snapshot_image_tag }}"
+
+- name: Remove openshift-pipelines project
+  k8s:
+    state: absent
+    api_version: project.openshift.io/v1
+    kind: Project
+    name: openshift-pipelines
+
+- name: Remove tkn and tkn bash completion
+  become: true
+  file:
+    state: absent
+    path: "{{ item }}"
+  loop:
+  - /usr/local/bin/tkn
+  - /etc/bash_completion.d/tkn
+
+- name: Remove Tekton CRDs
+  k8s:
+    state: absent
+    api_version: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    name: "{{ item }}.operator.tekton.dev"
+  loop:
+  - config
+  - tektonconfigs
+  - tektonpipelines
+  - tektontriggers
+  - tektonaddons
+
+# Leave this as the last task in the playbook.
+- name: remove_workload tasks complete
+  debug:
+    msg: "Remove Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/tasks/remove_workload.yml
@@ -1,81 +1,56 @@
 ---
 # Implement your Workload removal tasks here
 
-# Old Pipelines operator
-- name: Remove TektonConfig (old)
-  k8s:
-    state: absent
-    api_version: operator.tekton.dev/v1alpha1
-    kind: config
-    name: cluster
-  ignore_errors: true
 
 # New Pipelines operator
-- name: Remove TektonConfig (new)
+- name: Remove VPA
   k8s:
     state: absent
-    api_version: operator.tekton.dev/v1alpha1
-    kind: TektonConfig
-    name: config
+    api_version: autoscaling.openshift.io/v1
+    kind: "{{ item }}"
+    name: default
   ignore_errors: true
+  loop:
+    - VerticalPodAutoscalerController
 
-- name: Wait until all OpenShift pipelines pods have been removed
-  k8s_info:
-    api_version: v1
-    kind: Pod
-    namespace: openshift-pipelines
-  register: r_pipelines_pods
-  retries: 20
-  delay: 5
-  until: r_pipelines_pods.resources | length == 0
-  ignore_errors: true
-
-- name: Remove Pipelines operator
+- name: Remove VPA operator
   include_role:
     name: install_operator
   vars:
     install_operator_action: remove
-    install_operator_name: openshift-pipelines-operator
-    install_operator_namespace: openshift-operators
-    install_operator_channel: "{{ ocp4_workload_pipelines_channel }}"
+    install_operator_name: verticalpodautoscaler
+    install_operator_namespace: openshift-vertical-pod-autoscaler
+    install_operator_manage_namespaces:
+    - openshift-vertical-pod-autoscaler
+    install_operator_channel: "{{ ocp4_workload_vertical_pod_autoscaler_channel }}"
     install_operator_catalog: redhat-operators
-    install_operator_automatic_install_plan_approval: "{{ ocp4_workload_pipelines_automatic_install_plan_approval }}"
-    install_operator_csv_nameprefix: "redhat-openshift-pipelines"
-    install_operator_starting_csv: "{{ ocp4_workload_pipelines_starting_csv }}"
-    install_operator_catalogsource_setup: "{{ ocp4_workload_pipelines_use_catalog_snapshot }}"
-    install_operator_catalogsource_name: "{{ ocp4_workload_pipelines_catalogsource_name }}"
+    install_operator_packagemanifest_name: vertical-pod-autoscaler
+    install_operator_automatic_install_plan_approval: "{{ ocp4_workload_vertical_pod_autoscaler_automatic_install_plan_approval }}"
+    install_operator_csv_nameprefix: verticalpodautoscaler
+    install_operator_starting_csv: "{{ ocp4_workload_vertical_pod_autoscaler_starting_csv }}"
+    install_operator_catalogsource_setup: "{{ ocp4_workload_vertical_pod_autoscaler_use_catalog_snapshot }}"
+    install_operator_catalogsource_name: "{{ ocp4_workload_vertical_pod_autoscaler_catalogsource_name }}"
     install_operator_catalogsource_namespace: openshift-operators
-    install_operator_catalogsource_image: "{{ ocp4_workload_pipelines_catalog_snapshot_image | default('') }}"
-    install_operator_catalogsource_image_tag: "{{ ocp4_workload_pipelines_catalog_snapshot_image_tag }}"
+    install_operator_catalogsource_image: "{{ ocp4_workload_vertical_pod_autoscaler_catalog_snapshot_image | default('') }}"
+    install_operator_catalogsource_image_tag: "{{ ocp4_workload_vertical_pod_autoscaler_catalog_snapshot_image_tag }}"
 
-- name: Remove openshift-pipelines project
+- name: Remove openshift-vertical-pod-autoscaler project
   k8s:
     state: absent
     api_version: project.openshift.io/v1
     kind: Project
-    name: openshift-pipelines
+    name: openshift-vertical-pod-autoscaler
 
-- name: Remove tkn and tkn bash completion
-  become: true
-  file:
-    state: absent
-    path: "{{ item }}"
-  loop:
-  - /usr/local/bin/tkn
-  - /etc/bash_completion.d/tkn
-
-- name: Remove Tekton CRDs
+- name: Remove VPA CRDs
   k8s:
     state: absent
     api_version: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
-    name: "{{ item }}.operator.tekton.dev"
+    name: "{{ item }}"
   loop:
-  - config
-  - tektonconfigs
-  - tektonpipelines
-  - tektontriggers
-  - tektonaddons
+  - verticalpodautoscalercheckpoints.autoscaling.k8s.io
+  - verticalpodautoscalercontrollers.autoscaling.openshift.io
+  - verticalpodautoscalers.autoscaling.k8s.io
 
 # Leave this as the last task in the playbook.
 - name: remove_workload tasks complete

--- a/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/tasks/workload.yml
@@ -1,0 +1,47 @@
+---
+# Implement your Workload deployment tasks here
+
+- name: Setting up workload for user
+  debug:
+    msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
+
+- name: Install Operator
+  include_role:
+    name: install_operator
+  vars:
+    install_operator_action: install
+    install_operator_name: verticalpodautoscaler
+    install_operator_namespace: openshift-vertical-pod-autoscaler
+    install_operator_manage_namespaces:
+    - openshift-vertical-pod-autoscaler
+    install_operator_channel: "{{ ocp4_workload_vertical_pod_autoscaler_channel }}"
+    install_operator_catalog: redhat-operators
+    install_operator_packagemanifest_name: vertical-pod-autoscaler
+    install_operator_automatic_install_plan_approval: "{{ ocp4_workload_vertical_pod_autoscaler_automatic_install_plan_approval }}"
+    install_operator_csv_nameprefix: verticalpodautoscaler
+    install_operator_starting_csv: "{{ ocp4_workload_vertical_pod_autoscaler_starting_csv }}"
+    install_operator_catalogsource_setup: "{{ ocp4_workload_vertical_pod_autoscaler_use_catalog_snapshot }}"
+    install_operator_catalogsource_name: "{{ ocp4_workload_vertical_pod_autoscaler_catalogsource_name }}"
+    install_operator_catalogsource_namespace: openshift-operators
+    install_operator_catalogsource_image: "{{ ocp4_workload_vertical_pod_autoscaler_catalog_snapshot_image | default('') }}"
+    install_operator_catalogsource_image_tag: "{{ ocp4_workload_vertical_pod_autoscaler_catalog_snapshot_image_tag }}"
+
+- name: Wait until VPA Pods are ready
+  k8s_info:
+    api_version: v1
+    kind: Deployment
+    namespace: openshift-vertical-pod-autoscaler
+    name: vertical-pod-autoscaler-operator
+  register: r_operator_controller_deployment
+  retries: 30
+  delay: 10
+  until:
+  - r_operator_controller_deployment.resources | length | int > 0
+  - r_operator_controller_deployment.resources[0].status.readyReplicas is defined
+  - r_operator_controller_deployment.resources[0].status.readyReplicas | int == r_operator_controller_deployment.resources[0].spec.replicas | int
+
+# Leave this as the last task in the playbook.
+- name: workload tasks complete
+  debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent|bool

--- a/docs/Preparing_your_workstation.adoc
+++ b/docs/Preparing_your_workstation.adoc
@@ -29,7 +29,7 @@ include::../tools/builds/readme.adoc[leveloffset=3]
 
 === Workstation setup for OpenStack
 
-Please see the https://github.com/redhat-cop/agnosticd/blob/development/docs/First_OSP_Env_walkthrough.adoc[OpenStack tutorial]. 
+Please see the https://github.com/redhat-cop/agnosticd/blob/development/docs/First_OSP_Env_walkthrough.adoc[OpenStack tutorial].
 
 === Workstation setup for AWS
 


### PR DESCRIPTION
##### SUMMARY

The Vertical Pod Autoscaler is delivered as an operator since OCP4.6

This installs the operator, defaulting to 4.8 update channel

Uses the role/install_operator to add and remove the operator, namespace, CRDs

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New role Pull Request

##### COMPONENT NAME
ocp4_workload_vertical_pod_autoscaler


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
