### PR TITLE
WiP - rhel worker - admin key, again

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/tasks/workload.yml
@@ -163,7 +163,7 @@
   - name: Launch EC2 RHEL_worker instance
     ec2:
       region: "{{ aws_region }}"
-      key_name: "{{ __instance_key_name }}"
+      key_name: "opentlc_admin_backdoor"
       vpc_subnet_id: "{{ ec2_vpc_subnet_ids.subnets[0].subnet_id }}"
       instance_type: m5.4xlarge
       group_id: "{{ sg_RHEL_worker.group_id }}"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

key_name: "opentlc_admin_backdoor"

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

ocp4_workload_rhel_worker

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
