### PR TITLE
Update Gitops and Pipelines operators to support changed names

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/defaults/main.yml
@@ -20,6 +20,11 @@ ocp4_workload_openshift_gitops_automatic_install_plan_approval: true
 ocp4_workload_openshift_gitops_starting_csv: ""
 # ocp4_workload_openshift_gitops_starting_csv: "openshift-gitops-operator.v1.0.1"
 
+# Prefix for the pipelines operator CSV to look for
+# redhat-openshift-pipelines for Pipelines v1.5.2 and earlier
+# openshift-pipelines-operator-rh for Pipelines 1.6.0 and later
+ocp4_workload_openshift_gitops_pipelines_csv_prefix: redhat-openshift-pipelines
+
 # Install the workaround for bug https://access.redhat.com/solutions/6012601
 # Make sure to match the user_base and user_count to what has been defined for ocp4_workload_authentication
 ocp4_workload_openshift_gitops_install_workaround: false

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/workload.yml
@@ -17,7 +17,7 @@
     __ocp4_workload_openshift_gitops_pipelines_csv_name: "{{ r_csvs.resources | to_json | from_json | json_query(query) }}"
   vars:
     query: >-
-      [?starts_with(metadata.name, 'redhat-openshift-pipelines' )].metadata.name
+      [?starts_with(metadata.name, '{{ ocp4_workload_openshift_gitops_pipelines_csv_prefix }}' )].metadata.name
 
 - name: Assert that a CSV has been found
   assert:
@@ -26,7 +26,7 @@
     success_msg: "Found OpenShift Pipelines operator."
     fail_msg: "OpenShift Pipelines operator needs to be installed before the OpenShift GitOps operator."
 
-- name: Install Operator
+- name: Install OpenShift GitOps operator
   include_role:
     name: install_operator
   vars:

--- a/ansible/roles_ocp_workloads/ocp4_workload_pipelines/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_pipelines/defaults/main.yml
@@ -17,7 +17,7 @@ ocp4_installer_root_url: http://d3s3zqyaz8cp2d.cloudfront.net/pub/openshift-v4/c
 ocp4_workload_pipelines_tkn_version: 0.15.0
 
 # Channel to use for the OpenShift pipelines subscription
-ocp4_workload_pipelines_channel: preview
+ocp4_workload_pipelines_channel: stable
 
 # Set automatic InstallPlan approval. If set to false it is also suggested
 # to set the starting_csv to pin a specific version
@@ -30,8 +30,14 @@ ocp4_workload_pipelines_automatic_install_plan_approval: true
 # Highly recommended to be set when using a catalog snapshot but can be
 # empty to get the latest available in the channel at the time when
 # the catalog snapshot got created.
+# Match the first part of the CSV name to the nameprefix below
 ocp4_workload_pipelines_starting_csv: ""
 # ocp4_workload_pipelines_starting_csv: "openshift-pipelines-operator.v1.0.1"
+
+# The name of the CSV to be installed
+# redhat-openshift-pipelines for v1.5.2 and earlier
+# openshift-pipelines-operator-rh for 1.6.0 and later
+ocp4_workload_pipelines_csv_nameprefix: redhat-openshift-pipelines
 
 # --------------------------------
 # Operator Catalog Snapshot Settings

--- a/ansible/roles_ocp_workloads/ocp4_workload_pipelines/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_pipelines/tasks/workload.yml
@@ -5,7 +5,7 @@
   debug:
     msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
 
-- name: Install Operator
+- name: Install OpenShift Pipelines operator
   include_role:
     name: install_operator
   vars:
@@ -16,7 +16,7 @@
     install_operator_catalog: redhat-operators
     install_operator_packagemanifest_name: openshift-pipelines-operator-rh
     install_operator_automatic_install_plan_approval: "{{ ocp4_workload_pipelines_automatic_install_plan_approval }}"
-    install_operator_csv_nameprefix: "redhat-openshift-pipelines"
+    install_operator_csv_nameprefix: "{{ ocp4_workload_pipelines_csv_nameprefix }}"
     install_operator_starting_csv: "{{ ocp4_workload_pipelines_starting_csv }}"
     install_operator_catalogsource_setup: "{{ ocp4_workload_pipelines_use_catalog_snapshot }}"
     install_operator_catalogsource_name: "{{ ocp4_workload_pipelines_catalogsource_name }}"


### PR DESCRIPTION
##### SUMMARY

Pipelines Operator changed names in the latest release.

Adding variables to specify the CSV prefix. Default is the old name for compatibility.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_pipelines
ocp4_workload_openshift_gitops