### PR TITLE
Disable rhacm subscription auto-approve

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/workload.yml
@@ -19,6 +19,7 @@
     install_operator_use_catalog_snapshot: false
     install_operator_manage_namespaces:
       - "{{ ocp4_workload_rhacm_acm_project }}"
+    install_operator_automatic_install_plan_approval: "{{ ocp4_workload_rhacm_install_plan_approval | default('false') }}"
 
 - name: Ensure RHACM MultiClusterHub is present
   kubernetes.core.k8s:


### PR DESCRIPTION
##### SUMMARY

Defaulting install plan approve to false of rhacm workload

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_rhacm

##### ADDITIONAL INFORMATION

<!-- ansible --version -->
ansible 2.9.20
  config file = /Users/singularity/src/agnosticd/ansible.cfg
  configured module search path = ['/Users/singularity/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/singularity/.virtualenvs/deployer/lib/python3.10/site-packages/ansible
  executable location = /Users/singularity/.virtualenvs/deployer/bin/ansible
  python version = 3.10.2 (main, Feb  2 2022, 05:51:25) [Clang 13.0.0 (clang-1300.0.29.3)]

<!-- pip freeze -->
```
ansible==2.9.20
appdirs==1.4.4
attrs==21.4.0
autopage==0.5.0
Babel==2.9.1
boto3==1.20.46
botocore==1.23.46
certifi==2021.10.8
cffi==1.15.0
charset-normalizer==2.0.11
cliff==3.10.0
cmd2==2.3.3
cryptography==36.0.1
debtcollector==2.4.0
decorator==5.1.1
distro==1.6.0
dnspython==2.2.0
dogpile.cache==1.1.5
idna==3.3
iso8601==1.0.2
Jinja2==3.0.3
jmespath==0.10.0
jsonpatch==1.32
jsonpointer==2.2
jsonschema==3.2.0
keystoneauth1==4.4.0
MarkupSafe==2.0.1
msgpack==1.0.3
munch==2.5.0
netaddr==0.8.0
netifaces==0.11.0
openstacksdk==0.61.0
os-client-config==2.1.0
os-service-types==1.7.0
osc-lib==2.4.2
oslo.config==8.7.1
oslo.context==3.4.0
oslo.i18n==5.1.0
oslo.log==4.6.1
oslo.serialization==4.2.0
oslo.utils==4.12.1
packaging==21.3
passlib==1.7.4
pathspec==0.9.0
pbr==5.8.0
prettytable==3.0.0
pycparser==2.21
pyOpenSSL==22.0.0
pyparsing==3.0.7
pyperclip==1.8.2
pyrsistent==0.18.1
python-cinderclient==8.2.0
python-dateutil==2.8.2
python-glanceclient==3.5.0
python-heatclient==2.5.0
python-keystoneclient==4.4.0
python-neutronclient==7.7.0
python-novaclient==17.6.0
python-openstackclient==5.7.0
python-string-utils==1.0.0
python-swiftclient==3.13.0
pytz==2021.3
PyYAML==6.0
requests==2.27.1
requestsexceptions==1.4.0
rfc3986==2.0.0
s3transfer==0.5.0
selinux==0.2.1
simplejson==3.17.6
six==1.16.0
stevedore==3.5.0
urllib3==1.26.8
warlock==1.3.3
wcwidth==0.2.5
wrapt==1.13.3
yamllint==1.26.3
```
