### PR TITLE
Use CreationTime when creation_time is not defined

### DIFF
--- a/ansible/configs/ocp4-cluster/destroy_env_ec2.yml
+++ b/ansible/configs/ocp4-cluster/destroy_env_ec2.yml
@@ -22,13 +22,23 @@
       stack_name: "{{ project_tag }}"
     register: stack_facts
 
-  - name: Grab and set stack creation_time
+  - name: Grab and set stack creation time
     when: project_tag in stack_facts.ansible_facts.cloudformation
-    set_fact:
-      stack_creation_time: >-
-        {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time }}
-      stack_status: >-
-        {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.stack_status }}
+    block:
+    - name: Grab and set stack creation_time
+      when: stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time is defined
+      set_fact:
+        stack_creation_time: >-
+          {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time }}
+        stack_status: >-
+          {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.stack_status }}
+    - name: Grab and set stack CreationTime
+      when: stack_facts.ansible_facts.cloudformation[project_tag].stack_description.CreationTime is defined
+      set_fact:
+        stack_creation_time: >-
+          {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.CreationTime }}
+        stack_status: >-
+          {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.StackStatus }}
 
   - name: Run infra-ec2-create-inventory role
     include_role:

--- a/ansible/configs/ocp4-cluster/destroy_env_ec2.yml
+++ b/ansible/configs/ocp4-cluster/destroy_env_ec2.yml
@@ -24,21 +24,13 @@
 
   - name: Grab and set stack creation time
     when: project_tag in stack_facts.ansible_facts.cloudformation
-    block:
-    - name: Grab and set stack creation_time
-      when: stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time is defined
-      set_fact:
-        stack_creation_time: >-
-          {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time }}
-        stack_status: >-
-          {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.stack_status }}
-    - name: Grab and set stack CreationTime
-      when: stack_facts.ansible_facts.cloudformation[project_tag].stack_description.CreationTime is defined
-      set_fact:
-        stack_creation_time: >-
-          {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.CreationTime }}
-        stack_status: >-
-          {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.StackStatus }}
+    vars:
+      _stack_description: "{{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description }}"
+    set_fact:
+      stack_creation_time: >-
+        {{ _stack_description.creation_time | default(_stack_description.CreationTime) }}
+      stack_status: >-
+        {{ _stack_description.stack_status | default(_stack_description.StackStatus) }}
 
   - name: Run infra-ec2-create-inventory role
     include_role:

--- a/ansible/configs/ocp4-ha-lab/destroy_env.yml
+++ b/ansible/configs/ocp4-ha-lab/destroy_env.yml
@@ -19,22 +19,13 @@
     - when: project_tag in stack_facts.ansible_facts.cloudformation
       block:
         - name: Grab and set stack creation time
-          block:
-            - name: Grab and set stack creation_time
-              when: stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time is defined
-              set_fact:
-                stack_creation_time: >-
-                  {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time }}
-                stack_status: >-
-                  {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.stack_status }}
-            - name: Grab and set stack CreationTime
-              when: stack_facts.ansible_facts.cloudformation[project_tag].stack_description.CreationTime is defined
-              set_fact:
-                stack_creation_time: >-
-                  {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.CreationTime }}
-                stack_status: >-
-                  {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.StackStatus }}
-
+          vars:
+            _stack_description: "{{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description }}"
+          set_fact:
+            stack_creation_time: >-
+              {{ _stack_description.creation_time | default(_stack_description.CreationTime) }}
+            stack_status: >-
+              {{ _stack_description.stack_status | default(_stack_description.StackStatus) }}
         - when: stack_status == "CREATE_COMPLETE"
           block:
             - name: Grab student user

--- a/ansible/configs/ocp4-ha-lab/destroy_env.yml
+++ b/ansible/configs/ocp4-ha-lab/destroy_env.yml
@@ -20,20 +20,20 @@
       block:
         - name: Grab and set stack creation time
           block:
