### PR TITLE
config/sap-hana: Only deploy AAP software if offline_token is defined

### DIFF
--- a/ansible/configs/sap-hana/software.yml
+++ b/ansible/configs/sap-hana/software.yml
@@ -127,9 +127,11 @@
         state: present
         key: "{{ ansible_tower_epel_gpg_download_url }}"
 
+    ## Don't include the role if offline_token is not defined
     - name: Install AAP 2
       include_role:
         name: install-aap2
+      when: offline_token is defined
 
 - name: Software flight-check
   hosts: localhost


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.

make a fix to ensure successful deployment of sap-hana configuration, although there is a missing variable.
In case the variable is missing the post installation step is skipped

as per request of Ahsen Shah in the chat

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME


##### ADDITIONAL INFORMATION
