### PR TITLE
Set output_dir for migration host in osp-migration

### DIFF
--- a/ansible/configs/osp-migration/pre_infra.yml
+++ b/ansible/configs/osp-migration/pre_infra.yml
@@ -11,23 +11,13 @@
   - name: Create migration host group
     add_host:
       name: "{{ import_host }}"
-      group: "migration"
-      bastion: "{{ import_host }}"
-      ansible_user: "opentlc-mgr"
-      remote_user: "opentlc-mgr"
       ansible_become: true
-    when: migration_key_path is not defined
-
-  - name: Create migration host group
-    add_host:
-      name: "{{ import_host }}"
-      group: "migration"
-      bastion: "{{ import_host }}"
+      ansible_ssh_private_key_file: "{{ migration_key_path | default(omit) }}"
       ansible_user: "opentlc-mgr"
+      bastion: "{{ import_host }}"
+      group: "migration"
+      output_dir: "{{ output_dir }}"
       remote_user: "opentlc-mgr"
-      ansible_become: true
-      ansible_ssh_private_key_file: "{{ migration_key_path }}"
-    when: migration_key_path is defined
 
 - name: Step 001 Migrating blueprints
   hosts: migration


### PR DESCRIPTION
##### SUMMARY

The osp-migration config migration host group `add_host` command requires `output_dir` to be set.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Config osp-migration