-          - name: Grab and set stack creation_time
-            when: stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time is defined
-            set_fact:
-              stack_creation_time: >-
-                {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time }}
-              stack_status: >-
-                {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.stack_status }}
-          - name: Grab and set stack CreationTime
-            when: stack_facts.ansible_facts.cloudformation[project_tag].stack_description.CreationTime is defined
-            set_fact:
-              stack_creation_time: >-
-                {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.CreationTime }}
-              stack_status: >-
-                {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.StackStatus }}
+            - name: Grab and set stack creation_time
+              when: stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time is defined
+              set_fact:
+                stack_creation_time: >-
+                  {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time }}
+                stack_status: >-
+                  {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.stack_status }}
+            - name: Grab and set stack CreationTime
+              when: stack_facts.ansible_facts.cloudformation[project_tag].stack_description.CreationTime is defined
+              set_fact:
+                stack_creation_time: >-
+                  {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.CreationTime }}
+                stack_status: >-
+                  {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.StackStatus }}
 
         - when: stack_status == "CREATE_COMPLETE"
           block:

--- a/ansible/configs/ocp4-ha-lab/destroy_env.yml
+++ b/ansible/configs/ocp4-ha-lab/destroy_env.yml
@@ -18,12 +18,22 @@
 
     - when: project_tag in stack_facts.ansible_facts.cloudformation
       block:
-        - name: Grab and set stack creation_time
-          set_fact:
-            stack_creation_time: >-
-              {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time }}
-            stack_status: >-
-              {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.stack_status }}
+        - name: Grab and set stack creation time
+          block:
+          - name: Grab and set stack creation_time
+            when: stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time is defined
+            set_fact:
+              stack_creation_time: >-
+                {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time }}
+              stack_status: >-
+                {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.stack_status }}
+          - name: Grab and set stack CreationTime
+            when: stack_facts.ansible_facts.cloudformation[project_tag].stack_description.CreationTime is defined
+            set_fact:
+              stack_creation_time: >-
+                {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.CreationTime }}
+              stack_status: >-
+                {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.StackStatus }}
 
         - when: stack_status == "CREATE_COMPLETE"
           block:

--- a/ansible/configs/ocp4-workshop/destroy_env.yml
+++ b/ansible/configs/ocp4-workshop/destroy_env.yml
@@ -25,20 +25,20 @@
       block:
         - name: Grab and set stack creation time
           block:
-          - name: Grab and set stack creation_time
-            when: stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time is defined
-            set_fact:
-              stack_creation_time: >-
-                {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time }}
-              stack_status: >-
-                {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.stack_status }}
-          - name: Grab and set stack CreationTime
-            when: stack_facts.ansible_facts.cloudformation[project_tag].stack_description.CreationTime is defined
-            set_fact:
-              stack_creation_time: >-
-                {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.CreationTime }}
-              stack_status: >-
-                {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.StackStatus }}
+            - name: Grab and set stack creation_time
+              when: stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time is defined
+              set_fact:
+                stack_creation_time: >-
+                  {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time }}
+                stack_status: >-
+                  {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.stack_status }}
+            - name: Grab and set stack CreationTime
+              when: stack_facts.ansible_facts.cloudformation[project_tag].stack_description.CreationTime is defined
+              set_fact:
+                stack_creation_time: >-
+                  {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.CreationTime }}
+                stack_status: >-
+                  {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.StackStatus }}
 
         - when: stack_status == "CREATE_COMPLETE"
           block:

--- a/ansible/configs/ocp4-workshop/destroy_env.yml
+++ b/ansible/configs/ocp4-workshop/destroy_env.yml
@@ -23,12 +23,22 @@
 
     - when: project_tag in stack_facts.ansible_facts.cloudformation
       block:
