### PR TITLE
version of operators changed into the Debugging workshop 

### DIFF
--- a/ansible/roles-infra/infra-ec2-template-generate/defaults/main.yml
+++ b/ansible/roles-infra/infra-ec2-template-generate/defaults/main.yml
@@ -384,6 +384,17 @@ aws_ami_region_mapping:
     RHEL74: ami-1607ba6e # RHEL-7.4_HVM-20180122-x86_64-1-Hourly2-GP2
     WIN2012R2: ami-02cd0387b1ed07f2e # Windows_Server-2012-R2_RTM-English-64Bit-Base-2021.03.10
     WIN2019: ami-077475371a476c548 # Windows_Server-2019-English-Full-Base-2021.03.10
+  me-south-1:
+    RHEL84: ami-0002da9f8c387267b # RHEL-8.4.0_HVM-20210825-x86_64-0-Hourly2-GP2
+    RHEL83: ami-024834f67fc2bf97a # RHEL-8.3_HVM-20210209-x86_64-0-Hourly2-GP2
+    RHEL82: ami-0ea154ecbf7c8b3de # RHEL-8.2_HVM-20200803-x86_64-0-Hourly2-GP2
+    RHEL81: ami-01bc798104367e3ef # RHEL-8.1.0_HVM-20191029-x86_64-0-Hourly2-GP2
+    RHEL78: ami-04c5a64178193c259 # RHEL-7.8_HVM-20200803-x86_64-0-Hourly2-GP2
+    RHEL77: ami-0595b40184ea4f7ee # RHEL-7.7_HVM-20191119-x86_64-2-Hourly2-GP2
+    RHEL75: ami-0814d4549e66c77d7 # RHEL-7.5_HVM_GA-20180522-x86_64-0-Hourly2-GP2
+    RHEL74: ami-00cf5bff4d41f4286 # RHEL-7.4_HVM_GA-20180122-x86_64-0-Hourly2-GP2
+    WIN2012R2: ami-0cabf723b1032f552 # Windows_Server-2012-R2_RTM-English-64Bit-Base-2020.12.09
+    WIN2019: ami-04f95f8fff5f01620 # Windows_Server-2019-English-Full-Base-2020.12.09
 
 # DNSMapping is unlikely to change.  It's useful to keep env_type CF templates small
 aws_dns_mapping:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
During the process of the worshop deployment the installer was stuck on istio-system. The service mesh operator was not installed due to the version used to the previous main.yml file. I updated several operator version to allow to deploy the Workshop.
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
