### PR TITLE
Fix inventory exporter loop

### DIFF
--- a/ansible/export_inventory.yml
+++ b/ansible/export_inventory.yml
@@ -6,5 +6,3 @@
       when: agnosticd_inventory_exporter_enable | default(false) | bool
       include_role:
         name: agnosticd_inventory_exporter
-      vars:
-        stage: "{{ stage }}"

--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -57,7 +57,7 @@
 
 - import_playbook: "export_inventory.yml"
   vars:
-    stage: post_infra
+    agnosticd_inventory_exporter_stage: post_infra
   tags:
     - step002
     - post_infra
@@ -108,7 +108,7 @@
 
 - import_playbook: "export_inventory.yml"
   vars:
-    stage: post_software
+    agnosticd_inventory_exporter_stage: post_software
   tags:
     - step005
     - post_software

--- a/ansible/roles/agnosticd_inventory_exporter/tasks/main.yaml
+++ b/ansible/roles/agnosticd_inventory_exporter/tasks/main.yaml
@@ -2,5 +2,9 @@
 - name: Export in-memory inventory to file
   when: agnosticd_inventory_exporter_enable | bool
   template:
-    dest: "{{ output_dir }}/inventory_{{ stage }}.yaml"
+    dest: >-
+      {{- output_dir -}}
+      /inventory_
+      {{- agnosticd_inventory_exporter_stage
+      | default('unknown_stage') -}}.yaml
     src: inventory.yaml.j2


### PR DESCRIPTION
Fix the loop causing the error:

```
Error was a <class 'ansible.errors.AnsibleError'>, original message: An unhandled exception occurred while templating '{{ stage }}'.
```
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request