### PR TITLE
Allow optional AWS CLI bundle filename override in host-ocp4-provisioner

### DIFF
--- a/ansible/roles/host-ocp4-provisioner/tasks/ec2_prereqs.yml
+++ b/ansible/roles/host-ocp4-provisioner/tasks/ec2_prereqs.yml
@@ -1,10 +1,15 @@
 ---
+
+- name : Set fact with AWS cli bundle filename
+  set_fact:
+    aws_cli_bundle_filename: '{{ aws_cli_bundle_filename | default("awscli-bundle.zip") }}'
+
 - name: Get awscli bundle
   get_url:
-    url: https://s3.amazonaws.com/aws-cli/awscli-bundle.zip
+    url: https://s3.amazonaws.com/aws-cli/{{ aws_cli_bundle_filename }}
     dest: /tmp/awscli-bundle.zip
 
-- name: Unzip awscli-bundle.zip
+- name: Unzip {{ aws_cli_bundle_filename }}
   unarchive:
     src: /tmp/awscli-bundle.zip
     dest: /tmp/
@@ -22,7 +27,7 @@
     state: absent
   loop:
     - /tmp/awscli-bundle
-    - /tmp/awscli-bundle.zip
+    - /tmp/{{ aws_cli_bundle_filename }}
 
 - name: Create .aws directory
   become: false


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Small change to allow a user to override the version of the AWS CLI Bundle installed.

Defaults to the latest version if unspecified which is the current outcome pre-change.

Example

```yaml
# AWS cli bundle filename, defaults to aws-bundle.zip if undefined
aws_cli_bundle_filename: "awscli-bundle-1.18.200.zip"
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

host-ocp4-provisioner

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Useful for example if you have dependencies which require a specific version of the AWS CLI.
