### PR TITLE
[WiP] Judd rhel worker bastion key

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/defaults/main.yml
@@ -12,7 +12,7 @@ ocp4_workload_rhel_worker_exact_count: 1
 # and can be found in many AWS regions.
 ocp4_workload_rhel_worker_ami_name: "RHEL-8.4.0_HVM-20210825-x86_64-0-Access2-GP2"
 
-ocp4_worload_rhel_worker_use_backdoor_key: true
+ocp4_worload_rhel_worker_use_backdoor_key: false
 
 # owned: i.e. "owned by the OpenShift cluster" `openshift-installer destroy cluster`
 # will also delete these instances and related resources

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/tasks/workload.yml
@@ -50,29 +50,6 @@
       cluster_region: "{{ __control_plane.instances[0].placement.availability_zone| regex_replace('.$') }}"
     when: __control_plane.instances[0] is defined
 
-  - name: ssh-key - Use key opentlc_admin_backdoor
-    when: ocp4_worload_rhel_worker_use_backdoor_key | default(false) | bool
-    set_fact:
-      __instance_key_name: "opentlc_admin_backdoor"
-
-  - name: ssh-key - Get ansible_user ssh pubkey file for upload to AWS
-    when: not ocp4_worload_rhel_worker_use_backdoor_key | default(false) | bool
-    block:
-    - name: ssh-key - Set bastion local key name
-      set_fact:
-        __instance_key_name: "{{ guid }}-cluster-key"
-
-    - name: ssk-key - Get bastion local key data
-      ansible.builtin.slurp:
-        src: "/home/{{ ansible_user }}/.ssh/id_rsa.pub"
-      register: __id_rsa_pub
-
-    - name: ssh-key - Put the Cluster Public Key in AWS for RHEL_worker
-      ec2_key:
-        region: "{{ aws_region }}"
-        name: "{{ __instance_key_name }}"
-        key_material: "{{ __id_rsa_pub['content'] | b64decode }}"
-
   - name: get vpc_subnet_id
     ec2_vpc_subnet_info:
       region: "{{ aws_region }}"
@@ -186,7 +163,7 @@
   - name: Launch EC2 RHEL_worker instance
     ec2:
       region: "{{ aws_region }}"
-      key_name: "{{ __instance_key_name }}"
+      key_name: "opentlc_admin_backdoor"
       vpc_subnet_id: "{{ ec2_vpc_subnet_ids.subnets[0].subnet_id }}"
       instance_type: m5.4xlarge
       group_id: "{{ sg_RHEL_worker.group_id }}"
@@ -221,6 +198,7 @@
 - name: Wait for SSH to come up on the new RHEL_worker
   delegate_to: "{{ item.public_dns_name }}"
   loop: "{{ __RHEL_workers.instances }}"
+  become: false
   wait_for_connection:
     delay: 10
     timeout: 320

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/tasks/workload.yml
@@ -213,24 +213,10 @@
   set_fact:
     RHEL_worker_name: "{{ __RHEL_workers.instances[0].public_dns_name }}"
 
-      #- name: Add RHEL_worker instance public IP to host group
-      #  add_host:
-      #    name: "{{ RHEL_worker_ip }}"
-      #    groups:
-      #    - RHEL_worker
-
 - name: Add new __RHEL_workers instance to host RHEL_workers host group
   add_host:
     hostname: "{{ RHEL_worker_name }}"
     groupname: RHEL_workers
-
-  #- name: Associate IAM Instance Profile to RHEL Workers
-  #   66  aws ec2 describe-instances | less
-  #   67  i-0d3a0d0149ea2ae94
-  #   the following already done at instance creation time
-  #   68  aws ec2 associate-iam-instance-profile --instance-id i-0d3a0d0149ea2ae94 --iam-instance-profile Name="rhel-worker-policy"
-  #- name: make sure they have the tagz
-  #   74  aws ec2 create-tags --resources i-0d3a0d0149ea2ae94 --tags Key=kubernetes.io/cluster/cluster-wgm7b,Value=shared
 
 - name: Wait for SSH to come up on the new RHEL_worker
   delegate_to: "{{ item.public_dns_name }}"
