### PR TITLE
CHANGE: roles-infra/infra-azure-ssh-key

### DIFF
--- a/ansible/roles-infra/infra-azure-ssh-key/tasks/main.yml
+++ b/ansible/roles-infra/infra-azure-ssh-key/tasks/main.yml
@@ -20,6 +20,10 @@
   set_fact:
     infra_ssh_key: "{{ output_dir }}/{{ env_authorized_key }}"
 
+- name: Set name of the key
+  set_fact:
+    az_ssh_key_name: '{{ guid[:12] | regex_replace("-","0") }}'
+
 - name: Stat local infra key
   stat:
     path: "{{ infra_ssh_key }}"
@@ -38,7 +42,7 @@
       command: >
         az keyvault secret show
         --vault-name '{{ az_ssh_keyvault }}'
-        --name '{{guid[:12]}}'
+        --name '{{ az_ssh_key_name }}'
         --query value -o tsv
       register: r_ssh_key
       failed_when:
@@ -73,5 +77,5 @@
       command: >
           az keyvault secret set
           --vault-name '{{ az_ssh_keyvault }}'
-          --name '{{guid[:12]}}'
+          --name '{{ az_ssh_key_name }}'
           --file '{{ infra_ssh_key }}'


### PR DESCRIPTION
##### SUMMARY

Occasional errors with key vaults and names containing multiple dashes in a row, this is the easiest way to fix that.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
roles-infra/infra-azure-ssh-key/tasks/main.yml

##### ADDITIONAL INFORMATION
There could be more elegant ways to do this, but this will work.