### PR TITLE
Fix ocp4_workload_le_certificates home path in deploy_certs.yaml

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_le_certificates/files/deploy_certs.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_le_certificates/files/deploy_certs.yaml
@@ -8,9 +8,9 @@
   gather_facts: false
   become: false
   vars:
-  - _certbot_install_dir: "/home/{{ ansible_user }}/certificates"
-  - _certbot_remote_dir: "/home/{{ ansible_user }}"
-  - _certbot_dir: "/home/{{ ansible_user }}/certbot"
+  - _certbot_install_dir: "~/certificates"
+  - _certbot_remote_dir: "~"
+  - _certbot_dir: "~/certbot"
   tasks:
   - name: Determine API server URL
     k8s_info:


### PR DESCRIPTION
##### SUMMARY

Fix deploy_certs.yaml playbook for letsencrypt certbot. Use `~` for home directory. `ansible_user` is undefined when executing with local connection.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role ocp4_workload_le_certificates