### PR TITLE
Add retries to ocp4_workload_shared_cluster_access user group add

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_shared_cluster_access/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_shared_cluster_access/tasks/workload.yml
@@ -10,7 +10,10 @@
   when: ocp4_workload_shared_cluster_access_user_groups | default([]) | length > 0
   command: "oc adm groups add-users {{ item }} {{ ocp_username }}"
   register: r_groupadd_register
-  with_items: "{{ ocp4_workload_shared_cluster_access_user_groups }}"
+  loop: "{{ ocp4_workload_shared_cluster_access_user_groups }}"
+  until: r_groupadd_register is success
+  retries: 3
+  delay: 1
 
 - name: Print Debug information
   debug:


### PR DESCRIPTION
##### SUMMARY

Command to add users to groups can fail with a conflict if two simultaneous attempts are made to add users to the same group.

```
$ oc adm groups add-users OPENTLC-PROJECT-PROVISIONERS ryan.schulte@cgi.com
Error from server (Conflict): Operation cannot be fulfilled on groups.user.openshift.io "OPENTLC-PROJECT-PROVISIONERS": the object has been modified; please apply your changes to the latest version and try again
```

A simple ansible retries should resolve this issue.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role ocp4_workload_shared_cluster_access