### PR TITLE
Add support for single users for Gitea workload

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/defaults/main.yml
@@ -43,8 +43,8 @@ ocp4_workload_gitea_operator_project: gitea
 
 # Gitea Image and Tag
 ocp4_workload_gitea_operator_gitea_image: quay.io/gpte-devops-automation/gitea
-# Must not use `latest`. Minimum allowed version: 1.14.2
-ocp4_workload_gitea_operator_gitea_image_tag: 1.14.2
+# Must not use `latest`. Minimum allowed version: 1.15.2
+ocp4_workload_gitea_operator_gitea_image_tag: 1.15.2
 
 # PVC size for Gitea, empty storage class uses default storage class
 ocp4_workload_gitea_operator_gitea_volume_size: 10Gi
@@ -104,6 +104,9 @@ ocp4_workload_gitea_operator_admin_email: gitea@opentlc.com
 # Create users in Gitea - handled by the
 # workload, not the operator
 ocp4_workload_gitea_operator_create_users: false
+# Format for the users to create. E.g. user1, user2, ...
+# When ocp4_workload_gitea_operator_user_number=1 specify just the
+# user name: e.g. lab-user
 ocp4_workload_gitea_operator_generate_user_format: user%d
 ocp4_workload_gitea_operator_user_number: "{{ num_users }}"
 ocp4_workload_gitea_operator_user_password: openshift

--- a/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/tasks/create_user.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/tasks/create_user.yml
@@ -1,5 +1,11 @@
 ---
-- name: Set the username as a fact for easy reuse
+- name: Set the username as a fact for easy reuse (single user)
+  when: ocp4_workload_gitea_operator_user_number | int == 1
+  set_fact:
+    f_ocp4_workload_gitea_operator_username: "{{ ocp4_workload_gitea_operator_generate_user_format }}"
+
+- name: Set the username as a fact for easy reuse (multiple users)
+  when: ocp4_workload_gitea_operator_user_number | int > 1
   set_fact:
     f_ocp4_workload_gitea_operator_username: "{{ ocp4_workload_gitea_operator_generate_user_format | format(item) }}"
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/tasks/migrate_repos.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/tasks/migrate_repos.yml
@@ -3,7 +3,13 @@
 # item[1]['repo'] has the repo url
 # item[1]['name'] has the repo name
 # item[1]['private'] is a boolean flag to make the repo private
-- name: Set the username as a fact for easy reuse
+- name: Set the username as a fact for easy reuse (single user)
+  when: ocp4_workload_gitea_operator_user_number | int == 1
+  set_fact:
+    f_ocp4_workload_gitea_operator_username: "{{ ocp4_workload_gitea_operator_generate_user_format }}"
+
+- name: Set the username as a fact for easy reuse (multiple users)
+  when: ocp4_workload_gitea_operator_user_number | int > 1
   set_fact:
     f_ocp4_workload_gitea_operator_username: "{{ ocp4_workload_gitea_operator_generate_user_format | format(item[0]) }}"
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/tasks/workload.yml
@@ -114,12 +114,23 @@
     - "The Gitea admin username is '{{ ocp4_workload_gitea_operator_admin_user }}'."
     - "The Gitea admin password is '{{ _ocp4_workload_gitea_operator_admin_password }}'."
 
-  - name: Print the user details if users were created
-    when: ocp4_workload_gitea_operator_create_users | bool
+  - name: Print the user details if multiple users were created
+    when: 
+    - ocp4_workload_gitea_operator_create_users | bool
+    - ocp4_workload_gitea_operator_user_number | int > 1
     agnosticd_user_info:
       msg: >-
         Gitea users were created, from {{ ocp4_workload_gitea_operator_generate_user_format | format(1) }} to
         {{ ocp4_workload_gitea_operator_generate_user_format | format(ocp4_workload_gitea_operator_user_number | int) }} with the password
+        '{{ ocp4_workload_gitea_operator_user_password }}'
+
+  - name: Print the user details if a single user was created
+    when: 
+    - ocp4_workload_gitea_operator_create_users | bool
+    - ocp4_workload_gitea_operator_user_number | int == 1
+    agnosticd_user_info:
+      msg: >-
+        A Gitea user '{{ ocp4_workload_gitea_operator_generate_user_format }}' was created, with the password
         '{{ ocp4_workload_gitea_operator_user_password }}'
 
   - name: Print the repositories that were migrated if any were migrated

--- a/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/tasks/workload.yml
@@ -115,7 +115,7 @@
     - "The Gitea admin password is '{{ _ocp4_workload_gitea_operator_admin_password }}'."
 
   - name: Print the user details if multiple users were created
-    when: 
+    when:
     - ocp4_workload_gitea_operator_create_users | bool
     - ocp4_workload_gitea_operator_user_number | int > 1
     agnosticd_user_info:
@@ -125,7 +125,7 @@
         '{{ ocp4_workload_gitea_operator_user_password }}'
 
   - name: Print the user details if a single user was created
-    when: 
+    when:
     - ocp4_workload_gitea_operator_create_users | bool
     - ocp4_workload_gitea_operator_user_number | int == 1
     agnosticd_user_info:


### PR DESCRIPTION
##### SUMMARY

This PR adds support to set up just one (regular) user in Gitea (e.g. lab-user). The capability to set up multiple users remains.
 
##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_gitea_operator