### PR TITLE
Add requester vars for ibm-rhoic config

### DIFF
--- a/ansible/configs/ibm-rhoic/pre_infra.yml
+++ b/ansible/configs/ibm-rhoic/pre_infra.yml
@@ -34,9 +34,9 @@
             body_format: json
             body:
               guid: "{{ guid }}"
-              owner_name: "{{ student_name }}"
+              owner_name: "{{ requester_username | default(student_name) }}"
               env_type: "{{ env_type | default('') }}"
-              owner_email: "{{ email }}"
+              owner_email: "{{ requester_email | default(email) }}"
               note: "{{ sandbox_note | default('') }}"
               cloud_provider: "{{ cloud_provider }}"
           register: r_sandbox_account

--- a/ansible/configs/ibm-rhoic/software.yml
+++ b/ansible/configs/ibm-rhoic/software.yml
@@ -245,7 +245,9 @@
     - name: Setting the email variable if it is not defined so user.info won't fail
       set_fact:
         email: "no-valid-email-set"
-      when: email is not defined
+      when:
+      - email is not defined
+      - requester_email is not defined
 
     - name: Creating Cloud URL
       set_fact:
@@ -257,7 +259,7 @@
         msg: "{{ item }}"
       loop:
         - "The information below can be used to access your Red Hat OpenShift on IBM Cloud Sandbox environment."
-        - "IBM Cloud User: {{ email }}"
+        - "IBM Cloud User: {{ requester_email | default(email) }}"
         - "IBM Cloud Sandbox: {{ sandbox_account_name }}"
         - "IBM Cloud Console: https://cloud.ibm.com/"
         - "OpenShift Cluster Info (IBM Cloud): {{ rhoic_console_url }}"

--- a/ansible/configs/ibm-rhoic/software.yml
+++ b/ansible/configs/ibm-rhoic/software.yml
@@ -244,10 +244,10 @@
 
     - name: Setting the email variable if it is not defined so user.info won't fail
       set_fact:
-          email: "no-valid-email-set"
+        email: "no-valid-email-set"
       when:
-      - email is not defined
-      - requester_email is not defined
+        - email is not defined
+        - requester_email is not defined
 
     - name: Creating Cloud URL
       set_fact:

--- a/ansible/configs/ibm-rhoic/software.yml
+++ b/ansible/configs/ibm-rhoic/software.yml
@@ -244,7 +244,7 @@
 
     - name: Setting the email variable if it is not defined so user.info won't fail
       set_fact:
-        email: "no-valid-email-set"
+          email: "no-valid-email-set"
       when:
       - email is not defined
       - requester_email is not defined


### PR DESCRIPTION
##### SUMMARY

Add reference to `requester_username` and `requester_email` to facilitate transition for ibm-rhoic config to use these vars.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Config ibm-rhoic