### PR TITLE
Allow symmetric encryption of output_dir tarball

### DIFF
--- a/ansible/roles/agnosticd_restore_output_dir/tasks/restore-from-s3.yml
+++ b/ansible/roles/agnosticd_restore_output_dir/tasks/restore-from-s3.yml
@@ -4,16 +4,34 @@
     aws_access_key: "{{ agnosticd_save_output_dir_s3_access_key_id }}"
     aws_secret_key: "{{ agnosticd_save_output_dir_s3_secret_access_key }}"
     bucket: "{{ agnosticd_save_output_dir_s3_bucket }}"
-    dest: "{{ output_dir }}/restore.tar.gz"
+    dest: >-
+      {{ output_dir }}/restore.tar.gz
+      {{- '.gpg' if agnosticd_save_output_dir_archive_password is defined else '' -}}
     mode: get
     ignore_nonexistent_bucket: true
-    object: "{{ agnosticd_save_output_dir_archive }}"
+    object: >-
+      {{ agnosticd_save_output_dir_archive }}
+      {{- '.gpg' if agnosticd_save_output_dir_archive_password is defined else '' -}}
     region: "{{ agnosticd_save_output_dir_s3_region }}"
   register: r_get_output_dir_archive
   failed_when: >-
     r_get_output_dir_archive is failed
     and 'does not exist' not in r_get_output_dir_archive.msg
     and 'Could not find the key' not in r_get_output_dir_archive.msg
+
+- when: >-
+    agnosticd_save_output_dir_archive_password is defined
+    and
+    (output_dir ~ '/restore.tar.gz.gpg') is file
+  name: Decrypt archive
+  command: >-
+    gpg --decrypt --batch --passphrase-fd 0
+    --output {{ output_dir }}/restore.tar.gz
+    {{ output_dir }}/restore.tar.gz.gpg
+  args:
+    chdir: "{{ output_dir }}"
+    stdin: "{{ agnosticd_save_output_dir_archive_password }}"
+    creates: "{{ output_dir }}/restore.tar.gz"
 
 - name: Restore output_dir from archive
   when: >-
@@ -27,4 +45,9 @@
 - name: Remove archive file from output_dir
   ansible.builtin.file:
     path: "{{ output_dir }}/restore.tar.gz"
+    state: absent
+
+- name: Remove encrypted archive file from output_dir
+  ansible.builtin.file:
+    path: "{{ output_dir }}/restore.tar.gz.gpg"
     state: absent

--- a/ansible/roles/agnosticd_save_output_dir/README.adoc
+++ b/ansible/roles/agnosticd_save_output_dir/README.adoc
@@ -19,6 +19,8 @@ AWS access key id to use to authenticate to S3.
 `agnosticd_save_output_dir_s3_secret_access_key` -
 AWS secret access key to use to authenticate to S3.
 
+`agnosticd_save_output_dir_archive_password` -
+Protect archive with password, it can be useful if the S3 bucket is shared between multiple users. Behind the scene, it uses GPG symmetric encryption. Default: undefined.
 
 == AWS policy to attach to IAM users ==
 

--- a/ansible/roles/agnosticd_save_output_dir/defaults/main.yml
+++ b/ansible/roles/agnosticd_save_output_dir/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Archive object to create in S3 storage.
 #agnosticd_save_output_dir_archive: "{{ guid }}_{{ uuid }}.tar.gz"
-# TODO: IDEA protect password with symetric password, it can be useful if the S3 bucket is shared between multiple users.
+# Protect archive with password, it can be useful if the S3 bucket is shared between multiple users.
 # agnosticd_save_output_dir_archive_password: ...
 
 # S3 storage bucket access information, should be provided by a secret.

--- a/ansible/roles/agnosticd_save_output_dir/tasks/create-output-dir-archive.yml
+++ b/ansible/roles/agnosticd_save_output_dir/tasks/create-output-dir-archive.yml
@@ -18,4 +18,16 @@
     # Disable warning for using tar command rather than archive module.
     # archive module does not support chdir type option.
     warn: false
+
+- when: agnosticd_save_output_dir_archive_password is defined
+  block:
+    - name: Encrypt tarball using password
+      command: >-
+        gpg --symmetric --batch --passphrase-fd 0
+        --output {{ (agnosticd_save_output_dir_archive_tempfile ~ '.gpg') | quote }}
+        {{ agnosticd_save_output_dir_archive_tempfile | quote }}
+      args:
+        chdir: "{{ output_dir }}"
+        stdin: "{{ agnosticd_save_output_dir_archive_password }}"
+        creates: "{{ agnosticd_save_output_dir_archive_tempfile }}.gpg"
 ...

--- a/ansible/roles/agnosticd_save_output_dir/tasks/main.yml
+++ b/ansible/roles/agnosticd_save_output_dir/tasks/main.yml
@@ -17,4 +17,10 @@
     file:
       path: "{{ agnosticd_save_output_dir_archive_tempfile }}"
       state: absent
+
+  - name: Remove output_dir encrypted archive tempfile
+    when: agnosticd_save_output_dir_archive_password is defined
+    file:
+      path: "{{ agnosticd_save_output_dir_archive_tempfile }}.gpg"
+      state: absent
 ...

--- a/ansible/roles/agnosticd_save_output_dir/tasks/upload-archive-s3.yml
+++ b/ansible/roles/agnosticd_save_output_dir/tasks/upload-archive-s3.yml
@@ -9,9 +9,14 @@
     aws_secret_key: "{{ agnosticd_save_output_dir_s3_secret_access_key }}"
     mode: put
     ignore_nonexistent_bucket: true
-    src: "{{ agnosticd_save_output_dir_archive_tempfile }}"
+    src: >-
+      {{ agnosticd_save_output_dir_archive_tempfile -}}
+      {{- '.gpg' if agnosticd_save_output_dir_archive_password is defined else '' -}}
     region: "{{ agnosticd_save_output_dir_s3_region }}"
     bucket: "{{ agnosticd_save_output_dir_s3_bucket }}"
-    object: "{{ agnosticd_save_output_dir_archive }}"
+    object: >-
+      {{ agnosticd_save_output_dir_archive }}
+      {{- '.gpg' if agnosticd_save_output_dir_archive_password is defined else '' -}}
+
     tags: "{{ cloud_tags_final }}"
 ...


### PR DESCRIPTION
Allow user to define a password to protect the output_dir in s3 in case
of a shared s3 bucket.

> agnosticd_save_output_dir_archive_password

Append '.gpg' extension in that case.

Use GNUPG tool to perform the symmetric encryption (by default it's
AES256), as it's the most available, even in images (it's more
available in images by default than openssl).

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

* agnosticd_save_output_dir
* agnosticd_restore_output_dir
