### PR TITLE
Equinix: Harden deletion of resources

### DIFF
--- a/ansible/roles-infra/infra-equinix-metal-resources/defaults/main.yaml
+++ b/ansible/roles-infra/infra-equinix-metal-resources/defaults/main.yaml
@@ -14,3 +14,7 @@ equinix_metal_ssh_pub_key_path: "{{ output_dir }}/{{ guid }}_id_rsa.pub"
 
 # Naming of instances
 equinix_metal_instance_numeration: '%d'
+
+# Delete device retry
+equinix_metal_delete_retries: 20
+equinix_metal_delete_delay: 60

--- a/ansible/roles-infra/infra-equinix-metal-resources/tasks/delete_instances.yaml
+++ b/ansible/roles-infra/infra-equinix-metal-resources/tasks/delete_instances.yaml
@@ -26,3 +26,7 @@
           {{ r_equinix_metal_devices.json.devices
           | default([])
           | json_query('[].id') }}
+      register: r_delete
+      until: r_delete is succeeded
+      retries: "{{ equinix_metal_delete_retries }}"
+      delay: "{{ equinix_metal_delete_delay }}"


### PR DESCRIPTION
Fix error:

```
TASK [infra-equinix-metal-resources : Delete all devices] **********************
Friday 10 December 2021  18:59:04 +0000 (0:00:01.011)       0:00:47.201 *******
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: packet.baseapi.ResponseError: Error 422: Cannot delete a device while it is provisioning
fatal: [localhost]: FAILED! => {"changed": false, "msg": "failed to set device state absent, error: Error 422: Cannot delete a device while it is provisioning"}
```

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
