### PR TITLE
Use name `cloud_tags_final` and not cf_tags_final

### DIFF
--- a/ansible/configs/ocp4-workshop/files/install-config.yaml.j2
+++ b/ansible/configs/ocp4-workshop/files/install-config.yaml.j2
@@ -32,7 +32,7 @@ networking:
 platform:
   aws:
     region: {{ aws_region_final | default(aws_region) | to_json }}
-    userTags: {{ hostvars.localhost.cf_tags_final | default({}) | to_json }}
+    userTags: {{ hostvars.localhost.cloud_tags_final | default({}) | to_json }}
 {# ocp4_pull_secret may be either a dict (mapping) or a JSON string.       #}
 {# The install-config.yaml needs an quoted JSON string for the pullSecret. #}
 {# Passing a json string through to_json gives us the quoted string.       #}

--- a/ansible/roles/host-ocp4-installer/tasks/main.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/main.yml
@@ -102,10 +102,10 @@
       label: "{{ item.name }}"
 
   - name: Add additional metadata to instances
-    when: hostvars.localhost.cf_tags_final | default({}) | length > 0
+    when: hostvars.localhost.cloud_tags_final | default({}) | length > 0
     os_server_metadata:
       server: "{{ item.name }}"
-      meta: "{{ hostvars.localhost.cf_tags_final | default({}) | to_json }}"
+      meta: "{{ hostvars.localhost.cloud_tags_final | default({}) | to_json }}"
     loop: "{{ r_servers.openstack_servers }}"
     loop_control:
       label: "{{ item.name }}"

--- a/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
+++ b/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
@@ -95,19 +95,19 @@ platform:
 {% if cloud_provider == 'ec2' %}
   aws:
     region: {{ aws_region_final | default(aws_region) | to_json }}
-    userTags: {{ hostvars.localhost.cf_tags_final | default({}) | to_json }}
+    userTags: {{ hostvars.localhost.cloud_tags_final | default({}) | to_json }}
 {% endif %}
 {% if cloud_provider == 'azure' %}
   azure:
     region: {{ azure_region | to_json }}
     baseDomainResourceGroupName: {{ az_dnszone_resource_group | to_json }}
-    userTags: {{ hostvars.localhost.cf_tags_final | default({}) | to_json }}
+    userTags: {{ hostvars.localhost.cloud_tags_final | default({}) | to_json }}
 {% endif %}
 {% if cloud_provider == 'gcp' %}
   gcp:
     region: {{ gcp_region | to_json }}
     ProjectID: {{ gcp_project_id | to_json }}
-    userTags: {{ hostvars.localhost.cf_tags_final | default({}) | to_json }}
+    userTags: {{ hostvars.localhost.cloud_tags_final | default({}) | to_json }}
 {% endif %}
 {% if cloud_provider == 'osp' %}
   openstack:


### PR DESCRIPTION
Following up on #3930, which:
* introduced a dedicated role for tags
* removed the variable cf_tags_final in favor of cloud_tags_final.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request