### PR TITLE
Remove use_own_key  feature

### DIFF
--- a/ansible/configs/a-base-config/default_vars.yml
+++ b/ansible/configs/a-base-config/default_vars.yml
@@ -112,13 +112,8 @@ deploy_local_ssh_config_location: "{{output_dir}}/"
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-
-###V2WORK, these should just be set as default listed in the documentation
-use_own_key: false
 env_authorized_key: "{{guid}}key"
 set_env_authorized_key: true
 
-###V2WORK THIS SHOULD MOVE INTO THE ROLE
 # This var is used to identify stack (cloudformation, azure resourcegroup, ...)
 project_tag: "{{ env_type }}-{{ guid }}"

--- a/ansible/configs/aap2-ansible-workshops/env_vars.yml
+++ b/ansible/configs/aap2-ansible-workshops/env_vars.yml
@@ -35,7 +35,6 @@ users:
 
 ### END OF Ansible Workshops AWS Provisioner Variables
 #
-use_own_key: true
 env_authorized_key: "{{ guid }}key"
 set_env_authorized_key: true
 

--- a/ansible/configs/amq-messaging-foundations/default_vars.yml
+++ b/ansible/configs/amq-messaging-foundations/default_vars.yml
@@ -64,9 +64,6 @@ ftl_use_python3: true
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 key_name: "default_key_name"
 ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem

--- a/ansible/configs/ans-tower-lab-ng/default_vars.yml
+++ b/ansible/configs/ans-tower-lab-ng/default_vars.yml
@@ -44,8 +44,6 @@ install_common: true
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem
 set_env_authorized_key: true

--- a/ansible/configs/ans-tower-lab/default_vars.yml
+++ b/ansible/configs/ans-tower-lab/default_vars.yml
@@ -44,8 +44,6 @@ install_common: true
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 ansible_ssh_private_key_file: ~/.ssh/{{ key_name }}.pem
 set_env_authorized_key: true

--- a/ansible/configs/ans-tower-ops-demo/env_vars.yml
+++ b/ansible/configs/ans-tower-ops-demo/env_vars.yml
@@ -42,8 +42,6 @@ osrelease: 3.6
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{ key_name }})
-use_own_key: true
 env_authorized_key: "{{ guid }}key"
 ansible_ssh_private_key_file: ~/.ssh/{{ key_name }}.pem
 set_env_authorized_key: true

--- a/ansible/configs/ansible-advanced-v2/default_vars.yml
+++ b/ansible/configs/ansible-advanced-v2/default_vars.yml
@@ -20,7 +20,6 @@ update_packages: false
 
 ## Below used variables are set for Role:set_env_authorized_key
 ## for more details refer to README of the role 
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem
 set_env_authorized_key: true

--- a/ansible/configs/ansible-advanced/default_vars.yml
+++ b/ansible/configs/ansible-advanced/default_vars.yml
@@ -44,8 +44,6 @@ install_common: true
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem
 set_env_authorized_key: true

--- a/ansible/configs/ansible-automation-platform/env_vars.yml
+++ b/ansible/configs/ansible-automation-platform/env_vars.yml
@@ -57,8 +57,6 @@ bastion_student_user_ansible: true  # student user can use Ansible
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem
 set_env_authorized_key: true

--- a/ansible/configs/ansible-cicd-lab/env_vars.yml
+++ b/ansible/configs/ansible-cicd-lab/env_vars.yml
@@ -51,8 +51,6 @@ repo_version: "3.6"
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 
 

--- a/ansible/configs/ansible-gitOps-integration/default_vars.yml
+++ b/ansible/configs/ansible-gitOps-integration/default_vars.yml
@@ -27,7 +27,6 @@ update_packages: false
 
 ## Below used variables are set for Role:set_env_authorized_key
 ## for more details refer to README of the role 
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem
 set_env_authorized_key: true

--- a/ansible/configs/ansible-infoblox/default_vars.yml
+++ b/ansible/configs/ansible-infoblox/default_vars.yml
@@ -64,8 +64,6 @@ install_common: true
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-use_own_key: true
 env_authorized_key: "{{ guid }}key"
 ansible_ssh_private_key_file: ~/.ssh/{{ key_name }}.pem
 set_env_authorized_key: true

