### PR TITLE
Add alternative DNS names for instances

### DIFF
--- a/ansible/roles-infra/infra-dns/defaults/main.yml
+++ b/ansible/roles-infra/infra-dns/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-_infra_dns_default_ttl: 300
+infra_dns_default_ttl: 300
 _dns_state: present
 
 infra_dns_num_format: '%d'

--- a/ansible/roles-infra/infra-dns/readme.adoc
+++ b/ansible/roles-infra/infra-dns/readme.adoc
@@ -17,11 +17,10 @@ cluster_dns_zone: ...
   dns_records:
     - machine
     - server
-```
+----
 
 Will create:
 
 - node{1,2,3}.guid A records, using the public IP of each node
 - machine{1,2,3}.guid CNAME records pointing to the corresponding A records
 - server{1,2,3}.guid CNAME records pointing to the corresponding A records
-----

--- a/ansible/roles-infra/infra-dns/readme.adoc
+++ b/ansible/roles-infra/infra-dns/readme.adoc
@@ -8,3 +8,20 @@ ddns_key_secret: ...
 cluster_dns_server: ...
 cluster_dns_zone: ...
 ----
+
+.example
+----
+- name: node
+  count: 3
+  public_dns: true
+  dns_records:
+    - machine
+    - server
+```
+
+Will create:
+
+- node{1,2,3}.guid A records, using the public IP of each node
+- machine{1,2,3}.guid CNAME records pointing to the corresponding A records
+- server{1,2,3}.guid CNAME records pointing to the corresponding A records
+----

--- a/ansible/roles-infra/infra-dns/tasks/instance_loop.yml
+++ b/ansible/roles-infra/infra-dns/tasks/instance_loop.yml
@@ -7,7 +7,9 @@
   when: _instance.count|int == 1
   include_tasks: nested_loop.yml
   vars:
+    _index: ""
     _instance_name: "{{ _instance.name }}"
+    _alt_names: "{{ _instance.dns_records | default([]) }}"
 
 - when: _instance.count|int > 1
   vars:
@@ -21,5 +23,7 @@
       loop_control:
         loop_var: myindex
       vars:
-        _instance_name: "{{ _instance.name }}{{ infra_dns_num_format | format(myindex|int) }}"
+        _index: "{{ infra_dns_num_format | format(myindex|int) }}"
+        _instance_name: "{{ _instance.name }}{{ _index }}"
+        _alt_names: "{{ _instance.dns_records | default([]) }}"
       include_tasks: nested_loop.yml

--- a/ansible/roles-infra/infra-dns/tasks/nested_loop.yml
+++ b/ansible/roles-infra/infra-dns/tasks/nested_loop.yml
@@ -38,6 +38,27 @@
         name: "{{ _instance_name }}"
         public_dns_name: "{{ _instance_name }}.{{ guid }}.{{ cluster_dns_zone }}"
 
+    - name: DNS alternative entry ({{ _dns_state | default('present') }})
+      when: _alt_names | length > 0
+      loop: "{{ _alt_names }}"
+      loop_control:
+        loop_var: _alt_name
+      nsupdate:
+        server: >-
+          {{ cluster_dns_server
+          | ipaddr
+          | ternary(cluster_dns_server, lookup('dig', cluster_dns_server))
+          }}
+        zone: "{{ cluster_dns_zone }}"
+        record: "{{ _alt_name }}{{_index}}.{{ guid }}"
+        type: CNAME
+        ttl: "{{ _infra_dns_default_ttl }}"
+        value: "{{ _instance_name }}.{{ guid }}"
+        port: "{{ cluster_dns_port | d('53') }}"
+        key_name: "{{ ddns_key_name }}"
+        key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
+        key_secret: "{{ ddns_key_secret }}"
+
 # When state == absent, don't use inventory var (should not be needed)
 - when: _dns_state == 'absent'
   block:
@@ -52,6 +73,28 @@
         record: "{{ _instance_name }}.{{ guid }}"
         type: A
         ttl: "{{ _infra_dns_default_ttl }}"
+        port: "{{ cluster_dns_port | d('53') }}"
+        key_name: "{{ ddns_key_name }}"
+        key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
+        key_secret: "{{ ddns_key_secret }}"
+        state: absent
+
+    - name: DNS alternative entry ({{ _dns_state | default('present') }})
+      when: _alt_names | length > 0
+      loop: "{{ _alt_names }}"
+      loop_control:
+        loop_var: _alt_name
+      nsupdate:
+        server: >-
+          {{ cluster_dns_server
+          | ipaddr
+          | ternary(cluster_dns_server, lookup('dig', cluster_dns_server))
+          }}
+        zone: "{{ cluster_dns_zone }}"
+        record: "{{ _alt_name }}{{_index}}.{{ guid }}"
+        type: CNAME
+        ttl: "{{ _infra_dns_default_ttl }}"
+        value: "{{ _instance_name }}.{{ guid }}"
         port: "{{ cluster_dns_port | d('53') }}"
         key_name: "{{ ddns_key_name }}"
         key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"

