### PR TITLE
Sometimes the DNS zones dont exist, just move on

### DIFF
--- a/ansible/roles-infra/infra-azure-template-destroy/tasks/main.yml
+++ b/ansible/roles-infra/infra-azure-template-destroy/tasks/main.yml
@@ -18,6 +18,7 @@
       when:
         - dns_bastion is defined
         - dns_bastion == true
+      ignore_errors: true
 
     - name: Delete delegation for NS to the main DNSZone
       azure.azcollection.azure_rm_dnsrecordset:
@@ -30,6 +31,7 @@
         - dns_delegation is defined
         - dns_delegation == true
         - az_dnszone_resource_group != 'none'
+      ignore_errors: true
 
     - name: Destroy method resourceGroup (standalone ResourceGroup)
       when: az_destroy_method|default('resource_group') == 'resource_group'


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Sometimes when cleaning up, DNS zones dont exist so it should move on.
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
roles-infra/infra-azure-template-destroy
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
