### PR TITLE
Change reporting of OpenStack user data

### DIFF
--- a/ansible/configs/osp-migration/env_vars.yml
+++ b/ansible/configs/osp-migration/env_vars.yml
@@ -110,6 +110,11 @@ osp_cluster_dns_zone: blue.osp.opentlc.com
 # NOTE: This is only applicable when {{ use_dynamic_dns}} is true
 osp_cluster_dns_server: ddns01.opentlc.com
 
+# Configuration to control whether to report user info for the lab console.
+# This should be disabled for babylon deployment.
+osp_migration_report_labconsole: true
+osp_migration_labconsole_apps_domain: apps.shared-na4.na4.openshift.opentlc.com
+
 # Whether to wait for an ack from the DNS servers before continuing
 wait_for_dns: true
 

--- a/ansible/configs/osp-migration/infra.yml
+++ b/ansible/configs/osp-migration/infra.yml
@@ -54,9 +54,10 @@
     - name: Set OpenStack project information in provision data
       agnosticd_user_info:
         data:
-          osp_cluster_api: >-
-            {{ osp_auth_url | regex_replace('(://[^/]+).*', '\1') }}
-          osp_project_name: "{{ osp_project_name }}"
+          openstack_auth_url: "{{ osp_auth_url }}"
+          openstack_project_name: "{{ osp_project_name }}"
+          openstack_username: "{{ guid }}"
+          openstack_password: "{{ osp_migration_api_pass }}"
 
     # when deleting we need to be able to authenticate using that project
     - name: Grant access to admin account to the new project

--- a/ansible/configs/osp-migration/post_software.yml
+++ b/ansible/configs/osp-migration/post_software.yml
@@ -5,12 +5,13 @@
   gather_facts: false
   tasks:
     - name: Print labconsole information as user.info
+      when: osp_migration_report_labconsole | bool
       agnosticd_user_info:
         msg: "{{ item }}"
-      with_items:
+      loop:
         - ""
         - "In case you need to access to the console of the VMs for your lab:"
-        - "URL: https://{{ osp_cluster_dns_zone.split('.')[0] }}-labconsole.apps.shared-na4.na4.openshift.opentlc.com/"
+        - "URL: https://{{ osp_cluster_dns_zone.split('.')[0] }}-labconsole.{{ osp_migration_labconsole_apps_domain }}/"
         - "Username: {{ student_name }}"
         - "Password: *your opentlc password*"
 
@@ -24,10 +25,6 @@
     - name: Save user info
       agnosticd_user_info:
         data:
-          bookbag_os_auth_url: "{{ osp_auth_url }}"
-          bookbag_os_username: "{{ guid }}"
-          bookbag_os_password: "{{ osp_migration_api_pass }}"
-          bookbag_os_project_name: "{{ osp_project_name }}"
           student_ssh_password: >-
             {{ student_password | default(hostvars[groups.bastions.0].student_password) }}
           student_ssh_command: >-

--- a/ansible/roles-infra/infra-osp-project-create/defaults/main.yaml
+++ b/ansible/roles-infra/infra-osp-project-create/defaults/main.yaml
@@ -15,6 +15,9 @@ osp_create_sandbox: false
 # subnet for the floating IPs.
 osp_find_public_subnet: false
 
+# Set this to true to report generated project username and password
+osp_report_project_credentials: false
+
 # If osp_project_create is set to yes, define those:
 # Quotas to set for new project that is created
 quota_num_instances: 15

--- a/ansible/roles-infra/infra-osp-project-create/tasks/main.yml
+++ b/ansible/roles-infra/infra-osp-project-create/tasks/main.yml
@@ -79,10 +79,16 @@
     - name: Set OpenStack project information in provision data
       agnosticd_user_info:
         data:
-          osp_cluster_api: >-
-            {{ osp_auth_url | regex_replace('(://[^/]+).*', '\1') }}
-          osp_project_id: "{{ r_osp_project.project.id }}"
-          osp_project_name: "{{ r_osp_project.project.name }}"
+          openstack_auth_url: "{{ osp_auth_url }}"
+          openstack_project_id: "{{ r_osp_project.project.id }}"
+          openstack_project_name: "{{ r_osp_project.project.name }}"
+
+    - name: Set OpenStack project information in provision data
+      when: osp_report_project_credentials | bool
+      agnosticd_user_info:
+        data:
+          openstack_username: "{{ osp_auth_username_member }}"
+          openstack_password: "{{ osp_auth_password_member }}"
 
     - name: Set guid and uuid tags on project
       command: >-


### PR DESCRIPTION
##### SUMMARY

Change reporting of OpenStack user data to set `openstack_` prefix rather than `osp_`. This data will be visible to the end user in the new catalog user interface so we should avoid use of abbreviations that make it less obvious for the user.

This PR also introduces `osp_report_project_credentials` to allow configuration of whether project credentials should be reported to the end user.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Config osp-migration
Role infra-osp-project-create