### PR TITLE
Remove use of local_action in set_env_authorized_key

### DIFF
--- a/ansible/roles/set_env_authorized_key/tasks/main.yml
+++ b/ansible/roles/set_env_authorized_key/tasks/main.yml
@@ -33,9 +33,11 @@
 
 - name: Generate host .ssh/config Template
   become: false
-  local_action: >-
-    template src={{ role_path }}/templates/host_ssh_config.j2
-    dest={{ output_dir }}/ssh-config-{{ env_type }}-{{ guid }}
+  delegate_to: localhost
+  run_once: true
+  template:
+    src: host_ssh_config.j2
+    dest: "{{ output_dir }}/ssh-config-{{ env_type }}-{{ guid }}"
 
 - name: copy over host .ssh/config Template
   become: true


### PR DESCRIPTION
##### SUMMARY

For reasons unknown, using `local_action` here causes `~{{ ansible_user }}` to evaluate incorrectly on subsequent tasks when executed on tower. Switching to `delegate_to` resolves it somehow.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

role set_env_authorized_key