### PR TITLE
add second registered var to avoid conflicts

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/tasks/workload.yml
@@ -108,6 +108,10 @@
     retries: 30
     delay: 5
 
+  - name: Set gitea route variable
+    set_fact:
+      _ocp4_workload_gitea_operator_gitea_route: "{{ r_gitea.resources[0].status.giteaRoute }}"
+
   - name: Wait for Gitea admin password to be set
     when: ocp4_workload_gitea_operator_create_admin | bool
     k8s_info:
@@ -115,21 +119,17 @@
       kind: Gitea
       name: "{{ ocp4_workload_gitea_operator_name }}"
       namespace: "{{ ocp4_workload_gitea_operator_project }}"
-    register: r_gitea
-    until: r_gitea.resources[0].status.adminPassword is defined
+    register: r_gitea_admin_password
+    until: r_gitea_admin_password.resources[0].status.adminPassword is defined
     retries: 10
     delay: 5
-
-  - name: Set gitea route variable
-    set_fact:
-      _ocp4_workload_gitea_operator_gitea_route: "{{ r_gitea.resources[0].status.giteaRoute }}"
 
   - name: Set up users in Gitea
     when: ocp4_workload_gitea_operator_create_users | bool
     block:
     - name: Set variables to use while creating users
       set_fact:
-        _ocp4_workload_gitea_operator_admin_password: "{{ r_gitea.resources[0].status.adminPassword | default('') }}"
+        _ocp4_workload_gitea_operator_admin_password: "{{ r_gitea_admin_password.resources[0].status.adminPassword | default('') }}"
 
     - name: Create the users in Gitea
       include_tasks: create_user.yml


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

needed a second registered variable and to change ordering so ansible could find `r_gitea.resources[0]` OK.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

ocp4_workload_gitea_operator

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
