### PR TITLE
set false to use unique ssh key, not backdoor

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/defaults/main.yml
@@ -12,7 +12,7 @@ ocp4_workload_rhel_worker_exact_count: 1
 # and can be found in many AWS regions.
 ocp4_workload_rhel_worker_ami_name: "RHEL-8.4.0_HVM-20210825-x86_64-0-Access2-GP2"
 
-ocp4_worload_rhel_worker_use_backdoor_key: true
+ocp4_worload_rhel_worker_use_backdoor_key: false
 
 # owned: i.e. "owned by the OpenShift cluster" `openshift-installer destroy cluster`
 # will also delete these instances and related resources

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/tasks/workload.yml
@@ -50,29 +50,24 @@
       cluster_region: "{{ __control_plane.instances[0].placement.availability_zone| regex_replace('.$') }}"
     when: __control_plane.instances[0] is defined
 
-  - name: Get ansible_user ssh pubkey file for upload to AWS
-    ansible.builtin.slurp:
-      src: "/home/{{ ansible_user }}/.ssh/id_rsa.pub"
-    register: __id_rsa_pub
-
-  - name: Use which key?
+  - name: ssh-key - Use key opentlc_admin_backdoor
     when: ocp4_worload_rhel_worker_use_backdoor_key | default(false) | bool
     set_fact:
       __instance_key_name: "opentlc_admin_backdoor"
 
-  - name: Get ansible_user ssh pubkey file for upload to AWS
+  - name: ssh-key - Get ansible_user ssh pubkey file for upload to AWS
     when: not ocp4_worload_rhel_worker_use_backdoor_key | default(false) | bool
     block:
-    - name: Set bastion local key name
+    - name: ssh-key - Set bastion local key name
       set_fact:
         __instance_key_name: "{{ guid }}-cluster-key"
 
-    - name: Get bastion local key data
+    - name: ssk-key - Get bastion local key data
       ansible.builtin.slurp:
         src: "/home/{{ ansible_user }}/.ssh/id_rsa.pub"
       register: __id_rsa_pub
 
-    - name: "Put the Cluster Public Key in AWS for RHEL_worker {{ __bastion_local_key_name }}"
+    - name: ssh-key - Put the Cluster Public Key in AWS for RHEL_worker
       ec2_key:
         region: "{{ aws_region }}"
         name: "{{ __instance_key_name }}"
@@ -191,7 +186,7 @@
   - name: Launch EC2 RHEL_worker instance
     ec2:
       region: "{{ aws_region }}"
-      key_name: "opentlc_admin_backdoor"
+      key_name: "{{ __instance_key_name }}"
       vpc_subnet_id: "{{ ec2_vpc_subnet_ids.subnets[0].subnet_id }}"
       instance_type: m5.4xlarge
       group_id: "{{ sg_RHEL_worker.group_id }}"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

Trying to get the id_rsa.pub key on bastion into an aws-key and then use it to access RHEL Worker from bastion.

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

ocp4_workload_rhel_worker

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