--- a/ansible/configs/ansible-integrations/env_vars.yml
+++ b/ansible/configs/ansible-integrations/env_vars.yml
@@ -42,8 +42,6 @@ osrelease: 3.6
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem
 set_env_authorized_key: true

--- a/ansible/configs/ansible-multi-node/default_vars.yml
+++ b/ansible/configs/ansible-multi-node/default_vars.yml
@@ -63,8 +63,6 @@ install_common: true
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem
 set_env_authorized_key: true

--- a/ansible/configs/ansible-multitier-infra/default_vars.yml
+++ b/ansible/configs/ansible-multitier-infra/default_vars.yml
@@ -62,8 +62,6 @@ install_common: true
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem
 set_env_authorized_key: true

--- a/ansible/configs/ansible-multitier-rhel8/default_vars.yml
+++ b/ansible/configs/ansible-multitier-rhel8/default_vars.yml
@@ -59,8 +59,6 @@ install_bastion_lite: true
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem
 set_env_authorized_key: true

--- a/ansible/configs/ansible-platform-foundations/default_vars.yml
+++ b/ansible/configs/ansible-platform-foundations/default_vars.yml
@@ -44,8 +44,6 @@ deploy_local_ssh_config_location: "{{ output_dir }}/"
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem
 set_env_authorized_key: true

--- a/ansible/configs/ansible-tower-implementation/default_vars.yml
+++ b/ansible/configs/ansible-tower-implementation/default_vars.yml
@@ -21,7 +21,6 @@ update_packages: false
 ## Below used variables are set for Role:set_env_authorized_key
 ## for more details refer to README of the role 
 repo_method: file
-use_own_key: true
 install_ipa_client: false
 env_authorized_key: "{{guid}}key"
 ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem

--- a/ansible/configs/ansible-tower-implementation/templates/bastion_ssh_config.j2
+++ b/ansible/configs/ansible-tower-implementation/templates/bastion_ssh_config.j2
@@ -4,11 +4,7 @@ Host ec2* *.internal
 Host *.example.com
 {% endif %}	
   User {{ ansible_user }}
-{% if use_own_key|bool %}
-  IdentityFile ~/.ssh/{ {env_authorized_key }}.pem
-{% else %}
-  IdentityFile ~/.ssh/{{ key_name }}.pem
-{% endif %}
+  IdentityFile ~/.ssh/{{ env_authorized_key }}.pem
   ForwardAgent yes
   StrictHostKeyChecking no
   ConnectTimeout 60

--- a/ansible/configs/ansible-tower-pntae/default_vars.yml
+++ b/ansible/configs/ansible-tower-pntae/default_vars.yml
@@ -20,7 +20,6 @@ update_packages: false
 
 ## Below used variables are set for Role:set_env_authorized_key
 ## for more details refer to README of the role
-use_own_key: true
 install_ipa_client: false
 env_authorized_key: "{{ guid }}key"
 ansible_ssh_private_key_file: ~/.ssh/{{ key_name }}.pem

--- a/ansible/configs/ansible-tower-pntae/templates/bastion_ssh_config.j2
+++ b/ansible/configs/ansible-tower-pntae/templates/bastion_ssh_config.j2
@@ -4,11 +4,7 @@ Host ec2* *.internal
 Host *.example.com
 {% endif %}	
   User {{ ansible_user }}
-{% if use_own_key|bool %}
-  IdentityFile ~/.ssh/{ {env_authorized_key }}.pem
-{% else %}
-  IdentityFile ~/.ssh/{{ key_name }}.pem
-{% endif %}
+  IdentityFile ~/.ssh/{{ env_authorized_key }}.pem
   ForwardAgent yes
   StrictHostKeyChecking no
   ConnectTimeout 60

--- a/ansible/configs/ansible-tower/env_vars.yml
+++ b/ansible/configs/ansible-tower/env_vars.yml
@@ -42,8 +42,6 @@ repo_version: "{{tower_version}}"
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem
 set_env_authorized_key: true

--- a/ansible/configs/ansible-windows-elt/default_vars.yml
+++ b/ansible/configs/ansible-windows-elt/default_vars.yml
@@ -33,7 +33,6 @@ update_packages: false
 
 ## Below used variables are set for Role:set_env_authorized_key
 ## for more details refer to README of the role 
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem
 set_env_authorized_key: true

