### PR TITLE
Fix edge case bug printing users with htpasswd when no regular users …

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_authentication/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_authentication/tasks/workload.yml
@@ -101,6 +101,7 @@
   - name: Print user information
     when:
     - ocp4_workload_authentication_enable_user_info_messages | bool
+    - ocp4_workload_authentication_htpasswd_user_count | int > 0
     agnosticd_user_info:
       msg: "{{ item }}"
     loop:


### PR DESCRIPTION
##### SUMMARY

Fix edge case bug printing users with htpasswd when no regular users  are created. If the number of users was set to 0 the workload would print user1..user0 with password xxxx. Now if no users are created it doesn't print user information.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_authentication