### PR TITLE
Fix tower_agnosticd_virtualenvs, upgrade pip and set default python

### DIFF
--- a/ansible/roles/tower_agnosticd_virtualenvs/templates/agnosticd-venv.sh.j2
+++ b/ansible/roles/tower_agnosticd_virtualenvs/templates/agnosticd-venv.sh.j2
@@ -38,6 +38,8 @@ for REQUIREMENTS in /usr/local/src/agnosticd/tools/virtualenvs/*.txt; do
       else
         $PYTHON -m virtualenv $VENV
       fi
+      # Update pip
+      $VENV/bin/pip install pip --upgrade
     fi
     $VENV/bin/pip install -r $REQUIREMENTS
   fi

--- a/ansible/roles/tower_agnosticd_virtualenvs/templates/agnosticd-venv.sh.j2
+++ b/ansible/roles/tower_agnosticd_virtualenvs/templates/agnosticd-venv.sh.j2
@@ -31,6 +31,9 @@ for REQUIREMENTS in /usr/local/src/agnosticd/tools/virtualenvs/*.txt; do
     if [[ -z "${PYTHON}" ]]; then
       PYTHON="$(head -n1 $REQUIREMENTS | sed -rn 's/^# (python[0-9]+(\.[0-9]+)).*/\1/p')"
     fi
+    if [[ -z "${PYTHON}" ]]; then
+      PYTHON=python3
+    fi
 
     if [[ ! -d $VENV ]]; then
       if [[ ${PYTHON:0:7} == "python3" ]]; then


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

###### first
The logs show:

```
You are using pip version 9.0.3, however version 21.2.4 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```

And some virtualenv fail to install:

```
   Complete output from command python setup.py egg_info:

            =============================DEBUG ASSISTANCE==========================
            If you are seeing an error here please try the following to
            successfully install cryptography:

            Upgrade to the latest pip and try again. This will fix errors for most
            users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
            =============================DEBUG ASSISTANCE==========================

    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-ux_3cts5/cryptography/setup.py", line 14, in <module>
        from setuptools_rust import RustExtension
    ModuleNotFoundError: No module named 'setuptools_rust'
```
The fix is to upgrade pip.

###### second

The creation of some virtualenvs fail with the following:

```
/usr/local/src/agnosticd/tools/virtualenvs/ibm-ansible-2.10.txt
/etc/cron.hourly/agnosticd-venv: line 39: -m: command not found
```

Set the default to python3.

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
