### PR TITLE
Update ocp4-workload-jdg-workshop for enabling CRW login

### DIFF
--- a/ansible/roles/ocp4-workload-jdg-workshop/templates/devfile.json.j2
+++ b/ansible/roles/ocp4-workload-jdg-workshop/templates/devfile.json.j2
@@ -53,7 +53,7 @@
         {
           "type": "exec",
           "component": "quarkus-tools",
-          "command": "oc login https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT --insecure-skip-tls-verify=true",
+          "command": "oc login https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT --insecure-skip-tls-verify=true --username={{ user }} --password={{ workshop_che_user_password }}",
           "workdir": "${CHE_PROJECTS_ROOT}"
         }
       ]


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
To enable login OpenShift via CRW Terminal in OCP 4.7+

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
