### PR TITLE
Add the possibility to use Ansible as student user

### DIFF
--- a/ansible/configs/ansible-automation-platform/env_vars.yml
+++ b/ansible/configs/ansible-automation-platform/env_vars.yml
@@ -39,6 +39,7 @@ install_common: true
 install_ipa_client: false
 # Create student user, most likely "lab-user" with SSH password login
 install_student_user: true
+bastion_student_user_ansible: true  # student user can use Ansible
 #software_to_deploy: tower  # replaced by role deploy_automationcontroller in software
 
 ## Set Tower manifest and installer tarball location and creds if not specified in agnosticv vars file

--- a/ansible/roles/bastion-student-user/defaults/main.yml
+++ b/ansible/roles/bastion-student-user/defaults/main.yml
@@ -1,3 +1,11 @@
 ---
+# name of the student user
 student_name: lab-user
+
+# shall the student be able to become root?
 student_sudo: true
+
+# set this variable to true if you want the student user to be able to connect
+# to the other nodes in the environment without first becoming root
+# (avoiding to have to use Ansible as root)
+bastion_student_user_ansible: false

--- a/ansible/roles/bastion-student-user/tasks/main.yml
+++ b/ansible/roles/bastion-student-user/tasks/main.yml
@@ -71,3 +71,14 @@
   service:
     name: sshd
     state: restarted
+
+- name: prepare student user for using Ansible within the environment
+  include_role:
+    name: bastion
+    tasks_from: prepuser
+  vars:
+    bastion_prepared_user: "{{ student_name }}"
+    bastion_prepared_group: "users"
+  when:
+    - student_name is defined
+    - bastion_student_user_ansible | bool

--- a/ansible/roles/bastion/defaults/main.yml
+++ b/ansible/roles/bastion/defaults/main.yml
@@ -2,3 +2,13 @@
 # defaults file for bastion
 # by default, do not copy over the user's private key
 use_own_key: true
+
+# by default, the root user gets the necessary SSH keys to use Ansible
+# against the other hosts in the environment. Set this variable to another user
+# if # you prefer students to use a non-root Ansible user.
+bastion_prepared_user: root
+# NOTE: the task file prepuser.yml can be used after again to set-up additional
+# users (using include_role/tasks_from and passing the variable via vars)
+
+# the user group is equal by default to the user, but can be overwritten
+bastion_prepared_group: "{{ bastion_prepared_user }}"

--- a/ansible/roles/bastion/tasks/main.yml
+++ b/ansible/roles/bastion/tasks/main.yml
@@ -3,37 +3,6 @@
 # tasks file for bastion
 
 ######################### Setting up environment for post deployment administration
-- name: create /root/.ssh
-  file:
-    dest: /root/.ssh
-    mode: 0700
-    state: directory
-  when: not hostvars.localhost.skip_packer_tasks | default(false)
-  tags: packer
-
-- name: copy the environment .pem key
-  become: true
-  copy:
-    src: "{{output_dir}}/{{ env_authorized_key }}"
-    dest: /root/.ssh/{{env_authorized_key}}.pem
-    owner: root
-    group: root
-    mode: 0400
-  when:
-    - use_own_key | bool
-    - set_env_authorized_key | bool
-
-- name: copy the user's SSH private key
-  become: true
-  copy:
-    src: "~/.ssh/{{key_name}}.pem"
-    dest: "/root/.ssh/{{key_name}}.pem"
-    owner: root
-    group: root
-    mode: 0400
-  when: not use_own_key|bool
-  tags:
-    - copy_env_private_key
 
 - name: Generate host .ssh/config Template
   become: false
@@ -44,16 +13,18 @@
   tags:
     - gen_sshconfig_file
 
-- name: copy over host .ssh/config Template
+- name: prepare environment for {{ bastion_prepared_user }} user
+  include_tasks:
+    file: prepuser.yml
+
+- name: Install python-requests
+  ignore_errors: true
   become: true
-  copy:
-    src: "{{output_dir}}/ssh-config-{{ env_type }}-{{ guid }}"
-    dest: /root/.ssh/config
-    owner: root
-    group: root
-    mode: 0400
-  tags:
-    - copy_sshconfig_file
+  yum:
+    name:
+      - python-requests
+  when: not hostvars.localhost.skip_packer_tasks | default(false)
+  tags: packer
 
 - name: Install python-requests
   ignore_errors: true

--- a/ansible/roles/bastion/tasks/prepuser.yml
+++ b/ansible/roles/bastion/tasks/prepuser.yml
@@ -1,0 +1,48 @@
+---
+#vim: set ft=ansible:
+# tasks file for bastion to prepare given user
+
+- name: prepuser | create .ssh for prepared user
+  file:
+    dest: "~{{ bastion_prepared_user }}/.ssh"
+    owner: "{{ bastion_prepared_user }}"
+    group: "{{ bastion_prepared_group }}"
+    mode: 0700
+    state: directory
+  when: not hostvars.localhost.skip_packer_tasks | default(false)
+  tags: packer
+
+- name: prepuser | copy the environment .pem key
+  become: true
+  copy:
+    src: "{{output_dir}}/{{ env_authorized_key }}"
+    dest: "~{{ bastion_prepared_user }}/.ssh/{{env_authorized_key}}.pem"
+    owner: "{{ bastion_prepared_user }}"
+    group: "{{ bastion_prepared_group }}"
+    mode: 0400
+  when:
+    - use_own_key | bool
+    - set_env_authorized_key | bool
+
+- name: prepuser | copy the user's SSH private key
+  become: true
+  copy:
+    src: "~/.ssh/{{key_name}}.pem"
+    dest: "~{{ bastion_prepared_user }}/.ssh/{{key_name}}.pem"
+    owner: "{{ bastion_prepared_user }}"
+    group: "{{ bastion_prepared_group }}"
+    mode: 0400
+  when: not use_own_key|bool
+  tags:
+    - copy_env_private_key
+
+- name: prepuser | copy over host .ssh/config Template
+  become: true
+  copy:
+    src: "{{output_dir}}/ssh-config-{{ env_type }}-{{ guid }}"
+    dest: "~{{ bastion_prepared_user }}/.ssh/config"
+    owner: "{{ bastion_prepared_user }}"
+    group: "{{ bastion_prepared_group }}"
+    mode: 0400
+  tags:
+    - copy_sshconfig_file


### PR DESCRIPTION
##### SUMMARY

By default, only the root user can easily use Ansible throughout the environment,
this is definitely not best practice, and having the student user being able to do it is better.
The solution chosen is a bit complex but avoids duplicating code.

Add possibility to define a group different from user name,
because the student user is created with the "users" group

Add flag to allow the student user to use Ansible or not,
variable is false by default to be backward compatible

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

* bastion
* bastion-student-user

##### ADDITIONAL INFORMATION

Really the main driver for this is that it's hard to explain to students that they shouldn't use Ansible as root while we do it in our labs.