--- a/ansible/configs/ansible-windows/env_vars.yml
+++ b/ansible/configs/ansible-windows/env_vars.yml
@@ -31,9 +31,6 @@ osrelease: 3.6
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-
-use_own_key: true
 env_authorized_key: "{{ guid }}key"
 ansible_ssh_private_key_file: ~/.ssh/{{ key_name }}.pem
 set_env_authorized_key: true

--- a/ansible/configs/ansible-workshops-rhel/default_vars.yml
+++ b/ansible/configs/ansible-workshops-rhel/default_vars.yml
@@ -55,9 +55,6 @@ install_common: true
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-
-use_own_key: true
 env_authorized_key: "{{ guid }}key"
 ansible_ssh_private_key_file: ~/.ssh/{{ key_name }}.pem
 set_env_authorized_key: true

--- a/ansible/configs/ansible-workshops/env_vars.yml
+++ b/ansible/configs/ansible-workshops/env_vars.yml
@@ -33,7 +33,6 @@ users:
 
 ### END OF Ansible Workshops AWS Provisioner Variables    
 #
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 set_env_authorized_key: true
 

--- a/ansible/configs/hacluster-breakfix1-pntae/default_vars.yml
+++ b/ansible/configs/hacluster-breakfix1-pntae/default_vars.yml
@@ -47,8 +47,6 @@ install_common: true
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem
 set_env_authorized_key: true

--- a/ansible/configs/hacluster-pntae/default_vars.yml
+++ b/ansible/configs/hacluster-pntae/default_vars.yml
@@ -46,9 +46,6 @@ install_common: true
 
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
-# you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem
 set_env_authorized_key: true

--- a/ansible/configs/insights-technical-sales/default_vars.yml
+++ b/ansible/configs/insights-technical-sales/default_vars.yml
@@ -8,7 +8,6 @@ guid: defaultguid
 deploy_local_ssh_config_location: "{{output_dir}}/"
 
 key_name: ocpkey                        # Keyname must exist in AWS
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 set_env_authorized_key: true
 default_key_name: ~/.ssh/{{key_name}}.pem

--- a/ansible/configs/just-a-bunch-of-nodes/default_vars.yml
+++ b/ansible/configs/just-a-bunch-of-nodes/default_vars.yml
@@ -132,10 +132,6 @@ deploy_local_ssh_config_location: "{{output_dir}}/"
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-
-###V2WORK, these should just be set as default listed in the documentation
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 set_env_authorized_key: true
 

--- a/ansible/configs/kni-osp/default_vars.yml
+++ b/ansible/configs/kni-osp/default_vars.yml
@@ -695,13 +695,8 @@ deploy_local_ssh_config_location: "{{output_dir}}/"
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-
-###V2WORK, these should just be set as default listed in the documentation
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 set_env_authorized_key: true
 
-###V2WORK THIS SHOULD MOVE INTO THE ROLE
 # This var is used to identify stack (cloudformation, azure resourcegroup, ...)
 project_tag: "{{ env_type }}-{{ guid }}"

--- a/ansible/configs/linklight-foundations/env_vars.yml
+++ b/ansible/configs/linklight-foundations/env_vars.yml
@@ -35,9 +35,6 @@ users:
 #### If you want a Key Pair name created and injected into the hosts,
 ## set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 ## you can use the key used to create the environment or use your own self generated key
-## if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 set_env_authorized_key: true
 
@@ -45,7 +42,6 @@ set_env_authorized_key: true
 #
 #env_authorized_key: fookey
 #=======
-#use_own_key: true
 #
 #env_authorized_key: "{{guid}}key"
 #ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem

--- a/ansible/configs/linklight/env_vars.yml
+++ b/ansible/configs/linklight/env_vars.yml
@@ -37,9 +37,6 @@ users:
 #### If you want a Key Pair name created and injected into the hosts,
 ## set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 ## you can use the key used to create the environment or use your own self generated key
-## if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 set_env_authorized_key: true
 
@@ -47,7 +44,6 @@ set_env_authorized_key: true
 #
 #env_authorized_key: fookey
 #=======
-#use_own_key: true
 #
 #env_authorized_key: "{{guid}}key"
 #ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem

--- a/ansible/configs/multi-cloud-capsule/default_vars.yml
+++ b/ansible/configs/multi-cloud-capsule/default_vars.yml
@@ -8,7 +8,6 @@ guid: defaultguid
 
 deploy_local_ssh_config_location: "{{output_dir}}/"
 key_name: ocpkey                        # Keyname must exist in AWS
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 set_env_authorized_key: true
 default_key_name: ~/.ssh/{{key_name}}.pem

