### PR TITLE
Add wait for nodes to be ready to ocp4_approve_certificate_signing_requests

### DIFF
--- a/ansible/install_galaxy_roles.yml
+++ b/ansible/install_galaxy_roles.yml
@@ -38,7 +38,7 @@
       command: >-
         ansible-galaxy collection install
         -r "{{ requirements_path }}"
-        -p collections
+        -p {{ lookup('config', 'COLLECTIONS_PATHS')[0] | quote }}
         --force-with-deps
       when: >-
         r_requirements_stat.stat.exists

--- a/ansible/install_galaxy_roles.yml
+++ b/ansible/install_galaxy_roles.yml
@@ -38,7 +38,7 @@
       command: >-
         ansible-galaxy collection install
         -r "{{ requirements_path }}"
-        -p {{ lookup('config', 'COLLECTIONS_PATHS')[0] | quote }}
+        -p collections
         --force-with-deps
       when: >-
         r_requirements_stat.stat.exists

--- a/ansible/roles/ocp4_approve_certificate_signing_requests/defaults/main.yml
+++ b/ansible/roles/ocp4_approve_certificate_signing_requests/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Initial delay to wait for cluster node and pod start-up
-ocp4_approve_certificate_signing_requests_initial_delay: 300
+ocp4_approve_certificate_signing_requests_initial_delay: 60
 
 # Delay between rechecks for more CertificateSigningRequests to appear
 ocp4_approve_certificate_signing_requests_recheck_delay: 30

--- a/ansible/roles/ocp4_approve_certificate_signing_requests/tasks/approve-certificate-signing-requests.yml
+++ b/ansible/roles/ocp4_approve_certificate_signing_requests/tasks/approve-certificate-signing-requests.yml
@@ -4,6 +4,9 @@
     api_version: v1
     kind: Node
   register: r_get_nodes
+  retries: 10
+  delay: 30
+  until: r_get_nodes is succeeded
 
 - name: Get CertificateSigningRequests that need to be approved
   kubernetes.core.k8s_info:
@@ -28,7 +31,7 @@
   block:
   - name: Report nodes not ready
     debug:
-      msg: Nodes NotReady: {{ __nodes_not_ready | join(', ') }}
+      msg: "Nodes NotReady: {{ __nodes_not_ready | join(', ') }}"
 
   - name: Approve all pending CertificateSigningRequests
     loop: "{{ __unsigned_csr_names | default([]) }}"

--- a/ansible/roles/ocp4_approve_certificate_signing_requests/tasks/approve-certificate-signing-requests.yml
+++ b/ansible/roles/ocp4_approve_certificate_signing_requests/tasks/approve-certificate-signing-requests.yml
@@ -32,7 +32,7 @@
       {{ r_csrs.resources | default([]) | to_json | from_json
        | json_query("[?status.conditions[?type=='Approved' && status=='True']==`null`].metadata.name")
       }}
-  when: __unsigned_csr_names | length > 0 || __nodes_not_ready | length > 0
+  when: __unsigned_csr_names | length > 0 or __nodes_not_ready | length > 0
   block:
   - name: Report nodes not ready
     debug:

--- a/ansible/roles/ocp4_approve_certificate_signing_requests/tasks/approve-certificate-signing-requests.yml
+++ b/ansible/roles/ocp4_approve_certificate_signing_requests/tasks/approve-certificate-signing-requests.yml
@@ -23,7 +23,7 @@
       {{ '%FT%TZ' | strftime(now(utc=True).timestamp() - 600) }}
     # Consider node NotReady if Ready condition explicitly has status not true or last heartbeat is too long ago
     __nodes_not_ready_query: >-
