### PR TITLE
Enahnce control-user to allow ssh via random generated passwd

### DIFF
--- a/ansible/roles/control-user/tasks/create-user.yml
+++ b/ansible/roles/control-user/tasks/create-user.yml
@@ -6,7 +6,7 @@
     group: "{{ control_user_private_group }}"
     append: "{{ control_user_groups_append | default(true) }}"
     groups: "{{ control_user_groups | default(omit) }}"
-    password: "{{ control_user_password | default(omit) }}"
+    password: "{{ control_user_password | password_hash('sha512') | default(omit) }}"
     update_password: "{{ contole_user_password_update | default(omit) }}"
     state: present
 

--- a/ansible/roles/control-user/tasks/ssh-config.yml
+++ b/ansible/roles/control-user/tasks/ssh-config.yml
@@ -64,7 +64,4 @@
     name: sshd
     state: restarted
 
-
-
-
 ...

--- a/ansible/roles/control-user/tasks/ssh-config.yml
+++ b/ansible/roles/control-user/tasks/ssh-config.yml
@@ -46,4 +46,25 @@
     group: "{{ control_user_private_group }}"
     mode: 0400
   when: control_user_ssh_config is defined
+
+- name: Enable password ssh authentication
+  lineinfile:
+    line: PasswordAuthentication yes
+    regexp: '^ *PasswordAuthentication'
+    path: /etc/ssh/sshd_config
+
+- name: Disable root password ssh authentication
+  lineinfile:
+    line: PermitRootLogin without-password
+    regexp: '^ *PermitRootLogin'
+    path: /etc/ssh/sshd_config
+
+- name: Restart sshd to read conf changes
+  service:
+    name: sshd
+    state: restarted
+
+
+
+
 ...


### PR DESCRIPTION

##### SUMMARY

Simply allows the control node user to directly ssh to control (aka bastion) via a randomly generated password

Can be **optionally** activated to avoid the pattern `ssh student@bastion...; sudo su - devops`

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME

role: control-user

##### ADDITIONAL INFORMATION

