### PR TITLE
config ansible-multi-node user_info enhancement

### DIFF
--- a/ansible/configs/ansible-multi-node/post_software.yml
+++ b/ansible/configs/ansible-multi-node/post_software.yml
@@ -53,7 +53,7 @@
           {% endif %}
 
           To Access Control node via SSH:
-          ssh {{ student_name }}@{{ groups['bastions'][0] | regex_replace('\\..*$') }}.{{ guid }}{{ agnosticd_domain_name }}
+          ssh {{ control_user_name }}@{{ groups['bastions'][0] | regex_replace('\\..*$') }}.{{ guid }}{{ agnosticd_domain_name }}
           Enter ssh password when prompted: {{ student_password }}
 
     - name: Set visual studio code agnosticd_user_info data
@@ -82,7 +82,7 @@
     - name: Set agnosticd_user_info ssh data
       agnosticd_user_info:
         data: 
-          ssh_command: "ssh {{ student_name }}@{{ groups['bastions'][0] | regex_replace('\\..*$') }}.{{ guid }}{{ agnosticd_domain_name }}"
+          ssh_command: "ssh {{ control_user_name }}@{{ groups['bastions'][0] | regex_replace('\\..*$') }}.{{ guid }}{{ agnosticd_domain_name }}"
           ssh_password: "{{ student_password }}"
 
     - name: Deploy Bookbag

--- a/ansible/configs/ansible-multi-node/post_software.yml
+++ b/ansible/configs/ansible-multi-node/post_software.yml
@@ -28,62 +28,98 @@
             {{ subdomain_base_suffix }}
           {% endif %}
 
-    - name: Output user_info for osp or ec2 based deploys
-      agnosticd_user_info:
-        msg: |
-          {% if install_vscode_server is sameas true %}
-            To Access VScode UI via browser:
-            VScode UI URL: https://{{ groups['bastions'][0] | regex_replace('\\..*$') }}.{{ guid }}{{ agnosticd_domain_name }}
-            VScode UI Password: {{ vscode_user_password | default('password_not_set') }}
-
-          {% endif %}
-          {% if  automationcontroller_install is sameas true %}
-            To Access Ansible controller console via browser:
-            Ansible controller URL: https://{{ groups['automationcontroller'][0] | regex_replace('\\..*$') }}.{{ guid }}{{ agnosticd_domain_name }}
-            Ansible controller Username: {{ automationcontroller_admin_user }}
-            Ansible controller Admin Password: {{ automationcontroller_admin_password }}
-
-          {% endif %}
-          {% if hands_on_aap2 is sameas true %}
-            Your Ansible automation controller console will be at:
-            automationcontroller_url: "https://{{ groups['automationcontroller'][0] | regex_replace('\\..*$') }}.{{ guid }}{{ agnosticd_domain_name }}"
-            Note: You need to install it before you can access it
-            Ansible controller Username: Set by user during lab
-            Ansible controller Admin Password: Set by user during lab
-          {% endif %}
-
-          To Access Control node via SSH:
-          ssh {{ control_user_name }}@{{ groups['bastions'][0] | regex_replace('\\..*$') }}.{{ guid }}{{ agnosticd_domain_name }}
-          Enter ssh password when prompted: {{ student_password }}
-
     - name: Set visual studio code agnosticd_user_info data
       when: install_vscode_server | default(false) | bool
-      agnosticd_user_info:
-        data: 
-          vscode_ui_url: "https://{{ groups['bastions'][0] | regex_replace('\\..*$') }}.{{ guid }}{{ agnosticd_domain_name }}"
-          vscode_ui_password: "{{ vscode_user_password }}"
+      block:
 
-    - name: Set agnosticd_user_info automationcontroller data
+        - name: Visual Studio Code Users user_info
+          agnosticd_user_info:
+            msg: "{{ __user_info }}"
+          loop:
+            - "To Access VScode UI via browser:"
+            - "VScode UI URL: https://{{ groups['bastions'][0] | regex_replace('\\..*$') }}.{{ guid }}{{ agnosticd_domain_name }}"
+            - "VScode UI Password: {{ vscode_user_password | default('password_not_set') }}"
+            - ""
+          loop_control:
+            loop_var: __user_info
+
+        - name: Visual Studio Code Users user_info data
+          agnosticd_user_info:
+            data: 
+              vscode_ui_url: "https://{{ groups['bastions'][0] | regex_replace('\\..*$') }}.{{ guid }}{{ agnosticd_domain_name }}"
+              vscode_ui_password: "{{ vscode_user_password }}"
+
+    - name: Set installed automation controller agnosticd_user_info data
       when: automationcontroller_install | default(false) | bool
