### PR TITLE
remove container registry creds from installer inventory

### DIFF
--- a/ansible/roles/deploy_automationcontroller_cfg/tasks/main.yml
+++ b/ansible/roles/deploy_automationcontroller_cfg/tasks/main.yml
@@ -69,4 +69,16 @@
 - name: Display Ansible controller /api/v2/ping results
   debug:
     msg: '{{ r_automationcontroller_ping.json }}'
+
+- name: remove registry username from inventory file
+  lineinfile:
+    path: /tmp/automationcontroller_installer/inventory
+    regexp: '^registry_username='
+    line: 'registry_username=SECRET'
+
+- name: remove registry password from inventory file
+  lineinfile:
+    path: /tmp/automationcontroller_installer/inventory
+    regexp: '^registry_password='
+    line: registry_password=SECRET
 ...


### PR DESCRIPTION
Minor change to remove container registry credentials inserted at runtime into the installer inventory file.

Which ends up on the bastion after installation. 