### PR TITLE
set-repositories role: add logic

### DIFF
--- a/ansible/roles/set-repositories/defaults/main.yaml
+++ b/ansible/roles/set-repositories/defaults/main.yaml
@@ -10,5 +10,7 @@ set_repositories_satellite_hostname: "{{ set_repositories_satellite_url | defaul
 # pattern matching a pool name for attachment via Satellite
 #set_repositories_satellite_pool: "^$"
 
+set_repositories_satellite_force_register: false
+
 # By default use content view mode
 use_content_view: true

--- a/ansible/roles/set-repositories/tasks/satellite-repos.yml
+++ b/ansible/roles/set-repositories/tasks/satellite-repos.yml
@@ -83,6 +83,7 @@
   when: ansible_date_time is not defined
 
 - name: Set set_repositories_subscription_hostname with randomization
+  when: set_repositories_subscription_hostname is not defined
   set_fact:
     set_repositories_subscription_hostname: >-
       {%- if guid in inventory_hostname -%}
@@ -100,14 +101,13 @@
       network.fqdn: "{{ set_repositories_subscription_hostname }}"
 
 - name: Register with activation-key
-  when: set_repositories_satellite_activationkey != ''
+  when: set_repositories_satellite_ha is not defined or set_repositories_satellite_ha|bool == False
   redhat_subscription:
     state: present
     consumer_name: "{{ set_repositories_subscription_hostname }}"
     server_hostname: "{{ set_repositories_satellite_hostname }}"
     activationkey: "{{ set_repositories_satellite_activationkey }}"
     org_id: "{{ set_repositories_satellite_org | default(satellite_org) }}"
-  when: set_repositories_satellite_ha is not defined or set_repositories_satellite_ha|bool == False
 
 - name: Register with activation-key with HA
   redhat_subscription:
@@ -118,6 +118,7 @@
     activationkey: "{{ set_repositories_satellite_activationkey }}"
     org_id: "{{ set_repositories_satellite_org | default(satellite_org) }}"
     pool: "{{ set_repositories_satellite_pool | default(omit) }}"
+    force_register: "{{ set_repositories_force_register | default('false') }}"
   when: set_repositories_satellite_ha is defined and set_repositories_satellite_ha|bool == True
 
 - name: Enable RHSM to manage repositories
@@ -131,7 +132,7 @@
   - use_content_view
   - set_repositories_satellite_activationkey != ''
 
-# Remove all repos when using rhel_repos 
+# Remove all repos when using rhel_repos
 # This will resolve any dependency issues with unwanted repositories still being enabled
 - name: Purge existing repos
   rhsm_repository:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

set-repositories role:

-  added var and logic to control force registration of subscription
   - default:  set_repositories_satellite_force_register: false
- can now set set_repositories_subscription_hostname from outside role
   - added test to see if was set before computing set_repositories_subscription_hostname
- removed a duplicate `when:` syntax error

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

role: set-repositories

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

I was using this role from a `delegate_to:` and ran into some hostnaming issues.

Also, who doesn't love a good `force`?

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
