### PR TITLE
Add update entry point playbook

### DIFF
--- a/ansible/configs/test-empty-config/update.yml
+++ b/ansible/configs/test-empty-config/update.yml
@@ -1,0 +1,34 @@
+---
+- name: Update test-empty-config
+  hosts: localhost
+  connection: local
+  become: false
+  gather_facts: false
+  tasks:
+    - name: Entering the test-empty-config update.yml
+      debug:
+        msg:
+          - Entering the test-empty-config update.yml
+
+    - name: Check presence of random_string in user info from initial provision
+      debug:
+        msg: "random_string: {{ lookup('agnosticd_user_data', 'random_string') }}"
+
+    - when: fail_update | default(false) | bool
+      name: Fail the test-empty-config update.yml if requested
+      fail:
+        msg: update.yml failed as requested
+
+    - name: Test update agnosticd_user_info with current timestamp
+      agnosticd_user_info:
+        msg: Updated at {{ __timestamp }}
+        data:
+          test_update_timestamp: "{{ __timestamp }}"
+      vars:
+        __timestamp: "{{ now(utc=true, fmt='%FT%TZ') }}"
+
+    - name: Exiting the test-empty-config update.yml
+      debug:
+        msg:
+          - Exiting the test-empty-config update.yml
+...

--- a/ansible/lifecycle_hook.yml
+++ b/ansible/lifecycle_hook.yml
@@ -6,4 +6,6 @@
   tasks:
   - name: Placeholder
     debug:
-      msg: "No custom lifecycle hook provided. This is the lifecycle hook placeholder"
+      msg: >-
+        {{ env_type }} does not include lifecycle_hook_post_{{ ACTION }}.yml or lifecycle_hook.yml.
+        This is the lifecycle hook placeholder.

--- a/ansible/lookup_plugins/agnosticd_user_data.py
+++ b/ansible/lookup_plugins/agnosticd_user_data.py
@@ -1,0 +1,57 @@
+# (c) 2021 Johnathan Kupferer
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = """
+    name: agnosticd_user_data
+    author: Johnathan Kupferer <jkupfere@redhat.com>
+    version_added: "2.9"
+    short_description: fetch data values set with agnosticd_user_info
+    description:
+      - This lookup returns data values set with agnosticd_user_info. 
+    options:
+      _terms:
+        description: Data keys set in agnosticd_user_info.
+        required: True
+"""
+
+EXAMPLES = """
+- name: "Set admin_password from value set with agnosticd_user_info"
+  set_fact:
+    admin_password: "{{ lookup('agnosticd_user_data', 'admin_password') }}"
+  when: admin_password is undefined
+"""     
+
+RETURN = """
+  _raw:
+    description:
+      - list of values to get from agnosticd_user_info data
+    type: list
+    elements: raw   
+"""
+
+import os
+import yaml
+
+from ansible.errors import AnsibleError
+from ansible.plugins.lookup import LookupBase
+
+class LookupModule(LookupBase): 
+    def run(self, terms, **kwargs):
+        self.set_options(direct=kwargs)
+        ret = []
+
+        output_dir = self._templar.template('{{ output_dir | default(playbook_dir) | default(".") }}')
+        user_data = {}
+        try:
+            fh = open(os.path.join(output_dir, 'user-data.yaml'), 'r')
+            user_data = yaml.safe_load(fh)
+            fh.close()
+        except FileNotFoundError:
+            pass
+
+        for term in terms:
+            ret.append(user_data.get(term) if user_data else None)
+
+        return ret

--- a/ansible/roles/agnosticd_restore_output_dir/tasks/main.yml
+++ b/ansible/roles/agnosticd_restore_output_dir/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Restore output_dir from s3 bucket
+  when:
+  - agnosticd_save_output_dir_archive is defined
+  - agnosticd_save_output_dir_s3_access_key_id is defined
+  - agnosticd_save_output_dir_s3_bucket is defined
+  - agnosticd_save_output_dir_s3_region is defined
+  - agnosticd_save_output_dir_s3_secret_access_key is defined
+  ansible.builtin.include_tasks:
+    file: restore-from-s3.yml

