### PR TITLE
"Automated Smart Management" config vars definition for AAP2-based workshop

### DIFF
--- a/ansible/configs/aap2-ansible-workshops/vars/automate_smart_mgmt_vars.yml
+++ b/ansible/configs/aap2-ansible-workshops/vars/automate_smart_mgmt_vars.yml
@@ -1,0 +1,52 @@
+---
+
+workshop_type: smart_mgmt
+
+# Installs latest Controller
+towerinstall: true
+
+# turn DNS on for control nodes, and set to type in valid_dns_type
+dns_type: aws
+
+# creates AWS S3 website for ec2_name_prefix.workshop_dns_zone
+create_login_page: true
+
+# when towerinstall is on, this will license it with provided license
+autolicense: true
+
+# Install Code Server
+code_server: true
+xrdp: false
+
+# workshop or playground
+provision_mode: workshop
+
+# select rhel7 or rhel8 client nodes
+rhel: rhel7
+# choice of centos7 nodes
+# refer to https://wiki.centos.org/Cloud/AWS for available minor releases
+# select centos7 client node version
+centos7: centos78
+
+# Enable AWS IAM integration with control node and workshop nodes
+tower_node_aws_api_access: true
+
+# IBM Community Grid - defaults to true if you don't tell the provisioner
+ibm_community_grid: false
+
+# default vars for ec2 AMIs (ec2_info) are located in:
+# provisioner/roles/manage_ec2_instances/defaults/main/main.yml
+# select ec2_info AMI vars can be overwritten (must include entire var stanza
+# for a given resource) via ec2_xtra vars, e.g.:
+#ec2_xtra:
+#  satellite:
+#    owners: 012345678910
+#    filter: Satellite*
+#    username: ec2-user
+#    os_type: linux
+#    size: r5a.xlarge
+
+
+## Should be sourced from BASH script
+#admin_password: 'dynamic from BASH'                 # password used for student account on control node
+#windows_password: 'dynamic from BASH'

--- a/ansible/configs/aap2-ansible-workshops/vars/automate_smart_mgmt_vars.yml
+++ b/ansible/configs/aap2-ansible-workshops/vars/automate_smart_mgmt_vars.yml
@@ -34,10 +34,11 @@ tower_node_aws_api_access: true
 # IBM Community Grid - defaults to true if you don't tell the provisioner
 ibm_community_grid: false
 
-# default vars for ec2 AMIs (ec2_info) are located in:
+# default vars for ec2 AMIs (ec2_info) located in Ansible workshop provisioner
+# https://github.com/ansible/workshops ...here:
 # provisioner/roles/manage_ec2_instances/defaults/main/main.yml
 # select ec2_info AMI vars can be overwritten (must include entire var stanza
-# for a given resource) via ec2_xtra vars, e.g.:
+# for a given resource) via 'ec2_xtra' vars, e.g.:
 #ec2_xtra:
 #  satellite:
 #    owners: 012345678910
@@ -45,7 +46,6 @@ ibm_community_grid: false
 #    username: ec2-user
 #    os_type: linux
 #    size: r5a.xlarge
-
 
 ## Should be sourced from BASH script
 #admin_password: 'dynamic from BASH'                 # password used for student account on control node


### PR DESCRIPTION
##### SUMMARY
aap2-ansible-workshops config vars addition for Ansible "Automated Smart Management" workshop

##### ISSUE TYPE
- New config Pull Request

##### COMPONENT NAME
automate_smart_mgmt_vars.yml vars file for deploying Automated Smart Management workshop

##### ADDITIONAL INFORMATION
Entire `ec2_xtra` stanza will need to defined in order to point workshop provisioner to location of Satellite AMI, intentionally left commented out in order to provide the complete example of what will need to be defined, hidden from view here in a public repo
