### PR TITLE
rename *secret.yaml to *scrt.yaml to avoid gitignore issue

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_hands_on_openshift_48/files/dev_coffeeshop_scrt.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_hands_on_openshift_48/files/dev_coffeeshop_scrt.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: coffee-shop
+  namespace: "dev-coffeeshop"
+stringData:
+  quarkus.datasource.db-kind: postgresql
+  quarkus.datasource.jdbc.url: jdbc:postgresql://coffee-shop-database:5432/coffeeshop
+  quarkus.datasource.password: coffee
+  quarkus.datasource.username: coffee
+type: Opaque
+

--- a/ansible/roles_ocp_workloads/ocp4_workload_hands_on_openshift_48/files/dev_coffeeshop_scrt.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_hands_on_openshift_48/files/dev_coffeeshop_scrt.yaml
@@ -9,4 +9,3 @@ stringData:
   quarkus.datasource.password: coffee
   quarkus.datasource.username: coffee
 type: Opaque
-

--- a/ansible/roles_ocp_workloads/ocp4_workload_hands_on_openshift_48/files/dev_database_scrt.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_hands_on_openshift_48/files/dev_database_scrt.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: coffee-shop-database
+  namespace: dev-coffeeshop
+stringData:
+  POSTGRESQL_DATABASE: coffeeshop
+  POSTGRESQL_PASSWORD: coffee
+  POSTGRESQL_USER: coffee

--- a/ansible/roles_ocp_workloads/ocp4_workload_hands_on_openshift_48/files/prod_database_scrt.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_hands_on_openshift_48/files/prod_database_scrt.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: coffee-shop-database
+  namespace: prod-coffeeshop
+stringData:
+  POSTGRESQL_DATABASE: coffeeshop
+  POSTGRESQL_PASSWORD: coffee
+  POSTGRESQL_USER: coffee

--- a/ansible/roles_ocp_workloads/ocp4_workload_hands_on_openshift_48/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_hands_on_openshift_48/tasks/workload.yml
@@ -85,7 +85,7 @@
     definition: "{{ lookup('file',  item ) | from_yaml }}"
   loop:
     - prod_coffeeshop_namespace.yaml
-    - prod_database_secret.yaml
+    - prod_database_scrt.yaml
     - prod_coffeeshop_role_binding_argocd_edit.yaml
     - prod_database_deployment.yaml
     - prod_database_pvc.yaml

--- a/ansible/roles_ocp_workloads/ocp4_workload_hands_on_openshift_48/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_hands_on_openshift_48/tasks/workload.yml
@@ -100,15 +100,6 @@
     - pipelines_namespace.yaml
     - pipelines_role_binding_argocd_edit.yaml
 
-# skip this?
-#- name: Configure ArgoCD
-#  k8s:
-#    state: present
-#    definition: "{{ lookup('file',  item ) | from_yaml }}"
-#  loop:
-#  - argocd_app_of_apps.yaml
-
-
 # Leave this as the last task in the playbook.
 # --------------------------------------------
 - name: workload tasks complete


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

AgnosticD global `.gitignore` file selects to ignore `*secret.yaml`, which interferes with OpenShift kind: Secret yaml manifests.

Rename my `*secret.yaml` files to `*scrt.yaml`

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

roles_ocp_workloads/ocp4_workload_hands_on_openshift_48

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
