### PR TITLE
Equinix metal: add chdir to anisble-galaxy command

### DIFF
--- a/ansible/cloud_providers/equinix_metal_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/equinix_metal_infrastructure_deployment.yml
@@ -16,8 +16,11 @@
     - name: Install community.general collection for packet modules
       command: >-
         ansible-galaxy collection install
-        -p {{ playbook_dir }}/../collections community.general
+        -p collections community.general
         --force-with-deps
+      args:
+        chdir: "{{ playbook_dir }}/.."
+        creates: "{{ playbook_dir }}/../collections/ansible_collections/community/general"
 
     - name: Run infra-equinix-metal-resources Role
       include_role:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

Fix warning in tower:

```
[WARNING]: The specified collections path
/tmp/awx_8023_mfue6yvv/project/ansible/collections' is not part of the
configured Ansible collections paths '/tmp/awx_8023_mfue6yvv/requirements_collections:/var/lib/awx/.ansible/collections:/usr/share/ansible/collections'. The
minstalled collection won't be picked up in an Ansible run   
```
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
