### PR TITLE
Fixed sealed secrets yaml deployment

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_sealed_secrets/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_sealed_secrets/defaults/main.yml
@@ -46,3 +46,11 @@ ocp4_workload_sealed_secrets_helm_url: >-
 # Version to use from
 # https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.16.0/controller.yaml
 ocp4_workload_sealed_secrets_version: v0.16.0
+
+# Add the --update-status argument to the controller
+# Should no longer be necessary with 0.17+
+ocp4_workload_sealed_secrets_add_update_status_argument: true
+
+# Patch the APIVersion for RBAC
+# Should no longer be necessary with 0.17+
+ocp4_workload_sealed_secrets_patch_api_version: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_sealed_secrets/templates/kustomization.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_sealed_secrets/templates/kustomization.yaml.j2
@@ -8,6 +8,7 @@ resources:
 - https://github.com/bitnami-labs/sealed-secrets/releases/download/{{ ocp4_workload_sealed_secrets_version }}/controller.yaml
 
 patches:
+{% if ocp4_workload_sealed_secrets_patch_api_version | bool %}
 - target:
     group: rbac.authorization.k8s.io
     version: v1beta1
@@ -15,6 +16,7 @@ patches:
     - op: replace
       path: "/apiVersion"
       value: rbac.authorization.k8s.io/v1
+{% endif %}
 - target:
     group: apps
     version: v1
@@ -25,4 +27,8 @@ patches:
       path: "/spec/template/spec/securityContext"
     - op: remove
       path: "/spec/template/spec/containers/0/securityContext"
-  
+{% if ocp4_workload_sealed_secrets_add_update_status_argument | bool %}
+    - op: add
+      path: "/spec/template/spec/containers/0/args/0"
+      value: "--update-status"
+{% endif %}


### PR DESCRIPTION
##### SUMMARY

Bugfix. Sealed Secrets Controller 0.16 did not deploy the --update-status flag.
Also added parameters to turn that feature on or off (when or if 0.17 ships...)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_sealed_secrets