### PR TITLE
Add bookbag_deploy control to test-empty-config

### DIFF
--- a/ansible/configs/test-empty-config/default_vars.yml
+++ b/ansible/configs/test-empty-config/default_vars.yml
@@ -1,2 +1,6 @@
 ---
+# To use bookbag, bookbag_deploy must be true and a value must be provided for
+# bookbag_git_repo
+bookbag_deploy: false
+#bookbag_git_repo: https://github.com/redhat-gpte-labs/bookbag-template.git
 ...

--- a/ansible/configs/test-empty-config/post_software.yml
+++ b/ansible/configs/test-empty-config/post_software.yml
@@ -65,7 +65,8 @@
 
   - name: Deploy Bookbag
     when:
-    - bookbag_git_repo is defined
+    - bookbag_deploy | default(false) | bool
+    - bookbag_git_repo | default('') != ''
     include_role:
       name: bookbag
     vars:


### PR DESCRIPTION
##### SUMMARY

Add control for bookbag deploy to test-empty-config. This allows a default value for the bookbag_repo without triggering deploys by having the default defined in AgnosticV.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Config test-empty-config