### PR TITLE
Get mor info from pre_infra.yml for email 

### DIFF
--- a/ansible/configs/aap2-ansible-workshops/pre_infra.yml
+++ b/ansible/configs/aap2-ansible-workshops/pre_infra.yml
@@ -67,9 +67,10 @@
 
         - name: Output user.info string for email when a workshop, create_login_page set to true, S3 bucket
           agnosticd_user_info:
-            msg: >-
-              {{ (student_workloads | default('Ansible')) | regex_replace('_tower_workshop','') | regex_replace('_', ' ') | title }}
-              Workshop and Student VMs are available at: http://{{ guid }}.{{ workshop_dns_zone }}
+            msg: |-
+              {{ (student_workloads | default('Ansible')) | regex_replace('_tower_workshop','') | regex_replace('_', ' ') | title }} Workshop
+              - Auto-Assignment website located at: http://{{ guid }}.{{ workshop_dns_zone }}
+              - Instructor can see workbench assignments at: http://{{ guid }}.{{ workshop_dns_zone }}/list.php (password: {{ admin_password }})
 
 
         - name: Set user_info_data for Workshop url


### PR DESCRIPTION
##### SUMMARY

As discussed in the chat, it would be helpful to have more information (esp the admin password) in the RHPDS notification email.

The way it is right now a facilitator has to assign him/herself an environment first to get the password, then go to the admin page (/list.php) to login with the password to control environments. And free up the env assigned to self...

From what I know the information used in the email message comes from the user.info data so I changed these lines, not knowing completely how the  agnosticd_user_info handles line breaks.

The admin_password var is available to the provision_lab.yml Playbook.

@tonykay @IPvSean 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