-        - name: Grab and set stack creation_time
-          set_fact:
-            stack_creation_time: >-
-              {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time }}
-            stack_status: >-
-              {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.stack_status }}
+        - name: Grab and set stack creation time
+          block:
+          - name: Grab and set stack creation_time
+            when: stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time is defined
+            set_fact:
+              stack_creation_time: >-
+                {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time }}
+              stack_status: >-
+                {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.stack_status }}
+          - name: Grab and set stack CreationTime
+            when: stack_facts.ansible_facts.cloudformation[project_tag].stack_description.CreationTime is defined
+            set_fact:
+              stack_creation_time: >-
+                {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.CreationTime }}
+              stack_status: >-
+                {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.StackStatus }}
 
         - when: stack_status == "CREATE_COMPLETE"
           block:

--- a/ansible/configs/ocp4-workshop/destroy_env.yml
+++ b/ansible/configs/ocp4-workshop/destroy_env.yml
@@ -24,21 +24,13 @@
     - when: project_tag in stack_facts.ansible_facts.cloudformation
       block:
         - name: Grab and set stack creation time
-          block:
-            - name: Grab and set stack creation_time
-              when: stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time is defined
-              set_fact:
-                stack_creation_time: >-
-                  {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time }}
-                stack_status: >-
-                  {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.stack_status }}
-            - name: Grab and set stack CreationTime
-              when: stack_facts.ansible_facts.cloudformation[project_tag].stack_description.CreationTime is defined
-              set_fact:
-                stack_creation_time: >-
-                  {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.CreationTime }}
-                stack_status: >-
-                  {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.StackStatus }}
+          vars:
+            _stack_description: "{{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description }}"
+          set_fact:
+            stack_creation_time: >-
+              {{ _stack_description.creation_time | default(_stack_description.CreationTime) }}
+            stack_status: >-
+              {{ _stack_description.stack_status | default(_stack_description.StackStatus) }}
 
         - when: stack_status == "CREATE_COMPLETE"
           block:

--- a/ansible/configs/rosa/destroy_env.yml
+++ b/ansible/configs/rosa/destroy_env.yml
@@ -20,13 +20,23 @@
       stack_name: "{{ project_tag }}"
     register: stack_facts
 
-  - name: Grab and set stack creation_time
+  - name: Grab and set stack creation time
     when: project_tag in stack_facts.ansible_facts.cloudformation
-    set_fact:
-      stack_creation_time: >-
-        {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time }}
-      stack_status: >-
-        {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.stack_status }}
+    block:
+    - name: Grab and set stack creation_time
+      when: stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time is defined
+      set_fact:
+        stack_creation_time: >-
+          {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time }}
+        stack_status: >-
+          {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.stack_status }}
+    - name: Grab and set stack CreationTime
+      when: stack_facts.ansible_facts.cloudformation[project_tag].stack_description.CreationTime is defined
+      set_fact:
+        stack_creation_time: >-
+          {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.CreationTime }}
+        stack_status: >-
+          {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.StackStatus }}
 
   - name: Run infra-ec2-create-inventory role
     include_role:

--- a/ansible/configs/rosa/destroy_env.yml
+++ b/ansible/configs/rosa/destroy_env.yml
@@ -22,21 +22,13 @@
 
   - name: Grab and set stack creation time
     when: project_tag in stack_facts.ansible_facts.cloudformation
-    block:
-    - name: Grab and set stack creation_time
-      when: stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time is defined
-      set_fact:
-        stack_creation_time: >-
-          {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time }}
-        stack_status: >-
-          {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.stack_status }}
-    - name: Grab and set stack CreationTime
-      when: stack_facts.ansible_facts.cloudformation[project_tag].stack_description.CreationTime is defined
-      set_fact:
-        stack_creation_time: >-
-          {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.CreationTime }}
-        stack_status: >-
-          {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.StackStatus }}
+    vars:
+      _stack_description: "{{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description }}"
+    set_fact:
+      stack_creation_time: >-
+        {{ _stack_description.creation_time | default(_stack_description.CreationTime) }}
+      stack_status: >-
+        {{ _stack_description.stack_status | default(_stack_description.StackStatus) }}
 
   - name: Run infra-ec2-create-inventory role
     include_role:

