### PR TITLE
Add save OpenStack project info as user data

### DIFF
--- a/ansible/configs/osp-migration/infra.yml
+++ b/ansible/configs/osp-migration/infra.yml
@@ -51,6 +51,13 @@
           project_api_pass: "{{ osp_migration_api_pass }}"
           blueprint: "{{ project }}"
 
+    - name: Set OpenStack project information in provision data
+      agnosticd_user_info:
+        data:
+          osp_cluster_api: >-
+            {{ osp_auth_url | regex_replace('(://[^/]+).*', '\1') }}
+          osp_project_name: "{{ osp_project_name }}"
+
     # when deleting we need to be able to authenticate using that project
     - name: Grant access to admin account to the new project
       environment:

--- a/ansible/roles-infra/infra-osp-project-create/tasks/main.yml
+++ b/ansible/roles-infra/infra-osp-project-create/tasks/main.yml
@@ -74,6 +74,15 @@
         enabled: true
         domain_id: "Default"
         endpoint_type: public
+      register: r_osp_project
+
+    - name: Set OpenStack project information in provision data
+      agnosticd_user_info:
+        data:
+          osp_cluster_api: >-
+            {{ osp_auth_url | regex_replace('(://[^/]+).*', '\1') }}
+          osp_project_id: "{{ r_osp_project.project.id }}"
+          osp_project_name: "{{ r_osp_project.project.name }}"
 
     - name: Set guid and uuid tags on project
       command: >-


### PR DESCRIPTION
##### SUMMARY

Use `agnosticd_user_info` to save the OpenStack API as well as project id and name that was used for the provision. This is useful for automation to locate the project later to implement features such as console access.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Role infra-osp-project-create
Config osp-migration