--- a/ansible/configs/multi-network-app-pntae/default_vars.yml
+++ b/ansible/configs/multi-network-app-pntae/default_vars.yml
@@ -48,8 +48,6 @@ install_common: true
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem
 set_env_authorized_key: true

--- a/ansible/configs/multi-region-example/env_vars.yml
+++ b/ansible/configs/multi-region-example/env_vars.yml
@@ -175,10 +175,6 @@ deploy_local_ssh_config_location: "{{output_dir}}/"
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-
-###V2WORK, these should just be set as default listed in the documentation
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 set_env_authorized_key: true
 

--- a/ansible/configs/multi-region-tower/env_vars.yml
+++ b/ansible/configs/multi-region-tower/env_vars.yml
@@ -444,10 +444,6 @@ deploy_local_ssh_config_location: "{{output_dir}}/"
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-
-###V2WORK, these should just be set as default listed in the documentation
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 set_env_authorized_key: true
 

--- a/ansible/configs/ocp-clientvm/default_vars.yml
+++ b/ansible/configs/ocp-clientvm/default_vars.yml
@@ -74,9 +74,6 @@ ftl_use_python3: true
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 key_name: "default_key_name"
 ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem

--- a/ansible/configs/ocp-gpu-single-node/env_vars.yml
+++ b/ansible/configs/ocp-gpu-single-node/env_vars.yml
@@ -69,9 +69,6 @@ docker_device: /dev/xvdb
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem
 set_env_authorized_key: true

--- a/ansible/configs/ocp-implementation-lab/env_vars.yml
+++ b/ansible/configs/ocp-implementation-lab/env_vars.yml
@@ -204,9 +204,6 @@ docker_device: /dev/xvdb
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem
 set_env_authorized_key: true

--- a/ansible/configs/ocp-workshop-with-clientvms/env_vars.yml
+++ b/ansible/configs/ocp-workshop-with-clientvms/env_vars.yml
@@ -89,9 +89,6 @@ docker_device: /dev/xvdb
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem
 set_env_authorized_key: true

--- a/ansible/configs/ocp-workshop/env_vars.yml
+++ b/ansible/configs/ocp-workshop/env_vars.yml
@@ -94,9 +94,6 @@ docker_device: /dev/xvdb
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem
 set_env_authorized_key: true

--- a/ansible/configs/ocp4-ha-lab/default_vars.yml
+++ b/ansible/configs/ocp4-ha-lab/default_vars.yml
@@ -29,9 +29,6 @@ student_name: lab-user
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-
-use_own_key: true
 set_env_authorized_key: true
 env_authorized_key: "{{ guid }}key"
 ansible_ssh_private_key_file: ~/.ssh/{{ key_name }}.pem

--- a/ansible/configs/ocp4-workshop/env_vars.yml
+++ b/ansible/configs/ocp4-workshop/env_vars.yml
@@ -85,9 +85,6 @@ user_count_end: 0
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem
 set_env_authorized_key: true

--- a/ansible/configs/osp-example-workflow-images/default_vars.yml
+++ b/ansible/configs/osp-example-workflow-images/default_vars.yml
@@ -206,10 +206,6 @@ deploy_local_ssh_config_location: "{{output_dir}}/"
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-
-###V2WORK, these should just be set as default listed in the documentation
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 set_env_authorized_key: true
 

--- a/ansible/configs/osp-stf/default_vars.yml
+++ b/ansible/configs/osp-stf/default_vars.yml
@@ -304,10 +304,6 @@ deploy_local_ssh_config_location: "{{output_dir}}/"
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-
-###V2WORK, these should just be set as default listed in the documentation
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 set_env_authorized_key: true
 

--- a/ansible/configs/pntae-jabn/default_vars.yml
+++ b/ansible/configs/pntae-jabn/default_vars.yml
@@ -121,10 +121,6 @@ deploy_local_ssh_config_location: "{{output_dir}}/"
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-
-###V2WORK, these should just be set as default listed in the documentation
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 set_env_authorized_key: true
 

--- a/ansible/configs/pntae-jabn/templates/bastion_ssh_config.j2
+++ b/ansible/configs/pntae-jabn/templates/bastion_ssh_config.j2
@@ -4,11 +4,7 @@ Host ec2* *.internal
 Host *.example.com
 {% endif %}	
   User {{ ansible_user }}
