### PR TITLE
Increase SonarQube Memory Limits

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_dso/tasks/sonarqube.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_dso/tasks/sonarqube.yml
@@ -11,14 +11,14 @@
 - name: deploy sonarqube from template (persistent)
   shell: |
     {{ ocp4_dso_openshift_cli }} new-app -f {{ ocp4_dso_tmp_dir }}/sonarqube-persistent-template.yml \
-        --param=SONARQUBE_MEMORY_LIMIT=2Gi \
+        --param=SONARQUBE_MEMORY_LIMIT=4Gi \
         -n {{ ocp4_admin_project }}
   when: not ocp4_dso_ephemeral|bool
 
 - name: deploy sonarqube from template (ephemeral)
   shell: |
     {{ ocp4_dso_openshift_cli }} new-app -f {{ ocp4_dso_tmp_dir }}/sonarqube-template.yml \
-        --param=SONARQUBE_MEMORY_LIMIT=2Gi \
+        --param=SONARQUBE_MEMORY_LIMIT=4Gi \
         -n {{ ocp4_admin_project }}
   when: ocp4_dso_ephemeral|bool
 


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
The SonarQube memory limit was increased to 4GB. During testing, SonarQube was observed to consistently crash. When the pod restarted it was using ~ 95%  of its allocated memory. After updating the memory limit, memory usage has been consistent (~50%) without any crashes after executing multiple pipeline runs. 


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4_workload_dso (DevSecOps lab)

##### ADDITIONAL INFORMATION

