### PR TITLE
Fix ocp-workloads config to use ansible_host in target_host

### DIFF
--- a/ansible/configs/ocp-workloads/post_infra.yml
+++ b/ansible/configs/ocp-workloads/post_infra.yml
@@ -35,7 +35,7 @@
               | default(target_host.hostname)
               | default(target_host.ansible_host)
               }}
-            ansible_host: "{{ target_host.ansible_ssh_host | default(omit) }}"
+            ansible_host: "{{ target_host.ansible_host | default(omit) }}"
             group: ocp_bastions
             ansible_user: "{{ target_host.ansible_user | default(omit) }}"
             ansible_port: "{{ target_host.ansible_port | default(omit) }}"


### PR DESCRIPTION
##### SUMMARY

Fix bug in ocp-workloads config that inconsistently references both `ansible_host` and `ansible_ssh_host` keys in `target_host` variable.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Config ocp-workloads