### PR TITLE
Migrated to kubernetes.core packages and add validation to rhacm_csv.resources

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/post_workload.yml
@@ -1,7 +1,7 @@
 ---
 # Ensure ACM is working
 - name: Get the ACM console route
-  k8s_info:
+  kubernetes.core.k8s_info:
     api_version: route.openshift.io/v1
     kind: Route
     name: multicloud-console
@@ -9,7 +9,7 @@
   register: r_acm_console_route
 
 - name: Get Web Console route
-  k8s_info:
+  kubernetes.core.k8s_info:
     api_version: route.openshift.io/v1
     kind: Route
     namespace: openshift-console
@@ -17,7 +17,7 @@
   register: r_console_route
 
 - name: Get API server URL
-  k8s_info:
+  kubernetes.core.k8s_info:
     api_version: config.openshift.io/v1
     kind: Infrastructure
     name: cluster

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/remove_workload.yml
@@ -15,12 +15,12 @@
   when: whoami.stdout != "system:admin"
 
 - name: Ensure RHACM MultiClusterHub is absent
-  k8s:
+  kubernetes.core.k8s:
     state: absent
     definition: "{{ lookup('template', './templates/multiClusterHub.j2') }}"
 
 - name: Wait until no rcm controller is running before removing the subscriptions
-  k8s_info:
+  kubernetes.core.k8s_info:
     api_version: apps/v1
     kind: Deployment
     namespace: "{{ ocp4_workload_rhacm_acm_project }}"
@@ -31,17 +31,17 @@
   until: rcm_controller_deployment.resources | length == 0
 
 - name: Ensure RHACM Subscription is absent
-  k8s:
+  kubernetes.core.k8s:
     state: absent
     definition: "{{ lookup('template', './templates/subscription.j2') }}"
 
 - name: Ensure RHACM OperatorGroup is absent
-  k8s:
+  kubernetes.core.k8s:
     state: absent
     definition: "{{ lookup('template', './templates/operatorGroup.j2') }}"
 
 - name: Ensure ACM CSV is absent
-  k8s:
+  kubernetes.core.k8s:
     state: absent
     api_version: operators.coreos.com/v1alpha1
     kind: ClusterServiceVersion
@@ -49,7 +49,7 @@
     namespace: "{{ ocp4_workload_rhacm_acm_project }}"
 
 - name: Wait until no pods are running before removing the namespace
-  k8s_info:
+  kubernetes.core.k8s_info:
     kind: Pod
     namespace: "{{ ocp4_workload_rhacm_acm_project }}"
   register: pod_list
@@ -59,7 +59,7 @@
 
 
 - name: Ensure RHACM Namespace is absent
-  k8s:
+  kubernetes.core.k8s:
     name: "{{ ocp4_workload_rhacm_acm_project }}"
     api_version: v1
     kind: Namespace

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/workload.yml
@@ -12,30 +12,30 @@
   when: whoami.stdout != "system:admin"
 
 - name: Ensure RHACM Namespace is present
-  k8s:
+  kubernetes.core.k8s:
     name: "{{ ocp4_workload_rhacm_acm_project }}"
     api_version: v1
     kind: Namespace
     state: present
 
 - name: Ensure RHACM OperatorGroup is present
-  k8s:
+  kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('template', './templates/operatorGroup.j2') }}"
 
 - name: Create Catalogsource for use with catalog snapshot
   when: ocp4_workload_rhacm_use_catalog_snapshot | bool
-  k8s:
+  kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('template', './templates/catalogSource.j2' ) | from_yaml }}"
 
 - name: Ensure RHACM Subscription is present
-  k8s:
+  kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('template', './templates/subscription.j2') }}"
 
 - name: Wait until InstallPlan is created
-  k8s_info:
+  kubernetes.core.k8s_info:
     api_version: operators.coreos.com/v1alpha1
     kind: InstallPlan
     namespace: "{{ ocp4_workload_rhacm_acm_project }}"
@@ -57,7 +57,7 @@
       [?starts_with(spec.clusterServiceVersionNames[0], 'advanced-cluster-management')].metadata.name|[0]
 
 - name: Get InstallPlan
-  k8s_info:
+  kubernetes.core.k8s_info:
     api_version: operators.coreos.com/v1alpha1
     kind: InstallPlan
     name: "{{ ocp4_workload_rhacm_install_plan_name }}"
@@ -66,12 +66,12 @@
 
 - name: Approve InstallPlan if necessary
   when: r_install_plan.resources[0].status.phase is match("RequiresApproval")
