### PR TITLE
New role to detect env_authorized_key path

### DIFF
--- a/ansible/cloud_providers/ec2_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/ec2_infrastructure_deployment.yml
@@ -37,6 +37,9 @@
         name: create_ssh_provision_key
       when: instances | default([]) | length > 0
 
+    - include_role:
+        name: locate_env_authorized_key
+
     - name: Create keypair in ec2
       include_role:
         name: infra-ec2-ssh-key

--- a/ansible/cloud_providers/ec2_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/ec2_infrastructure_deployment.yml
@@ -37,7 +37,8 @@
         name: create_ssh_provision_key
       when: instances | default([]) | length > 0
 
-    - include_role:
+    - name: Locate environment SSH key
+      include_role:
         name: locate_env_authorized_key
 
     - name: Create keypair in ec2

--- a/ansible/cloud_providers/osp_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/osp_infrastructure_deployment.yml
@@ -23,7 +23,8 @@
       import_role:
         name: infra-osp-template-create
 
-    - include_role:
+    - name: Locate environment SSH key
+      include_role:
         name: locate_env_authorized_key
 
 - name: Step 001.2 Create Inventory and SSH config setup

--- a/ansible/cloud_providers/osp_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/osp_infrastructure_deployment.yml
@@ -23,6 +23,9 @@
       import_role:
         name: infra-osp-template-create
 
+    - include_role:
+        name: locate_env_authorized_key
+
 - name: Step 001.2 Create Inventory and SSH config setup
   hosts: localhost
   connection: local

--- a/ansible/roles/bastion-student-user/defaults/main.yml
+++ b/ansible/roles/bastion-student-user/defaults/main.yml
@@ -9,15 +9,4 @@ student_sudo: true
 # to the other nodes in the environment without first becoming root
 # (avoiding to have to use Ansible as root)
 bastion_student_user_ansible: false
-
-## Provision SSH key
-# Use provision ssh key if possible
-env_authorized_key_path: >-
-  {%- if hostvars.localhost.ssh_provision_key_path is defined -%}
-  {{ hostvars.localhost.ssh_provision_key_path }}
-  {%- else -%}
-  {{ output_dir }}/{{ env_authorized_key }}
-  {%- endif -%}
-
-env_authorized_key_path_pub: "{{ env_authorized_key_path }}.pub"
 ...

--- a/ansible/roles/bastion-student-user/tasks/main.yml
+++ b/ansible/roles/bastion-student-user/tasks/main.yml
@@ -42,7 +42,7 @@
   authorized_key:
     user: "{{ student_name }}"
     state: present
-    key: "{{ lookup('file', env_authorized_key_path_pub) }}"
+    key: "{{ hostvars.localhost.env_authorized_key_content_pub }}"
   when:
     - set_env_authorized_key | bool
     - student_name is defined

--- a/ansible/roles/bastion/tasks/prepuser.yml
+++ b/ansible/roles/bastion/tasks/prepuser.yml
@@ -15,7 +15,7 @@
 - name: prepuser | copy the environment .pem key
   become: true
   copy:
-    src: "{{output_dir}}/{{ env_authorized_key }}"
+    src: "{{ hostvars.localhost.env_authorized_key_path }}"
     dest: "~{{ bastion_prepared_user }}/.ssh/{{env_authorized_key}}.pem"
     owner: "{{ bastion_prepared_user }}"
     group: "{{ bastion_prepared_group }}"

--- a/ansible/roles/control-user/defaults/main.yml
+++ b/ansible/roles/control-user/defaults/main.yml
@@ -7,15 +7,4 @@ control_user_skel_files:                # list of user skel files
 ## User's variable used in tasks/create-user.yml
 control_user_name: devops               # User name
 control_user_private_group: users       # User's private group name
-
-## Provision SSH key
-# Use provision ssh key if possible
-env_authorized_key_path: >-
-  {%- if hostvars.localhost.ssh_provision_key_path is defined -%}
-  {{ hostvars.localhost.ssh_provision_key_path }}
-  {%- else -%}
-  {{ output_dir }}/{{ env_authorized_key }}
-  {%- endif -%}
-
-env_authorized_key_path_pub: "{{ env_authorized_key_path }}.pub"
 ...

--- a/ansible/roles/control-user/tasks/ssh-config.yml
+++ b/ansible/roles/control-user/tasks/ssh-config.yml
@@ -12,7 +12,7 @@
   block:
     - name: copy the environment .pem key
       copy:
-        src: "{{ env_authorized_key_path }}"
+        src: "{{ hostvars.localhost.env_authorized_key_path }}"
         dest: "/home/{{ control_user_name }}/.ssh/{{env_authorized_key}}.pem"
         owner: "{{ control_user_name }}"
         group: "{{ control_user_private_group }}"
@@ -20,7 +20,7 @@
 
     - name: copy the environment .pub key
       copy:
-        src: "{{ env_authorized_key_path_pub }}"
+        src: "{{ hostvars.localhost.env_authorized_key_path_pub }}"
         dest: "/home/{{ control_user_name }}/.ssh/{{env_authorized_key}}.pub"
         owner: "{{ control_user_name }}"
         group: "{{ control_user_private_group }}"

