### PR TITLE
AWS has ended support for python 2.7 client.

### DIFF
--- a/ansible/configs/ocp4-workshop/software.yml
+++ b/ansible/configs/ocp4-workshop/software.yml
@@ -10,7 +10,7 @@
     block:
     - name: Get awscli bundle
       get_url:
-        url: https://s3.amazonaws.com/aws-cli/awscli-bundle.zip
+        url: https://s3.amazonaws.com/aws-cli/awscli-bundle-1.18.200.zip
         dest: /tmp/awscli-bundle.zip
 
     - name: Unzip awscli-bundle.zip


### PR DESCRIPTION
##### SUMMARY
Few of the CI's were affected due to this python 2.7 end of support. Hence updating this awscli bundle to pickup the available one.

Example error we are receiving:
```
TASK [Install awscli] **********************************************************
Friday 16 July 2021  03:58:13 -0400 (0:00:03.152)       0:08:32.655 *********** 
fatal: [clientvm.tst-55d4.internal]: FAILED! => {"changed": true, "cmd": ["/tmp/awscli-bundle/install", "-i", "/usr/local/aws", "-b", "/bin/aws"], "delta": "0:00:00.040229", "end": "2021-07-16 07:58:15.331303", "msg": "non-zero return code", "rc": 1, "start": "2021-07-16 07:58:15.291074", "stderr": "Unsupported Python version detected: Python 2.7\nTo continue using this installer you must use Python 3.6 or later.\nFor more information see the following blog post: https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-python-2-7-in-aws-sdk-for-python-and-aws-cli-v1/", "stderr_lines": ["Unsupported Python version detected: Python 2.7", "To continue using this installer you must use Python 3.6 or later.", "For more information see the following blog post: https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-python-2-7-in-aws-sdk-for-python-and-aws-cli-v1/"], "stdout": "", "stdout_lines": []}
```

According to this we received today from AWS: https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-python-2-7-in-aws-sdk-for-python-and-aws-cli-v1/
```
On July 15, 2021, in order to continue supporting our customers with tools that are secure and maintainable, AWS will publish a minor version bump of the AWS Command Line Interface (AWS CLI) v1 and AWS SDK for Python (boto3 and botocore). These new versions will require a Python 3.6+ runtime, formally ending our Python 2.7 support.
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-workshop environments