### PR TITLE
Fix ocp4-workload-ccn-cuttingedge to fix 'm1' yaml error

### DIFF
--- a/ansible/roles/ocp4-workload-ccnrd-cuttingedge/tasks/post_workload.yml
+++ b/ansible/roles/ocp4-workload-ccnrd-cuttingedge/tasks/post_workload.yml
@@ -30,25 +30,25 @@
     
 
 - name: output workshop info guides
-  when: (m1 in modules)
+  when: ("m1" in modules)
   agnosticd_user_info:
     msg:
       Module 1 http://guides-m1-labs-infra.{{ route_subdomain }}
 
 - name: output workshop info guides
-  when: (m2 in modules)
+  when: ("m2" in modules)
   agnosticd_user_info:
     msg:
       Module 2 http://guides-m2-labs-infra.{{ route_subdomain }}
 
 - name: output workshop info guides
-  when: (m3 in modules)
+  when: ("m3" in modules)
   agnosticd_user_info:
     msg:
       Module 3 http://guides-m3-labs-infra.{{ route_subdomain }}
 
 - name: output workshop info guides
-  when: (m4 in modules)
+  when: ("m4" in modules)
   agnosticd_user_info:
     msg:
       Module 4 http://guides-m4-labs-infra.{{ route_subdomain }}


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

Fix ocp4-workload-ccn-cuttingedge to fix 'm1' yaml error

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
