### PR TITLE
Adding config_drive to sap-hana osp template

### DIFF
--- a/ansible/configs/sap-hana/files/cloud_providers/osp_cloud_template_master.j2
+++ b/ansible/configs/sap-hana/files/cloud_providers/osp_cloud_template_master.j2
@@ -151,7 +151,7 @@ resources:
       name: {{ iname }}
       flavor: {{ instance.flavor.osp }}
       key_name: {get_resource: {{ guid }}-infra_key}
-
+      config_drive: True
       block_device_mapping_v2:
         - image: {{ instance.image_id | default(instance.image) }}
           delete_on_termination: true


### PR DESCRIPTION
Adding `config_drive: True` to the osp template.
This should help with metadata configuration during provisions. A disk will be mounted with the metadata and it will reduce the risk of errors

