### PR TITLE
Adding RHEL7 test for virtualenv change in ocp4-workload-migration

### DIFF
--- a/ansible/roles/ocp4-workload-migration/tasks/download-content.yml
+++ b/ansible/roles/ocp4-workload-migration/tasks/download-content.yml
@@ -16,6 +16,9 @@
       mode: "{{ mig_download_content_item.mode | default('u+rwx') }}"
 
   - name: Disable ansible virtualenv to install sshpass package
+    # RHEL8 uses a 3.8 python interpreter which does not have a dnf python module needed
+    # to run the installation of required packages from within current virtualenv. Need to switch
+    # to the python3 RHEL8 interpreter to avoid errors. Not switching for older RHELs.
     set_fact:
       ansible_python_interpreter: /usr/bin/python3
       __save_ansible_python_interpreter: "{{ ansible_python_interpreter }}"

--- a/ansible/roles/ocp4-workload-migration/tasks/download-content.yml
+++ b/ansible/roles/ocp4-workload-migration/tasks/download-content.yml
@@ -19,6 +19,7 @@
     set_fact:
       ansible_python_interpreter: /usr/bin/python3
       __save_ansible_python_interpreter: "{{ ansible_python_interpreter }}"
+    when: "{{ hostvars[groups.bastions.0].ansible_distribution_major_version is version('8', '>=') }}"
 
   - name: "Install packages needed for prepare_station.sh and bookbag"
     package:
@@ -30,5 +31,6 @@
   - name: Reenable ansible virtualenv
     set_fact:
       ansible_python_interpreter: "{{ __save_ansible_python_interpreter }}"
+    when: "{{ hostvars[groups.bastions.0].ansible_distribution_major_version is version('8', '>=') }}"
 
   become: true


### PR DESCRIPTION

##### SUMMARY

The change of virtualenv to python3 in download-content.yaml causes some tests to fail on RHEL7.
Since this virtual environment has to be enabled for RHEL8, a check is added before the virtualenv change/restore.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ocp4-workload-migration, download-content.yaml file 


