### PR TITLE
fix workload output for storage

### DIFF
--- a/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/workload.yml
@@ -88,13 +88,15 @@
     namespace: lab-ocp-cns
   register: Route
 
-- debug:
-    msg:
-    - "user.info: "
-    - "user.info: Access the workshop at 'https://{{ Route.resources[0].spec.host }}'"
-    - "user.info: Login with 'kubeadmin' and '{{ kubeadmin_password }}'"
-    - "user.info: "
-    - "user.info: Workshop may not be accessible until rollout finishes shortly."
+- name: Provide workshop information
+  agnosticd_user_info:
+    msg: "{{ item }}"
+  loop:
+    - ""
+    - "Access the workshop at 'https://{{ Route.resources[0].spec.host }}'"
+    - "Login with 'kubeadmin' and '{{ kubeadmin_password }}'"
+    - ""
+    - "Workshop may not be accessible until rollout finishes shortly."
 
 # Leave this as the last task in the playbook.
 

--- a/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/workload.yml
@@ -92,11 +92,11 @@
   agnosticd_user_info:
     msg: "{{ item }}"
   loop:
-    - ""
-    - "Access the workshop at 'https://{{ Route.resources[0].spec.host }}'"
-    - "Login with 'kubeadmin' and '{{ kubeadmin_password }}'"
-    - ""
-    - "Workshop may not be accessible until rollout finishes shortly."
+  - ""
+  - "Access the workshop at 'https://{{ Route.resources[0].spec.host }}'"
+  - "Login with 'kubeadmin' and '{{ kubeadmin_password }}'"
+  - ""
+  - "Workshop may not be accessible until rollout finishes shortly."
 
 # Leave this as the last task in the playbook.
 


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
fix workload output for storage
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
roles/ocp4-workload-workshop-admin-storage
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
workshop output was using debug not agnosticd_user_info module which does not populate babylon

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
