### PR TITLE
Switch to use ec2 module to start/stop instances

### DIFF
--- a/ansible/lifecycle_ec2.yml
+++ b/ansible/lifecycle_ec2.yml
@@ -6,25 +6,19 @@
   block:
     - when: ACTION == 'stop'
       name: Stop instances by (guid,env_type) tags
-      ec2_instance:
+      ec2:
         state: stopped
-        wait: no
-        filters:
-          "tag:guid": "{{ guid }}"
-          instance-state-name: running
-          # TODO: uncomment this after a few weeks
-          #"tag:env_type": "{{ env_type }}"
+        wait: false
+        instance_tags:
+          guid: "{{ guid }}"
 
     - when: ACTION == 'start'
       name: Start instances by (guid, env_type) tags
-      ec2_instance:
-        state: started
-        wait: no
-        filters:
-          "tag:guid": "{{ guid }}"
-          instance-state-name: stopped
-          # TODO: uncomment this after a few weeks
-          #"tag:env_type": "{{ env_type }}"
+      ec2:
+        state: running
+        wait: false
+        instance_tags:
+          guid: "{{ guid }}"
 
     - when: ACTION == 'status'
       block:


### PR DESCRIPTION
##### SUMMARY

Change to use `ec2` module to start and stop instances rather than `ec2_instance`. The `ec2` module is idempotent and does not produce an error when all instances are found to already be started or stopped.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ec2 cloud provider