### PR TITLE
Added empty infra.yml to AAP2 config to avoid ec2 cloud provider checks

### DIFF
--- a/ansible/configs/aap2-ansible-workshops/infra.yml
+++ b/ansible/configs/aap2-ansible-workshops/infra.yml
@@ -1,0 +1,6 @@
+---
+- name: Empty infra play to deflect unnecessary cloud provider code
+  hosts: localhost
+  gather_facts: false
+  become: false
+...


### PR DESCRIPTION
##### SUMMARY

The AAP2 Workshops already use Ansible 2.12 to deploy and even with `--skip-tags` Ansible tries to validate the ec2 cloud provider modules leading to failures as they are now distributed across 2 collections. For example despite skipping ec2_instance_facts deploys fail as they attempt to locate the module. (There appear to be some bugs in how 2.12 and collections redirect references to modules as by design 2.12 **should** be able to correctly locate the module without its FQCN)

To be clear the Workshop make **zero** use of AgnosticD Cloud Provider code still preferring their own so this PR brings no loss of functionality.

(As an aside all cloud "facts" modules are depreciated and 1) need to move to the `*_info` versions and 2) the register structure changes so loops and conditionals etc will break with a simple find and replace and need a relatively simple re-write)

The empty `infra.yml` avoids the ec2 cloud provider code from being parsed e.g.

https://github.com/redhat-cop/agnosticd/blob/cfeb5f1c3751911137e099fe7373c942e15644cd/ansible/main.yml#L38

Fixes run time issues as AAP2 Workshop config moves to 2.12


##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Config: aap2-ansible-workshops

##### ADDITIONAL INFORMATION
