### PR TITLE
ocp4_workload_rhel_worker: new workload

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/defaults/main.yml
@@ -17,4 +17,3 @@ ocp4_workload_rhel_worker_ownership: "owned"
 # Legacy, unused:
 # aws_newbox_virtualenv_home: "/home/{{ ansible_user }}/virtualenvs/aws-newbox"
 # aws_newbox_home: "/home/{{ ansible_user }}/aws-newbox"
-

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/defaults/main.yml
@@ -1,0 +1,20 @@
+---
+become_override: false
+ocp_username: opentlc-mgr
+silent: false
+
+ocp4_workload_rhel_worker_exact_count: 3
+
+ocp4_workload_rhel_worker_ami_name: "RHEL-8.4.0_HVM-20210825-x86_64-0-Access2-GP2"
+
+ocp4_worload_rhel_worker_use_backdoor_key: true
+
+# owned: i.e. "owned by the OpenShift cluster" `openshift-installer destroy cluster` will also delete these
+# shared: i.e. "shared with the OpenShift cluster" `openshift-installer destroy cluster` will NOT delete these
+
+ocp4_workload_rhel_worker_ownership: "owned"
+
+# Legacy, unused:
+# aws_newbox_virtualenv_home: "/home/{{ ansible_user }}/virtualenvs/aws-newbox"
+# aws_newbox_home: "/home/{{ ansible_user }}/aws-newbox"
+

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/defaults/main.yml
@@ -3,17 +3,14 @@ become_override: false
 ocp_username: opentlc-mgr
 silent: false
 
-ocp4_workload_rhel_worker_exact_count: 3
+# numer of RHEL8 instances to deploy into the OpenShift VPC
+ocp4_workload_rhel_worker_exact_count: 1
 
+  # RHEL Worker ocp4_workload_rhel_worker_ami_name: "RHEL-8.4.0_HVM-20210825-x86_64-0-Access2-GP2" is fixed because it's proven to work, and can be found in many AWS regions.
 ocp4_workload_rhel_worker_ami_name: "RHEL-8.4.0_HVM-20210825-x86_64-0-Access2-GP2"
 
 ocp4_worload_rhel_worker_use_backdoor_key: true
 
-# owned: i.e. "owned by the OpenShift cluster" `openshift-installer destroy cluster` will also delete these
-# shared: i.e. "shared with the OpenShift cluster" `openshift-installer destroy cluster` will NOT delete these
-
+# owned: i.e. "owned by the OpenShift cluster" `openshift-installer destroy cluster` will also delete these instances and related resources
+# shared: i.e. "shared with the OpenShift cluster" `openshift-installer destroy cluster` will NOT delete these instances and related resources
 ocp4_workload_rhel_worker_ownership: "owned"
-
-# Legacy, unused:
-# aws_newbox_virtualenv_home: "/home/{{ ansible_user }}/virtualenvs/aws-newbox"
-# aws_newbox_home: "/home/{{ ansible_user }}/aws-newbox"

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/defaults/main.yml
@@ -6,11 +6,16 @@ silent: false
 # numer of RHEL8 instances to deploy into the OpenShift VPC
 ocp4_workload_rhel_worker_exact_count: 1
 
-  # RHEL Worker ocp4_workload_rhel_worker_ami_name: "RHEL-8.4.0_HVM-20210825-x86_64-0-Access2-GP2" is fixed because it's proven to work, and can be found in many AWS regions.
+# RHEL Worker ocp4_workload_rhel_worker_ami_name:
+# "RHEL-8.4.0_HVM-20210825-x86_64-0-Access2-GP2"
+# is fixed because it's proven to work,
+# and can be found in many AWS regions.
 ocp4_workload_rhel_worker_ami_name: "RHEL-8.4.0_HVM-20210825-x86_64-0-Access2-GP2"
 
 ocp4_worload_rhel_worker_use_backdoor_key: true
 
