### PR TITLE
Install ansible with disabled EPEL

### DIFF
--- a/ansible/configs/ansible-automation-platform/software.yml
+++ b/ansible/configs/ansible-automation-platform/software.yml
@@ -51,6 +51,14 @@
     - name: update CA trusts
       shell: update-ca-trust
 
+    # note that we remove YUM/RPM installed ansible before installing
+    # automationcontroller, now we install it back to avoid needing EPEL
+    - name: install ansible on the bastion (avoiding EPEL)
+      dnf:
+        name: ansible
+        state: present
+        disablerepo: epel
+
 - name: Install license and LE certs on autoctl nodes
   hosts: automationcontroller
   gather_facts: false


### PR DESCRIPTION
##### SUMMARY

In order to not use EPEL software, we install ansible beforehand from RHEL while disabling EPEL

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
config ansible-automation-platform

##### ADDITIONAL INFORMATION
only the config is impacted, nothing else.