-{% if use_own_key|bool %}
-  IdentityFile ~/.ssh/{ {env_authorized_key }}.pem
-{% else %}
-  IdentityFile ~/.ssh/{{ key_name }}.pem
-{% endif %}
+  IdentityFile ~/.ssh/{{ env_authorized_key }}.pem
   ForwardAgent yes
   StrictHostKeyChecking no
   ConnectTimeout 60

--- a/ansible/configs/pntae-vilt-bastion/default_vars.yml
+++ b/ansible/configs/pntae-vilt-bastion/default_vars.yml
@@ -122,10 +122,6 @@ deploy_local_ssh_config_location: "{{output_dir}}/"
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-
-###V2WORK, these should just be set as default listed in the documentation
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 set_env_authorized_key: true
 

--- a/ansible/configs/pntae-vilt-bastion/templates/bastion_ssh_config.j2
+++ b/ansible/configs/pntae-vilt-bastion/templates/bastion_ssh_config.j2
@@ -4,11 +4,7 @@ Host ec2* *.internal
 Host *.example.com
 {% endif %}	
   User {{ ansible_user }}
-{% if use_own_key|bool %}
-  IdentityFile ~/.ssh/{ {env_authorized_key }}.pem
-{% else %}
-  IdentityFile ~/.ssh/{{ key_name }}.pem
-{% endif %}
+  IdentityFile ~/.ssh/{{ env_authorized_key }}.pem
   ForwardAgent yes
   StrictHostKeyChecking no
   ConnectTimeout 60

--- a/ansible/configs/rhel-container-security/env_vars.yml
+++ b/ansible/configs/rhel-container-security/env_vars.yml
@@ -198,10 +198,6 @@ deploy_local_ssh_config_location: "{{output_dir}}/"
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-
-###V2WORK, these should just be set as default listed in the documentation
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 set_env_authorized_key: true
 

--- a/ansible/configs/rhel-custom-security-content/default_vars.yml
+++ b/ansible/configs/rhel-custom-security-content/default_vars.yml
@@ -113,14 +113,8 @@ deploy_local_ssh_config_location: "{{output_dir}}/"
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-
-###V2WORK, these should just be set as default listed in the documentation
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 set_env_authorized_key: true
 
-
-###V2WORK THIS SHOULD MOVE INTO THE ROLE
 # This var is used to identify stack (cloudformation, azure resourcegroup, ...)
 project_tag: "{{ env_type }}-{{ guid }}"

--- a/ansible/configs/rhel-security/default_vars.yml
+++ b/ansible/configs/rhel-security/default_vars.yml
@@ -612,10 +612,6 @@ deploy_local_ssh_config_location: "{{output_dir}}/"
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-
-###V2WORK, these should just be set as default listed in the documentation
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 set_env_authorized_key: true
 

--- a/ansible/configs/rhel8lab/env_vars.yml
+++ b/ansible/configs/rhel8lab/env_vars.yml
@@ -50,8 +50,6 @@ repo_version: "3.6"
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem
 set_env_authorized_key: true

--- a/ansible/configs/rhte-ans-tower/env_vars.yml
+++ b/ansible/configs/rhte-ans-tower/env_vars.yml
@@ -42,8 +42,6 @@ repo_version: "{{tower_version}}"
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem
 set_env_authorized_key: true

--- a/ansible/configs/rhte-oc-cluster-vms/env_vars.yml
+++ b/ansible/configs/rhte-oc-cluster-vms/env_vars.yml
@@ -33,9 +33,6 @@ docker_version: "{{ '1.12.6' if repo_version is version_compare('3.9', '<')  els
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-
-use_own_key: true
 env_authorized_key: "{{ guid }}key"
 ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem
 set_env_authorized_key: true

--- a/ansible/configs/rosa/default_vars.yml
+++ b/ansible/configs/rosa/default_vars.yml
@@ -28,7 +28,6 @@ cloud_tags:
   course_name: "{{ course_name | default( 'unknown' ) }}"
   platform: "{{ platform | default( 'unknown' ) }}"
 
-use_own_key: true
 set_env_authorized_key: true
 env_authorized_key: "{{guid}}key"
 key_name: "rosa_key"

