### PR TITLE
Add user count for test-empty-config

### DIFF
--- a/ansible/configs/test-empty-config/default_vars.yml
+++ b/ansible/configs/test-empty-config/default_vars.yml
@@ -3,4 +3,8 @@
 # bookbag_git_repo
 bookbag_deploy: false
 #bookbag_git_repo: https://github.com/redhat-gpte-labs/bookbag-template.git
+
+# Control whether to simulate multi-user environment by reporting per-user info messages and data
+test_empty_config_multi_user: false
+test_empty_config_user_count: "{{ user_count | default(num_users) | default(10) }}"
 ...

--- a/ansible/configs/test-empty-config/post_software.yml
+++ b/ansible/configs/test-empty-config/post_software.yml
@@ -33,7 +33,7 @@
       random_string: >-
         {{ lookup('password', '/dev/null length=15 chars=ascii_letters') }}
 
-  - when: test_empty_config_multi_user | default(false) | bool
+  - when: test_empty_config_multi_user | bool
     block:
     - name: Test set agnosticd_user_info for users
       agnosticd_user_info:
@@ -41,7 +41,7 @@
         msg: student{{ n }} password is {{ random_string }}
         data:
           password: "{{ random_string }}"
-      loop: "{{ range(1, 10) | list }}"
+      loop: "{{ range(1, test_empty_config_user_count) | list }}"
       loop_control:
         loop_var: n
       vars:
@@ -53,7 +53,7 @@
         user: student{{ n }}
         data:
           dns_domain: student{{ n }}.example.com
-      loop: "{{ range(1, 10) | list }}"
+      loop: "{{ range(1, test_empty_config_user_count) | list }}"
       loop_control:
         loop_var: n
 


### PR DESCRIPTION
##### SUMMARY

Add `test_empty_config_user_count` for test-empty-config. Previously this was hard-coded to 10 users.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Config test-empty-config