### PR TITLE
Re-added argocd namespace operator to ILT workload

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_adv_app_deploy_ilt/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_adv_app_deploy_ilt/defaults/main.yml
@@ -2,3 +2,11 @@
 become_override: false
 ocp_username: opentlc-mgr
 silent: false
+
+# Deploy the ArgoCD Namespace Operator
+ocp4_workload_adv_app_deploy_ilt_deploy_argocd_namespace_operator: true
+ocp4_workload_adv_app_deploy_ilt_argocd_namespace_operator_channel: stable
+ocp4_workload_adv_app_deploy_ilt_argocd_namespace_operator_automatic_install_plan_approval: true
+ocp4_workload_adv_app_deploy_ilt_argocd_namespace_operator_starting_csv: ""
+ocp4_workload_adv_app_deploy_ilt_argocd_namespace_operator_catalog_image: quay.io/gpte-devops-automation/argocd-namespace-catalog
+ocp4_workload_adv_app_deploy_ilt_argocd_namespace_operator_catalog_image_tag: v1.0.0

--- a/ansible/roles_ocp_workloads/ocp4_workload_adv_app_deploy_ilt/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_adv_app_deploy_ilt/tasks/workload.yml
@@ -8,6 +8,23 @@
     state: present
     definition: "{{ lookup('file', 'helm_chart_repository.yaml' ) | from_yaml }}"
 
+- name: Deploy ArgoCD Namespace Operator
+  when: ocp4_workload_adv_app_deploy_ilt_deploy_argocd_namespace_operator | bool
+  include_role:
+    name: install_operator
+  vars:
+    install_operator_action: install
+    install_operator_name: argocd-namespace-operator
+    install_operator_namespace: openshift-operators
+    install_operator_channel: "{{ ocp4_workload_adv_app_deploy_ilt_argocd_namespace_operator_channel }}"
+    install_operator_automatic_install_plan_approval: "{{ ocp4_workload_adv_app_deploy_ilt_argocd_namespace_operator_automatic_install_plan_approval | default(true) }}"
+    install_operator_starting_csv: "{{ ocp4_workload_adv_app_deploy_ilt_argocd_namespace_operator_starting_csv }}"
+    install_operator_catalogsource_setup: true
+    install_operator_catalogsource_name: argocd-namespace-operator-catalogsource
+    install_operator_catalogsource_namespace: openshift-operators
+    install_operator_catalogsource_image: "{{ ocp4_workload_adv_app_deploy_ilt_argocd_namespace_operator_catalog_image }}"
+    install_operator_catalogsource_image_tag: "{{ ocp4_workload_adv_app_deploy_ilt_argocd_namespace_operator_catalog_image_tag }}"
+
 # Leave this as the last task in the playbook.
 # --------------------------------------------
 - name: workload tasks complete

--- a/ansible/roles_ocp_workloads/ocp4_workload_adv_app_deploy_ilt/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_adv_app_deploy_ilt/tasks/workload.yml
@@ -16,14 +16,19 @@
     install_operator_action: install
     install_operator_name: argocd-namespace-operator
     install_operator_namespace: openshift-operators
-    install_operator_channel: "{{ ocp4_workload_adv_app_deploy_ilt_argocd_namespace_operator_channel }}"
-    install_operator_automatic_install_plan_approval: "{{ ocp4_workload_adv_app_deploy_ilt_argocd_namespace_operator_automatic_install_plan_approval | default(true) }}"
-    install_operator_starting_csv: "{{ ocp4_workload_adv_app_deploy_ilt_argocd_namespace_operator_starting_csv }}"
+    install_operator_channel: >-
+      {{ ocp4_workload_adv_app_deploy_ilt_argocd_namespace_operator_channel }}
+    install_operator_automatic_install_plan_approval: >-
+      {{ ocp4_workload_adv_app_deploy_ilt_argocd_namespace_operator_automatic_install_plan_approval | default(true) }}
+    install_operator_starting_csv: >-
+      {{ ocp4_workload_adv_app_deploy_ilt_argocd_namespace_operator_starting_csv }}
     install_operator_catalogsource_setup: true
     install_operator_catalogsource_name: argocd-namespace-operator-catalogsource
     install_operator_catalogsource_namespace: openshift-operators
-    install_operator_catalogsource_image: "{{ ocp4_workload_adv_app_deploy_ilt_argocd_namespace_operator_catalog_image }}"
-    install_operator_catalogsource_image_tag: "{{ ocp4_workload_adv_app_deploy_ilt_argocd_namespace_operator_catalog_image_tag }}"
+    install_operator_catalogsource_image: >-
+      {{ ocp4_workload_adv_app_deploy_ilt_argocd_namespace_operator_catalog_image }}
+    install_operator_catalogsource_image_tag: >-
+      {{ ocp4_workload_adv_app_deploy_ilt_argocd_namespace_operator_catalog_image_tag }}
 
 # Leave this as the last task in the playbook.
 # --------------------------------------------


### PR DESCRIPTION
##### SUMMARY

The ILT Needs an operator to be able to create ArgoCD managed namespaces. Somehow I had missed to commit that before.

Here it is.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_adv_app_deploy_ilt