### PR TITLE
Update awscli and botocore

### DIFF
--- a/tools/virtualenvs/ansible2.9-python3.6-2021-09-02.txt
+++ b/tools/virtualenvs/ansible2.9-python3.6-2021-09-02.txt
@@ -7,7 +7,7 @@ asciitree==0.3.3
 attrs==21.2.0
 autopage==0.4.0
 aws==0.2.5
-awscli==1.20.34
+awscli==1.20.53
 azure-cli-core==2.27.2
 azure-cli-nspkg==3.0.4
 azure-cli-telemetry==1.0.6
@@ -52,7 +52,7 @@ Babel==2.9.1
 bcrypt==3.2.0
 boto==2.49.0
 boto3==1.18.34
-botocore==1.21.34
+botocore==1.21.53
 cachetools==4.2.2
 certifi==2021.5.30
 cffi==1.14.6


### PR DESCRIPTION
fix issue:

```
 file://output_dir/ocp-workshop.91a0.ec2_cloud_template
Traceback (most recent call last):
  File "/home/opentlc-mgr/virtualenvs/ansible2.9-python3.6-2021-09-02/bin/aws", line 5, in <module>
    from aws.main import main
  File "/home/opentlc-mgr/virtualenvs/ansible2.9-python3.6-2021-09-02/lib64/python3.6/site-packages/aws/main.py", line 23
    print '%(name)s: %(endpoint)s' % {
```

We can update that venv as it's not used anywhere yet