--- a/ansible/configs/rosa/templates/bastion_ssh_config.j2
+++ b/ansible/configs/rosa/templates/bastion_ssh_config.j2
@@ -4,11 +4,7 @@ Host ec2* *.internal
 Host *.example.com
 {% endif %}	
   User {{ ansible_user }}
-{% if use_own_key|bool %}
-  IdentityFile ~/.ssh/{ {env_authorized_key }}.pem
-{% else %}
-  IdentityFile ~/.ssh/{{ key_name }}.pem
-{% endif %}
+  IdentityFile ~/.ssh/{{ env_authorized_key }}.pem
   ForwardAgent yes
   StrictHostKeyChecking no
   ConnectTimeout 60

--- a/ansible/configs/sap-hana/default_vars.yml
+++ b/ansible/configs/sap-hana/default_vars.yml
@@ -45,8 +45,6 @@ rh_internal: true
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 #ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem
 set_env_authorized_key: true

--- a/ansible/configs/sap-rhvh/default_vars.yml
+++ b/ansible/configs/sap-rhvh/default_vars.yml
@@ -27,10 +27,7 @@ sap_rhv_debug_vars: false
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-use_own_key: true
 env_authorized_key: "{{guid}}key"
-#ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem
 set_env_authorized_key: true
 
 # Is this running from Red Hat Ansible Tower

--- a/ansible/configs/sap-smart/default_vars.yml
+++ b/ansible/configs/sap-smart/default_vars.yml
@@ -50,8 +50,6 @@ rh_internal: false
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 #ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem
 set_env_authorized_key: true

--- a/ansible/configs/satellite-hackfest/default_vars.yml
+++ b/ansible/configs/satellite-hackfest/default_vars.yml
@@ -8,7 +8,6 @@ guid: defaultguid
 deploy_local_ssh_config_location: "{{output_dir}}/"
 
 key_name: ocpkey                        # Keyname must exist in AWS
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 set_env_authorized_key: true
 default_key_name: ~/.ssh/{{key_name}}.pem

--- a/ansible/configs/satellite-infrastructure/default_vars.yml
+++ b/ansible/configs/satellite-infrastructure/default_vars.yml
@@ -13,7 +13,6 @@ satellite_version: "6.8"
 
 deploy_local_ssh_config_location: "{{ output_dir }}/"
 key_name: ocpkey                        # Keyname must exist in AWS
-use_own_key: true
 env_authorized_key: "{{ guid }}key"
 set_env_authorized_key: true
 default_key_name: ~/.ssh/{{ key_name }}.pem

--- a/ansible/configs/satellite-multi-region/env_vars.yml
+++ b/ansible/configs/satellite-multi-region/env_vars.yml
@@ -197,7 +197,6 @@ install_capsule: true
 configure_capsule: true
 
 deploy_local_ssh_config_location: "{{ output_dir }}/"
-use_own_key: true
 env_authorized_key: "{{ guid }}key"
 set_env_authorized_key: true
 

--- a/ansible/configs/satellite-two-nodes/default_vars.yml
+++ b/ansible/configs/satellite-two-nodes/default_vars.yml
@@ -13,7 +13,6 @@ satellite_org_set_default: true
 
 deploy_local_ssh_config_location: "{{output_dir}}/"
 key_name: ocpkey                        # Keyname must exist in AWS
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 set_env_authorized_key: true
 default_key_name: ~/.ssh/{{key_name}}.pem

--- a/ansible/configs/satellite-vm/default_vars.yml
+++ b/ansible/configs/satellite-vm/default_vars.yml
@@ -18,7 +18,6 @@ satellite_host_repo_method: file
 
 deploy_local_ssh_config_location: "{{output_dir}}/"
 key_name: ocpkey                        # Keyname must exist in AWS
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 set_env_authorized_key: true
 default_key_name: ~/.ssh/{{key_name}}.pem

--- a/ansible/configs/selinux-policy/env_vars.yml
+++ b/ansible/configs/selinux-policy/env_vars.yml
@@ -114,10 +114,6 @@ deploy_local_ssh_config_location: "{{output_dir}}/"
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-
-###V2WORK, these should just be set as default listed in the documentation
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 set_env_authorized_key: true
 

--- a/ansible/configs/simple-example/env_vars.yml
+++ b/ansible/configs/simple-example/env_vars.yml
@@ -109,10 +109,6 @@ deploy_local_ssh_config_location: "{{output_dir}}/"
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-
-###V2WORK, these should just be set as default listed in the documentation
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 set_env_authorized_key: true
 