--- a/ansible/configs/sap-integration/destroy_env_ec2.yml
+++ b/ansible/configs/sap-integration/destroy_env_ec2.yml
@@ -22,13 +22,23 @@
       stack_name: "{{ project_tag }}"
     register: stack_facts
   
-  - name: Grab and set stack creation_time
+  - name: Grab and set stack creation time
     when: project_tag in stack_facts.ansible_facts.cloudformation
-    set_fact:
-      stack_creation_time: >-
-        {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time }}
-      stack_status: >-
-        {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.stack_status }}
+    block:
+    - name: Grab and set stack creation_time
+      when: stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time is defined
+      set_fact:
+        stack_creation_time: >-
+          {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time }}
+        stack_status: >-
+          {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.stack_status }}
+    - name: Grab and set stack CreationTime
+      when: stack_facts.ansible_facts.cloudformation[project_tag].stack_description.CreationTime is defined
+      set_fact:
+        stack_creation_time: >-
+          {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.CreationTime }}
+        stack_status: >-
+          {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.StackStatus }}
 
   - name: Run infra-ec2-create-inventory role
     include_role:

--- a/ansible/configs/sap-integration/destroy_env_ec2.yml
+++ b/ansible/configs/sap-integration/destroy_env_ec2.yml
@@ -24,21 +24,13 @@
   
   - name: Grab and set stack creation time
     when: project_tag in stack_facts.ansible_facts.cloudformation
-    block:
-      - name: Grab and set stack creation_time
-        when: stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time is defined
-        set_fact:
-          stack_creation_time: >-
-            {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time }}
-          stack_status: >-
-            {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.stack_status }}
-      - name: Grab and set stack CreationTime
-        when: stack_facts.ansible_facts.cloudformation[project_tag].stack_description.CreationTime is defined
-        set_fact:
-          stack_creation_time: >-
-            {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.CreationTime }}
-          stack_status: >-
-            {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.StackStatus }}
+    vars:
+      _stack_description: "{{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description }}"
+    set_fact:
+      stack_creation_time: >-
+        {{ _stack_description.creation_time | default(_stack_description.CreationTime) }}
+      stack_status: >-
+        {{ _stack_description.stack_status | default(_stack_description.StackStatus) }}
 
   - name: Run infra-ec2-create-inventory role
     include_role:

--- a/ansible/configs/sap-integration/destroy_env_ec2.yml
+++ b/ansible/configs/sap-integration/destroy_env_ec2.yml
@@ -25,20 +25,20 @@
   - name: Grab and set stack creation time
     when: project_tag in stack_facts.ansible_facts.cloudformation
     block:
-    - name: Grab and set stack creation_time
-      when: stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time is defined
-      set_fact:
-        stack_creation_time: >-
-          {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time }}
-        stack_status: >-
-          {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.stack_status }}
-    - name: Grab and set stack CreationTime
-      when: stack_facts.ansible_facts.cloudformation[project_tag].stack_description.CreationTime is defined
-      set_fact:
-        stack_creation_time: >-
-          {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.CreationTime }}
-        stack_status: >-
-          {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.StackStatus }}
+      - name: Grab and set stack creation_time
+        when: stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time is defined
+        set_fact:
+          stack_creation_time: >-
+            {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.creation_time }}
+          stack_status: >-
+            {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.stack_status }}
+      - name: Grab and set stack CreationTime
+        when: stack_facts.ansible_facts.cloudformation[project_tag].stack_description.CreationTime is defined
+        set_fact:
+          stack_creation_time: >-
+            {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.CreationTime }}
+          stack_status: >-
+            {{ stack_facts.ansible_facts.cloudformation[project_tag].stack_description.StackStatus }}
 
   - name: Run infra-ec2-create-inventory role
     include_role:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

ocp4-cluster currently does not destroy correctly on some hosts. This PR ensure that creation_time if not defined uses CreationTime instead.

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4-cluster and related configs
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
