### PR TITLE
Add another error handler for azure keyvault check

### DIFF
--- a/ansible/roles-infra/infra-azure-ssh-key/tasks/main.yml
+++ b/ansible/roles-infra/infra-azure-ssh-key/tasks/main.yml
@@ -48,6 +48,7 @@
       failed_when:
         - (r_ssh_key.rc != 0)
         - ("VaultNotFound" not in r_ssh_key.stderr)
+        - ("SecretNotFound" not in r_ssh_key.stderr)
 
     - name: Copy the SSH key locally
       copy:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Add another error handler for azure keyvault check - this failure is breaking destroys when the ssh key is not in the vault.

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
ocp4-cluster
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
