### PR TITLE
Add collections to cluster

### DIFF
--- a/ansible/configs/ocp4-cluster/destroy_env_osp.yml
+++ b/ansible/configs/ocp4-cluster/destroy_env_osp.yml
@@ -1,6 +1,29 @@
 ---
 - import_playbook: ../../setup_runtime.yml
 
+# Call Remove Workloads for workloads that need to clean up "other" infrastructure.
+# Those removal playbooks need to be able to be run on the provisioning host (aka not a Bastion)
+- name: Remove workloads
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  run_once: true
+  become: false
+  tasks:
+  - name: Remove ocp workloads
+    when:
+    - remove_workloads | default("") | length > 0
+    block:
+    - name: Invoke roles to remove ocp workloads
+      include_role:
+        name: "{{ workload_loop_var }}"
+      vars:
+        ocp_username: "system:admin"
+        ACTION: "remove"
+      loop: "{{ remove_workloads }}"
+      loop_control:
+        loop_var: workload_loop_var
+
 - name: Delete environment on OpenStack
   hosts: localhost
   connection: local

--- a/ansible/configs/ocp4-cluster/requirements.yml
+++ b/ansible/configs/ocp4-cluster/requirements.yml
@@ -8,3 +8,7 @@ roles:
 collections:
 - name: kubernetes.core
   version: 1.2.0
+- name: openstack.cloud
+  version: 1.5.1
+- name: amazon.aws
+  version: 1.5.0

--- a/ansible/roles_ocp_workloads/ocp4_workload_adv_day2_ops_ilt/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_adv_day2_ops_ilt/tasks/remove_workload.yml
@@ -11,12 +11,17 @@
     fail_msg: "AWS Credentials need to be provided."
 
 - name: Destroy CloudFormation template to remove Route53 entries
-  cloudformation:
+  amazon.aws.cloudformation:
     aws_access_key: "{{ ocp4_workload_adv_dey2_ops_ilt_aws_key }}"
     aws_secret_key: "{{ ocp4_workload_adv_dey2_ops_ilt_aws_secret_key }}"
     stack_name: "{{ guid }}-m-route53"
     state: absent
     region: "{{ aws_region_loop | default(aws_region) | default(region) | default('us-east-1')}}"
+  register: r_cloudformation_out
+  until: >-
+    r_cloudformation_out is succeeded
+  retries: 3
+  delay: 30
 
 # Leave this as the last task in the playbook.
 # --------------------------------------------

--- a/ansible/roles_ocp_workloads/ocp4_workload_adv_day2_ops_ilt/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_adv_day2_ops_ilt/tasks/workload.yml
@@ -93,7 +93,7 @@
       'output' in r_cloudformation_out
       and r_cloudformation_out.output in ["Stack CREATE complete", "Stack is already up-to-date."]
     )
-  retries: 1
+  retries: 3
   delay: 30
 
 - name: get Route53User credentials from cloudformation stack outputs

--- a/ansible/roles_ocp_workloads/ocp4_workload_adv_day2_ops_ilt/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_adv_day2_ops_ilt/tasks/workload.yml
@@ -79,7 +79,7 @@
     dest: "/tmp/cloudformation-{{ guid }}.yaml"
 
 - name: Launch CloudFormation template to create Route53 entries
-  cloudformation:
+  amazon.aws.cloudformation:
     aws_access_key: "{{ ocp4_workload_adv_dey2_ops_ilt_aws_key }}"
     aws_secret_key: "{{ ocp4_workload_adv_dey2_ops_ilt_aws_secret_key }}"
     stack_name: "{{ guid }}-m-route53"

--- a/ansible/roles_ocp_workloads/ocp4_workload_adv_day2_ops_ilt/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_adv_day2_ops_ilt/tasks/workload.yml
@@ -18,17 +18,15 @@
   debug:
     msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
 
-- name: Check that OpenStack credentials are provided
+- name: Check that OpenStack variables are provided
   assert:
     that:
     - osp_auth_url             | default('') | length > 0
-    - osp_auth_username_member | default('') | length > 0
-    - osp_auth_password_member | default('') | length > 0
     - osp_project_name         | default('') | length > 0
     - osp_auth_project_domain  | default('') | length > 0
     - osp_auth_user_domain     | default('') | length > 0
     quiet: true
-    fail_msg: "OpenStack Credentials need to be provided."
+    fail_msg: "OpenStack variables need to be provided."
 
 - name: Check that AWS credentials are provided
   assert:
@@ -41,8 +39,8 @@
 - name: Get Floating IP for Managed API
   environment:
     OS_AUTH_URL: "{{ osp_auth_url }}"
-    OS_USERNAME: "{{ osp_auth_username_member }}"
-    OS_PASSWORD: "{{ osp_auth_password_member }}"
+    OS_USERNAME: "{{ hostvars.localhost.osp_auth_username_member }}"
+    OS_PASSWORD: "{{ hostvars.localhost.osp_auth_password_member }}"
     OS_PROJECT_NAME: "{{ osp_project_name }}"
     OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
     OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"
@@ -53,8 +51,8 @@
 - name: Get Floating IP for managed Ingress
   environment:
     OS_AUTH_URL: "{{ osp_auth_url }}"
-    OS_USERNAME: "{{ osp_auth_username_member }}"
-    OS_PASSWORD: "{{ osp_auth_password_member }}"
+    OS_USERNAME: "{{ hostvars.localhost.osp_auth_username_member }}"
+    OS_PASSWORD: "{{ hostvars.localhost.osp_auth_password_member }}"
     OS_PROJECT_NAME: "{{ osp_project_name }}"
     OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
     OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"


### PR DESCRIPTION
##### SUMMARY

3 Changes:

- Add OpenStack and AWS collections to ocp4-cluster. This should enable developers to use the collections in workloads etc but not affect any existing workloads
- Add support for workload removal during destroy on an OCP 4 Cluster on OpenStack. This is necessary to cleanup things that are not part of the OpenStack environment. For example Route53 entries for the GitOps ILT 
- Fix ILT workload to use proper localhost variables to access OpenStack.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
- ocp4-cluster
- ocp4_workload_adv_day2_ops_ilt
