### PR TITLE
Update config osp-migration to use new labconsole url

### DIFF
--- a/ansible/configs/osp-migration/env_vars.yml
+++ b/ansible/configs/osp-migration/env_vars.yml
@@ -113,7 +113,7 @@ osp_cluster_dns_server: ddns01.opentlc.com
 # Configuration to control whether to report user info for the lab console.
 # This should be disabled for babylon deployment.
 osp_migration_report_labconsole: true
-osp_migration_labconsole_apps_domain: apps.shared-na4.na4.openshift.opentlc.com
+osp_migration_labconsole_url: https://console.apps.open.redhat.com/
 
 # Whether to wait for an ack from the DNS servers before continuing
 wait_for_dns: true

--- a/ansible/configs/osp-migration/post_software.yml
+++ b/ansible/configs/osp-migration/post_software.yml
@@ -11,7 +11,7 @@
       loop:
         - ""
         - "In case you need to access to the console of the VMs for your lab:"
-        - "URL: https://{{ osp_labconsole_url }}/"
+        - "URL: https://{{ osp_migration_labconsole_url }}/"
         - "Username: {{ student_name }}"
         - "Password: *your opentlc password*"
 

--- a/ansible/configs/osp-migration/post_software.yml
+++ b/ansible/configs/osp-migration/post_software.yml
@@ -11,7 +11,7 @@
       loop:
         - ""
         - "In case you need to access to the console of the VMs for your lab:"
-        - "URL: https://{{ osp_migration_labconsole_url }}/"
+        - "URL: {{ osp_migration_labconsole_url }}"
         - "Username: {{ student_name }}"
         - "Password: *your opentlc password*"
 

--- a/ansible/configs/osp-migration/post_software.yml
+++ b/ansible/configs/osp-migration/post_software.yml
@@ -11,7 +11,7 @@
       loop:
         - ""
         - "In case you need to access to the console of the VMs for your lab:"
-        - "URL: https://{{ osp_cluster_dns_zone.split('.')[0] }}-labconsole.{{ osp_migration_labconsole_apps_domain }}/"
+        - "URL: https://{{ osp_labconsole_url }}/"
         - "Username: {{ student_name }}"
         - "Password: *your opentlc password*"
 


### PR DESCRIPTION
Labconsole was on https://dynamic-labconsole.apps.shared-na4.na4.openshift.opentlc.com/ (shared ocp4) and idea is to use the babylon environment (https://console.apps.open.redhat.com/)