### PR TITLE
Fix gitea workload variable names

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/defaults/main.yml
@@ -113,8 +113,8 @@ ocp4_workload_gitea_operator_user_password: openshift
 
 # Set up repositories for all created users - also handled
 # by the workload, not the operator
-ocp4_workload_gitea_migrate_repositories: false
-ocp4_workload_gitea_repositories_list:
+ocp4_workload_gitea_operator_migrate_repositories: false
+ocp4_workload_gitea_operator_repositories_list:
 - repo: "https://github.com/someuser/thing1"
   name: "thing1"
   private: "true"

--- a/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/tasks/workload.yml
@@ -3,6 +3,45 @@
   debug:
     msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
 
+#####################################################################
+# Fix variables
+#####################################################################
+# The variables to migrate repositories had the wrong name (they were
+# missing the 'operator' in the name)
+# This has now been fixed.
+# To prevent breaking existing deployments the following three
+# steps map the old variables to the new ones and print a warning
+- name: Print warning if old variables are defined
+  debug:
+    msg: "{{ item }}"
+  loop:
+  - "*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*"
+  - "Variable names have changed. Please use "
+  - "ocp4_workload_gitea_operator_migrate_repositories and"
+  - "ocp4_workload_gitea_operator_repositories_list instead of"
+  - "the old variable names!!"
+  - "*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*"
+
+- name: Check if old flag variable has been passed and set new variable
+  when: ocp4_workload_gitea_migrate_repositories is defined
+  set_fact:
+    ocp4_workload_gitea_operator_migrate_repositories: "{{ ocp4_workload_gitea_migrate_repositories }}"
+
+- name: Check if old repos list variable has been passed and set new variable
+  when: ocp4_workload_gitea_repositories_list is defined
+  set_fact:
+    ocp4_workload_gitea_operator_repositories_list: "{{ ocp4_workload_gitea_repositories_list }}"
+
+- name: Print variables
+  debug:
+    msg: "{{ item }}"
+  loop:
+  - "Migrate: {{ ocp4_workload_gitea_operator_migrate_repositories }}"
+  - "List: {{ ocp4_workload_gitea_operator_repositories_list }}"
+#####################################################################
+# Check valid tags for the Gitea Image
+#####################################################################
+
 - name: Check Gitea Tag
   assert:
     that:
@@ -98,7 +137,7 @@
       loop: >-
         {{
         ( range(1, ocp4_workload_gitea_operator_user_number | int + 1) | list )
-        | product(ocp4_workload_gitea_repositories_list)
+        | product(ocp4_workload_gitea_operator_repositories_list)
         | list
         }}
 
@@ -134,12 +173,12 @@
         '{{ ocp4_workload_gitea_operator_user_password }}'
 
   - name: Print the repositories that were migrated if any were migrated
-    when: ocp4_workload_gitea_migrate_repositories | bool
+    when: ocp4_workload_gitea_operator_migrate_repositories | bool
     agnosticd_user_info:
       msg: "{{ item }}"
     loop:
     - "The following repositories were migrated for the created users:"
-    - "{{ ocp4_workload_gitea_repositories_list | join(', ', attribute='repo') }}"
+    - "{{ ocp4_workload_gitea_operator_repositories_list | join(', ', attribute='repo') }}"
 
 # Leave this as the last task in the playbook.
 - name: workload tasks complete


### PR DESCRIPTION
##### SUMMARY

The Gitea Workload had wrong variable names to import repositories.
Fixed the variable names - and added logic to still allow old variable names while printing a warning message to avoid breaking existing configs.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_gitea_operator