### PR TITLE
Fix AAP2 using ec2_instance_facts to _info

### DIFF
--- a/ansible/configs/aap2-ansible-workshops/post_infra.yml
+++ b/ansible/configs/aap2-ansible-workshops/post_infra.yml
@@ -17,26 +17,26 @@
   tasks:
 
     - name: Gather EC2 facts
-      ec2_instance_facts:
-        region: "{{ aws_region_final|d(aws_region) | default(region) | default('us-east-1')}}"
+      ec2_instance_info:
+        region: "{{ aws_region_final | default(aws_region) | default(region) | default('us-east-1')}}"
         filters:
           instance-state-name: running
           "tag:Workshop": "{{ guid }}"
-      register: r_ec2_facts
+      register: r_ec2_info
 
     - name: Print our new instances
       debug:
         var: item.instance_id
         verbosity: 2
-      loop: "{{ r_ec2_facts['instances'] }}"
+      loop: "{{ r_ec2_info['instances'] }}"
 
     - name: Tag all machines with owner
       ec2_tag:
-        region: "{{ aws_region_final | d(aws_region) | d(region) | d('us-east-1') }}"
+        region: "{{ aws_region_final | default(aws_region) | default(region) | default('us-east-1') }}"
         resource: "{{ item.instance_id }}"
         state: present
         tags:
           Owner: "{{ user_owner }}"
           Email: "{{ user_email }}"
           Workshop_type: "{{ workshop_type }}"
-      loop: "{{ r_ec2_facts['instances'] }}"
+      loop: "{{ r_ec2_info['instances'] }}"


### PR DESCRIPTION
##### SUMMARY

Ansible Workshops is on the latest amazon.aws collection and ec_instance_facts becomes ec2_instance_info
This PR fixes that

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Config aap2-ansible-workshops

##### ADDITIONAL INFORMATION
