### PR TITLE
Update ocp4-cluster to optionally deploy an OCP on ARM cluster

### DIFF
--- a/ansible/configs/ocp4-cluster/default_vars.yml
+++ b/ansible/configs/ocp4-cluster/default_vars.yml
@@ -91,7 +91,11 @@ worker_instance_count: 2
 
 # Install OpenShift 4 - and which version
 install_ocp4: true
-ocp4_installer_version: "4.5.15"
+
+# Use 4.9 for latest available release in the `stable-4.9` directory.
+# Use 4.9.9 for exactly the specified release
+ocp4_installer_version: "4.9"
+
 # Run logic to enable cluster shutdown before 24h initial certificate rotation
 # Only works for OCP 4.1 and 4.2. OCP 4.4.8 and later no longer require this.
 ocp4_enable_cluster_shutdown: false
@@ -99,11 +103,19 @@ ocp4_enable_cluster_shutdown: false
 # Where to download the OpenShift installer and client binaries from
 # Only used if the ocp4_installer_url and ocp4_client_url are not defined
 # Official Mirror
-# ocp4_installer_root_url: https://mirror.openshift.com/pub/openshift-v4/clients
+# ocp4_installer_root_url: >-
+#   {{ 'https://mirror.openshift.com/pub/openshift-v4/aarch64/clients' if openshift_architecture | default('x86_64') is match('arm64')
+#   else 'https://mirror.openshift.com/pub/openshift-v4/clients'
+#   }}
+
 # CloudFront Mirror
-ocp4_installer_root_url: http://d3s3zqyaz8cp2d.cloudfront.net/pub/openshift-v4/clients
+ocp4_installer_root_url: >-
+  {{ 'http://d3s3zqyaz8cp2d.cloudfront.net/pub/openshift-v4/aarch64/clients' if openshift_architecture | default('x86_64') is match('arm64')
+  else 'http://d3s3zqyaz8cp2d.cloudfront.net/pub/openshift-v4/clients'
+  }}
 
 # Install an OpenShift 4 Developer Preview Release
+# In which case the ocp4_installer_root_url is being ignored
 # ocp4_installer_use_dev_preview: true
 # ocp4_installer_version: 4.6.0
 # ocp4_installer_url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/latest-4.6/openshift-install-linux.tar.gz

--- a/ansible/configs/ocp4-cluster/default_vars_ec2.yml
+++ b/ansible/configs/ocp4-cluster/default_vars_ec2.yml
@@ -36,6 +36,12 @@ openshift_machineset_aws_zones: []
 # - us-east-1c
 
 # -------------------------------------------------------------------
+# Compute Architecture
+# -------------------------------------------------------------------
+openshift_architecture: x86_64
+# openshift_architecture: arm64
+
+# -------------------------------------------------------------------
 # Project Tag
 # -------------------------------------------------------------------
 
@@ -72,7 +78,7 @@ ocp4_base_domain: "{{ subdomain_base }}"
 
 # Bastion Configuration
 bastion_instance_type: "t3a.medium"
-bastion_instance_image: RHEL82GOLD-latest
+bastion_instance_image: RHEL8-default
 #bastion_instance_platform: Linux/UNIX
 # For standard (not GOLD) RHEL images:
 #bastion_instance_platform: Red Hat Enterprise Linux
@@ -93,7 +99,12 @@ bastion_rootfs_size: 30
 
 # Masters
 
-master_instance_type_family: m5a
+master_instance_type_family: >-
+  {{ 'm6g' if openshift_architecture is match('arm64')
+  else 'm5a' if openshift_architecture is match('x86_64')
+  else 'm5a'
+  }}
+
 master_instance_type_size: >-
   {{ 'xlarge' if worker_instance_count|int <= 10
   else '2xlarge' if worker_instance_count|int <= 20
@@ -110,7 +121,13 @@ master_storage_type: >-
 # You usually want to leave it as the default IOPS value is calculated in the role host-ocp4-installer
 # master_storage_iops: 2000
 
-worker_instance_type: "m5a.4xlarge"
+worker_instance_type_family: >-
+  {{ 'm6g' if openshift_architecture is match('arm64')
+  else 'm5a' if openshift_architecture is match('x86_64')
+  else 'm5a'
+  }}
+
+worker_instance_type: "{{ master_instance_type_family }}.4xlarge"
 worker_instance_count: 2
 worker_storage_type: "gp2"
 

--- a/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
+++ b/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
@@ -7,6 +7,9 @@ fips: {{ ocp4_fips_enable | bool | to_json }}
 controlPlane:
   name: master
   hyperthreading: Enabled
+{% if openshift_architecture | default('x86_64') is match('arm64') %}
+  architecture: arm64
+{% endif %}
   platform:
 {% if cloud_provider == 'ec2' %}
 {%   if custom_image is defined and custom_image.image_id is defined %}
@@ -44,6 +47,9 @@ controlPlane:
 compute:
 - name: worker
   hyperthreading: Enabled
+{% if openshift_architecture | default('x86_64') is match('arm64') %}
+  architecture: arm64
+{% endif %}
   platform:
 {% if cloud_provider == 'ec2' %}
 {%   if custom_image is defined and custom_image.image_id is defined %}


### PR DESCRIPTION
##### SUMMARY

Updated ocp4-cluster config to allow for deployment of OpenShift on ARM64 (on AWS).

Additional environment variable: openshift_architecture with default x86_64. When set to arm64 an ARM cluster is being installed. Default instance types: m6g.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4-cluster
host-ocp4-installer
