### PR TITLE
Change workload ocp4_workload_servicemesh_workshop, update homeroom version

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/defaults/main.yml
@@ -14,7 +14,7 @@ silent: false
 ## Workshop Settings
 ocp4_workload_servicemesh_workshop_user_count: "{{ num_users | default(user_count) | default(1) }}"
 ocp4_workload_servicemesh_workshop_image_repo: quay.io/redhatgov/service-mesh-workshop-dashboard
-ocp4_workload_servicemesh_workshop_image_tag: "2.1"
+ocp4_workload_servicemesh_workshop_image_tag: "2.2"
 
 ## Operator Settings
 ocp4_workload_servicemesh_workshop_elasticsearch_channel: "4.6"


### PR DESCRIPTION
##### SUMMARY

Updates the homeroom version in the workshop to V2.2.  This addresses a bug that prevents participants from completing the authorization RH-SSO lab in the workshop (https://github.com/RedHatGov/service-mesh-workshop-dashboard/issues/12).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_servicemesh_workshop
