### PR TITLE
Fix ocp4-workload-ccn-stable to replace user.info module

### DIFF
--- a/ansible/roles/ocp4-workload-ccnrd-stable/tasks/post_workload.yml
+++ b/ansible/roles/ocp4-workload-ccnrd-stable/tasks/post_workload.yml
@@ -1,78 +1,72 @@
 ---
 # Implement your Post Workload deployment tasks here
 - name: output workshop info
-  debug:
-    msg:
-    - "user.info: "
-    - "user.info: CCN Roadshow Dev Track provisioned for {{ num_users }} user(s)"
+  agnosticd_user_info:
+    msg: |
+      CCN Roadshow Dev Track provisioned for {{ num_users }} user(s)
 
 - name: output workshop info guides
-  debug:
-    msg:
-    - "user.info: "
-    - "user.info: URL for attendees to get a username assigned to them and links to labs:"
-    - "user.info: "
-    - "user.info: https://get-a-username-labs-infra.{{ route_subdomain }}"
-    - "user.info: "
-    - "user.info: You should share this URL (or a shortlink for it) -- It is all they will need to get started!"
-    - "user.info: "
-    - "user.info: [Instructor Only] To access the admin see which user is assigned to which user ID, use the following:"
-    - "user.info: "
-    - "user.info: [Instructor Only] https://get-a-username-labs-infra.{{ route_subdomain }}/admin"
-    - "user.info: "
-    - "user.info: [Instructor Only] Admin login with 'admin' / '{{ workshop_openshift_user_password }}'"
+  agnosticd_user_info:
+    msg: |
+      URL for attendees to get a username assigned to them and links to labs:
+    
+      https://get-a-username-labs-infra.{{ route_subdomain }}
+    
+      You should share this URL (or a shortlink for it) -- It is all they will need to get started!
+    
+      [Instructor Only] To access the admin see which user is assigned to which user ID, use the following:
+    
+      [Instructor Only] https://get-a-username-labs-infra.{{ route_subdomain }}/admin
+    
+      [Instructor Only] Admin login with 'admin' / '{{ workshop_openshift_user_password }}'
 
 - name: output workshop username distribution URL
-  debug:
-    msg:
-    - "user.info: "
-    - "user.info: Individual module guide URLs (in case you need them for direct linking):"
-    - "user.info: "
-
-
+  agnosticd_user_info:
+    msg: |
+      Individual module guide URLs (in case you need them for direct linking):
+    
 - name: output workshop info guides
   when: ("m1" in modules)
-  debug:
-    msg:
-    - "user.info: Module 1 http://guides-m1-labs-infra.{{ route_subdomain }}"
+  agnosticd_user_info:
+    msg: |
+      "Module 1 http://guides-m1-labs-infra.{{ route_subdomain }}"
 
 - name: output workshop info guides
   when: ("m2" in modules)
-  debug:
-    msg:
-    - "user.info: Module 2 http://guides-m2-labs-infra.{{ route_subdomain }}"
+  agnosticd_user_info:
+    msg: |
+      Module 2 http://guides-m2-labs-infra.{{ route_subdomain }}
 
 - name: output workshop info guides
   when: ("m3" in modules)
-  debug:
-    msg:
-    - "user.info: Module 3 http://guides-m3-labs-infra.{{ route_subdomain }}"
+  agnosticd_user_info:
+    msg: |
+      Module 3 http://guides-m3-labs-infra.{{ route_subdomain }}
 
 - name: output workshop info guides
   when: ("m4" in modules)
-  debug:
-    msg:
-    - "user.info: Module 4 http://guides-m4-labs-infra.{{ route_subdomain }}"
+  agnosticd_user_info:
+    msg: |
+      Module 4 http://guides-m4-labs-infra.{{ route_subdomain }}
 
 - name: output workshop info guides
-  debug:
-    msg:
-    - "user.info: "
-    - "user.info: OpenShift credentials for attendees: {{ workshop_openshift_user_name }} / {{ workshop_openshift_user_password }}"
-    - "user.info: CodeReady Workspaces credentials for attendees: {{ workshop_che_user_name }} / {{ workshop_che_user_password }}"
-    - "user.info: "
-    - "user.info: OpenShift Console: {{ console_url }}"
-    - "user.info: Cluster admin login with '{{ ocp_username }}' / 'r3dh4t1!'"
-    - "user.info: "
-    - "user.info: CodeReady Console: https://codeready-labs-infra.{{ route_subdomain }}"
-    - "user.info: Admin login with 'admin' / 'admin'"
-    - "user.info: "
-    - "user.info: NOTE: Workspaces in CodeReady AND service mesh are provisioned asynchronously and may not"
-    - "user.info: be accessible until rollout finishes shortly."
+  agnosticd_user_info:
+    msg: |
+      OpenShift credentials for attendees: {{ workshop_openshift_user_name }} / {{ workshop_openshift_user_password }}
+      CodeReady Workspaces credentials for attendees: {{ workshop_che_user_name }} / {{ workshop_che_user_password }}
+    
+      OpenShift Console: {{ console_url }}
+      Cluster admin login with '{{ ocp_username }}' / 'r3dh4t1!'
+    
+      CodeReady Console: https://codeready-labs-infra.{{ route_subdomain }}
+      Admin login with 'admin' / 'admin'
+    
+      NOTE: Workspaces in CodeReady AND service mesh are provisioned asynchronously and may not be accessible until rollout finishes shortly.
   when: not silent|bool
 
 # Leave this as the last task in the playbook.
 - name: post_workload tasks complete
-  debug:
-    msg: "Post-Workload Tasks completed successfully."
+  agnosticd_user_info:
+    msg: |
+      Post-Workload Tasks completed successfully.
   when: not silent|bool


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
Fix ocp4-workload-ccn-stable to replace user.info module

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
