### PR TITLE
Add workload ocp4_workload_vertical_pod_autoscaler

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/defaults/main.yml
@@ -36,4 +36,4 @@ ocp4_workload_vertical_pod_autoscaler_catalogsource_name: redhat-operators-snaps
 ocp4_workload_vertical_pod_autoscaler_catalog_snapshot_image: quay.io/gpte-devops-automation/olm_snapshot_redhat_catalog
 
 # Catalog snapshot image tag
-ocp4_workload_vertical_pod_autoscaler_catalog_snapshot_image_tag: v4.8_2021_7_15
+ocp4_workload_vertical_pod_autoscaler_catalog_snapshot_image_tag: v4.8_2021_07_15

--- a/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/defaults/main.yml
@@ -36,4 +36,4 @@ ocp4_workload_vertical_pod_autoscaler_catalogsource_name: redhat-operators-snaps
 ocp4_workload_vertical_pod_autoscaler_catalog_snapshot_image: quay.io/gpte-devops-automation/olm_snapshot_redhat_catalog
 
 # Catalog snapshot image tag
-ocp4_workload_vertical_pod_autoscaler_catalog_snapshot_image_tag: v4.7_2021_2_240
+ocp4_workload_vertical_pod_autoscaler_catalog_snapshot_image_tag: v4.8_2021_7_15

--- a/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/defaults/main.yml
@@ -1,0 +1,39 @@
+---
+become_override: false
+ocp_username: opentlc-mgr
+silent: false
+
+# Channel to use for the OpenShift vertical_pod_autoscaler subscription
+ocp4_workload_vertical_pod_autoscaler_channel: '4.8'
+
+# Set automatic InstallPlan approval. If set to false it is also suggested
+# to set the starting_csv to pin a specific version
+# This variable has no effect when using a catalog snapshot (always true)
+ocp4_workload_vertical_pod_autoscaler_automatic_install_plan_approval: true
+
+# Set a starting ClusterServiceVersion.
+# Recommended to leave empty to get latest in the channel when not using
+# a catalog snapshot.
+# Highly recommended to be set when using a catalog snapshot but can be
+# empty to get the latest available in the channel at the time when
+# the catalog snapshot got created.
+ocp4_workload_vertical_pod_autoscaler_starting_csv: ""
+
+# --------------------------------
+# Operator Catalog Snapshot Settings
+# --------------------------------
+# See https://github.com/redhat-cop/agnosticd/blob/development/docs/Operator_Catalog_Snapshots.adoc
+# for instructions on how to set up catalog snapshot images
+
+# Use a catalog snapshot
+ocp4_workload_vertical_pod_autoscaler_use_catalog_snapshot: false
+
+# Catalog Source Name when using a catalog snapshot. This should be unique
+# in the cluster to avoid clashes
+ocp4_workload_vertical_pod_autoscaler_catalogsource_name: redhat-operators-snapshot-vertical_pod_autoscaler
+
+# Catalog snapshot image
+ocp4_workload_vertical_pod_autoscaler_catalog_snapshot_image: quay.io/gpte-devops-automation/olm_snapshot_redhat_catalog
+
+# Catalog snapshot image tag
+ocp4_workload_vertical_pod_autoscaler_catalog_snapshot_image_tag: v4.7_2021_2_240

--- a/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/meta/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/meta/main.yml
@@ -1,6 +1,6 @@
 ---
 galaxy_info:
-  role_name: ocp4_workload_pipelines
+  role_name: ocp4_workload_vertical_pod_autoscaler
   author: Red Hat GPTE, Judd Maltin (jmaltin@redhat.com)
   description: |
     Set up OpenShift Vertical Pod Autoscaler (Operator).

--- a/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/meta/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/meta/main.yml
@@ -1,0 +1,13 @@
+---
+galaxy_info:
+  role_name: ocp4_workload_pipelines
+  author: Red Hat GPTE, Judd Maltin (jmaltin@redhat.com)
+  description: |
+    Set up OpenShift Vertical Pod Autoscaler (Operator).
+  license: MIT
+  min_ansible_version: 2.9
+  platforms: []
+  galaxy_tags:
+  - ocp
+  - openshift
+dependencies: []

