### PR TITLE
Simplify and enhance config ansible-multi-node for HONA

### DIFF
--- a/ansible/configs/ansible-multi-node/pre_software.yml
+++ b/ansible/configs/ansible-multi-node/pre_software.yml
@@ -59,7 +59,7 @@
 
   roles:
     - { role: "common", when: 'install_common | default(true) | bool' }
-    - { role: "bastion", when: 'install_bastion | default(true) |bool' }
+    - { role: "bastion-lite", when: 'install_bastion | default(true) |bool' }
     - { role: "bastion-student-user", when: 'install_student_user | default(true) | bool' }
     - { role: "bastion-opentlc-ipa", when: 'install_ipa_client | default(false)| bool' }
     - { role: "control-user", when: 'install_control_user | default(true) | bool' }

--- a/ansible/configs/ansible-multi-node/setup_hands_on_aap2.yml
+++ b/ansible/configs/ansible-multi-node/setup_hands_on_aap2.yml
@@ -4,12 +4,13 @@
   hosts: bastions[0]
   gather_facts: false
   become: true
+  become_user: "{{ lab_user | default('devops') }}" 
 
   tasks:
 
     - name: Create devops resources directory
       file:
-        path: "~/{{ lab_user | default('devops') }}/resources"
+        path: "~/resources"
         state: directory
         mode: '0755'
         owner: "{{ lab_user | default('devops') }}"
@@ -31,7 +32,6 @@
       ansible.builtin.git:
         repo: "https://github.com/redhat-gpe/ansible_resources_and_demos.git"
         dest: "~/resources/ansible_resources_and_demos"
-      become_user: "{{ lab_user | default('devops') }}"
       ignore_errors: true
       tags:
         - inject_repos

--- a/ansible/configs/ansible-multi-node/setup_hands_on_aap2.yml
+++ b/ansible/configs/ansible-multi-node/setup_hands_on_aap2.yml
@@ -9,7 +9,7 @@
 
     - name: Create devops resources directory
       file:
-        path: "/home/{{ lab_user | default('devops') }}/resources"
+        path: "~/{{ lab_user | default('devops') }}/resources"
         state: directory
         mode: '0755'
         owner: "{{ lab_user | default('devops') }}"
@@ -27,6 +27,18 @@
         loop_var: __resource
       no_log: true
 
+    - name: Inject a utilities git repo for demos and other resources
+      ansible.builtin.git:
+        repo: "https://github.com/redhat-gpe/ansible_resources_and_demos.git"
+        dest: "~/resources/ansible_resources_and_demos"
+      become_user: "{{ lab_user | default('devops') }}"
+      ignore_errors: true
+      tags:
+        - inject_repos
+
+# Extract this code for the core of a role to create repos from tar archives etc
+# Perhaps roles/create_repos_from_archive
+#
 #    - name: Create repo resources directory for the Hands on Ansible Automation Platform 2 lab
 #      file:
 #        path: /opt/aap2-repo


### PR DESCRIPTION
##### SUMMARY

Simplifies and extends the config ansible-multi-node

- move to `bastion-lite` as it is simpler and cleaner than `bastion`
- Add git repo resource injection
- Refactor some paths e.g replace `/home/devops` with more versatile/robust `~devops/` etc
- Eliminate some repo making code in favor of curated Satellite HA Content view

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
config ansible-multi-node

##### ADDITIONAL INFORMATION

