### PR TITLE
Allowing for htpasswd_oauth provider to have customizable name

### DIFF
--- a/ansible/roles/ocp4-workload-authentication/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-authentication/defaults/main.yml
@@ -8,6 +8,9 @@ ocp4_workload_authentication_defaults:
   # admin_user: wkulhane-redhat.com
   idm_type: htpasswd
 
+  # Default htpasswd oauth identity provider name (visible on OCP login screens)
+  htpasswd_oauth_name: htpasswd_provider
+
   # Base of the users for htpasswd
   htpasswd_user_base: user
   htpasswd_user_count: 10

--- a/ansible/roles/ocp4-workload-authentication/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-authentication/tasks/workload.yml
@@ -94,7 +94,7 @@
       state: present
       definition: "{{ lookup('template', item ) | from_yaml }}"
     loop:
-    - ./files/oauth-htpasswd.yaml
+    - ./templates/oauth-htpasswd.yaml
 
   - name: Retrieve API server configuration (for API endpoint)
     k8s_facts:

--- a/ansible/roles/ocp4-workload-authentication/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-authentication/tasks/workload.yml
@@ -92,7 +92,7 @@
   - name: Update OAuth Configuration
     k8s:
       state: present
-      definition: "{{ lookup('file', item ) | from_yaml }}"
+      definition: "{{ lookup('template', item ) | from_yaml }}"
     loop:
     - ./files/oauth-htpasswd.yaml
 

--- a/ansible/roles/ocp4-workload-authentication/templates/oauth-htpasswd.j2
+++ b/ansible/roles/ocp4-workload-authentication/templates/oauth-htpasswd.j2
@@ -5,7 +5,7 @@ metadata:
   name: cluster
 spec:
   identityProviders:
-  - name: htpasswd_provider
+  - name: {{ ocp4_workload_authentication.htpasswd_oauth_name }}
     challenge: true
     login: true
     mappingMethod: claim


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

This will allow for the default `htpasswd` identity provider to be customized with a name other than the default `htpasswd_provider`. At times when there are multiple identity providers configured, the default name isn't descriptive enough and hence this change to allow for a custom name at deploy time. 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4-workload-authentication

##### ADDITIONAL INFORMATION

Example for default value override:

```
    ocp4_workload_authentication_vars:
      htpasswd_oauth_name: admin_identity_provider
```
