### PR TITLE
Update Sealed Secrets workload for 0.17.1 (and Helm Chart 2.0.0)

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_sealed_secrets/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_sealed_secrets/defaults/main.yml
@@ -11,15 +11,15 @@ ocp4_workload_sealed_secrets_namespace: sealed-secrets
 # via individual role bindings
 ocp4_workload_sealed_secrets_deploy_admin_role: true
 
-# Install kubeseal binary and version
+# Install kubeseal binary and version (without the leading 'v')
+# Minimum version supported: 0.17.1
 ocp4_workload_sealed_secrets_kubeseal_install: true
-ocp4_workload_sealed_secrets_kubeseal_version: v0.16.0
+ocp4_workload_sealed_secrets_kubeseal_version: "0.17.1"
 
 # Sealed Secrets can be deployed either via Helm or by deploying the
 # sealed secrets controller manifest directly. Installing sealed secrets
-# on OpenShift 4.9+ requires the manifest with a kustomization to fix some
-# API versions used. Once the Helm Chart is released for 0.17 this can be changed
-# back
+# without Helm on OpenShift 4.9+ requires the manifest with a kustomization
+# to fix the security context.
 
 # Deploy using HELM (true by default to not break existing behaviour)
 ocp4_workload_sealed_secrets_deploy_using_helm: true
@@ -31,7 +31,10 @@ ocp4_workload_sealed_secrets_deploy_using_helm: true
 ocp4_workload_sealed_secrets_name: sealed-secrets-controller
 
 # Helm Chart version
-ocp4_workload_sealed_secrets_helm_chart_version: 1.16.1
+# 2.0.1 and 2.0.2 do NOT work (service uses 'name: http' which breaks kubeseal)
+# 2.0.3 (or whatever comes next) should work again
+# https://github.com/bitnami-labs/sealed-secrets/issues/502#issuecomment-1000852121
+ocp4_workload_sealed_secrets_helm_chart_version: 2.0.0
 
 # Version of dedicated helm CLI (to be installed as /usr/local/bin/helm-sealed-secrets)
 ocp4_workload_sealed_secrets_helm_version: 3.6.2
@@ -44,13 +47,6 @@ ocp4_workload_sealed_secrets_helm_url: >-
 # sealed-secrets-controller.yaml settings
 #####################################################################
 # Version to use from
-# https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.16.0/controller.yaml
-ocp4_workload_sealed_secrets_version: v0.16.0
-
-# Add the --update-status argument to the controller
-# Should no longer be necessary with 0.17+
-ocp4_workload_sealed_secrets_add_update_status_argument: true
-
-# Patch the APIVersion for RBAC
-# Should no longer be necessary with 0.17+
-ocp4_workload_sealed_secrets_patch_api_version: true
+# https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.17.1/controller.yaml
+# Minimum version supported: v0.17.1
+ocp4_workload_sealed_secrets_version: v0.17.1

--- a/ansible/roles_ocp_workloads/ocp4_workload_sealed_secrets/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_sealed_secrets/tasks/workload.yml
@@ -41,16 +41,16 @@
     kubernetes.core.helm:
       name: "{{ ocp4_workload_sealed_secrets_name }}"
       chart_ref: sealed-secrets/sealed-secrets
+      chart_version: "{{ ocp4_workload_sealed_secrets_helm_chart_version }}"
       release_namespace: "{{ ocp4_workload_sealed_secrets_namespace }}"
       create_namespace: false
       values:
-        version: "{{ ocp4_workload_sealed_secrets_helm_chart_version }}"
-        commandArgs: ['--update-status']
         crd:
           keep: false
-        securityContext:
-          runAsUser: ""
-          fsGroup: ""
+        podSecurityContext:
+          enabled: false
+        containerSecurityContext:
+          enabled: false
 
 #####################################################################
 # Deploy Sealed Secrets controller YAML
@@ -96,14 +96,18 @@
 - name: Download kubeseal
   when: ocp4_workload_sealed_secrets_kubeseal_install | bool
   become: true
-  get_url:
-    url: >-
-      https://github.com/bitnami-labs/sealed-secrets/releases/download/{{
-      ocp4_workload_sealed_secrets_kubeseal_version }}/kubeseal-linux-amd64
-    dest: /usr/local/bin/kubeseal
+  unarchive:
+    src: >-
+      https://github.com/bitnami-labs/sealed-secrets/releases/download/v{{
+      ocp4_workload_sealed_secrets_kubeseal_version }}/kubeseal-{{
+      ocp4_workload_sealed_secrets_kubeseal_version }}-linux-amd64.tar.gz
+    remote_src: true
+    dest: /usr/local/bin
     owner: root
     group: root
     mode: 0775
+  args:
+    creates: /usr/local/bin/kubeseal
 
 # Leave this as the last task in the playbook.
 - name: workload tasks complete

--- a/ansible/roles_ocp_workloads/ocp4_workload_sealed_secrets/templates/kustomization.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_sealed_secrets/templates/kustomization.yaml.j2
@@ -8,15 +8,6 @@ resources:
 - https://github.com/bitnami-labs/sealed-secrets/releases/download/{{ ocp4_workload_sealed_secrets_version }}/controller.yaml
 
 patches:
-{% if ocp4_workload_sealed_secrets_patch_api_version | bool %}
-- target:
-    group: rbac.authorization.k8s.io
-    version: v1beta1
-  patch: |-
-    - op: replace
-      path: "/apiVersion"
-      value: rbac.authorization.k8s.io/v1
-{% endif %}
 - target:
     group: apps
     version: v1
@@ -27,8 +18,3 @@ patches:
       path: "/spec/template/spec/securityContext"
     - op: remove
       path: "/spec/template/spec/containers/0/securityContext"
-{% if ocp4_workload_sealed_secrets_add_update_status_argument | bool %}
-    - op: add
-      path: "/spec/template/spec/containers/0/args/0"
-      value: "--update-status"
-{% endif %}


### PR DESCRIPTION
##### SUMMARY

Sealed Secrets finally released 0.17.1. And Helm Chart 2.0.0. Updated workload to support those versions (and only those versions at a minimum).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_sealed_secrets