### PR TITLE
Add user key in agnosticd_user_info result

### DIFF
--- a/ansible/action_plugins/agnosticd_user_info.py
+++ b/ansible/action_plugins/agnosticd_user_info.py
@@ -62,7 +62,7 @@ class ActionModule(ActionBase):
             return result
 
         if not user and msg != None:
-            # Output msg in result, prepend "user.info: " for cloudforms compatibility
+            # Output msg in result, prepend "user.info: " to support parsing from log
             if isinstance(msg, list):
                 result['msg'] = ['user.info: ' + m for m in msg]
             else:
@@ -70,7 +70,7 @@ class ActionModule(ActionBase):
                 # Force display of result like debug
 
         if not user and body != None:
-            # Output msg in result, prepend "user.info: " for cloudforms compatibility
+            # Output msg in result, prepend "user.body: " to support parsing from log
             result['msg'] = 'user.body: ' + body
             # Force display of result like debug
 
@@ -80,6 +80,9 @@ class ActionModule(ActionBase):
                 result['failed'] = True
                 result['error'] = 'data must be a dictionary of name/value pairs'
                 return result
+
+        if user:
+            result['user'] = user
 
         try:
             output_dir = self._templar.template(


### PR DESCRIPTION
##### SUMMARY

Add `user` key to result from `agnosticd_user_info` action plugin to support parsing per-user data and messages from ansible logs. This is required for full compatibility with picking up per-user data and messages from the ansible job logs when the callback is not processed or the job check occurs after job completion but before the callback in processed.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`agnosticd_user_info` action plugin