### PR TITLE
Avoid installing Controller

### DIFF
--- a/ansible/configs/sap-hana/default_vars.yml
+++ b/ansible/configs/sap-hana/default_vars.yml
@@ -68,8 +68,9 @@ cf_template_description: "{{ env_type }}-{{ guid }} Ansible Agnostic Deployer "
 
 ### Variables ofr the role to download AAP2 ###
 app_image: "ansible-automation-platform-2.0-early-access-for-rhel-8-x86_64-files"
-offline_token: "{{ offline_token }}"
+offline_token: "{{ sap-e2e-offline-token }}"
 
+### TODO: Change here
 ### Ansible Tower default variables ###
 ansible_tower_download_url: "https://releases.ansible.com/ansible-tower/setup/ansible-tower-setup-3.6.3-1.tar.gz"
 ansible_tower_epel_download_url: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"

--- a/ansible/configs/sap-hana/default_vars_osp.yml
+++ b/ansible/configs/sap-hana/default_vars_osp.yml
@@ -229,4 +229,4 @@ ansible_s4hana_hostname: "s4hana-{{ guid }}"
 bastion_hostname: "bastion-{{ guid }}"
 deployment_db_host: "hana-{{ guid }}1"
 
-__run_aap_deployment: true
+__run_aap_deployment: false

--- a/ansible/configs/sap-hana/software.yml
+++ b/ansible/configs/sap-hana/software.yml
@@ -111,6 +111,14 @@
         - "{{ groups['hanas'] }}"
         - "{{ groups['s4hanas'] }}"
 
+- name: Debug offline token
+  debug:
+     var: offline_token
+
+- name: Debug sap-e2e-offline token
+  debug:
+     var: sap-e2e-offline-token
+
 - name: Deploy Ansible Tower
   hosts: towers
   gather_facts: False

--- a/ansible/configs/sap-hana/software.yml
+++ b/ansible/configs/sap-hana/software.yml
@@ -111,14 +111,6 @@
         - "{{ groups['hanas'] }}"
         - "{{ groups['s4hanas'] }}"
 
-- name: Debug offline token
-  debug:
-     var: offline_token
-
-- name: Debug sap-e2e-offline token
-  debug:
-     var: sap-e2e-offline-token
-
 - name: Deploy Ansible Tower
   hosts: towers
   gather_facts: False
@@ -126,6 +118,14 @@
   tasks:
     # This is a bit hacky but we are facing some issues with Ansible, RHEL8 and python for some
     # modules and this workaround solved this particular issue
+    - name: Debug offline token
+      debug:
+         var: offline_token
+
+    - name: Debug sap-e2e-offline token
+      debug:
+         var: sap-e2e-offline-token
+
     - name: Ensure Python3 package is installed and alternatives for python updated
       shell: >
         yum install -y python3 && alternatives --set python /usr/bin/python3
@@ -139,7 +139,7 @@
     - name: Install AAP 2
       include_role:
         name: install-aap2
-      when: __run_aap_deployment
+        # when: __run_aap_deployment
 
 - name: Software flight-check
   hosts: localhost

--- a/ansible/configs/sap-hana/software.yml
+++ b/ansible/configs/sap-hana/software.yml
@@ -139,7 +139,7 @@
     - name: Install AAP 2
       include_role:
         name: install-aap2
-        # when: __run_aap_deployment
+      when: __run_aap_deployment
 
 - name: Software flight-check
   hosts: localhost


### PR DESCRIPTION
##### SUMMARY

I have disabled the deployment of controller again, so that the lab deploys without error.
This is needed to do my lab next week

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Temporary Bugfix Pull Request

##### COMPONENT NAME
configs/sap-hana

##### ADDITIONAL INFORMATION

The current lab does not deploy due to api authenticaton problems within the role. Unfortunately I need the environment to run a lab next week. I do not necessarily need controller during that lab, but I need the servers for my students to successfully roll out.
We will do everything on CLI, if we manage to get controller deployed, that would be great. 