### PR TITLE
Update ocp4-workload-ccn-cuttingedge to update serverless 1.17.0

### DIFF
--- a/ansible/roles/ocp4-workload-ccnrd-cuttingedge/files/stack.Dockerfile
+++ b/ansible/roles/ocp4-workload-ccnrd-cuttingedge/files/stack.Dockerfile
@@ -7,7 +7,7 @@ FROM registry.redhat.io/codeready-workspaces/plugin-java11-rhel8:latest
 ENV MANDREL_VERSION=20.3.1.2-Final
 ENV QUARKUS_VERSION=1.11.6.Final-redhat-00001
 ENV TKN_VERSION=0.19.1
-ENV KN_VERSION=0.22.0
+ENV KN_VERSION=0.23.2
 ENV OC_VERSION=4.8
 ENV GRAALVM_HOME="/usr/local/mandrel-java11-${MANDREL_VERSION}"
 


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Update ocp4-workload-ccn-cuttingedge to update serverless 1.17.0
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
