### PR TITLE
Fix kube config permissions

### DIFF
--- a/ansible/roles/host-ocp4-installer/tasks/main.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/main.yml
@@ -21,7 +21,7 @@
 
   - name: Run the installer
     become: false
-    command: openshift-install create cluster --dir=~{{ ansible_user }}/{{ cluster_name }}
+    command: openshift-install create cluster --dir=/home/{{ ansible_user }}/{{ cluster_name }}
     async: "{{ 2 * 60 * 60 }}"
     poll: "{{ 0 if ocp4_ansible_managed_osp_external_network | bool else 15 }}"
     register: r_openshift_install
@@ -34,7 +34,7 @@
   rescue:
   - name: Run destroy to reset before retry
     become: false
-    command: openshift-install destroy cluster --dir=~{{ ansible_user }}/{{ cluster_name }}
+    command: openshift-install destroy cluster --dir=/home/{{ ansible_user }}/{{ cluster_name }}
 
   - name: Pause briefly for cloud provider cleanup to finish
     pause:
@@ -43,8 +43,8 @@
   - name: Restore install config from backup copy
     copy:
       remote_src: true
-      src: ~{{ ansible_user }}/{{ cluster_name }}/install-config.yaml.bak
-      dest: ~{{ ansible_user }}/{{ cluster_name }}/install-config.yaml
+      src: /home/{{ ansible_user }}/{{ cluster_name }}/install-config.yaml.bak
+      dest: /home/{{ ansible_user }}/{{ cluster_name }}/install-config.yaml
       owner: "{{ ansible_user }}"
       mode: ug=rw,o=
 
@@ -53,7 +53,7 @@
 
   - name: Retry the installer
     become: false
-    command: openshift-install create cluster --dir=~{{ ansible_user }}/{{ cluster_name }}
+    command: openshift-install create cluster --dir=/home/{{ ansible_user }}/{{ cluster_name }}
     async: "{{ 2 * 60 * 60 }}"
     poll: "{{ 0 if ocp4_ansible_managed_osp_external_network | bool else 15 }}"
     register: r_openshift_install
@@ -66,13 +66,13 @@
   always:
   - name: Gzip Install log
     archive:
-      path: ~{{ ansible_user }}/{{ cluster_name }}/.openshift_install.log
-      dest: ~{{ ansible_user }}/{{ cluster_name }}/.openshift_install.log.gz
+      path: /home/{{ ansible_user }}/{{ cluster_name }}/.openshift_install.log
+      dest: /home/{{ ansible_user }}/{{ cluster_name }}/.openshift_install.log.gz
       format: gz
 
   - name: Get Install log
     fetch:
-      src: ~{{ ansible_user }}/{{ cluster_name }}/.openshift_install.log.gz
+      src: /home/{{ ansible_user }}/{{ cluster_name }}/.openshift_install.log.gz
       dest: "{{ output_dir }}/{{ env_type }}_{{ guid }}_log/"
       flat: true
 
@@ -113,7 +113,7 @@
 - name: Fetch kube config
   fetch:
     flat: true
-    src: ~{{ ansible_user }}/{{ cluster_name }}/auth/{{ item }}
+    src: /home/{{ ansible_user }}/{{ cluster_name }}/auth/{{ item }}
     dest: "{{ hostvars.localhost.output_dir }}/{{ env_type }}_{{ guid }}_{{ item }}"
   loop:
   - kubeconfig
@@ -124,23 +124,26 @@
     state: directory
     path: "{{ item.path }}"
     owner: "{{ item.owner }}"
+    group: "{{ item.group }}"
     mode: 0700
   loop:
-  - path: "~{{ ansible_user }}/.kube"
+  - path: "/home/{{ ansible_user }}/.kube"
     owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
   - path: /root/.kube
     owner: root
+    group: root
 
 - name: Set up .kube/config files
   copy:
     remote_src: true
-    src: "~{{ ansible_user }}/{{ cluster_name }}/auth/kubeconfig"
+    src: "/home/{{ ansible_user }}/{{ cluster_name }}/auth/kubeconfig"
     dest: "{{ item.path }}"
     owner: "{{ item.owner }}"
     group: "{{ item.group }}"
     mode: 0600
   loop:
-  - path: "~{{ ansible_user }}/.kube/config"
+  - path: "/home/{{ ansible_user }}/.kube/config"
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
   - path: /root/.kube/config
@@ -150,20 +153,20 @@
 - name: Set up Student User
   when: install_student_user | bool
   block:
