### PR TITLE
Update ocp4-workload-ccn-cuttingedge to Add a task to check if CRW API is up

### DIFF
--- a/ansible/roles/ocp4-workload-ccnrd-cuttingedge/tasks/create_che_workspace.yaml
+++ b/ansible/roles/ocp4-workload-ccnrd-cuttingedge/tasks/create_che_workspace.yaml
@@ -12,7 +12,20 @@
     body_format: form-urlencoded
     status_code: 200
   register: user_token
- 
+
+- name: Wait for CRW APIs to be ready
+  uri:
+    url: "https://codeready-labs-infra.{{ route_subdomain }}/api/workspace/"
+    validate_certs: false
+    method: GET
+    headers:
+      Content-Type: application/json
+      Authorization: "Bearer {{ user_token.json.access_token }}"
+  register: r_crw_dashboard
+  until: r_crw_dashboard.status == 200
+  retries: 200
+  delay: 15
+  
 - name: Create workspace for {{ user }} from devfile
   uri:
     url: "https://codeready-labs-infra.{{ route_subdomain }}/api/workspace/devfile?start-after-create=true&namespace={{ user }}"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Add a task to check if CRW API is up
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
