### PR TITLE
Ocp4 equinix aio

### DIFF
--- a/ansible/configs/ocp4-equinix-aio/default_vars_equinix_metal.yml
+++ b/ansible/configs/ocp4-equinix-aio/default_vars_equinix_metal.yml
@@ -2,7 +2,7 @@
 equinix_metal_facility: am6
 hypervisor_type: s3.xlarge.x86
 hypervisor_count: 1
-hypervisor_os: centos_8
+hypervisor_os: rocky_8
 
 ansible_user: root
 

--- a/ansible/configs/ocp4-equinix-aio/pre_software.yml
+++ b/ansible/configs/ocp4-equinix-aio/pre_software.yml
@@ -57,6 +57,7 @@
 
 - name: Setup Bastion VM
   hosts: bastion-vm
+  gather_facts: false
   tasks:
     - include_role:
         name: ocp4_aio_deploy_bastion

--- a/ansible/configs/ocp4-equinix-aio/requirements.yml
+++ b/ansible/configs/ocp4-equinix-aio/requirements.yml
@@ -2,12 +2,12 @@ roles:
   - src: https://github.com/RHFieldProductManagement/ocp4_aio_infra_role_base_software.git
     scm: git
     name: ocp4_aio_base_software
-    version: v0.0.2
+    version: v0.0.3
 
   - name: ocp4_aio_base_virt
     src: https://github.com/RHFieldProductManagement/ocp4_aio_infra_role_base_virt.git
     scm: git
-    version: v0.0.4
+    version: v0.0.5
 
   - name: ocp4_aio_prepare_bastion
     src: https://github.com/RHFieldProductManagement/ocp4_aio_infra_role_prepare_bastion.git
@@ -47,7 +47,7 @@ roles:
   - name: ocp4_aio_deploy_bastion
     src: https://github.com/RHFieldProductManagement/ocp4_aio_infra_role_deploy_bastion.git
     scm: git
-    version: v0.0.4
+    version: v0.0.6
 
   - name: ocp4_aio_deploy_guac
     src: https://github.com/RHFieldProductManagement/ocp4_aio_infra_role_deploy_guacamole.git

--- a/ansible/configs/ocp4-equinix-aio/sample_vars_equinix_metal.yml
+++ b/ansible/configs/ocp4-equinix-aio/sample_vars_equinix_metal.yml
@@ -47,6 +47,7 @@ ocp4_aio_deploy_ods: false
 ocp4_aio_deploy_nfs: false
 ocp4_aio_deploy_sno: false
 ocp4_aio_deploy_ipi: true
+ocp4_aio_use_ddns: true
 
 # Enable larger VMs for Equinix metal hosts
 ocp4_aio_deploy_big_vms: true

--- a/ansible/configs/ocp4-equinix-aio/sample_vars_equinix_metal.yml
+++ b/ansible/configs/ocp4-equinix-aio/sample_vars_equinix_metal.yml
@@ -47,6 +47,11 @@ ocp4_aio_deploy_ods: false
 ocp4_aio_deploy_nfs: false
 ocp4_aio_deploy_sno: false
 ocp4_aio_deploy_ipi: true
+
+# Enable deployment of CNVLAB on top of ocp
+ocp4_aio_deploy_cnvlab: true
+
+# Enable Dynamic DNS updates
 ocp4_aio_use_ddns: true
 
 # Enable larger VMs for Equinix metal hosts


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

As equinix metal doesn't support centos streams and centos 8 is not supported/doesn't have repos anymore, this change makes the aio work with the closest alternative on equinix metal : Rocky Linux


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-equinix-aio

##### ADDITIONAL INFORMATION

