### PR TITLE
Add retries to first k8s task in ocp4_workload_authentication

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_authentication/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_authentication/tasks/workload.yml
@@ -74,6 +74,10 @@
       kind: Secret
       name: htpasswd-secret
       namespace: openshift-config
+    register: r_htpasswd_secret_absent
+    retries: 5
+    delay: 10
+    until: r_htpasswd_secret_absent is success
 
   - name: Create htpasswd secret from htpasswd file
     shell: >-


### PR DESCRIPTION
##### SUMMARY

Add retries on task to remove htpasswd secret.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role ocp4_workload_authentication