### PR TITLE
Revert AWS Collection to 2.2

### DIFF
--- a/ansible/configs/ocp4-cluster/requirements.yml
+++ b/ansible/configs/ocp4-cluster/requirements.yml
@@ -11,7 +11,7 @@ collections:
 - name: openstack.cloud
   version: 1.7.2
 - name: amazon.aws
-  version: 3.1.1
+  version: 2.2.0
 - name: community.general
   version: 4.6.1
 - name: ansible.posix


### PR DESCRIPTION
##### SUMMARY

amazon.aws==3.x breaks AgnosticD. Reverting back to 2.2.0

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-cluster