### PR TITLE
ocp4_workload_rhel_worker: add volume to RHEL worker

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhel_worker/tasks/workload.yml
@@ -161,6 +161,11 @@
       count_tag: "{{ RHEL_instance_tags }}"
       instance_tags: "{{ RHEL_instance_tags }}"
       instance_profile_name: "rhel-worker-access-role"
+      volumes:
+      - device_name: /dev/sda1
+        volume_type: gp2
+        volume_size: 120
+        delete_on_termination: true
       wait: true
     register: __new_RHEL
 


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

Default volume size was 10G.  Lab failed with such a small volume.  Increase volume size to 120G.

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4_workload_rhel_worker

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