-# owned: i.e. "owned by the OpenShift cluster" `openshift-installer destroy cluster` will also delete these instances and related resources
-# shared: i.e. "shared with the OpenShift cluster" `openshift-installer destroy cluster` will NOT delete these instances and related resources
+# owned: i.e. "owned by the OpenShift cluster" `openshift-installer destroy cluster`
+# will also delete these instances and related resources
+# shared: i.e. "shared with the OpenShift cluster" `openshift-installer destroy cluster`
+# will NOT delete these instances and related resources
 ocp4_workload_rhel_worker_ownership: "owned"

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/files/ec2-role-access-policy.json
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/files/ec2-role-access-policy.json
@@ -1,0 +1,15 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["ec2:DescribeInstances"],
+      "Resource": ["*"]
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["ec2:DescribeRegions"],
+      "Resource": ["*"]
+    }
+  ]
+}

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/files/ec2-role-trust-policy.json
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/files/ec2-role-trust-policy.json
@@ -1,0 +1,11 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": { "Service": "ec2.amazonaws.com"},
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/readme.adoc
@@ -1,0 +1,58 @@
+= ocp4-workload-rhel-worker - Set up AWS RHEL8 worker via tasks on Bastion
+
+== Role overview
+
+* This role installs playbooks and shell scripts to deploy a RHEL8 Worker for AWS based deployments.
+
+Once this role has been executed there is a directory `/opt/rhel_worker` with the necessary files to deploy a rhel_worker.
+If `ocp4_workloads_rhel_worker_deploy_worker` is set, this workload will deploy one worker.
+You can deploy subsequent workers with the playbook.
+SSH into the bastion, change to the `/opt/rhel_worker` directory and run `./setup_rhel_worker.sh`.
+This script will execute the playbook to deploy a rhel_worker into the region specified.
+
+Currently only `eu-central-1`, `us-east-1` and `us-east-2` are supported. This is because only for these three regions the AMI for the RHEL 8 image is specified.
+
+. The role consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment
+*** Debug task will print out: `pre_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/workload.yml[workload.yml] - Install the RHEL 8 Worker Playbooks onto the Bastion
+*** Debug task will print out: `workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to configure the workload after deployment
+*** This role doesn't do anything here
+*** Debug task will print out: `post_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to delete the workload
+*** This role doesn't do anything here
+*** Debug task will print out: `remove_workload Tasks completed successfully.`
+
+== Review the defaults variable file
+
+* This file link:./defaults/main.yml[./defaults/main.yml] contains all the variables you need to define to control the deployment of your workload.
+* The variable *ocp_username* is mandatory to assign the workload to the correct OpenShift user.
+* A variable *silent=True* can be passed to suppress debug messages.
+* You can modify any of these default values by adding `-e "variable_name=variable_value"` to the command line
+
+=== Deploy a Workload with the `ocp-workload` playbook [Mostly for testing]
+
+----
+TARGET_HOST="bastion.GUID.example.opentlc.com"
+OCP_USERNAME="jmaltin-redhat.com"
+WORKLOAD="ocp4-workload-rhel-worker"
+GUID=1001
+AWS_REGION=us-east-1 # or us-east-2 or eu-central-1
+CLUSTER_NAME=xxxxx
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=ec2-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"silent=False" \
+    -e"guid=${GUID}" \
+    -e"aws_region=${AWS_REGION}" \
+    -e"cluster_name=${CLUSTER_NAME}" \
+    -e"ACTION=create"
+----

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/readme.adoc
@@ -2,15 +2,17 @@
 
 == Role overview
 
-* This role installs playbooks and shell scripts to deploy a RHEL8 Worker for AWS based deployments.
+* This role installs one or more AWS RHEL8 instances after OpenShift cluster installation.
+* The student is expected to run the `openshift-ansible` playbook on the bastion host in order for the RHEL8 Workers to join the cluster.
 
-Once this role has been executed there is a directory `/opt/rhel_worker` with the necessary files to deploy a rhel_worker.
-If `ocp4_workloads_rhel_worker_deploy_worker` is set, this workload will deploy one worker.
-You can deploy subsequent workers with the playbook.
-SSH into the bastion, change to the `/opt/rhel_worker` directory and run `./setup_rhel_worker.sh`.
-This script will execute the playbook to deploy a rhel_worker into the region specified.
-
-Currently only `eu-central-1`, `us-east-1` and `us-east-2` are supported. This is because only for these three regions the AMI for the RHEL 8 image is specified.
+* This role was created because the AWS EC2 instances created for the RHEL8 Workers nodes must be deployed AFTER the OpenShift cluster.
+** This is so because the OpenShift clouster deployer creates a new VPC for the OpenShift cluster, and AWS EC2 instances' VPC_id and subnets cannot be modified after they have been deployed.
+* It sets up all AWS permissions necessary for the new RHEL nodes to join the cluster.
+* It updates the bastion host with a checkout of the openshift-ansible project and a list of RHEL_workers.txt to be added to an ansible inventory.
+* The user/student must run the openshift-ansible playbooks from the Bastion in order to install OpenShift on the RHEL nodes, and the playbooks will approve the CSRs and have the new RHEL workers join the cluster.
+* There is the added benefit of allowing this workoad role to be run after ANY config that deploys a suitable AWS OpenShift cluster.
+* You can deploy more than one worker by setting `ocp4_workload_rhel_worker_exact_count`.
+* RHEL Worker ocp4_workload_rhel_worker_ami_name: "RHEL-8.4.0_HVM-20210825-x86_64-0-Access2-GP2" is fixed because it's proven to work, and can be found in many AWS regions.
 
 . The role consists of the following tasks files:
 ** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an environment for the workload deployment
@@ -30,7 +32,6 @@ Currently only `eu-central-1`, `us-east-1` and `us-east-2` are supported. This i
 == Review the defaults variable file
 
 * This file link:./defaults/main.yml[./defaults/main.yml] contains all the variables you need to define to control the deployment of your workload.
-* The variable *ocp_username* is mandatory to assign the workload to the correct OpenShift user.
 * A variable *silent=True* can be passed to suppress debug messages.
 * You can modify any of these default values by adding `-e "variable_name=variable_value"` to the command line
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+# Do not modify this file
+
+- name: Running Pre Workload Tasks
+  include_tasks:
+    file: ./pre_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload Tasks
+  include_tasks:
+    file: ./workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  include_tasks:
+    file: ./post_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload removal Tasks
+  include_tasks:
+    file: ./remove_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/tasks/post_workload.yml
@@ -1,0 +1,24 @@
+---
+# Implement your Post Workload deployment tasks here
+
+# Leave these as the last tasks in the playbook
+
+# For deployment onto a dedicated cluster (as part of the
+# cluster deployment) set workload_shared_deployment to False
+# This is the default so it does not have to be set explicitely
+- name: pre_workload tasks complete
+  debug:
+    msg: "Post-Workload tasks completed successfully."
+  when:
+  - not silent | bool
+  - not workload_shared_deployment | default(false) | bool
+
+# For RHPDS deployment (onto a shared cluster) set
+# workload_shared_deployment to True
+# (in the deploy script or AgnosticV configuration)
+- name: pre_workload tasks complete
+  debug:
+    msg: "Post-Software checks completed successfully"
+  when:
+  - not silent | bool
+  - workload_shared_deployment | default(false) | bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/tasks/pre_workload.yml
@@ -1,0 +1,24 @@
+---
+# Implement your Pre Workload deployment tasks here
+
+# Leave these as the last tasks in the playbook
+
+# For deployment onto a dedicated cluster (as part of the
+# cluster deployment) set workload_shared_deployment to False
+# This is the default so it does not have to be set explicitely
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Workload tasks completed successfully."
+  when:
+  - not silent | bool
+  - not workload_shared_deployment | default(false) | bool
+
+# For RHPDS deployment (onto a shared cluster) set
+# workload_shared_deployment to True
+# (in the deploy script or AgnosticV configuration)
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Software checks completed successfully"
+  when:
+  - not silent | bool
+  - workload_shared_deployment | default(false) | bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/tasks/remove_workload.yml
@@ -1,0 +1,50 @@
+---
+# Implement your Workload removal tasks here
+
+- name: Make sure no newbox is active
+  shell: "/opt/aws-newbox/delete_newbox.sh"
+  ignore_errors: true
+
+- name: Remove newbox directories
+  file:
+    name: "{{ item }}"
+    state: absent
+  loop:
+  - "/opt/aws-newbox"
+  - "/opt/virtualenvs/ocp-newbox"
+
+- name: Remove RHEL_Worker instances
+  ec2_instance:
+    region: "{{ aws_region }}"
+    state: absent
+    filters:
+      "tag:type": "RHEL_worker"
+      "tag:guid": "{{ guid }}"
+      instance-state-name: [ "running" ]
+
+- name: find the RHEL_worker security group(s)
+  ec2_group_info:
+    region: "{{ aws_region }}"
+    filters:
+      "tag:type": "RHEL_worker"
+  register: RHEL_worker_sg
+
+- name: debug rhel sg
+  debug:
+    verbosity: 3
+    var: RHEL_worker_sg
+
+- name: Remove RHEL_Worker Security Group
+  ec2_group:
+    region: "{{ aws_region }}"
+    state: absent
+    group_id: "{{ item.group_id }}"
+  loop: "{{ RHEL_worker_sg.security_groups }}"
+
+
+# Leave this as the last task in the playbook.
+- name: remove_workload tasks complete
+  debug:
+    msg: "Remove Workload tasks completed successfully."
+  when: not silent | bool
+

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/tasks/remove_workload.yml
@@ -47,4 +47,3 @@
   debug:
     msg: "Remove Workload tasks completed successfully."
   when: not silent | bool
-

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/tasks/workload.yml
@@ -1,0 +1,341 @@
+---
+# Implement your Workload deployment tasks here
+
+- name: Setting up workload for user
+  debug:
+    verbosity: 3
+    msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
+
+# is there already a RHEL_worker?
+#
+- name: Are there already RHEL_workers?
+  ec2_instance_info:
+    aws_region: "{{ aws_region }}"
+    filters:
+      "tag:type": "RHEL_worker"
+      "tag:guid": "{{ guid }}"
+      instance-state-name: [ "running" ]
+  register: __RHEL_workers
+
+- name: Create RHEL workers if there arent enough
+  when: __RHEL_workers.instances | length < ocp4_workload_rhel_worker_exact_count
+  block:
+  - name: Find AMI to launch
+    ec2_ami_info:
+      aws_region: "{{ aws_region }}"
+      owners: 309956199498
+      filters:
+        name: "{{ ocp4_workload_rhel_worker_ami_name }}"
+    register: __rhel_ami
+
+  - name: "Get Control Plane Instances for cluster {{ cluster_name }}"
+    ec2_instance_info:
+      aws_region: "{{ aws_region }}"
+      filters:
+        "tag:Name": "*master*"
+        "tag:guid": "{{ guid }}"
+    register: __control_plane
+
+  - name: Add Control plane Instances to Inventory
+    add_host:
+      name: "{{ item.private_dns_name }}"
+      groups: control_plane
+    loop: "{{ __control_plane.instances }}"
+    when: __control_plane.instances[0] is defined
+
+  - name: Get Cluster VPC ID
+    set_fact:
+      cluster_vpc: "{{ __control_plane.instances[0].vpc_id }}"
+      # chop off the last character
+      cluster_region: "{{ __control_plane.instances[0].placement.availability_zone| regex_replace('.$') }}"
+    when: __control_plane.instances[0] is defined
+
+  - name: Get ansible_user ssh pubkey file for upload to AWS
+    ansible.builtin.slurp:
+      src: "/home/{{ ansible_user }}/.ssh/id_rsa.pub"
+    register: __id_rsa_pub
+
+  - name: Use which key?
+    when: ocp4_worload_rhel_worker_use_backdoor_key | default(false) | bool
+    set_fact:
+      __instance_key_name: "opentlc_admin_backdoor"
+
+  - name: Get ansible_user ssh pubkey file for upload to AWS
+    when: not ocp4_worload_rhel_worker_use_backdoor_key | default(false) | bool
+    block:
+      - name: Set bastion local key name
+        set_fact:
+          __instance_key_name: "{{ guid }}-cluster-key"
+
+      - name: Get bastion local key data
+        ansible.builtin.slurp:
+          src: "/home/{{ ansible_user }}/.ssh/id_rsa.pub"
+        register: __id_rsa_pub
+
+      - name: "Put the Cluster Public Key in AWS for RHEL_worker {{ __bastion_local_key_name }}"
+        ec2_key:
+          region: "{{ aws_region }}"
+          name: "{{ __instance_key_name }}"
+          key_material: "{{ __id_rsa_pub['content'] | b64decode }}"
+
+  - name: get vpc_subnet_id
+    ec2_vpc_subnet_info:
+      region: "{{ aws_region }}"
+      filters:
+        vpc-id: "{{ cluster_vpc }}"
+        # public
+        cidr-block: "10.0.0.0/*"
+        # private
+        #cidr-block: "192.168.0.0/*"
+    register: ec2_vpc_subnet_ids
+
+  - name: short subnet cidr
+    set_fact:
+      ocp_network_subnet_cidr: "{{ ec2_vpc_subnet_ids.subnets[0].cidr_block }}"
+
+  - name: Create IAM role based on trust policy
+    register: __rhel_worker_access_role
+    # aws iam create-role --role-name rhel-worker-access-role --assume-role-policy-document file://ec2-role-trust-policy.json
+    iam_role:
+      name: rhel-worker-access-role
+      assume_role_policy_document: "{{ lookup('file','./files/ec2-role-trust-policy.json') }}"
+      create_instance_profile: true
+      description: IAM Role for RHEL Worker trust policy
+      state: present
+        # `create_instance_profile: true` does the following:
+        # aws iam create-instance-profile --instance-profile-name rhel-worker-profile
+        # aws iam add-role-to-instance-profile --instance-profile-name rhel-worker-profile --role-name rhel-worker-access-role
+
+  - name: Create IAM access policy
+    # vim ec2-role-access-policy.json
+    # aws iam put-role-policy --role-name rhel-worker-access-role --policy-name rhel-worker-permissions-policy --policy-document file://ec2-role-access-policy.json
+    iam_policy:
+      state: present
+      iam_type: role
+      iam_name: rhel-worker-access-role
+      policy_name: rhel-worker-permissions-policy
+      policy_json: "{{ lookup('file', './files/ec2-role-access-policy.json') }}"
+
+  - name: Create RHEL Worker security group
+    register: sg_RHEL_worker
+    ec2_group:
+      region: "{{ aws_region }}"
+      name: "RHEL_worker-{{ cluster_name }}"
+      description: RHEL_worker security group
+      tags:
+        type: RHEL_worker
+      vpc_id: "{{ cluster_vpc }}"
+      rules:
+        - proto: udp
+          ports: 632
+          cidr_ip: 0.0.0.0/0
+        - proto: tcp
+          ports: 22
+          rule_desc: "SSH"
+          cidr_ip: 0.0.0.0/0
+        - proto: udp
+          ports: 5353
+          rule_desc: "mDNS"
+          cidr_ip: 0.0.0.0/0
+        - proto: tcp
+          ports: 80
+          rule_desc: "Ingress HTTP"
+          cidr_ip: 0.0.0.0/0
+        - proto: tcp
+          ports: 443
+          rule_desc: "Ingress HTTPS"
+          cidr_ip: 0.0.0.0/0
+        - proto: tcp
+          ports: 1936
+          rule_desc: "router stats"
+          cidr_ip: 0.0.0.0/0
+        - proto: udp
+          ports: 4789
+          rule_desc: "VXLAN"
+          cidr_ip: 0.0.0.0/0
+        - proto: udp
+          ports: 6081
+          rule_desc: "Geneve"
+          cidr_ip: 0.0.0.0/0
+        - proto: tcp
+          ports: 9000-9999
+          rule_desc: "Worker ingress internal (tcp)"
+          cidr_ip: 0.0.0.0/0
+        - proto: tcp
+          ports: 10250
+          rule_desc: "master ingress kubelet secure"
+          cidr_ip: 0.0.0.0/0
+        - proto: tcp
+          ports: 30000-32767
+          rule_desc: "worker ingress services (tcp)"
+          cidr_ip: 0.0.0.0/0
+        - proto: udp
+          ports: 30000-32767
+          rule_desc: "worker ingress services (udp)"
+          cidr_ip: 0.0.0.0/0
+
+  - name: set a fact for the instance tags
+    set_fact:
+      instance_tags: >-
+        {
+          "type": "RHEL_worker",
+          "guid": "{{ guid }}",
+          "cluster_name": "{{ cluster_name }}",
+          "kubernetes.io/cluster/{{ cluster_name }}": "{{ ocp4_workload_rhel_worker_ownership }}"
+        }
+
+  - name: Launch EC2 RHEL_worker instance
+    ec2:
+      region: "{{ aws_region }}"
+      key_name: "opentlc_admin_backdoor"
+      vpc_subnet_id: "{{ ec2_vpc_subnet_ids.subnets[0].subnet_id }}"
+      instance_type: m5.4xlarge
+      group_id: "{{ sg_RHEL_worker.group_id }}"
+      image: "{{ __rhel_ami.images[0].image_id }}"
+      assign_public_ip: true
+      exact_count: "{{ ocp4_workload_rhel_worker_exact_count }}"
+      count_tag: "{{ instance_tags }}"
+      instance_tags: "{{ instance_tags }}"
+      instance_profile_name: "rhel-worker-access-role"
+      wait: true
+    register: __new_RHEL
+
+- name: "add/replace __new_RHEL to __RHEL_workers"
+  when: __new_RHEL.instances[0] is defined
+  set_fact:
+    __RHEL_workers: "{{ __new_RHEL }}"
+
+- name: debug RHEL_workers
+  debug:
+    verbosity: 3
+    var: __RHEL_workers
+
+- name: Convenience fact for the first RHEL_worker_name
+  set_fact:
+    RHEL_worker_name: "{{ __RHEL_workers.instances[0].public_dns_name }}"
+
+      #- name: Add RHEL_worker instance public IP to host group
+      #  add_host:
+      #    name: "{{ RHEL_worker_ip }}"
+      #    groups:
+      #    - RHEL_worker
+
+- name: Add new __RHEL_workers instance to host RHEL_workers host group
+  add_host:
+    hostname: "{{ RHEL_worker_name }}"
+    groupname: RHEL_workers
+
+  #- name: Associate IAM Instance Profile to RHEL Workers
+  #   66  aws ec2 describe-instances | less
+  #   67  i-0d3a0d0149ea2ae94
+  #   the following already done at instance creation time
+  #   68  aws ec2 associate-iam-instance-profile --instance-id i-0d3a0d0149ea2ae94 --iam-instance-profile Name="rhel-worker-policy"
+  #- name: make sure they have the tagz
+  #   74  aws ec2 create-tags --resources i-0d3a0d0149ea2ae94 --tags Key=kubernetes.io/cluster/cluster-wgm7b,Value=shared
+
+- name: Wait for SSH to come up on the new RHEL_worker
+  delegate_to: "{{ item.public_dns_name }}"
+  loop: "{{ __RHEL_workers.instances }}"
+  wait_for_connection:
+    delay: 10
+    timeout: 320
+
+# add RHEL_worker to inventory
+- name: Print RHEL_worker information
+  debug:
+   verbosity: 3
+   msg: "{{ hostvars | to_nice_yaml }}"
+
+     #- name: do things to new host
+     #  delegate_to: "{{ RHEL_worker_name }}"
+     #  become: true
+     #  command: systemctl disable --now firewalld.service
+
+- name: Run setup if gather_facts hasn't been run
+  setup:
+    gather_subset: min
+  when: ansible_date_time is not defined
+
+- name: set subs hostname
+  set_fact:
+    set_repositories_subscription_hostname_rando: "{{ RHEL_worker_name }}-{{ ansible_date_time.iso8601_basic | lower }}"
+
+- name: debug the subs hostname
+  debug:
+    verbosity: 3
+    var: set_repositories_subscription_hostname_rando
+
+      #- name: run set-repositories on new host
+      #  delegate_to: "{{ RHEL_worker_name }}"
+      #  ansible.builtin.setup:
+      #  delegate_facts: True
+      #  become: true
+      #
+- name: Setup RHEL Repositories on the RHEL Worker
+  include_role:
+    name: set-repositories
+    apply:
+        delegate_to: "{{ item.public_dns_name }}"
+        delegate_facts: True
+        become: true
+        vars:
+          set_repositories_subscription_hostname: "{{ item.public_dns_name }}-{{ ansible_date_time.iso8601_basic | lower }}"
+  loop: "{{ __RHEL_workers.instances }}"
+
+    #- name: Setup RHEL Repositories on the RHEL Worker
+    #  delegate_to: "{{ RHEL_worker_name }}"
+    #  delegate_facts: True
+    #  become: true
+    #  import_role:
+    #    name: set-repositories
+    #  vars:
+
+- name: Add tmux to RHEL_workers
+  delegate_to: "{{ item.public_dns_name }}"
+  loop: "{{ __RHEL_workers.instances }}"
+  delegate_facts: True
+  become: true
+  package:
+    state: present
+    name: tmux
+
+# prep the bastion with openshift-ansible
+- name: set openshift-ansible path
+  set_fact:
+    openshift_ansible_path: "/home/{{ ansible_user }}/openshift-ansible/"
+
+- name: clone the openshift-ansible repo
+  git:
+    repo: 'https://github.com/openshift/openshift-ansible'
+    version: release-4.9
+    dest: "{{ openshift_ansible_path }}"
+    depth: 1
+
+- name: put the RHEL workers names in a file
+  lineinfile:
+    path: ~/RHEL_workers.txt
+    line: "{{ item.public_dns_name }}"
+    create: true
+  loop: "{{ __RHEL_workers.instances }}"
+
+    # cd openshift-ansible
+    # virtualenv venv
+    # source venv/bin/activate
+    # pip install -r requirements.txt
+    # which ansible # ensure that this is from the virtualenv
+    # cd ~/openshift-ansible
+    # cp inventory/hosts-* inventory/hosts
+    # cat ~/RHEL_workers >> openshift-ansible/inventory/hosts
+    # vi inventory/hosts # remove the detritus
+    #   ansible-playbook -vvvvv -i inventory/hosts playbooks/scaleup.yml
+    #   76  oc get csr
+    #   83  oc adm certificate approve csr-pr95z
+    #   92  oc get nodes
+    #   93  oc describe nodes |grep rhel
+    #   94  oc get pods -A
+
+# Leave this as the last task in the playbook.
+- name: workload tasks complete
+  debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent | bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/tasks/workload.yml
@@ -63,20 +63,20 @@
   - name: Get ansible_user ssh pubkey file for upload to AWS
     when: not ocp4_worload_rhel_worker_use_backdoor_key | default(false) | bool
     block:
-      - name: Set bastion local key name
-        set_fact:
-          __instance_key_name: "{{ guid }}-cluster-key"
+    - name: Set bastion local key name
+      set_fact:
+        __instance_key_name: "{{ guid }}-cluster-key"
 
-      - name: Get bastion local key data
-        ansible.builtin.slurp:
-          src: "/home/{{ ansible_user }}/.ssh/id_rsa.pub"
-        register: __id_rsa_pub
+    - name: Get bastion local key data
+      ansible.builtin.slurp:
+        src: "/home/{{ ansible_user }}/.ssh/id_rsa.pub"
+      register: __id_rsa_pub
 
-      - name: "Put the Cluster Public Key in AWS for RHEL_worker {{ __bastion_local_key_name }}"
-        ec2_key:
-          region: "{{ aws_region }}"
-          name: "{{ __instance_key_name }}"
-          key_material: "{{ __id_rsa_pub['content'] | b64decode }}"
+    - name: "Put the Cluster Public Key in AWS for RHEL_worker {{ __bastion_local_key_name }}"
+      ec2_key:
+        region: "{{ aws_region }}"
+        name: "{{ __instance_key_name }}"
+        key_material: "{{ __id_rsa_pub['content'] | b64decode }}"
 
   - name: get vpc_subnet_id
     ec2_vpc_subnet_info:
@@ -95,7 +95,8 @@
 
   - name: Create IAM role based on trust policy
     register: __rhel_worker_access_role
-    # aws iam create-role --role-name rhel-worker-access-role --assume-role-policy-document file://ec2-role-trust-policy.json
+    # aws iam create-role --role-name rhel-worker-access-role \
+    # --assume-role-policy-document file://ec2-role-trust-policy.json
     iam_role:
       name: rhel-worker-access-role
       assume_role_policy_document: "{{ lookup('file','./files/ec2-role-trust-policy.json') }}"
@@ -104,11 +105,14 @@
       state: present
         # `create_instance_profile: true` does the following:
         # aws iam create-instance-profile --instance-profile-name rhel-worker-profile
-        # aws iam add-role-to-instance-profile --instance-profile-name rhel-worker-profile --role-name rhel-worker-access-role
+        # aws iam add-role-to-instance-profile --instance-profile-name rhel-worker-profile
+        # --role-name rhel-worker-access-role
 
   - name: Create IAM access policy
     # vim ec2-role-access-policy.json
-    # aws iam put-role-policy --role-name rhel-worker-access-role --policy-name rhel-worker-permissions-policy --policy-document file://ec2-role-access-policy.json
+    # aws iam put-role-policy --role-name rhel-worker-access-role \
+    # --policy-name rhel-worker-permissions-policy
+    # --policy-document file://ec2-role-access-policy.json
     iam_policy:
       state: present
       iam_type: role
@@ -126,53 +130,53 @@
         type: RHEL_worker
       vpc_id: "{{ cluster_vpc }}"
       rules:
-        - proto: udp
-          ports: 632
-          cidr_ip: 0.0.0.0/0
-        - proto: tcp
-          ports: 22
-          rule_desc: "SSH"
-          cidr_ip: 0.0.0.0/0
-        - proto: udp
-          ports: 5353
-          rule_desc: "mDNS"
-          cidr_ip: 0.0.0.0/0
-        - proto: tcp
-          ports: 80
-          rule_desc: "Ingress HTTP"
-          cidr_ip: 0.0.0.0/0
-        - proto: tcp
-          ports: 443
-          rule_desc: "Ingress HTTPS"
-          cidr_ip: 0.0.0.0/0
-        - proto: tcp
-          ports: 1936
-          rule_desc: "router stats"
-          cidr_ip: 0.0.0.0/0
-        - proto: udp
-          ports: 4789
-          rule_desc: "VXLAN"
-          cidr_ip: 0.0.0.0/0
-        - proto: udp
-          ports: 6081
-          rule_desc: "Geneve"
-          cidr_ip: 0.0.0.0/0
-        - proto: tcp
-          ports: 9000-9999
-          rule_desc: "Worker ingress internal (tcp)"
-          cidr_ip: 0.0.0.0/0
-        - proto: tcp
-          ports: 10250
-          rule_desc: "master ingress kubelet secure"
-          cidr_ip: 0.0.0.0/0
-        - proto: tcp
-          ports: 30000-32767
-          rule_desc: "worker ingress services (tcp)"
-          cidr_ip: 0.0.0.0/0
-        - proto: udp
-          ports: 30000-32767
-          rule_desc: "worker ingress services (udp)"
-          cidr_ip: 0.0.0.0/0
+      - proto: udp
+        ports: 632
+        cidr_ip: 0.0.0.0/0
+      - proto: tcp
+        ports: 22
+        rule_desc: "SSH"
+        cidr_ip: 0.0.0.0/0
+      - proto: udp
+        ports: 5353
+        rule_desc: "mDNS"
+        cidr_ip: 0.0.0.0/0
+      - proto: tcp
+        ports: 80
+        rule_desc: "Ingress HTTP"
+        cidr_ip: 0.0.0.0/0
+      - proto: tcp
+        ports: 443
+        rule_desc: "Ingress HTTPS"
+        cidr_ip: 0.0.0.0/0
+      - proto: tcp
+        ports: 1936
+        rule_desc: "router stats"
+        cidr_ip: 0.0.0.0/0
+      - proto: udp
+        ports: 4789
+        rule_desc: "VXLAN"
+        cidr_ip: 0.0.0.0/0
+      - proto: udp
+        ports: 6081
+        rule_desc: "Geneve"
+        cidr_ip: 0.0.0.0/0
+      - proto: tcp
+        ports: 9000-9999
+        rule_desc: "Worker ingress internal (tcp)"
+        cidr_ip: 0.0.0.0/0
+      - proto: tcp
+        ports: 10250
+        rule_desc: "master ingress kubelet secure"
+        cidr_ip: 0.0.0.0/0
+      - proto: tcp
+        ports: 30000-32767
+        rule_desc: "worker ingress services (tcp)"
+        cidr_ip: 0.0.0.0/0
+      - proto: udp
+        ports: 30000-32767
+        rule_desc: "worker ingress services (udp)"
+        cidr_ip: 0.0.0.0/0
 
   - name: set a fact for the instance tags
     set_fact:
@@ -243,13 +247,13 @@
 # add RHEL_worker to inventory
 - name: Print RHEL_worker information
   debug:
-   verbosity: 3
-   msg: "{{ hostvars | to_nice_yaml }}"
+    verbosity: 3
+    msg: "{{ hostvars | to_nice_yaml }}"
 
-     #- name: do things to new host
-     #  delegate_to: "{{ RHEL_worker_name }}"
-     #  become: true
-     #  command: systemctl disable --now firewalld.service
+    #- name: do things to new host
+    #  delegate_to: "{{ RHEL_worker_name }}"
+    #  become: true
+    #  command: systemctl disable --now firewalld.service
 
 - name: Run setup if gather_facts hasn't been run
   setup:
@@ -265,35 +269,21 @@
     verbosity: 3
     var: set_repositories_subscription_hostname_rando
 
-      #- name: run set-repositories on new host
-      #  delegate_to: "{{ RHEL_worker_name }}"
-      #  ansible.builtin.setup:
-      #  delegate_facts: True
-      #  become: true
-      #
 - name: Setup RHEL Repositories on the RHEL Worker
   include_role:
     name: set-repositories
     apply:
-        delegate_to: "{{ item.public_dns_name }}"
-        delegate_facts: True
-        become: true
-        vars:
-          set_repositories_subscription_hostname: "{{ item.public_dns_name }}-{{ ansible_date_time.iso8601_basic | lower }}"
+      delegate_to: "{{ item.public_dns_name }}"
+      delegate_facts: true
+      become: true
+      vars:
+        set_repositories_subscription_hostname: "{{ item.public_dns_name }}-{{ ansible_date_time.iso8601_basic | lower }}"
   loop: "{{ __RHEL_workers.instances }}"
-
-    #- name: Setup RHEL Repositories on the RHEL Worker
-    #  delegate_to: "{{ RHEL_worker_name }}"
-    #  delegate_facts: True
-    #  become: true
-    #  import_role:
-    #    name: set-repositories
-    #  vars:
 
 - name: Add tmux to RHEL_workers
   delegate_to: "{{ item.public_dns_name }}"
   loop: "{{ __RHEL_workers.instances }}"
-  delegate_facts: True
+  delegate_facts: true
   become: true
   package:
     state: present

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/tasks/workload.yml
@@ -199,7 +199,7 @@
       assign_public_ip: true
       exact_count: "{{ ocp4_workload_rhel_worker_exact_count }}"
       count_tag: "{{ instance_tags }}"
-      instance_tags: "{{ instance_tags }}"
+      instance_tags: "{{ instance_tags | combine(hostvars.localhost.cloud_tags_final) }}"
       instance_profile_name: "rhel-worker-access-role"
       wait: true
     register: __new_RHEL


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

This new ocp4_workload role is (I hope) useful with any OCP4 cluster config (or BYO cluster).

It deploys any number of RHEL8 instances to be used as worker nodes.   It does not run the playbooks to install OpenShift on the RHEL nodes, or automate their joining the cluster.  That's for the student to do.  Samples code of the steps necessary to setup OpenShift on the RHEL nodes and have them join the cluster are in the workload.yml comments.

It deploys the RHEL instances into the VPC of the existing cluster in the sandbox.

It sets up all AWS permissions necessary for the new RHEL nodes to join the cluster.

It updates the bastion host with a checkout of the openshift-ansible project and a list of RHEL_workers.txt to be added to an ansible inventory.

The user must run the openshift-ansible playbooks from the Bastion in order to install OpenShift on the RHEL nodes, and the playbooks will approve the CSRs and have the new RHEL workers join the cluster.
 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

roles_ocp_workloads/ocp4_workload_rhel_worker

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
