### PR TITLE
Equinix: Omit ipv6 when not present

### DIFF
--- a/ansible/roles-infra/infra-equinix-metal-create-inventory/tasks/main.yaml
+++ b/ansible/roles-infra/infra-equinix-metal-create-inventory/tasks/main.yaml
@@ -37,7 +37,7 @@
     shortname: "{{ item.hostname }}"
     private_ip_address: "{{ item.private_ipv4 }}"
     public_ip_address: "{{ item.public_ipv4 }}"
-    public_ip6_address: "{{ item.public_ipv6 }}"
+    public_ip6_address: "{{ item.public_ipv6 | default(omit) }}"
     groups: "{{ (item.tags | equinix_metal_tags_to_dict).AnsibleGroup }}"
     bastion: "{{ local_bastion | default('') }}"
     isolated: >-


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
```
TASK [infra-equinix-metal-create-inventory : Create inventory (add_host)] ******
Friday 10 December 2021  17:38:11 +0000 (0:00:00.038)       0:07:40.638 ******* 
fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'public_ipv6'\n\nThe error appears to be in '/tmp/awx_314755_1nw664eu/project/ansible/roles-infra/infra-equinix-metal-create-inventory/tasks/main.yaml': line 31, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Create inventory (add_host)\n  ^ here\n"}
```
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