--- a/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/readme.adoc
@@ -1,0 +1,63 @@
+= ocp4_workload_vertical_pod_autoscaler - Deploy OpenShift Vertical Pod Autoscaler to an OpenShift Cluster
+
+== Role overview
+
+* This role installs OpenShift Vertical Pod Autoscaler into an OpenShift Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+ environment for the workload deployment.
+*** Debug task will print out: `pre_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy OpenShift Vertical Pod Autoscaler
+*** This role creates the Vertical Pod Autoscaler Install object that deploys the controllers etc.
+*** Debug task will print out: `workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+ configure the workload after deployment
+*** This role doesn't do anything here
+*** Debug task will print out: `post_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+ delete the workload
+*** This role removes OpenShift Pipelines
+*** Debug task will print out: `remove_workload Tasks completed successfully.`
+
+== Review the defaults variable file
+
+* This file link:./defaults/main.yml[./defaults/main.yml] contains all the variables you need to define to control the deployment of your workload.
+* The variable *ocp_username* is mandatory to assign the workload to the correct OpenShift user.
+* A variable *silent=True* can be passed to suppress debug messages.
+
+
+=== Deploy a Workload with the `ocp-workload` config [Mostly for testing]
+
+Create a file `workload_vars.yaml` with your variables:
+----
+cloud_provider: none
+env_type: ocp-workloads
+target_host: bastion.dev4.openshift.opentlc.com
+
+ocp_workloads:
+- ocp4_workload_vertical_pod_autoscaler
+
+#become_override: false
+
+# If the ocp-workload supports it, you should specify the OCP user:
+ocp_username: system:admin
+
+# Usually the ocp-workloads want a GUID also:
+guid: changeme
+----
+
+From the Agnosticd/ansible directory run the playbook:
+
+----
+ansible-playbook main.yml -e @workload_vars.yml -e ACTION="create"
+----
+
+=== To Delete an environment
+
+From the Agnosticd/ansible directory run the playbook:
+
+----
+ansible-playbook main.yml -e @workload_vars.yml -e ACTION="remove"
+----

--- a/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+
+# Do not modify this file
+
+- name: Running Pre Workload Tasks
+  include_tasks:
+    file: ./pre_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload Tasks
+  include_tasks:
+    file: ./workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  include_tasks:
+    file: ./post_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload removal Tasks
+  include_tasks:
+    file: ./remove_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/tasks/post_workload.yml
@@ -1,0 +1,9 @@
+---
+# Implement your Post Workload deployment tasks here
+
+
+# Leave this as the last task in the playbook.
+- name: post_workload tasks complete
+  debug:
+    msg: "Post-Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/tasks/pre_workload.yml
@@ -1,0 +1,8 @@
+---
+# Implement your Pre Workload deployment tasks here
+
+# Leave this as the last task in the playbook.
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/tasks/remove_workload.yml
@@ -2,7 +2,7 @@
 # Implement your Workload removal tasks here
 
 
-# New Pipelines operator
+# New VPA operator
 - name: Remove VPA
   k8s:
     state: absent

--- a/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/tasks/remove_workload.yml
@@ -1,0 +1,59 @@
+---
+# Implement your Workload removal tasks here
+
+
+# New Pipelines operator
+- name: Remove VPA
+  k8s:
+    state: absent
+    api_version: autoscaling.openshift.io/v1
+    kind: "{{ item }}"
+    name: default
+  ignore_errors: true
+  loop:
+    - VerticalPodAutoscalerController
+
+- name: Remove VPA operator
+  include_role:
+    name: install_operator
+  vars:
+    install_operator_action: remove
+    install_operator_name: verticalpodautoscaler
+    install_operator_namespace: openshift-vertical-pod-autoscaler
+    install_operator_manage_namespaces:
+    - openshift-vertical-pod-autoscaler
+    install_operator_channel: "{{ ocp4_workload_vertical_pod_autoscaler_channel }}"
+    install_operator_catalog: redhat-operators
+    install_operator_packagemanifest_name: vertical-pod-autoscaler
+    install_operator_automatic_install_plan_approval: "{{ ocp4_workload_vertical_pod_autoscaler_automatic_install_plan_approval }}"
+    install_operator_csv_nameprefix: verticalpodautoscaler
+    install_operator_starting_csv: "{{ ocp4_workload_vertical_pod_autoscaler_starting_csv }}"
+    install_operator_catalogsource_setup: "{{ ocp4_workload_vertical_pod_autoscaler_use_catalog_snapshot }}"
+    install_operator_catalogsource_name: "{{ ocp4_workload_vertical_pod_autoscaler_catalogsource_name }}"
+    install_operator_catalogsource_namespace: openshift-operators
+    install_operator_catalogsource_image: "{{ ocp4_workload_vertical_pod_autoscaler_catalog_snapshot_image | default('') }}"
+    install_operator_catalogsource_image_tag: "{{ ocp4_workload_vertical_pod_autoscaler_catalog_snapshot_image_tag }}"
+
+- name: Remove openshift-vertical-pod-autoscaler project
+  k8s:
+    state: absent
+    api_version: project.openshift.io/v1
+    kind: Project
+    name: openshift-vertical-pod-autoscaler
+
+- name: Remove VPA CRDs
+  k8s:
+    state: absent
+    api_version: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    name: "{{ item }}"
+  loop:
+  - verticalpodautoscalercheckpoints.autoscaling.k8s.io
+  - verticalpodautoscalercontrollers.autoscaling.openshift.io
+  - verticalpodautoscalers.autoscaling.k8s.io
+
+# Leave this as the last task in the playbook.
+- name: remove_workload tasks complete
+  debug:
+    msg: "Remove Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/tasks/remove_workload.yml
@@ -21,7 +21,7 @@
     install_operator_name: verticalpodautoscaler
     install_operator_namespace: openshift-vertical-pod-autoscaler
     install_operator_manage_namespaces:
-    - openshift-vertical-pod-autoscaler
+      - openshift-vertical-pod-autoscaler
     install_operator_channel: "{{ ocp4_workload_vertical_pod_autoscaler_channel }}"
     install_operator_catalog: redhat-operators
     install_operator_packagemanifest_name: vertical-pod-autoscaler
@@ -48,9 +48,9 @@
     kind: CustomResourceDefinition
     name: "{{ item }}"
   loop:
-  - verticalpodautoscalercheckpoints.autoscaling.k8s.io
-  - verticalpodautoscalercontrollers.autoscaling.openshift.io
-  - verticalpodautoscalers.autoscaling.k8s.io
+    - verticalpodautoscalercheckpoints.autoscaling.k8s.io
+    - verticalpodautoscalercontrollers.autoscaling.openshift.io
+    - verticalpodautoscalers.autoscaling.k8s.io
 
 # Leave this as the last task in the playbook.
 - name: remove_workload tasks complete

--- a/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_vertical_pod_autoscaler/tasks/workload.yml
@@ -1,0 +1,47 @@
+---
+# Implement your Workload deployment tasks here
+
+- name: Setting up workload for user
+  debug:
+    msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
+
+- name: Install Operator
+  include_role:
+    name: install_operator
+  vars:
+    install_operator_action: install
+    install_operator_name: verticalpodautoscaler
+    install_operator_namespace: openshift-vertical-pod-autoscaler
+    install_operator_manage_namespaces:
+    - openshift-vertical-pod-autoscaler
+    install_operator_channel: "{{ ocp4_workload_vertical_pod_autoscaler_channel }}"
+    install_operator_catalog: redhat-operators
+    install_operator_packagemanifest_name: vertical-pod-autoscaler
+    install_operator_automatic_install_plan_approval: "{{ ocp4_workload_vertical_pod_autoscaler_automatic_install_plan_approval }}"
+    install_operator_csv_nameprefix: verticalpodautoscaler
+    install_operator_starting_csv: "{{ ocp4_workload_vertical_pod_autoscaler_starting_csv }}"
+    install_operator_catalogsource_setup: "{{ ocp4_workload_vertical_pod_autoscaler_use_catalog_snapshot }}"
+    install_operator_catalogsource_name: "{{ ocp4_workload_vertical_pod_autoscaler_catalogsource_name }}"
+    install_operator_catalogsource_namespace: openshift-operators
+    install_operator_catalogsource_image: "{{ ocp4_workload_vertical_pod_autoscaler_catalog_snapshot_image | default('') }}"
+    install_operator_catalogsource_image_tag: "{{ ocp4_workload_vertical_pod_autoscaler_catalog_snapshot_image_tag }}"
+
+- name: Wait until VPA Pods are ready
+  k8s_info:
+    api_version: v1
+    kind: Deployment
+    namespace: openshift-vertical-pod-autoscaler
+    name: vertical-pod-autoscaler-operator
+  register: r_operator_controller_deployment
+  retries: 30
+  delay: 10
+  until:
+  - r_operator_controller_deployment.resources | length | int > 0
+  - r_operator_controller_deployment.resources[0].status.readyReplicas is defined
+  - r_operator_controller_deployment.resources[0].status.readyReplicas | int == r_operator_controller_deployment.resources[0].spec.replicas | int
+
+# Leave this as the last task in the playbook.
+- name: workload tasks complete
+  debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent|bool


### PR DESCRIPTION
##### SUMMARY

owner: jmaltin

The Vertical Pod Autoscaler (VPA) made its debut in OCP4.6.  In OCP4.8 it is now GA.

VPA is deployed via Operator, available in the redhat operator hub channels.

This implementation defaults to subscription channel '4.8'

Deploys, configures, and removes the VPA

Depends on nothing but OCP >= 4.8

##### ISSUE TYPE
- New role Pull Request

##### COMPONENT NAME
roles_ocp4_workloads/ocp4_workload_vertical_pod_autoscaler

##### ADDITIONAL INFORMATION