--- a/ansible/configs/smart-management-foundations/default_vars.yml
+++ b/ansible/configs/smart-management-foundations/default_vars.yml
@@ -8,7 +8,6 @@ guid: defaultguid
 deploy_local_ssh_config_location: "{{output_dir}}/"
 
 key_name: ocpkey                        # Keyname must exist in AWS
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 set_env_authorized_key: true
 default_key_name: ~/.ssh/{{key_name}}.pem

--- a/ansible/configs/smart-management/default_vars.yml
+++ b/ansible/configs/smart-management/default_vars.yml
@@ -12,7 +12,6 @@ setup-sync: false
 
 deploy_local_ssh_config_location: "{{output_dir}}/"
 key_name: ocpkey                        # Keyname must exist in AWS
-use_own_key: true
 env_authorized_key: "{{guid}}key"
 set_env_authorized_key: true
 default_key_name: ~/.ssh/{{key_name}}.pem

--- a/ansible/configs/studentvm/default_vars.yml
+++ b/ansible/configs/studentvm/default_vars.yml
@@ -44,9 +44,6 @@ cloud_tags:
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-
-use_own_key: true
 set_env_authorized_key: true
 env_authorized_key: "{{guid}}key"
 key_name: "student_key"

--- a/ansible/configs/studentvm/templates/bastion_ssh_config.j2
+++ b/ansible/configs/studentvm/templates/bastion_ssh_config.j2
@@ -4,11 +4,7 @@ Host ec2* *.internal
 Host *.example.com
 {% endif %}	
   User {{ ansible_user }}
-{% if use_own_key|bool %}
-  IdentityFile ~/.ssh/{ {env_authorized_key }}.pem
-{% else %}
-  IdentityFile ~/.ssh/{{ key_name }}.pem
-{% endif %}
+  IdentityFile ~/.ssh/{{ env_authorized_key }}.pem
   ForwardAgent yes
   StrictHostKeyChecking no
   ConnectTimeout 60

--- a/ansible/configs/three-tier-app/default_vars.yml
+++ b/ansible/configs/three-tier-app/default_vars.yml
@@ -47,8 +47,6 @@ install_common: true
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
 # you can use the key used to create the environment or use your own self generated key
-# if you set "use_own_key" to false your PRIVATE key will be copied to the bastion. (This is {{key_name}})
-use_own_key: true
 env_authorized_key: "{{ guid }}key"
 ansible_ssh_private_key_file: ~/.ssh/{{ key_name }}.pem
 set_env_authorized_key: true

--- a/ansible/roles/bastion-lite/defaults/main.yml
+++ b/ansible/roles/bastion-lite/defaults/main.yml
@@ -1,4 +1,2 @@
 ---
 # defaults file for bastion
-# by default, do not copy over the user's private key
-use_own_key: true

--- a/ansible/roles/bastion-lite/tasks/main.yml
+++ b/ansible/roles/bastion-lite/tasks/main.yml
@@ -1,16 +1,4 @@
 ---
-- name: copy the user's SSH private key
-  become: true
-  copy:
-    src: "~/.ssh/{{key_name}}.pem"
-    dest: "/root/.ssh/{{key_name}}.pem"
-    owner: root
-    group: root
-    mode: 0400
-  when: not use_own_key|bool
-  tags:
-    - copy_env_private_key
-
 - name: Generate host .ssh/config Template
   become: false
   template:

--- a/ansible/roles/bastion-lite/templates/bastion_ssh_config.j2
+++ b/ansible/roles/bastion-lite/templates/bastion_ssh_config.j2
@@ -4,11 +4,7 @@ Host ec2* *.internal
 Host *.example.com
 {% endif %}	
   User {{remote_user | default(hostvars.localhost.remote_user) }}
-{% if use_own_key|bool %}
-  IdentityFile ~/.ssh/{{env_authorized_key}}.pem
-{% else %}
-  IdentityFile ~/.ssh/{{key_name}}.pem
-{% endif %}
+  IdentityFile ~/.ssh/{{ env_authorized_key }}.pem
   ForwardAgent yes
   StrictHostKeyChecking no
   ConnectTimeout 60

--- a/ansible/roles/bastion/defaults/main.yml
+++ b/ansible/roles/bastion/defaults/main.yml
@@ -1,7 +1,5 @@
 ---
 # defaults file for bastion
