### PR TITLE
Fix deployment with default variables

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/defaults/main.yml
@@ -44,7 +44,7 @@ ocp4_workload_gitea_operator_project: gitea
 # Gitea Image and Tag
 ocp4_workload_gitea_operator_gitea_image: quay.io/gpte-devops-automation/gitea
 # Must not use `latest`. Minimum allowed version: 1.15.2
-ocp4_workload_gitea_operator_gitea_image_tag: 1.15.2
+ocp4_workload_gitea_operator_gitea_image_tag: 1.15.7
 
 # PVC size for Gitea, empty storage class uses default storage class
 ocp4_workload_gitea_operator_gitea_volume_size: 10Gi

--- a/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/tasks/workload.yml
@@ -42,14 +42,14 @@
 # Check valid tags for the Gitea Image
 #####################################################################
 
-- name: Check Gitea Tag
+- name: Check Gitea tag
   assert:
     that:
     - ocp4_workload_gitea_operator_gitea_image_tag is not match('latest')
     - ocp4_workload_gitea_operator_gitea_image_tag is version_compare('1.14.2', '>=')
     fail_msg: "Gitea image tag must not be set to 'latest' and must be no older than 1.14.2. Please specify the image version explicitely."
 
-- name: Install Operator
+- name: Install Gitea operator
   include_role:
     name: install_operator
   vars:
@@ -120,14 +120,17 @@
     retries: 10
     delay: 5
 
-  - name: Set variables to use while creating users
+  - name: Set gitea route variable
     set_fact:
       _ocp4_workload_gitea_operator_gitea_route: "{{ r_gitea.resources[0].status.giteaRoute }}"
-      _ocp4_workload_gitea_operator_admin_password: "{{ r_gitea.resources[0].status.adminPassword | default('') }}"
 
   - name: Set up users in Gitea
     when: ocp4_workload_gitea_operator_create_users | bool
     block:
+    - name: Set variables to use while creating users
+      set_fact:
+        _ocp4_workload_gitea_operator_admin_password: "{{ r_gitea.resources[0].status.adminPassword | default('') }}"
+
     - name: Create the users in Gitea
       include_tasks: create_user.yml
       loop: "{{ range(1, ocp4_workload_gitea_operator_user_number | int + 1) | list }}"


### PR DESCRIPTION
##### SUMMARY

Deployment of the Gitea Operator with default variables failed because the logic assumed an admin password to be set.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_gitea_operator