### PR TITLE
Fix ansible kubernetes.core v2.0.0 k8s_facts error ocp4-cluster

### DIFF
--- a/ansible/configs/ocp4-cluster/post_software.yml
+++ b/ansible/configs/ocp4-cluster/post_software.yml
@@ -89,7 +89,7 @@
       when: test_deploy_runs is defined
       block:
       - name: Check on status of job
-        k8s_facts:
+        kubernetes.core.k8s_info:
           api_version: batch/v1
           kind: Job
           name: fio-test


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
k8s_facts will **ERROR** if kubernetes.core version is 2.0.0 or greater.
```bash
redirecting (type: modules) ansible.builtin.k8s_facts to kubernetes.core.k8s_facts
ERROR! [DEPRECATED]: kubernetes.core.k8s_facts has been removed. Use kubernetes.core.k8s_info instead. This feature was removed from kubernetes.core in version 2.0.0. Please update your playbooks.
```
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-cluster

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below
ansible [core 2.11.3] 
  config file = /Users/tiger/git/agnosticd/ansible.cfg
  configured module search path = ['/Users/tiger/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.9/site-packages/ansible
  ansible collection location = /Users/tiger/.ansible/collections:/usr/share/ansible/collections
  executable location = /usr/local/bin/ansible
  python version = 3.9.7 (default, Sep  3 2021, 12:37:55) [Clang 12.0.5 (clang-1205.0.22.9)]
  jinja version = 3.0.1
  libyaml = True

ansible==4.2.0
ansible-core==2.11.3
ansible-lint==5.1.2
backports.entry-points-selectable==1.1.0
boto==2.49.0
boto3==1.14.43
botocore==1.17.43
bracex==2.1.1
cachetools==4.1.1
certifi==2020.6.20
cffi==1.14.6
chardet==3.0.4
colorama==0.4.4
commonmark==0.9.1
cryptography==3.4.7
debugpy==1.5.1
distlib==0.3.3
docutils==0.15.2
enrich==1.2.6
epdb==0.15.1
filelock==3.2.0
google-api-core==1.22.1
google-api-python-client==1.10.0
google-auth==1.20.1
google-auth-httplib2==0.0.4
google-auth-oauthlib==0.4.1
googleapis-common-protos==1.52.0
httplib2==0.19.0
idna==2.10
Jinja2==3.0.1
jmespath==0.10.0
MarkupSafe==2.0.1
oauthlib==3.1.0
packaging==21.0
passlib==1.7.4
pathspec==0.9.0
platformdirs==2.4.0
pluggy==1.0.0
protobuf==3.13.0
py==1.10.0
pyasn1==0.4.8
pyasn1-modules==0.2.8
pycparser==2.20
Pygments==2.9.0
pyparsing==2.4.7
python-dateutil==2.8.1
pytz==2020.1
PyYAML==5.4.1
requests==2.24.0
requests-oauthlib==1.3.0
resolvelib==0.5.4
rich==10.6.0
rsa==4.7
ruamel.yaml==0.17.10
ruamel.yaml.clib==0.2.6
s3transfer==0.3.3
six==1.15.0
tenacity==8.0.1
toml==0.10.2
tox==3.24.4
uritemplate==3.0.1
urllib3==1.25.11
virtualenv==20.8.1
wcmatch==8.2
yamllint==1.26.3
```
