### PR TITLE
fix where token comes from in aro

### DIFF
--- a/ansible/configs/aro/software.yml
+++ b/ansible/configs/aro/software.yml
@@ -30,6 +30,11 @@
           --aad-client-app-secret '{{az_appreg_secret.stdout}}'
       when: aro_version == "3"
 
+    - name: Create token file for ARO installer
+      copy:
+        dest: "{{ output_dir }}/token.txt"
+        content: "{{ ocp4_pull_secret }}"
+
     - name: Creating the Azure Red Hat OpenShift on OpenShift 4 cluster instance
       command: >
           az aro create --resource-group {{az_resource_group}} --name {{project_tag}}
@@ -41,7 +46,7 @@
           --worker-subnet '{{project_tag}}-worker'
           --client-id '{{az_appreg_objectid.stdout}}'
           --client-secret '{{az_appreg_secret.stdout}}'
-          --pull-secret '{{ocp4_pull_secret}}'
+          --pull-secret "@{{ output_dir }}/token.txt"
       when: aro_version == "4"
 
 - name: Software flight-check


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Make aro installer get token from file
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
aro
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
