### PR TITLE
smart_management, updating pip to resolve ansible-tower-cli install error

### DIFF
--- a/ansible/configs/smart-management/pre_software.yml
+++ b/ansible/configs/smart-management/pre_software.yml
@@ -49,7 +49,7 @@
 
     - name: Upgrade python2-pip with pip
       pip:
-       name: pip==20.3
+        name: pip==20.3
 
     - name: Disable EPEL from satellite
       rhsm_repository:

--- a/ansible/configs/smart-management/pre_software.yml
+++ b/ansible/configs/smart-management/pre_software.yml
@@ -47,6 +47,10 @@
         name: python2-pip
         state: latest
 
+    - name: Upgrade python2-pip with pip
+      pip:
+       name: pip==20.3
+
     - name: Disable EPEL from satellite
       rhsm_repository:
         name: Red_Hat_GPTE_Labs_Extra_Packages_for_Enterprise_Linux_EPEL_RHEL_7


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

This fix is in respond to failures of the tower-install role with python2. Pip is installed natively at version 8.1 which fails to install the packages. version 20.3 works and is available. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
smart-management config
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