--- a/ansible/roles-infra/infra-dns/tasks/nested_loop.yml
+++ b/ansible/roles-infra/infra-dns/tasks/nested_loop.yml
@@ -26,7 +26,7 @@
         zone: "{{ cluster_dns_zone }}"
         record: "{{ _instance_name }}.{{ guid }}"
         type: A
-        ttl: "{{ _infra_dns_default_ttl }}"
+        ttl: "{{ infra_dns_default_ttl }}"
         value: "{{ vars[infra_dns_inventory_var] | json_query(find_ip_query) }}"
         port: "{{ cluster_dns_port | d('53') }}"
         key_name: "{{ ddns_key_name }}"
@@ -52,7 +52,7 @@
         zone: "{{ cluster_dns_zone }}"
         record: "{{ _alt_name }}{{_index}}.{{ guid }}"
         type: CNAME
-        ttl: "{{ _infra_dns_default_ttl }}"
+        ttl: "{{ infra_dns_default_ttl }}"
         value: "{{ _instance_name }}.{{ guid }}"
         port: "{{ cluster_dns_port | d('53') }}"
         key_name: "{{ ddns_key_name }}"
@@ -72,7 +72,7 @@
         zone: "{{ cluster_dns_zone }}"
         record: "{{ _instance_name }}.{{ guid }}"
         type: A
-        ttl: "{{ _infra_dns_default_ttl }}"
+        ttl: "{{ infra_dns_default_ttl }}"
         port: "{{ cluster_dns_port | d('53') }}"
         key_name: "{{ ddns_key_name }}"
         key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
@@ -93,7 +93,7 @@
         zone: "{{ cluster_dns_zone }}"
         record: "{{ _alt_name }}{{_index}}.{{ guid }}"
         type: CNAME
-        ttl: "{{ _infra_dns_default_ttl }}"
+        ttl: "{{ infra_dns_default_ttl }}"
         value: "{{ _instance_name }}.{{ guid }}"
         port: "{{ cluster_dns_port | d('53') }}"
         key_name: "{{ ddns_key_name }}"

--- a/ansible/roles-infra/infra-osp-dns/defaults/main.yml
+++ b/ansible/roles-infra/infra-osp-dns/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-_infra_osp_dns_default_ttl: 300
+infra_osp_dns_default_ttl: 300
 _dns_state: present
 
 infra_dns_num_format: '%d'

--- a/ansible/roles-infra/infra-osp-dns/defaults/main.yml
+++ b/ansible/roles-infra/infra-osp-dns/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 _infra_osp_dns_default_ttl: 300
 _dns_state: present
+
+infra_dns_num_format: '%d'

--- a/ansible/roles-infra/infra-osp-dns/tasks/instance_loop.yml
+++ b/ansible/roles-infra/infra-osp-dns/tasks/instance_loop.yml
@@ -7,7 +7,9 @@
   when: _instance.count|int == 1
   include_tasks: nested_loop.yml
   vars:
+    _index: ""
     _instance_name: "{{ _instance.name }}"
+    _alt_names: "{{ _instance.dns_records | default([]) }}"
 
 - when: _instance.count|int > 1
   vars:
@@ -21,5 +23,7 @@
       loop_control:
         loop_var: myindex
       vars:
-        _instance_name: "{{ _instance.name }}{{ myindex }}"
+        _index: "{{ infra_dns_num_format | format(myindex|int) }}"
+        _instance_name: "{{ _instance.name }}{{ _index }}"
+        _alt_names: "{{ _instance.dns_records | default([]) }}"
       include_tasks: nested_loop.yml

--- a/ansible/roles-infra/infra-osp-dns/tasks/nested_loop.yml
+++ b/ansible/roles-infra/infra-osp-dns/tasks/nested_loop.yml
@@ -28,6 +28,32 @@
         key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
         key_secret: "{{ ddns_key_secret }}"
 
