### PR TITLE
fix azure deletion to use collection fully quallified path

### DIFF
--- a/ansible/roles-infra/infra-azure-template-destroy/tasks/main.yml
+++ b/ansible/roles-infra/infra-azure-template-destroy/tasks/main.yml
@@ -7,7 +7,7 @@
     AZURE_CONFIG_DIR: "{{ output_dir }}/.azure-{{project_tag}}"
   block:
     - name: Delete CNAME for bastion to the main DNSZone
-      azure_rm_dnsrecordset:
+      azure.azcollection.azure_rm_dnsrecordset:
         resource_group: "{{az_dnszone_resource_group|default('dns')}}"
         relative_name: "bastion.{{guid}}"
         zone_name: "{{HostedZoneId}}"
@@ -20,7 +20,7 @@
         - dns_bastion == true
 
     - name: Delete delegation for NS to the main DNSZone
-      azure_rm_dnsrecordset:
+      azure.azcollection.azure_rm_dnsrecordset:
         resource_group: "{{az_dnszone_resource_group|default('dns')}}"
         relative_name: "{{guid}}"
         zone_name: "{{HostedZoneId}}"
@@ -35,7 +35,7 @@
       when: az_destroy_method|default('resource_group') == 'resource_group'
       block:
         - name: Delete the resource group
-          azure_rm_resourcegroup:
+          azure.azcollection.azure_rm_resourcegroup:
             name: "{{az_resource_group}}"
             state: absent
             force: true


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
fix azure deletion to use collection fully quallified path
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
infra-azure-template-destroy
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
