### PR TITLE
Updating the OC link to download the package

### DIFF
--- a/ansible/roles/codeready_containers_hacks/tasks/configure-oc-cli.yml
+++ b/ansible/roles/codeready_containers_hacks/tasks/configure-oc-cli.yml
@@ -6,7 +6,7 @@
 
 - name: Extract ocp client  into /usr/local/bin/oc
   unarchive:
-    src: "{{ codeready_containers_hacks_ocp4_release_url }}/{{ codeready_containers_hacks_ocp4_client }}"
+    src: "{{ codeready_containers_hacks_ocp4_release_url }}{{ codeready_containers_hacks_ocp4_client }}"
     dest: /usr/local/bin
     remote_src: yes
   become: true


### PR DESCRIPTION
Updating the OC link to download the package, file not found however path has extra / in the link.

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
