### PR TITLE
Default ocp4_workload_authentication to use user_count and num_users

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_authentication/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_authentication/defaults/main.yml
@@ -15,7 +15,7 @@ ocp4_workload_authentication_idm_type: htpasswd
 # -----------------------------------------------
 # Base of the users for htpasswd
 ocp4_workload_authentication_htpasswd_user_base: user
-ocp4_workload_authentication_htpasswd_user_count: 10
+ocp4_workload_authentication_htpasswd_user_count: "{{ user_count | default(num_users) | default(10) }}"
 # Set a password for all htpasswd users
 # If no password is provided a random password will be generated
 # ocp4_workload_authentication_htpasswd_user_password: openshift


### PR DESCRIPTION
##### SUMMARY

Set default user count for ocp4_workload_authentication to use well known variables `user_count` and `num_users` as defaults.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Role ocp4_workload_authentication