### PR TITLE
Update main.yml file

### DIFF
--- a/ansible/roles/ocp-client-vm/tasks/main.yml
+++ b/ansible/roles/ocp-client-vm/tasks/main.yml
@@ -71,7 +71,7 @@
   - name: Get the OpenShift CLI for OCP 4
     become: yes
     unarchive:
-      src: "{{ ocp_clientvm_installer_root_url }}/openshift-v4/x86_64/clients/ocp/{{ ocp_clientvm_oc_version }}/openshift-client-linux.tar.gz"
+      src: "{{ ocp_clientvm_installer_root_url }}/openshift-v4/clients/ocp/{{ ocp_clientvm_oc_version }}/openshift-client-linux.tar.gz"
       remote_src: yes
       dest: /usr/local/sbin
       mode: 0775
@@ -80,7 +80,7 @@
 
   - name: Download OpenShift Do (odo)
     get_url:
-      url: "{{ ocp_clientvm_installer_root_url }}/openshift-v4/x86_64/clients/odo/{{ ocp_clientvm_odo_version }}/odo-linux-amd64"
+      url: "{{ ocp_clientvm_installer_root_url }}/openshift-v4/clients/odo/{{ ocp_clientvm_odo_version }}/odo-linux-amd64"
       dest: /usr/local/sbin/odo
       owner: root
       group: root
@@ -91,7 +91,7 @@
 
   - name: Download OpenShift Helm 3
     get_url:
-      url: "{{ ocp_clientvm_installer_root_url }}/openshift-v4/x86_64/clients/helm/{{ ocp_clientvm_helm_version }}/helm-linux-amd64"
+      url: "{{ ocp_clientvm_installer_root_url }}/openshift-v4/clients/helm/{{ ocp_clientvm_helm_version }}/helm-linux-amd64"
       dest: /usr/local/sbin/helm
       owner: root
       group: root


### PR DESCRIPTION
Update main.yml file to remove x86_64 entry as this directory doesn't exist in the repository.
This is to resolve following fatal error.
fatal: [clientvm.0b0e.internal]: FAILED! => {"changed": false, "msg": "Failure downloading http://d3s3zqyaz8cp2d.cloudfront.net/pub/openshift-v4/x86_64/clients/ocp/4.6.0/openshift-client-linux.tar.gz, HTTP Error 404: Not Found"}