@@ -244,11 +230,6 @@
   debug:
     verbosity: 3
     msg: "{{ hostvars | to_nice_yaml }}"
-
-    #- name: do things to new host
-    #  delegate_to: "{{ RHEL_worker_name }}"
-    #  become: true
-    #  command: systemctl disable --now firewalld.service
 
 - name: Run setup if gather_facts hasn't been run
   setup:
@@ -302,22 +283,6 @@
     line: "{{ item.public_dns_name }}"
     create: true
   loop: "{{ __RHEL_workers.instances }}"
-
-    # cd openshift-ansible
-    # virtualenv venv
-    # source venv/bin/activate
-    # pip install -r requirements.txt
-    # which ansible # ensure that this is from the virtualenv
-    # cd ~/openshift-ansible
-    # cp inventory/hosts-* inventory/hosts
-    # cat ~/RHEL_workers >> openshift-ansible/inventory/hosts
-    # vi inventory/hosts # remove the detritus
-    #   ansible-playbook -vvvvv -i inventory/hosts playbooks/scaleup.yml
-    #   76  oc get csr
-    #   83  oc adm certificate approve csr-pr95z
-    #   92  oc get nodes
-    #   93  oc describe nodes |grep rhel
-    #   94  oc get pods -A
 
 # Leave this as the last task in the playbook.
 - name: workload tasks complete

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/tasks/workload.yml
@@ -50,29 +50,24 @@
       cluster_region: "{{ __control_plane.instances[0].placement.availability_zone| regex_replace('.$') }}"
     when: __control_plane.instances[0] is defined
 
-  - name: Get ansible_user ssh pubkey file for upload to AWS
-    ansible.builtin.slurp:
-      src: "/home/{{ ansible_user }}/.ssh/id_rsa.pub"
-    register: __id_rsa_pub
-
-  - name: Use which key?
+  - name: ssh-key - Use key opentlc_admin_backdoor
     when: ocp4_worload_rhel_worker_use_backdoor_key | default(false) | bool
     set_fact:
       __instance_key_name: "opentlc_admin_backdoor"
 
-  - name: Get ansible_user ssh pubkey file for upload to AWS
+  - name: ssh-key - Get ansible_user ssh pubkey file for upload to AWS
     when: not ocp4_worload_rhel_worker_use_backdoor_key | default(false) | bool
     block:
-    - name: Set bastion local key name
+    - name: ssh-key - Set bastion local key name
       set_fact:
         __instance_key_name: "{{ guid }}-cluster-key"
 
-    - name: Get bastion local key data
+    - name: ssk-key - Get bastion local key data
       ansible.builtin.slurp:
         src: "/home/{{ ansible_user }}/.ssh/id_rsa.pub"
       register: __id_rsa_pub
 
-    - name: "Put the Cluster Public Key in AWS for RHEL_worker {{ __bastion_local_key_name }}"
+    - name: ssh-key - Put the Cluster Public Key in AWS for RHEL_worker
       ec2_key:
         region: "{{ aws_region }}"
         name: "{{ __instance_key_name }}"
@@ -191,7 +186,7 @@
   - name: Launch EC2 RHEL_worker instance
     ec2:
       region: "{{ aws_region }}"
-      key_name: "opentlc_admin_backdoor"
+      key_name: "{{ __instance_key_name }}"
       vpc_subnet_id: "{{ ec2_vpc_subnet_ids.subnets[0].subnet_id }}"
       instance_type: m5.4xlarge
       group_id: "{{ sg_RHEL_worker.group_id }}"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

more WiP:

* revert use of custom key
* use backdoor key
* asserted become: false in wait_for_connection play 
* * ansible was connection to bastion as ec2-user, and then connecting to worker as root. BAD

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
