### PR TITLE
Fix variable name in Quay Operator workload

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/tasks/workload.yml
@@ -34,7 +34,7 @@
       _ocp4_workload_quay_operator_managed_namespace:
       - "{{ ocp4_workload_quay_operator_operator_namespace }}"
 
-  - name: Install Operator
+  - name: Install Quay Operator
     include_role:
       name: install_operator
     vars:
@@ -52,7 +52,7 @@
       install_operator_catalogsource_name: "{{ ocp4_workload_quay_operator_catalogsource_name }}"
       install_operator_catalogsource_namespace: "{{ _ocp4_workload_quay_operator_namespace }}"
       install_operator_catalogsource_image: "{{ ocp4_workload_quay_operator_catalog_snapshot_image | default('') }}"
-      install_operator_catalogsource_image_tag: "{{ ocp4_workload_pipelines_catalog_snapshot_image_tag }}"
+      install_operator_catalogsource_image_tag: "{{ ocp4_workload_quay_operator_catalog_snapshot_image_tag }}"
 
 - name: Install QuayRegistry
   when: ocp4_workload_quay_operator_install_quay | bool


### PR DESCRIPTION
##### SUMMARY

Fix wrong variable name in install operator.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_quay_operator