### PR TITLE
FIX: gitea operator -- Set gitea CR string defaults to non-null

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/templates/gitea.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/templates/gitea.yaml.j2
@@ -7,16 +7,16 @@ spec:
   giteaImage: {{ ocp4_workload_gitea_operator_gitea_image }}
   giteaImageTag: {{ ocp4_workload_gitea_operator_gitea_image_tag }}
   giteaVolumeSize: {{ ocp4_workload_gitea_operator_gitea_volume_size }}
-  giteaVolumeStorageClass: {{ ocp4_workload_gitea_operator_gitea_volume_storage_class }}
+  giteaVolumeStorageClass: "{{ ocp4_workload_gitea_operator_gitea_volume_storage_class }}"
   postgresqlVolumeSize: {{ ocp4_workload_gitea_operator_postgresql_volume_size }}
-  postgresqlVolumeStorageClass: {{ ocp4_workload_gitea_operator_postgresql_volume_storage_class }}
+  postgresqlVolumeStorageClass: "{{ ocp4_workload_gitea_operator_postgresql_volume_storage_class }}"
   giteaSsl: {{ ocp4_workload_gitea_operator_ssl_route | bool }}
 {% if _ocp4_workload_gitea_operator_gitea_hostname | default("") | length > 0 %}  
   giteaRoute: {{ _ocp4_workload_gitea_operator_gitea_hostname }}
 {% endif %}
 {% if ocp4_workload_gitea_operator_create_admin | bool %}
   giteaAdminUser: {{ ocp4_workload_gitea_operator_admin_user }}
-  giteaAdminPassword: {{ ocp4_workload_gitea_operator_admin_password }}
+  giteaAdminPassword: "{{ ocp4_workload_gitea_operator_admin_password }}"
   giteaAdminPasswordLength: "{{ ocp4_workload_gitea_operator_admin_password_length }}"
   giteaAdminEmail: {{ ocp4_workload_gitea_operator_admin_email }}
 {% endif %}


### PR DESCRIPTION
##### SUMMARY
Fixes an issue where gitea would fail to the create the gitea CR due to
null values when the default value ('') for the ansible vars below was used

* ocp4_workload_gitea_operator_gitea_volume_storage_class
* ocp4_workload_gitea_operator_gitea_volume_size
* ocp4_workload_gitea_operator_admin_password

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
`roles_ocp_workloads/ocp4_workload_gitea_operator`

##### ADDITIONAL INFORMATION
Ansible output error is 
`"msg": "Failed to create object: b'{"kind":"Status","apiVersion":"v1","metadata": },"status":"Failure","message":"Gitea.gpte.opentlc.com "gitea" is invalid:`
with failures for `XXXX: Invalid value:  null: XXXX in body must be of type string`
for each all of the Gitea CR entries below
```
spec.giteaAdminPassword
spec.giteaVolumeStorageClass
spec.postgresqlVolumeStorageClass
```