### PR TITLE
Fix test-empty-config test_empty_config_user_count bug

### DIFF
--- a/ansible/configs/test-empty-config/post_software.yml
+++ b/ansible/configs/test-empty-config/post_software.yml
@@ -41,7 +41,7 @@
         msg: student{{ n }} password is {{ random_string }}
         data:
           password: "{{ random_string }}"
-      loop: "{{ range(1, test_empty_config_user_count) | list }}"
+      loop: "{{ range(1, test_empty_config_user_count | int) | list }}"
       loop_control:
         loop_var: n
       vars:
@@ -53,7 +53,7 @@
         user: student{{ n }}
         data:
           dns_domain: student{{ n }}.example.com
-      loop: "{{ range(1, test_empty_config_user_count) | list }}"
+      loop: "{{ range(1, test_empty_config_user_count | int) | list }}"
       loop_control:
         loop_var: n
 


### PR DESCRIPTION
##### SUMMARY

Fix bug with `test_empty_config_user_count` requiring `int` filter.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Config test-empty-config