### PR TITLE
UPDATE roles/host-ocp4-installer -- adding Tigera Calico support

### DIFF
--- a/ansible/configs/ocp4-cluster/default_vars.yml
+++ b/ansible/configs/ocp4-cluster/default_vars.yml
@@ -115,10 +115,13 @@ ocp4_installer_root_url: http://d3s3zqyaz8cp2d.cloudfront.net/pub/openshift-v4/c
 
 ocp4_base_domain: "example.opentlc.com"
 
-# Network Plugin for OpenShift:
+# Red Hat Network Plugins for OpenShift:
 # - OpenshiftSDN
-# - OVNKubernetes
-# OVNKubernetes requires OCP 4.6 and newer
+# - OVNKubernetes (requires OCP 4.6 and newer)
+#
+# Third Party Network Plugins for OpenShift
+# - Calico (tested on OCP 4.7)
+#
 ocp4_network_type: OpenshiftSDN
 
 # Install the workaround for OVN deployments. Only for 4.6+

--- a/ansible/roles/host-ocp4-installer/create-manifests.yml
+++ b/ansible/roles/host-ocp4-installer/create-manifests.yml
@@ -26,3 +26,49 @@
     dest: "/home/{{ ansible_user }}/{{ cluster_name }}/manifests/99-scsi-device-detection-machineconfig.yml"
     owner: "{{ ansible_user }}"
     mode: ug=rw,o=
+
+# Tigera Calico is an alternative CNI to OpenShiftSDN or OVNKubernetes
+# This downloads all the extra manifests which are maintained by Tigera
+- name: Download Project Calico Manifests
+  when: ocp4_network_type|default("OpenshiftSDN") == "Calico"
+  get_url:
+    url: "{{ item }}"
+    dest: "/home/{{ ansible_user }}/{{ cluster_name }}/manifests/"
+    mode: 0644
+  loop:
+    - https://docs.projectcalico.org/manifests/ocp/crds/01-crd-installation.yaml
+    - https://docs.projectcalico.org/manifests/ocp/crds/01-crd-imageset.yaml
+    - https://docs.projectcalico.org/manifests/ocp/crds/01-crd-tigerastatus.yaml
+    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_bgpconfigurations.yaml
+    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_bgppeers.yaml
+    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_blockaffinities.yaml
+    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_clusterinformations.yaml
+    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_felixconfigurations.yaml
+    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_globalnetworkpolicies.yaml
+    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_globalnetworksets.yaml
+    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_hostendpoints.yaml
+    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_ipamblocks.yaml
+    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_ipamconfigs.yaml
+    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_ipamhandles.yaml
+    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_ippools.yaml
+    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_kubecontrollersconfigurations.yaml
+    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_networkpolicies.yaml
+    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_networksets.yaml
+    - https://docs.projectcalico.org/manifests/ocp/tigera-operator/00-namespace-tigera-operator.yaml
+    - https://docs.projectcalico.org/manifests/ocp/tigera-operator/02-rolebinding-tigera-operator.yaml
+    - https://docs.projectcalico.org/manifests/ocp/tigera-operator/02-role-tigera-operator.yaml
+    - https://docs.projectcalico.org/manifests/ocp/tigera-operator/02-serviceaccount-tigera-operator.yaml
+    - https://docs.projectcalico.org/manifests/ocp/tigera-operator/02-configmap-calico-resources.yaml
+    - https://docs.projectcalico.org/manifests/ocp/tigera-operator/02-tigera-operator.yaml
+  retries: 3
+  delay: 3
+  register: result
+  until: result is not failed
+
+- name: Create Project Calico CR to enable VXLAN
+  when: ocp4_network_type|default("OpenshiftSDN") == "Calico"
+  template:
+    src: "templates/calico-01-cr-installation.yaml.j2"
+    dest: "/home/{{ ansible_user }}/{{ cluster_name }}/manifests/01-cr-installation.yaml"
+    owner: "{{ ansible_user }}"
+    mode: 0644

--- a/ansible/roles/host-ocp4-installer/templates/calico-01-cr-installation.yaml.j2
+++ b/ansible/roles/host-ocp4-installer/templates/calico-01-cr-installation.yaml.j2
@@ -1,0 +1,14 @@
+apiVersion: operator.tigera.io/v1
+kind: Installation
+metadata:
+  name: default
+spec:
+  variant: Calico
+  calicoNetwork:
+    bgp: Disabled
+    ipPools:
+    - blockSize: 26
+      cidr: 10.128.0.0/14
+      encapsulation: VXLAN
+      natOutgoing: Enabled
+      nodeSelector: all()

--- a/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
+++ b/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
@@ -86,6 +86,8 @@ networking:
   - {{ ocp_service_network | default('172.30.0.0/16') }}
 {% if ocp4_network_type | default("OpenshiftSDN") is match("OVNKubernetes") %}
   networkType: OVNKubernetes
+{% elif ocp4_network_type | default("OpenshiftSDN") is match("Calico") %}
+  networkType: Calico
 {% else %}
   networkType: OpenshiftSDN
 {% endif %}


### PR DESCRIPTION
##### SUMMARY
Adding support for Calico as a networking provider during ocp4-cluster provisioning

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
roles/host-ocp4-installer -- added support for Calico being added to the manifests
configs/ocp4-cluster -- Only default_vars.yaml

##### ADDITIONAL INFORMATION
This is tested on OpenShift 4.7.15+, not earlier versions