### PR TITLE
Update RHACM workload defaults to 2.3

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm/defaults/main.yml
@@ -4,8 +4,8 @@ ocp_username: opentlc-mgr
 silent: false
 
 ocp4_workload_rhacm_acm_project: "open-cluster-management"
-ocp4_workload_rhacm_acm_release: "release-2.0"
-ocp4_workload_rhacm_acm_csv: "advanced-cluster-management.v2.0.3"
-ocp4_workload_rhacm_catalog_source_image: "quay.io/gpte-devops-automation/olm_snapshot_acm_redhat_catalog"
-ocp4_workload_rhacm_catalog_source_tag: "v4.5_2020_09_25"
+ocp4_workload_rhacm_acm_release: "release-2.3"
+ocp4_workload_rhacm_acm_csv: "advanced-cluster-management.v2.3.1"
+ocp4_workload_rhacm_catalog_source_image: "quay.io/gpte-devops-automation/olm_snapshot_redhat_catalog"
+ocp4_workload_rhacm_catalog_source_tag: "v4.8_2021_08_09"
 ocp4_workload_rhacm_use_catalog_snapshot: false


### PR DESCRIPTION
##### SUMMARY

Update defaults of ACM workshop role to 2.3.1

Updated vars, `acm-release` `acm-csv` `catalog_source_image` `source_tag`

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_rhacm

##### ADDITIONAL INFORMATION
ACM 2.3.1 is now GA, this change defaults acm role to 2.3.1
