### PR TITLE
ocp4-cluster config option to leave aws creds on bastion FOR DEV ONLY

### DIFF
--- a/ansible/configs/ocp4-cluster/default_vars.yml
+++ b/ansible/configs/ocp4-cluster/default_vars.yml
@@ -28,6 +28,10 @@ install_ipa_client: false
 # Mutually exclusive with {{ install_ipa_client }}
 install_student_user: true
 
+# default true.  Make false if you want to leave the AWS credentials in
+# place after cluster deployment.  USE FOR TESTING/DEVELOPMENT
+ocp4_cluster_remove_aws_creds: true
+
 # This should be overwritten based on the user ordering the catalog item
 # It will be used by the bastion-student-user role and created on the bastion
 student_name: lab-user

--- a/ansible/configs/ocp4-cluster/post_software.yml
+++ b/ansible/configs/ocp4-cluster/post_software.yml
@@ -127,6 +127,7 @@
     when: cloud_provider == 'ec2'
     block:
     - name: Remove AWS credentials file
+      when: ocp4_cluster_remove_aws_creds | default( true ) | bool
       file:
         path: "/home/{{ ansible_user }}/.aws/credentials"
         state: absent

--- a/tools/find_ami.sh
+++ b/tools/find_ami.sh
@@ -43,6 +43,9 @@ do
     echo -n "  RHEL81GOLD: "
     search_last_image 309956199498 'RHEL-8.1*x86_64*Access*' false
 
+    echo -n "  RHEL79GOLD: "
+    search_last_image 309956199498 'RHEL-7.9*x86_64*Access*' false
+
     echo -n "  RHEL77GOLD: "
     search_last_image 309956199498 'RHEL-7.7*x86_64*Access*' false
 


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

Sometimes you need to leave the AWS creds on the server and have them cleaned up AFTER workloads, because workloads might need to create instances.

This is the first step in creating that process.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

ocp4-cluster config

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