+    - name: Add public_dns entry to host
+      add_host:
+        name: "{{ _instance_name }}"
+        public_dns_name: "{{ _instance_name }}.{{ guid }}.{{ cluster_dns_zone }}"
+
+    - name: DNS alternative entry ({{ _dns_state | default('present') }})
+      when: _alt_names | length > 0
+      loop: "{{ _alt_names }}"
+      loop_control:
+        loop_var: _alt_name
+      nsupdate:
+        server: >-
+          {{ cluster_dns_server
+          | ipaddr
+          | ternary(cluster_dns_server, lookup('dig', cluster_dns_server))
+          }}
+        zone: "{{ cluster_dns_zone }}"
+        record: "{{ _alt_name }}{{_index}}.{{ guid }}"
+        type: CNAME
+        ttl: "{{ _infra_osp_dns_default_ttl }}"
+        value: "{{ _instance_name }}.{{ guid }}"
+        port: "{{ cluster_dns_port | d('53') }}"
+        key_name: "{{ ddns_key_name }}"
+        key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
+        key_secret: "{{ ddns_key_secret }}"
+
 # When state == absent, don't use r_osp_facts (should not be needed)
 - when: _dns_state == 'absent'
   block:
@@ -43,6 +69,28 @@
         type: A
         ttl: "{{ _infra_osp_dns_default_ttl }}"
         port: "{{ osp_cluster_dns_port | d('53') }}"
+        key_name: "{{ ddns_key_name }}"
+        key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
+        key_secret: "{{ ddns_key_secret }}"
+        state: absent
+
+    - name: DNS alternative entry ({{ _dns_state | default('present') }})
+      when: _alt_names | length > 0
+      loop: "{{ _alt_names }}"
+      loop_control:
+        loop_var: _alt_name
+      nsupdate:
+        server: >-
+          {{ cluster_dns_server
+          | ipaddr
+          | ternary(cluster_dns_server, lookup('dig', cluster_dns_server))
+          }}
+        zone: "{{ cluster_dns_zone }}"
+        record: "{{ _alt_name }}{{_index}}.{{ guid }}"
+        type: CNAME
+        ttl: "{{ _infra_osp_dns_default_ttl }}"
+        value: "{{ _instance_name }}.{{ guid }}"
+        port: "{{ cluster_dns_port | d('53') }}"
         key_name: "{{ ddns_key_name }}"
         key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
         key_secret: "{{ ddns_key_secret }}"

--- a/ansible/roles-infra/infra-osp-dns/tasks/nested_loop.yml
+++ b/ansible/roles-infra/infra-osp-dns/tasks/nested_loop.yml
@@ -21,7 +21,7 @@
         zone: "{{ osp_cluster_dns_zone }}"
         record: "{{ _instance_name }}.{{ guid }}"
         type: A
-        ttl: "{{ _infra_osp_dns_default_ttl }}"
+        ttl: "{{ infra_osp_dns_default_ttl }}"
         value: "{{ r_osp_facts | json_query(find_ip_query) }}"
         port: "{{ osp_cluster_dns_port | d('53') }}"
         key_name: "{{ ddns_key_name }}"
@@ -47,7 +47,7 @@
         zone: "{{ cluster_dns_zone }}"
         record: "{{ _alt_name }}{{_index}}.{{ guid }}"
         type: CNAME
-        ttl: "{{ _infra_osp_dns_default_ttl }}"
+        ttl: "{{ infra_osp_dns_default_ttl }}"
         value: "{{ _instance_name }}.{{ guid }}"
         port: "{{ cluster_dns_port | d('53') }}"
         key_name: "{{ ddns_key_name }}"
@@ -67,7 +67,7 @@
         zone: "{{ osp_cluster_dns_zone }}"
         record: "{{ _instance_name }}.{{ guid }}"
         type: A
-        ttl: "{{ _infra_osp_dns_default_ttl }}"
+        ttl: "{{ infra_osp_dns_default_ttl }}"
         port: "{{ osp_cluster_dns_port | d('53') }}"
         key_name: "{{ ddns_key_name }}"
         key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
@@ -88,7 +88,7 @@
         zone: "{{ cluster_dns_zone }}"
         record: "{{ _alt_name }}{{_index}}.{{ guid }}"
         type: CNAME
-        ttl: "{{ _infra_osp_dns_default_ttl }}"
+        ttl: "{{ infra_osp_dns_default_ttl }}"
         value: "{{ _instance_name }}.{{ guid }}"
         port: "{{ cluster_dns_port | d('53') }}"
         key_name: "{{ ddns_key_name }}"


### PR DESCRIPTION
instances[].dns_records   list of alt names for instances.

```
- name: node
  count: 3
  public_dns: true
  dns_records:
    - machine
    - server
```

Will create:

- node{1,2,3}.guid A records, using the public IP of each node
- machine{1,2,3}.guid CNAME records pointing to the corresponding A records
- server{1,2,3}.guid CNAME records pointing to the corresponding A records

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request