-      agnosticd_user_info:
-        data: 
-          automationcontroller_url: "https://{{ groups['automationcontroller'][0] | regex_replace('\\..*$') }}.{{ guid }}{{ agnosticd_domain_name }}"
-          automationcontroller_admin_user: "{{ automationcontroller_admin_user }}"
-          automationcontroller_admin_password: "{{ automationcontroller_admin_password }}"
+      block:
 
-    - name: Set agnosticd_user_info automationcontroller Hands on data
+        - name: Set installed ansible automation controller user_info
+          agnosticd_user_info:
+            msg: "{{ __user_info }}"
+          loop:
+            - "To Access Ansible controller console via browser:"
+            - "Ansible controller URL: https://{{ groups['automationcontroller'][0] | regex_replace('\\..*$') }}.{{ guid }}{{ agnosticd_domain_name }}"
+            - "Ansible controller Username: {{ automationcontroller_admin_user }}"
+            - "Ansible controller Admin Password: {{ automationcontroller_admin_password }}"
+            - ""
+          loop_control:
+            loop_var: __user_info
+
+        - name: Set installed ansible automation controller user_info data
+          agnosticd_user_info:
+            data: 
+              automationcontroller_url: "https://{{ groups['automationcontroller'][0] | regex_replace('\\..*$') }}.{{ guid }}{{ agnosticd_domain_name }}"
+              automationcontroller_admin_user: "{{ automationcontroller_admin_user }}"
+              automationcontroller_admin_password: "{{ automationcontroller_admin_password }}"
+
+    - name: Set hands_on_aap2 agnosticd_user_info data
       when: hands_on_aap2 | default(false) | bool
-      agnosticd_user_info:
-        data: 
-          automationcontroller_url: "https://{{ groups['automationcontroller'][0] | regex_replace('\\..*$') }}.{{ guid }}{{ agnosticd_domain_name }}"
-          automationcontroller_admin_user: Set by user during lab
-          automationcontroller_admin_password: Set by user during lab
+      block:
 
-    - name: Set agnosticd_user_info ssh data
-      agnosticd_user_info:
-        data: 
-          ssh_command: "ssh {{ control_user_name }}@{{ groups['bastions'][0] | regex_replace('\\..*$') }}.{{ guid }}{{ agnosticd_domain_name }}"
-          ssh_password: "{{ student_password }}"
+        - name: Set fact for ac controller url
+          set_fact:
+            f_ac_url: "https://{{ groups['automationcontroller'][0] | regex_replace('\\..*$') }}.{{ guid }}{{ agnosticd_domain_name }}"
+
+        - name: Set hands_on_aap2 ansible automation controller user_info
+          agnosticd_user_info:
+            msg: "{{ __user_info }}"
+          loop:
+            - "Your Ansible automation controller console will be at:"
+            - "https://{{ groups['automationcontroller'][0] | regex_replace('\\..*$') }}.{{ guid }}{{ agnosticd_domain_name }}"
+            - "automationcontroller_url: {{ f_ac_url }}"
+            - "Note: You need to install it before you can access it"
+            - "Ansible controller Username: Set by user during lab"
+            - "Ansible controller Admin Password: Set by user during lab"
+            - ""
+          loop_control:
+            loop_var: __user_info
+
+        - name: Set agnosticd_user_info automationcontroller Hands on data
+          agnosticd_user_info:
+            data: 
+              automationcontroller_url: "{{ f_ac_url }}"
+              automationcontroller_admin_user: Set by user during lab
+              automationcontroller_admin_password: Set by user during lab
+
+    - name: Output ssh user_info for osp or ec2 based deploys
+      block:
+
+        - name: Set ssh user_info
+          agnosticd_user_info:
+            msg: "{{ __user_info }}"
+          loop:
+            - "To Access Control node via SSH:"
+            - "ssh {{ student_name }}@{{ groups['bastions'][0] | regex_replace('\\..*$') }}.{{ guid }}{{ agnosticd_domain_name }}"
+            - "Enter ssh password when prompted: {{ student_password }}"
+            - ""
+          loop_control:
+            loop_var: __user_info
+
+        - name: Set agnosticd_user_info ssh data
+          agnosticd_user_info:
+            data: 
+              ssh_command: "ssh {{ student_name }}@{{ groups['bastions'][0] | regex_replace('\\..*$') }}.{{ guid }}{{ agnosticd_domain_name }}"
+              ssh_password: "{{ student_password }}"
 
     - name: Deploy Bookbag
       when: bookbag_git_repo is defined


### PR DESCRIPTION

##### SUMMARY

CF's ruby script doesn't acknowledge \n from Jinja templates
Reverted to calling agnostic_user_info via loop to clean up the user email

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
config ansible-multi-node 

##### ADDITIONAL INFORMATION
