### PR TITLE
Default ansible collections

### DIFF
--- a/ansible/install_galaxy_roles.yml
+++ b/ansible/install_galaxy_roles.yml
@@ -10,8 +10,28 @@
     ## PS: ROLE_IMPROVE_TASK
     ## Needs to be validated
     ## var is called from main.yml
+    ## config:
     requirements_path: "configs/{{ env_type }}/requirements.yml"
+    ## Agnosticd Default collections:
+    requirements_default: "requirements.yml"
   tasks:
+    - name: Install default collections
+      vars:
+        __from_ee: "{{ lookup('env', 'LAUNCHED_BY_RUNNER') == '1' }}"
+        __collections_path: "{{ lookup('config', 'COLLECTIONS_PATHS')[0] }}"
+      command: >-
+        ansible-galaxy collection install
+        -r "{{ requirements_default }}"
+        -p "{{ __collections_path | quote }}"
+        --force-with-deps
+      when: >-
+        not __from_ee
+        and __collections_path.startswith('/tmp/')
+      register: r_ansible_galaxy_install_default_collections
+      until: r_ansible_galaxy_install_default_collections is successful
+      retries: 10
+      delay: 30
+
     - name: Check if requirements.yml exists
       stat:
         path: "{{ requirements_path }}"

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,0 +1,5 @@
+collections:
+- name: community.general
+  version: 4.6.1
+- name: ansible.posix
+  version: 1.3.0


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

Some ansible collections should be present, regardless of the config.

This change, if applied, adds a step in install_galaxy_roles playbook to
install collections using ansible/requirements.yml file.

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request

