### PR TITLE
Add UPDATE_COMPLETE as a valid Cloudformation status for ocp4-workshop destroy

### DIFF
--- a/ansible/configs/ocp4-workshop/destroy_env.yml
+++ b/ansible/configs/ocp4-workshop/destroy_env.yml
@@ -390,4 +390,5 @@
       when:
         # delete stack if stack creation failed
         - stack_status is defined
-        - stack_status != 'CREATE_COMPLETE' or stack_status != 'UPDATE_COMPLETE'
+        - stack_status != 'CREATE_COMPLETE'
+        - stack_status != 'UPDATE_COMPLETE'

--- a/ansible/configs/ocp4-workshop/destroy_env.yml
+++ b/ansible/configs/ocp4-workshop/destroy_env.yml
@@ -30,7 +30,7 @@
             stack_status: >-
               {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.stack_status }}
 
-        - when: stack_status == "CREATE_COMPLETE"
+        - when: stack_status == "CREATE_COMPLETE" or stack_status == "UPDATE_COMPLETE"
           block:
             - name: Grab student user
               set_fact:
@@ -80,7 +80,7 @@
   tasks:
     - when:
         - stack_status is defined
-        - stack_status == 'CREATE_COMPLETE'
+        - stack_status == "CREATE_COMPLETE" or stack_status == "UPDATE_COMPLETE"
       block:
         - set_fact:
             clientvm_id: "{{ hostvars[groups.bastions[0]].instance_id }}"
@@ -95,7 +95,7 @@
 
         - when:
             - stack_status is defined
-            - stack_status == 'CREATE_COMPLETE'
+            - stack_status == "CREATE_COMPLETE" or stack_status == "UPDATE_COMPLETE"
           block:
             - name: Start clientVM instance
               command: "aws ec2 start-instances --instance-ids '{{clientvm_id}}'"
@@ -174,7 +174,8 @@
   tasks:
     - when:
         - hostvars.localhost.stack_status is defined
-        - hostvars.localhost.stack_status == 'CREATE_COMPLETE'
+        - hostvars.localhost.stack_status == 'CREATE_COMPLETE' or
+          hostvars.localhost.stack_status == 'UPDATE_COMPLETE'
       block:
         - name: Set facts for remote access
           set_fact:
@@ -378,7 +379,7 @@
       when:
         # Before deleting the provisioner, make sure destroy terraform successfully run.
         - stack_status is defined
-        - stack_status == 'CREATE_COMPLETE'
+        - stack_status == 'CREATE_COMPLETE' or stack_status == 'UPDATE_COMPLETE'
         - "'bastions' in groups"
         - groups.bastions | length > 0
         - hostvars[groups.bastions[0]].oktodelete
@@ -389,4 +390,4 @@
       when:
         # delete stack if stack creation failed
         - stack_status is defined
-        - stack_status != 'CREATE_COMPLETE'
+        - stack_status != 'CREATE_COMPLETE' or stack_status != 'UPDATE_COMPLETE'


### PR DESCRIPTION


<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-workshop

##### ADDITIONAL INFORMATION
There are various reasons why ocp4-workshop's underlying Cloudformation stack might end up in `UPDATE_COMPLETE` rather than simply `CREATE_COMPLETE` and is a common reason to need to manually clean up resources created by the Openshift installer.

This will help a common situation where the Cloudformation resources get cleaned up but the Openshift environment gets left behind.