-# by default, do not copy over the user's private key
-use_own_key: true
 
 # by default, the root user gets the necessary SSH keys to use Ansible
 # against the other hosts in the environment. Set this variable to another user

--- a/ansible/roles/bastion/tasks/prepuser.yml
+++ b/ansible/roles/bastion/tasks/prepuser.yml
@@ -20,21 +20,7 @@
     owner: "{{ bastion_prepared_user }}"
     group: "{{ bastion_prepared_group }}"
     mode: 0400
-  when:
-    - use_own_key | bool
-    - set_env_authorized_key | bool
-
-- name: prepuser | copy the user's SSH private key
-  become: true
-  copy:
-    src: "~/.ssh/{{key_name}}.pem"
-    dest: "~{{ bastion_prepared_user }}/.ssh/{{key_name}}.pem"
-    owner: "{{ bastion_prepared_user }}"
-    group: "{{ bastion_prepared_group }}"
-    mode: 0400
-  when: not use_own_key|bool
-  tags:
-    - copy_env_private_key
+  when: set_env_authorized_key | bool
 
 - name: prepuser | copy over host .ssh/config Template
   become: true

--- a/ansible/roles/bastion/templates/bastion_ssh_config.j2
+++ b/ansible/roles/bastion/templates/bastion_ssh_config.j2
@@ -4,11 +4,7 @@ Host ec2* *.internal
 Host *.example.com
 {% endif %}	
   User {{ remote_user | default(hostvars.localhost.remote_user) }}
-{% if use_own_key|bool %}
   IdentityFile ~/.ssh/{{env_authorized_key}}.pem
-{% else %}
-  IdentityFile ~/.ssh/{{key_name}}.pem
-{% endif %}
   ForwardAgent yes
   StrictHostKeyChecking no
   ConnectTimeout 60

--- a/training/03_Infrastructure/02_Advanced/06_Setting_Up_SSH.adoc
+++ b/training/03_Infrastructure/02_Advanced/06_Setting_Up_SSH.adoc
@@ -111,7 +111,6 @@ env_authorized_key: "{{ guid }}key"
 
 # # bastion-lite role
 # Allow the use of an admin backdoor key for this machine
-use_own_key: true
 key_name: opentlc_admin_backdoor
 
 # # files/hosts_template.j2 used by bastion

--- a/training/files/2Everything.yml
+++ b/training/files/2Everything.yml
@@ -31,7 +31,6 @@ student_password: "r3dh4t1!"             # Customize the student password here. 
 # # bastion-lite role
 # Allow the use of an admin backdoor key for this machine
 install_bastion_lite: true
-use_own_key: true
 key_name: opentlc_admin_backdoor
 
 # Users:

--- a/training/files/2RHELs.yml
+++ b/training/files/2RHELs.yml
@@ -30,7 +30,6 @@ student_password: "r3dh4t1!"             # Customize the student password here. 
 
 # bastion-lite role
 install_bastion_lite: true
-use_own_key: true
 key_name: opentlc_admin_backdoor
 
 # Environment Variables for SSH key generation and assignment

--- a/training/files/2Users-SSH.yml
+++ b/training/files/2Users-SSH.yml
@@ -36,7 +36,6 @@ env_authorized_key: "{{guid}}key"
 # bastion-lite role
 install_bastion_lite: true
 # Allow the use of an admin backdoor key for this machine
-use_own_key: true
 key_name: opentlc_admin_backdoor
 
 # # files/hosts_template.j2 used by bastion

--- a/training/files/2Users.yml
+++ b/training/files/2Users.yml
@@ -31,7 +31,6 @@ student_password: "r3dh4t1!"             # Customize the student password here. 
 # bastion-lite role
 install_bastion_lite: true
 # Allow the use of an admin backdoor key for this machine
-use_own_key: true
 key_name: opentlc_admin_backdoor
 
 # Networks


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

This option, when `use_own_key == false`,  pushes the user's key directly to the remote host. This is
wrong by design and it has been a point of confusion.

Plus, the feature is always disabled (we never push the key) by default.
I also checked in agnosticV, it's not used.

This change, if applied, removes entirely any use of that variable and
remove the tasks that push the private keys to the remote hosts entirely.

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature removal Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
- bastion role
- prepuser role
- all configs 

