### PR TITLE
Removing forced external subnet definition

### DIFF
--- a/ansible/configs/sap-hana/files/cloud_providers/osp_cloud_template_master.j2
+++ b/ansible/configs/sap-hana/files/cloud_providers/osp_cloud_template_master.j2
@@ -132,13 +132,9 @@ resources:
     type: OS::Neutron::FloatingIP
     properties:
       floating_network: {{ provider_network }}
-      floating_subnet:
-        get_attr:
-          - {{ instance['network'] | default('default') }}-router
-          - external_gateway_info
-          - external_fixed_ips
-          - 0
-          - subnet_id
+{% if osp_public_subnet is defined %}
+      floating_subnet: "{{ osp_public_subnet }}"
+{% endif %}
     depends_on:
       - {{ instance['network'] | default('default') }}-router_private_interface
 


### PR DESCRIPTION

##### SUMMARY

This Change removes the forced external subnet of the floating ip and
instead implements a variable check to define, using the 
"find_osp_public_subnet" boolean in the generic OSP cloud provider.

This particular forced tag is the reason for all of the failed sap-hana
config deployments.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Config: sap-hana, OSP cloud template j2

##### ADDITIONAL INFORMATION
None