--- a/ansible/roles/locate_env_authorized_key/readme.adoc
+++ b/ansible/roles/locate_env_authorized_key/readme.adoc
@@ -1,0 +1,23 @@
+= `locate_env_authorized_key` role =
+
+This role is used to detect where the env_authorized_key key is located on the provisioning host (localhost).
+
+The main reason is to facilitate the transition of all configs and roles to a common `ssh_provision_key` created by the `create_ssh_provision_key` role that creates also the necessary facts on localhost.
+
+This role, `locate_env_authorized_key`, will use the available keys if found, in order:
+
+* `ssh_provision_key` - created by `create_ssh_provision_key`
+* `infra_ssh_key` - created by OSP heat template
+* defaults to `{{ output_dir }}/{{ env_authorized_key }}`
+** generally the key is created directly in the config
+
+
+The role can be included from any host, it will always delegate to the provisioning host (localhost).
+
+== output facts ==
+
+All facts are set on the provisioning host (localhost):
+
+* `env_authorized_key_path`
+* `env_authorized_key_path_pub`
+* `env_authorized_key_content_pub`

--- a/ansible/roles/locate_env_authorized_key/tasks/main.yaml
+++ b/ansible/roles/locate_env_authorized_key/tasks/main.yaml
@@ -1,0 +1,40 @@
+---
+- name: Set env_authorized_key_path
+  delegate_to: localhost
+  become: false
+  delegate_facts: true
+  set_fact:
+    env_authorized_key_path: >-
+      {%- if hostvars.localhost.ssh_provision_key_path is defined -%}
+      {{ hostvars.localhost.ssh_provision_key_path }}
+      {%- elif hostvars.localhost.infra_ssh_key is defined -%}
+      {{ hostvars.localhost.infra_ssh_key }}
+      {%- else -%}
+      {{ output_dir }}/{{ env_authorized_key }}
+      {%- endif -%}
+
+- name: Set env_authorized_key_path_pub
+  delegate_to: localhost
+  become: false
+  delegate_facts: true
+  set_fact:
+    env_authorized_key_path_pub: >-
+      {{ hostvars.localhost.env_authorized_key_path
+      | regex_replace('\.pem$', '') }}.pub
+
+- name: Generate SSH pub key content if it doesn't exist
+  shell: >-
+    ssh-keygen -y -f {{ hostvars.localhost.env_authorized_key_path | quote }}
+    > {{ hostvars.localhost.env_authorized_key_path_pub | quote }}
+  args:
+    creates: "{{ hostvars.localhost.env_authorized_key_path_pub }}"
+  delegate_to: localhost
+  become: false
+
+- name: Save SSH pub key content as fact
+  delegate_to: localhost
+  delegate_facts: true
+  become: false
+  set_fact:
+    env_authorized_key_content_pub: >-
+      {{ lookup('file', hostvars.localhost.env_authorized_key_path_pub) }}

--- a/ansible/roles/set_env_authorized_key/defaults/main.yaml
+++ b/ansible/roles/set_env_authorized_key/defaults/main.yaml
@@ -1,14 +1,2 @@
 ---
 output_dir: /tmp/output_dir
-# Use provision ssh key if possible
-env_authorized_key_path: >-
-  {%- if hostvars.localhost.ssh_provision_key_path is defined -%}
-  {{ hostvars.localhost.ssh_provision_key_path }}
-  {%- elif hostvars.localhost.infra_ssh_key is defined -%}
-  {{ hostvars.localhost.infra_ssh_key }}
-  {%- else -%}
-  {{ output_dir }}/{{ env_authorized_key }}
-  {%- endif -%}
-
-env_authorized_key_path_pub: >-
-  {{ env_authorized_key_path | regex_replace('\.pem$', '') }}.pub

--- a/ansible/roles/set_env_authorized_key/tasks/main.yml
+++ b/ansible/roles/set_env_authorized_key/tasks/main.yml
@@ -8,25 +8,17 @@
 - name: copy the environment .pem key
   become: true
   copy:
-    src: "{{ env_authorized_key_path }}"
+    src: "{{ hostvars.localhost.env_authorized_key_path }}"
     dest: "/root/.ssh/{{ env_authorized_key }}.pem"
     owner: root
     group: root
     mode: 0400
   when: set_env_authorized_key|bool
 
-- name: Generate pub key if it doesn't exist
-  shell: >-
-    ssh-keygen -y -f {{ env_authorized_key_path | quote }}
-    > {{ env_authorized_key_path_pub | quote }}
-  args:
-    creates: "{{ env_authorized_key_path_pub }}"
-  delegate_to: localhost
-
 - name: copy the environment .pub key
   become: true
   copy:
-    src: "{{ env_authorized_key_path_pub }}"
+    src: "{{ hostvars.localhost.env_authorized_key_path_pub }}"
     dest: "/root/.ssh/{{ env_authorized_key }}.pub"
     owner: root
     group: root
@@ -37,7 +29,7 @@
   authorized_key:
     user: "{{ ansible_user }}"
     state: present
-    key: "{{ lookup('file', env_authorized_key_path_pub) }}"
+    key: "{{ hostvars.localhost.env_authorized_key_content_pub }}"
 
 - name: Generate host .ssh/config Template
   become: false


### PR DESCRIPTION
This change, if applied, add a new role to detect the env_authorized_key
to use, see its readme.

- use those facts instead of role defaults in diverse places
- run 'locate_env_authorized_key' role at the beginning of infra, after
  key creation

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
