### PR TITLE
Remove use of ansible_user in loops

### DIFF
--- a/ansible/roles/bastion-lite/tasks/main.yml
+++ b/ansible/roles/bastion-lite/tasks/main.yml
@@ -62,20 +62,26 @@
     owner: root
     group: root
 
-- name: Add GUID to /etc/skel/.bashrc and ~{{ ansible_user }}/.bashrc
+- name: Add GUID to /etc/skel/.bashrc
   lineinfile:
-    path: "{{ item }}"
+    path: /etc/skel/.bashrc
     regexp: "^export GUID"
     line: "export GUID={{ guid }}"
-  loop:
-    - "/etc/skel/.bashrc"
-    - "~{{ ansible_user }}/.bashrc"
 
-- name: Add CLOUDUSER to /etc/skel/.bashrc and ~{{ ansible_user }}/.bashrc
+- name: Add GUID to ~{{ ansible_user }}/.bashrc
   lineinfile:
-    path: "{{ item }}"
+    path: "~{{ ansible_user }}/.bashrc"
+    regexp: "^export GUID"
+    line: "export GUID={{ guid }}"
+
+- name: Add CLOUDUSER to /etc/skel/.bashrc
+  lineinfile:
+    path: /etc/skel/.bashrc
     regexp: "^export CLOUDUSER"
     line: "export CLOUDUSER={{ ansible_user }}"
-  loop:
-    - "/etc/skel/.bashrc"
-    - "~{{ ansible_user }}/.bashrc"
+
+- name: Add CLOUDUSER to ~{{ ansible_user }}/.bashrc
+  lineinfile:
+    path: "~{{ ansible_user }}/.bashrc"
+    regexp: "^export CLOUDUSER"
+    line: "export CLOUDUSER={{ ansible_user }}"

--- a/ansible/roles/bastion/tasks/main.yml
+++ b/ansible/roles/bastion/tasks/main.yml
@@ -116,8 +116,14 @@
     clone: true
   loop:
     - "/root"
-    - "/home/{{ ansible_user }}"
     - "/etc/skel"
+  tags:
+    - install_bash_customization
+
+- name: Install bash-git-prompt for {{ ansible_user }}
+  git:
+    repo: https://github.com/magicmonty/bash-git-prompt.git
+    dest: "/home/{{ ansible_user }}/.bash-git-prompt"
   tags:
     - install_bash_customization
 
@@ -134,9 +140,15 @@
     - directory: /etc/skel
       user: root
       group: root
-    - directory: /home/{{ ansible_user }}
-      user: "{{ ansible_user }}"
-      group: "{{ ansible_user }}"
+  tags:
+    - install_bash_customization
+
+- name: Change ownership of bash-git-prompt for {{ ansible_user }}
+  file:
+    path: "/home/{{ ansible_user }}/.bash-git-prompt"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    recurse: true
   tags:
     - install_bash_customization
 
@@ -154,9 +166,16 @@
     - directory: /etc/skel
       user: root
       group: root
-    - directory: /home/{{ ansible_user }}
-      user: "{{ ansible_user }}"
-      group: "{{ ansible_user }}"
+  tags:
+    - install_bash_customization
+
+- name: Install .bashrc for {{ ansible_user }}
+  copy:
+    src: ../files/bashrc
+    dest: "/home/{{ ansible_user }}/.bashrc"
+    mode: 0644
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
   tags:
     - install_bash_customization
 
@@ -174,9 +193,16 @@
     - directory: /etc/skel
       user: root
       group: root
-    - directory: /home/{{ ansible_user }}
-      user: "{{ ansible_user }}"
-      group: "{{ ansible_user }}"
+  tags:
+    - install_bash_customization
+
+- name: Install .bash_profile for {{ ansible_user }}
+  template:
+    src: ../templates/bash_profile.j2
+    dest: "/home/{{ ansible_user }}/.bash_profile"
+    mode: 0644
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
   tags:
     - install_bash_customization
 

--- a/ansible/roles/host-ocp4-installer/tasks/main.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/main.yml
@@ -128,7 +128,7 @@
     mode: 0700
 
 - name: Make sure .kube directory exists for root
-  become: True
+  become: true
   file:
     state: directory
     path: /root/.kube
@@ -146,7 +146,8 @@
     mode: 0600
 
 - name: Copy cluster kubeconfig to /root/.kube/config
-  become: True
+  become: true
+  copy:
     remote_src: true
     src: /home/{{ ansible_user }}/{{ cluster_name }}/auth/kubeconfig
     dest: /root/.kube/config

--- a/ansible/roles/host-ocp4-installer/tasks/main.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/main.yml
@@ -119,38 +119,40 @@
   - kubeconfig
   - kubeadmin-password
 
-- name: Make sure .kube directory exists in home directories
+- name: Make sure .kube directory exists for {{ ansible_user }}
+  file:
+    state: directory
+    path: /home/{{ ansible_user }}/.kube
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: 0700
+
+- name: Make sure .kube directory exists for root
   become: True
   file:
     state: directory
-    path: "{{ item.path }}"
-    owner: "{{ item.owner }}"
-    group: "{{ item.group }}"
-    mode: 0700
-  loop:
-  - path: "/home/{{ ansible_user }}/.kube"
-    owner: "{{ ansible_user }}"
-    group: "{{ ansible_user }}"
-  - path: /root/.kube
+    path: /root/.kube
     owner: root
     group: root
+    mode: 0700
 