--- a/ansible/roles/agnosticd_restore_output_dir/tasks/restore-from-s3.yml
+++ b/ansible/roles/agnosticd_restore_output_dir/tasks/restore-from-s3.yml
@@ -1,0 +1,27 @@
+---
+- name: Get output_dir archive from s3
+  amazon.aws.aws_s3:
+    aws_access_key: "{{ agnosticd_save_output_dir_s3_access_key_id }}"
+    aws_secret_key: "{{ agnosticd_save_output_dir_s3_secret_access_key }}"
+    bucket: "{{ agnosticd_save_output_dir_s3_bucket }}"
+    dest: "{{ output_dir }}/restore.tar.gz"
+    mode: get
+    object: "{{ agnosticd_save_output_dir_archive }}"
+    region: "{{ agnosticd_save_output_dir_s3_region }}"
+  register: r_get_output_dir_archive
+  failed_when: >-
+    r_get_output_dir_archive is failed and 'does not exist' not in r_get_output_dir_archive.msg
+
+- name: Restore output_dir from archive
+  when: >-
+    (output_dir ~ '/restore.tar.gz') is file
+  ansible.builtin.unarchive:
+    src: "{{ output_dir }}/restore.tar.gz"
+    dest: "{{ output_dir }}"
+    extra_opts:
+    - --strip-components=1
+
+- name: Remove archive file from output_dir
+  ansible.builtin.file:
+    path: "{{ output_dir }}/restore.tar.gz"
+    state: absent

--- a/ansible/setup_runtime.yml
+++ b/ansible/setup_runtime.yml
@@ -54,6 +54,11 @@
       - user-info.yaml
       - user-data.yaml
 
+    - name: Attempt to restore output_dir contents
+      when: agnosticd_save_output_dir_archive is defined
+      include_role:
+        name: agnosticd_restore_output_dir
+
 # include global vars from the config
 - import_playbook: include_vars.yml
 

--- a/ansible/update.yml
+++ b/ansible/update.yml
@@ -1,0 +1,38 @@
+---
+# Entry point for update action.
+
+- name: Setup AgnosticD Runtime
+  import_playbook: setup_runtime.yml
+
+- name: Start environment
+  import_playbook: >-
+    {{ lookup('first_found', {
+         'files': [ 'start.yml', 'lifecycle.yml' ],
+         'paths': ['configs/' + env_type, playbook_dir]
+       })
+    }}
+  vars:
+    ACTION: start
+
+- name: Process Lifecycle Post Start Hook
+  vars:
+    __find_lifecycle_hook_params:
+      files:
+        - configs/{{ env_type }}/lifecycle_hook_post_start.yml
+        - configs/{{ env_type }}/lifecycle_hook.yml
+        - lifecycle_hook.yml
+  import_playbook: >-
+    {{ lookup('first_found', __find_lifecycle_hook_params) }}
+
+- name: Update deployment
+  vars:
+    __find_update_params:
+      files:
+        - configs/{{ env_type }}/update.yml
+        - update_placeholder.yml
+  import_playbook: >-
+    {{ lookup('first_found', __find_update_params) }}
+
+- import_playbook: save_output_dir.yml
+
+- import_playbook: completion_callback.yml

--- a/ansible/update.yml
+++ b/ansible/update.yml
@@ -4,27 +4,7 @@
 - name: Setup AgnosticD Runtime
   import_playbook: setup_runtime.yml
 
-- name: Start environment
-  import_playbook: >-
-    {{ lookup('first_found', {
-         'files': [ 'start.yml', 'lifecycle.yml' ],
-         'paths': ['configs/' + env_type, playbook_dir]
-       })
-    }}
-  vars:
-    ACTION: start
-
-- name: Process Lifecycle Post Start Hook
-  vars:
-    __find_lifecycle_hook_params:
-      files:
-        - configs/{{ env_type }}/lifecycle_hook_post_start.yml
-        - configs/{{ env_type }}/lifecycle_hook.yml
-        - lifecycle_hook.yml
-  import_playbook: >-
-    {{ lookup('first_found', __find_lifecycle_hook_params) }}
-
-- name: Update deployment
+- name: Update
   vars:
     __find_update_params:
       files:

--- a/ansible/update_placeholder.yml
+++ b/ansible/update_placeholder.yml
@@ -1,0 +1,11 @@
+- name: Update Hook (fallback)
+  hosts: localhost
+  run_once: true
+  become: false
+  gather_facts: false
+  tasks:
+  - name: Post update fallback placeholder
+    debug:
+      msg: >-
+        {{ env_type }} does not include update.yml.
+        This is the update placeholder.


### PR DESCRIPTION
##### SUMMARY

The update entry point playbook allows for updating existing
deployments. The update functionality must be implemented within the
config. An example for test-empty-config is provided.

Update functionality includes the new `agnosticd_user_data` lookup
plugin and `agnosticd_restore_output_dir` role so that updates can
fetch data items set during the initial provision.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

- Core update.yml entry-point playbook
- Config test-empty-config
- `agnosticd_user_data` lookup plugin
- `agnosticd_restore_output_dir` role