### PR TITLE
Set sensible defaults for test-empty-config on ec2 for simpler deploys

### DIFF
--- a/ansible/configs/test-empty-config/default_vars_ec2.yml
+++ b/ansible/configs/test-empty-config/default_vars_ec2.yml
@@ -1,10 +1,6 @@
 ---
 # mandatory to run ansible/destroy.yml playbook
-
 aws_region: us-east-1
-
 env_type: test-empty-config
 cloud_provider: ec2
-
 guid: test-config-ec2-00
-

--- a/ansible/configs/test-empty-config/default_vars_ec2.yml
+++ b/ansible/configs/test-empty-config/default_vars_ec2.yml
@@ -1,3 +1,10 @@
 ---
 # mandatory to run ansible/destroy.yml playbook
+
 aws_region: us-east-1
+
+env_type: test-empty-config
+cloud_provider: ec2
+
+guid: test-config-ec2-00
+


### PR DESCRIPTION
##### SUMMARY

config test-empty-config lacks sensible ec2 defaults leading to constructs like

`-e env_type=test-empty-config -e cloud_provider=ec2 -e guid=1234`

It is normal for the defaults file to contain these vars already set.

Given that this is often used by people getting started it makes sense to clean this up, hence this PR


##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

config: test-empty-config

##### ADDITIONAL INFORMATION
