### PR TITLE
 ocp4-workload-debezium-demo - provision streams retires increase

### DIFF
--- a/ansible/roles/ocp4-workload-debezium-demo/tasks/provision_streams.yaml
+++ b/ansible/roles/ocp4-workload-debezium-demo/tasks/provision_streams.yaml
@@ -11,5 +11,5 @@
     name: kafkas.kafka.strimzi.io
   register: crd_streams
   until: crd_streams.resources | list | length == 1
-  retries: 10
+  retries: 15
   delay: 30


### PR DESCRIPTION


##### SUMMARY
Increasing retires from 10 - 15 to attempt to fix demo

---
--
  | - name: Evaluate Streams Subscription
  | k8s:
  | state: present
  | resource_definition: "{{ lookup('template', 'streams-subscription.yaml.j2') }}"
  |  
  | - name: Wait for Streams operator to install
  | k8s_info:
  | api_version: apiextensions.k8s.io/v1beta1
  | kind: CustomResourceDefinition
  | name: kafkas.kafka.strimzi.io
  | register: crd_streams
  | until: crd_streams.resources \| list \| length == 1
  | retries: 10 >>>>>>>>  15 
  | delay: 30

---
- name: Evaluate Streams Subscription
  k8s:
    state: present
    resource_definition: "{{ lookup('template', 'streams-subscription.yaml.j2') }}"

- name: Wait for Streams operator to install
  k8s_info:
    api_version: [apiextensions.k8s.io/v1beta1](http://apiextensions.k8s.io/v1beta1)
    kind: CustomResourceDefinition
    name: [kafkas.kafka.strimzi.io](http://kafkas.kafka.strimzi.io/)
  register: crd_streams
  until: crd_streams.resources | list | length == 1
  retries: 10
  delay: 30


##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
 ocp4-workload-debezium-demo 



```