-- name: Set up .kube/config files
-  become: True
+- name: Copy cluster kubeconfig to /home/{{ ansible_user }}/.kube/config
   copy:
     remote_src: true
     src: "/home/{{ ansible_user }}/{{ cluster_name }}/auth/kubeconfig"
-    dest: "{{ item.path }}"
-    owner: "{{ item.owner }}"
-    group: "{{ item.group }}"
-    mode: 0600
-  loop:
-  - path: "/home/{{ ansible_user }}/.kube/config"
+    dest: "/home/{{ ansible_user }}/.kube/config"
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
-  - path: /root/.kube/config
+    mode: 0600
+
+- name: Copy cluster kubeconfig to /root/.kube/config
+  become: True
+    remote_src: true
+    src: /home/{{ ansible_user }}/{{ cluster_name }}/auth/kubeconfig
+    dest: /root/.kube/config
     owner: root
     group: root
+    mode: 0600
 
 - name: Set up Student User
   when: install_student_user | bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_industrial_edge/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_industrial_edge/tasks/workload.yml
@@ -206,14 +206,20 @@
       name: user.email
       value: "{{ ocp4_workload_industrial_edge_gitea_user_email }}"
 
-  - name: Ensure previous repositories are absent
+  - name: Ensure previous ~/values-secret.yaml is absent
     file:
-      path: "{{ item }}"
+      path: "~{{ ansible_user }}/values-secret.yaml"
       state: absent
-    loop:
-    - "~{{ ansible_user }}/values-secret.yaml"
-    - "~{{ ansible_user }}/common"
-    - "{{ ocp4_workload_industrial_edge_repo_root_dir }}"
+
+  - name: Ensure previous ~/common is absent
+    file:
+      path: "~{{ ansible_user }}/common"
+      state: absent
+
+  - name: Ensure previous repo root dir is absent
+    file:
+      path: "{{ ocp4_workload_industrial_edge_repo_root_dir }}"
+      state: absent
 
   - name: Clone the industrial-edge repositories
     ansible.builtin.git:
@@ -235,7 +241,11 @@
     loop:
     - "{{ ocp4_workload_industrial_edge_repo_root_dir }}/common"
     - "{{ ocp4_workload_industrial_edge_repo_root_dir }}/.gitmodules"
-    - "~{{ ansible_user }}/common/.git"
+
+  - name: Cleanup ~/common/.git
+    file:
+      state: absent
+      path: "~{{ ansible_user }}/common/.git"
 
   - name: Commit changes to the industrial-edge repository
     command:

--- a/ansible/roles_ocp_workloads/ocp4_workload_paloalto_prismacloud/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_paloalto_prismacloud/tasks/remove_workload.yml
@@ -24,10 +24,7 @@
   become: true
   file:
     state: absent
-    path: "{{ item }}"
-  loop:
-  - ~{{ansible_user}}/twistlock
-
+    path: "~{{ansible_user}}/twistlock"
 
 # Leave this as the last task in the playbook.
 # --------------------------------------------

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/pre_workload.yml
@@ -2,18 +2,37 @@
 # Implement your Pre Workload deployment tasks here
 
 # Create various needed directories
-- name: Create various needed directories
+- name: Create ~/windows_node_scripts
   file:
-    path: "{{ item }}"
+    path: "~{{ ansible_user }}/windows_node_scripts"
     state: directory
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
-    mode: '0775'
-  loop:
-    - "/home/{{ ansible_user }}/windows_node_scripts"
-    - "/home/{{ ansible_user }}/windows_node_artifacts"
-    - "/home/{{ ansible_user }}/bin"
-    - "/home/{{ ansible_user }}/src"
+    mode: u=rwx,g=rwx=,o=rx
+
+- name: Create ~/windows_node_artifacts
+  file:
+    path: "~{{ ansible_user }}/windows_node_scripts"
+    state: directory
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: u=rwx,g=rwx=,o=rx
+
+- name: Create ~/bin
+  file:
+    path: "~{{ ansible_user }}/bin"
+    state: directory
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: u=rwx,g=rwx=,o=rx
+
+- name: Create ~/bin
+  file:
+    path: "~{{ ansible_user }}/src"
+    state: directory
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: u=rwx,g=rwx=,o=rx
 
 # Extract the AWS keys from OpenShift
 - name: Extract the AWS keys from OpenShift

--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/remove_workload.yml
@@ -112,13 +112,15 @@
     definition: "{{ lookup('template', 'namespace.j2' ) }}"
 
 # Remove various needed directories
-- name: Remove various needed directories
+- name: Remove windows_node_artifacts
   file:
-    path: "{{ item }}"
+    path: "~{{ ansible_user }}/windows_node_artifacts"
     state: absent
-  loop:
-    - "/home/{{ ansible_user }}/windows_node_scripts"
-    - "/home/{{ ansible_user }}/windows_node_artifacts"
+
+- name: Remove windows_node_scripts
+  file:
+    path: "~{{ ansible_user }}/windows_node_scripts"
+    state: absent
 
 # Leave this as the last task in the playbook.
 - name: remove_workload tasks complete


### PR DESCRIPTION
##### SUMMARY

Remove use of `ansible_user` in loops. When executed in tower with Ansible 2.9 `ansible_user` does not consistently evaluate to the correct user, instead evaluating to `root` when used in loops.

Ex: https://tower.dark-tower-prod.infra.open.redhat.com/#/jobs/playbook/298923

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Various components