### PR TITLE
Fix duplicate /pub in url

### DIFF
--- a/ansible/roles/ocp-client-vm/tasks/main.yml
+++ b/ansible/roles/ocp-client-vm/tasks/main.yml
@@ -58,7 +58,7 @@
   become: yes
   when: ocp_clientvm_oc_version is version_compare('4.0', '<')
   unarchive:
-    src: "{{ ocp_clientvm_installer_root_url }}/pub/openshift-v3/clients/{{ ocp_clientvm_oc_version }}/linux/oc.tar.gz"
+    src: "{{ ocp_clientvm_installer_root_url }}/openshift-v3/clients/{{ ocp_clientvm_oc_version }}/linux/oc.tar.gz"
     remote_src: yes
     dest: /usr/local/sbin
     mode: 0775


### PR DESCRIPTION
##### SUMMARY

Error in deployer causing duplicate /pub/pub to show up in deployer and fail

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
roles/ocp-client-vm/tasks/main.yaml

##### ADDITIONAL INFORMATION
**Error message received using AgnosticD**
```
fatal: [clientvm.57cc.internal]: FAILED! => {"changed": false, "msg": "Failure downloading http://d3s3zqyaz8cp2d.cloudfront.net/pub/pub/openshift-v3/clients/3.11.154/linux/oc.tar.gz, HTTP Error 404: Not Found"}
```