-      [?status.conditions[?type=='Ready' && (status != 'True' || lastHeartbeatTime < `{{ __min_heartbeat }}`)]].metadata.name
+      [?status.conditions[?type=='Ready' && (status != 'True' || lastHeartbeatTime < '{{ __min_heartbeat }}')]].metadata.name
     __nodes_not_ready: >-
       {{ r_get_nodes.resources | default([]) | to_json | from_json
        | json_query(__nodes_not_ready_query)

--- a/ansible/roles/ocp4_approve_certificate_signing_requests/tasks/approve-certificate-signing-requests.yml
+++ b/ansible/roles/ocp4_approve_certificate_signing_requests/tasks/approve-certificate-signing-requests.yml
@@ -1,6 +1,12 @@
 ---
+- name: Get Nodes in order to check status
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Node
+  register: r_get_nodes
+
 - name: Get CertificateSigningRequests that need to be approved
-  k8s_info:
+  kubernetes.core.k8s_info:
     api_version: certificates.k8s.io/v1beta1
     kind: CertificateSigningRequest
   register: r_csrs
@@ -10,12 +16,20 @@
 
 - name: Approve CerrtificateSigningRequests
   vars:
+    __nodes_not_ready: >-
+      {{ r_get_nodes.resources | default([]) | to_json | from_json
+       | json_query("[?status.conditions[?type=='Ready' && status!='True']].metadata.name")
+      }}
     __unsigned_csr_names: >-
       {{ r_csrs.resources | default([]) | to_json | from_json
        | json_query("[?status.conditions[?type=='Approved' && status=='True']==`null`].metadata.name")
       }}
-  when: __unsigned_csr_names | length > 0
+  when: __unsigned_csr_names | length > 0 || __nodes_not_ready | length > 0
   block:
+  - name: Report nodes not ready
+    debug:
+      msg: Nodes NotReady: {{ __nodes_not_ready | join(', ') }}
+
   - name: Approve all pending CertificateSigningRequests
     loop: "{{ __unsigned_csr_names | default([]) }}"
     command: "oc adm certificate approve {{ item }}"

--- a/ansible/roles/ocp4_approve_certificate_signing_requests/tasks/approve-certificate-signing-requests.yml
+++ b/ansible/roles/ocp4_approve_certificate_signing_requests/tasks/approve-certificate-signing-requests.yml
@@ -19,9 +19,14 @@
 
 - name: Approve CerrtificateSigningRequests
   vars:
+    __min_heartbeat: >-
+      {{ '%FT%TZ' | strftime(now(utc=True).timestamp() - 600) }}
+    # Consider node NotReady if Ready condition explicitly has status not true or last heartbeat is too long ago
+    __nodes_not_ready_query: >-
+      [?status.conditions[?type=='Ready' && (status != 'True' || lastHeartbeatTime < `{{ __min_heartbeat }}`)]].metadata.name
     __nodes_not_ready: >-
       {{ r_get_nodes.resources | default([]) | to_json | from_json
-       | json_query("[?status.conditions[?type=='Ready' && status!='True']].metadata.name")
+       | json_query(__nodes_not_ready_query)
       }}
     __unsigned_csr_names: >-
       {{ r_csrs.resources | default([]) | to_json | from_json

--- a/ansible/roles/ocp4_approve_certificate_signing_requests/tasks/approve-certificate-signing-requests.yml
+++ b/ansible/roles/ocp4_approve_certificate_signing_requests/tasks/approve-certificate-signing-requests.yml
@@ -34,9 +34,10 @@
       }}
   when: __unsigned_csr_names | length > 0 or __nodes_not_ready | length > 0
   block:
-  - name: Report nodes not ready
+  - name: Report Nodes NotReady
     debug:
       msg: "Nodes NotReady: {{ __nodes_not_ready | join(', ') }}"
+    when: __nodes_not_ready | length > 0
 
   - name: Approve all pending CertificateSigningRequests
     loop: "{{ __unsigned_csr_names | default([]) }}"


### PR DESCRIPTION
##### SUMMARY

Add logic to the ocp4_approve_certificate_signing_requests role to check the node status to confirm that all nodes report Ready status with a recent lastHeartbeatTime before completing. This gives nodes time to request CSRs rather than relying on an arbitrary wait time.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Role ocp4_approve_certificate_signing_requests