-  - name: Make sure .kube directory exists in ~{{ student_name }}
+  - name: Make sure .kube directory exists in /home/{{ student_name }}
     become: true
     file:
       state: directory
-      path: "~{{ student_name }}/.kube"
+      path: "/home/{{ student_name }}/.kube"
       owner: "{{ student_name }}"
       group: users
       mode: 0700
 
-  - name: Copy ~{{ ansible_user }}/{{ cluster_name }}/auth/kubeconfig to ~{{ student_name }}/.kube
+  - name: Copy /home/{{ ansible_user }}/{{ cluster_name }}/auth/kubeconfig to /home/{{ student_name }}/.kube
     become: true
     copy:
-      src: ~{{ ansible_user }}/{{ cluster_name }}/auth/kubeconfig
-      dest: ~{{ student_name }}/.kube/config
+      src: /home/{{ ansible_user }}/{{ cluster_name }}/auth/kubeconfig
+      dest: /home/{{ student_name }}/.kube/config
       remote_src: true
       owner: "{{ student_name }}"
       group: users

--- a/ansible/roles/host-ocp4-installer/tasks/main.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/main.yml
@@ -21,7 +21,7 @@
 
   - name: Run the installer
     become: false
-    command: openshift-install create cluster --dir=/home/{{ ansible_user }}/{{ cluster_name }}
+    command: openshift-install create cluster --dir=~{{ ansible_user }}/{{ cluster_name }}
     async: "{{ 2 * 60 * 60 }}"
     poll: "{{ 0 if ocp4_ansible_managed_osp_external_network | bool else 15 }}"
     register: r_openshift_install
@@ -34,7 +34,7 @@
   rescue:
   - name: Run destroy to reset before retry
     become: false
-    command: openshift-install destroy cluster --dir=/home/{{ ansible_user }}/{{ cluster_name }}
+    command: openshift-install destroy cluster --dir=~{{ ansible_user }}/{{ cluster_name }}
 
   - name: Pause briefly for cloud provider cleanup to finish
     pause:
@@ -43,8 +43,8 @@
   - name: Restore install config from backup copy
     copy:
       remote_src: true
-      src: /home/{{ ansible_user }}/{{ cluster_name }}/install-config.yaml.bak
-      dest: /home/{{ ansible_user }}/{{ cluster_name }}/install-config.yaml
+      src: ~{{ ansible_user }}/{{ cluster_name }}/install-config.yaml.bak
+      dest: ~{{ ansible_user }}/{{ cluster_name }}/install-config.yaml
       owner: "{{ ansible_user }}"
       mode: ug=rw,o=
 
@@ -53,7 +53,7 @@
 
   - name: Retry the installer
     become: false
-    command: openshift-install create cluster --dir=/home/{{ ansible_user }}/{{ cluster_name }}
+    command: openshift-install create cluster --dir=~{{ ansible_user }}/{{ cluster_name }}
     async: "{{ 2 * 60 * 60 }}"
     poll: "{{ 0 if ocp4_ansible_managed_osp_external_network | bool else 15 }}"
     register: r_openshift_install
@@ -66,13 +66,13 @@
   always:
   - name: Gzip Install log
     archive:
-      path: /home/{{ ansible_user }}/{{ cluster_name }}/.openshift_install.log
-      dest: /home/{{ ansible_user }}/{{ cluster_name }}/.openshift_install.log.gz
+      path: ~{{ ansible_user }}/{{ cluster_name }}/.openshift_install.log
+      dest: ~{{ ansible_user }}/{{ cluster_name }}/.openshift_install.log.gz
       format: gz
 
   - name: Get Install log
     fetch:
-      src: /home/{{ ansible_user }}/{{ cluster_name }}/.openshift_install.log.gz
+      src: ~{{ ansible_user }}/{{ cluster_name }}/.openshift_install.log.gz
       dest: "{{ output_dir }}/{{ env_type }}_{{ guid }}_log/"
       flat: true
 
@@ -113,7 +113,7 @@
 - name: Fetch kube config
   fetch:
     flat: true
-    src: /home/{{ ansible_user }}/{{ cluster_name }}/auth/{{ item }}
+    src: ~{{ ansible_user }}/{{ cluster_name }}/auth/{{ item }}
     dest: "{{ hostvars.localhost.output_dir }}/{{ env_type }}_{{ guid }}_{{ item }}"
   loop:
   - kubeconfig
@@ -126,7 +126,7 @@
     owner: "{{ item.owner }}"
     mode: 0700
   loop:
-  - path: "/home/{{ ansible_user }}/.kube"
+  - path: "~{{ ansible_user }}/.kube"
     owner: "{{ ansible_user }}"
   - path: /root/.kube
     owner: root
@@ -134,13 +134,13 @@
 - name: Set up .kube/config files
   copy:
     remote_src: true
-    src: "/home/{{ ansible_user }}/{{ cluster_name }}/auth/kubeconfig"
+    src: "~{{ ansible_user }}/{{ cluster_name }}/auth/kubeconfig"
     dest: "{{ item.path }}"
     owner: "{{ item.owner }}"
     group: "{{ item.group }}"
     mode: 0600
   loop:
-  - path: "/home/{{ ansible_user }}/.kube/config"
+  - path: "~{{ ansible_user }}/.kube/config"
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
   - path: /root/.kube/config
@@ -150,20 +150,20 @@
 - name: Set up Student User
   when: install_student_user | bool
   block:
-  - name: Make sure .kube directory exists in /home/{{ student_name }}
+  - name: Make sure .kube directory exists in ~{{ student_name }}
     become: true
     file:
       state: directory
-      path: "/home/{{ student_name }}/.kube"
+      path: "~{{ student_name }}/.kube"
       owner: "{{ student_name }}"
       group: users
       mode: 0700
 
-  - name: Copy /home/{{ ansible_user }}/{{ cluster_name }}/auth/kubeconfig to /home/{{ student_name }}/.kube
+  - name: Copy ~{{ ansible_user }}/{{ cluster_name }}/auth/kubeconfig to ~{{ student_name }}/.kube
     become: true
     copy:
-      src: /home/{{ ansible_user }}/{{ cluster_name }}/auth/kubeconfig
-      dest: /home/{{ student_name }}/.kube/config
+      src: ~{{ ansible_user }}/{{ cluster_name }}/auth/kubeconfig
+      dest: ~{{ student_name }}/.kube/config
       remote_src: true
       owner: "{{ student_name }}"
       group: users

--- a/ansible/roles/host-ocp4-installer/tasks/main.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/main.yml
@@ -119,33 +119,33 @@
   - kubeconfig
   - kubeadmin-password
 
-- name: Make sure .kube directory exists in home directory
+- name: Make sure .kube directory exists in home directories
   file:
     state: directory
-    path: "/home/{{ ansible_user }}/.kube"
-    owner: "{{ ansible_user }}"
-    mode: 0775
-
-- name: Set up .kube/config
-  copy:
-    remote_src: true
-    src: "/home/{{ ansible_user }}/{{ cluster_name }}/auth/kubeconfig"
-    dest: "/home/{{ ansible_user }}/.kube/config"
-
-- name: Make sure .kube directory exists in /root
-  become: true
-  file:
-    state: directory
-    path: /root/.kube
-    owner: root
+    path: "{{ item.path }}"
+    owner: "{{ item.owner }}"
     mode: 0700
+  loop:
+  - path: "/home/{{ ansible_user }}/.kube"
+    owner: "{{ ansible_user }}"
+  - path: /root/.kube
+    owner: root
 
-- name: Set up .kube/config for root
-  become: true
+- name: Set up .kube/config files
   copy:
     remote_src: true
     src: "/home/{{ ansible_user }}/{{ cluster_name }}/auth/kubeconfig"
-    dest: /root/.kube/config
+    dest: "{{ item.path }}"
+    owner: "{{ item.owner }}"
+    group: "{{ item.group }}"
+    mode: 0600
+  loop:
+  - path: "/home/{{ ansible_user }}/.kube/config"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+  - path: /root/.kube/config
+    owner: root
+    group: root
 
 - name: Set up Student User
   when: install_student_user | bool
@@ -156,6 +156,7 @@
       state: directory
       path: "/home/{{ student_name }}/.kube"
       owner: "{{ student_name }}"
+      group: users
       mode: 0700
 
   - name: Copy /home/{{ ansible_user }}/{{ cluster_name }}/auth/kubeconfig to /home/{{ student_name }}/.kube
@@ -165,6 +166,7 @@
       dest: /home/{{ student_name }}/.kube/config
       remote_src: true
       owner: "{{ student_name }}"
+      group: users
       mode: 0600
 
 - name: Create OpenShift Bash completion file


### PR DESCRIPTION
##### SUMMARY

Permissions were wrong for /root/.kube and /home/{{ ansible_user }}/.kube and .kube/config files resulting in warnings when using helm.

Also changed all `/home/xxx` to `~xxx` notation.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
host-ocp4-installer