### PR TITLE
Added collections keyword to AAP2 post_infra as 2.12 workaround

### DIFF
--- a/ansible/configs/aap2-ansible-workshops/post_infra.yml
+++ b/ansible/configs/aap2-ansible-workshops/post_infra.yml
@@ -7,9 +7,13 @@
   vars_files:
     - "./env_vars.yml"
   gather_facts: false
+  collections:
+    - community.aws
+    - amazon.aws  
   tags:
     - step002
     - post_infrastructure
+
   tasks:
 
     - name: Gather EC2 facts


### PR DESCRIPTION
##### SUMMARY

Bugs in 2.12 and changes in the **2** AWS Collections are breaking AgnosticD's ability to locate the correct module. This PR adds the 2 collections via the `collections` keyword

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
Config: aap2-ansible-workshops

##### ADDITIONAL INFORMATION
