### PR TITLE
ocp4_workload_4 - fix the race condition for ACS Central installation

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_dso/tasks/acs.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_dso/tasks/acs.yml
@@ -28,6 +28,10 @@
   retries: 30
   delay: 10
 
+- name: Wait for ACS Operator to be up and running
+  pause:
+    minutes: 2
+
 # Install ACS Central
 - name: Create ACS Central
   kubernetes.core.k8s:


### PR DESCRIPTION
##### SUMMARY

Due to a race condition detected in the DSO Lab 4 during the installation of the Security Lab rhpds environment, a delay until the ACS Operator is ready is needed.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
ocp4_workload_dso