-  k8s:
+  kubernetes.core.k8s:
     state: present
     definition: "{{ lookup( 'template', './templates/installPlan.j2' ) }}"
 
 - name: Wait until some pods are running before checking the sub status
-  k8s_info:
+  kubernetes.core.k8s_info:
     kind: Pod
     namespace: "{{ ocp4_workload_rhacm_acm_project }}"
   register: pod_list
@@ -80,7 +80,7 @@
   until: pod_list.resources | length != 0
 
 - name: Wait until RHACM Subscription is Ready
-  k8s_info:
+  kubernetes.core.k8s_info:
     api_version: operators.coreos.com/v1alpha1
     kind: ClusterServiceVersion
     name: "{{ ocp4_workload_rhacm_acm_csv }}"
@@ -96,12 +96,12 @@
   - rhacm_csv.resources[0].status.phase == "Succeeded"
 
 - name: Ensure RHACM MultiClusterHub is present
-  k8s:
+  kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('template', './templates/multiClusterHub.j2') }}"
 
 - name: Wait until RHACM MultiClusterHub is Ready
-  k8s_info:
+  kubernetes.core.k8s_info:
     api_version: operator.open-cluster-management.io/v1
     kind: MultiClusterHub
     name: "multiclusterhub"

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/workload.yml
@@ -110,6 +110,7 @@
   retries: 30
   delay: 30
   until:
+  - rhacm_csv.resources is defined
   - rhacm_multiclusterhub.resources | length > 0
   - rhacm_multiclusterhub.resources[0].status is defined
   - rhacm_multiclusterhub.resources[0].status.phase is defined

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/workload.yml
@@ -89,6 +89,7 @@
   retries: 30
   delay: 20
   until:
+  - rhacm_csv.resources is defined
   - rhacm_csv.resources | length > 0
   - rhacm_csv.resources[0].status is defined
   - rhacm_csv.resources[0].status.phase is defined


### PR DESCRIPTION
##### SUMMARY

This PR migrated from `k8s` and `k8s_info` to `kubernetes.core`.
Also includes a validation for rhacm resources.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_rhacm

##### ADDITIONAL INFORMATION
Deployments on overloaded regions can result in an ocp race condition resulting an error on a `lenght` validation, this PR ensures the variable `rhacm_csv.resources` is defined before moving on.

<!-- ansible --version -->
Tested on Ansible 2.9.20

<!-- pip freeze -->
```
ansible==2.9.20
appdirs==1.4.4
attrs==21.4.0
autopage==0.5.0
Babel==2.9.1
boto3==1.20.46
botocore==1.23.46
certifi==2021.10.8
cffi==1.15.0
charset-normalizer==2.0.11
cliff==3.10.0
cmd2==2.3.3
cryptography==36.0.1
debtcollector==2.4.0
decorator==5.1.1
distro==1.6.0
dnspython==2.2.0
dogpile.cache==1.1.5
idna==3.3
iso8601==1.0.2
Jinja2==3.0.3
jmespath==0.10.0
jsonpatch==1.32
jsonpointer==2.2
jsonschema==3.2.0
keystoneauth1==4.4.0
MarkupSafe==2.0.1
msgpack==1.0.3
munch==2.5.0
netaddr==0.8.0
netifaces==0.11.0
openstacksdk==0.61.0
os-client-config==2.1.0
os-service-types==1.7.0
osc-lib==2.4.2
oslo.config==8.7.1
oslo.context==3.4.0
oslo.i18n==5.1.0
oslo.log==4.6.1
oslo.serialization==4.2.0
oslo.utils==4.12.1
packaging==21.3
passlib==1.7.4
pbr==5.8.0
prettytable==3.0.0
pycparser==2.21
pyOpenSSL==22.0.0
pyparsing==3.0.7
pyperclip==1.8.2
pyrsistent==0.18.1
python-cinderclient==8.2.0
python-dateutil==2.8.2
python-glanceclient==3.5.0
python-heatclient==2.5.0
python-keystoneclient==4.4.0
python-neutronclient==7.7.0
python-novaclient==17.6.0
python-openstackclient==5.7.0
python-string-utils==1.0.0
python-swiftclient==3.13.0
pytz==2021.3
PyYAML==6.0
requests==2.27.1
requestsexceptions==1.4.0
rfc3986==2.0.0
s3transfer==0.5.0
selinux==0.2.1
simplejson==3.17.6
six==1.16.0
stevedore==3.5.0
urllib3==1.26.8
warlock==1.3.3
wcwidth==0.2.5
wrapt==1.13.3

```
