### PR TITLE
make role backwards compatible with email/requester_email

### DIFF
--- a/ansible/roles/open-env-azure-invite-user/tasks/main.yml
+++ b/ansible/roles/open-env-azure-invite-user/tasks/main.yml
@@ -6,22 +6,23 @@
 - name: Get CICD User Default
   set_fact:
     cicd_user: "{{ open_env_azure_cicd_user | default('jenkins.sfo01@gmail.com') }}"
+    user_email: "{{ requester_email | default(email) }}"
 - name: Check if email is Red Hat associate or CICD User
   fail:
-    msg: User requester_email ({{ requester_email }}) does not match cicd_user ({{ cicd_user}}) and does not contain @redhat.com
+    msg: "user_email ({{ user_email }}) does not match cicd_user ({{ cicd_user }}) and does not contain @redhat.com"
   when:
-    - '"@redhat.com" not in requester_email'
-    - 'cicd_user not in requester_email'
+    - '"@redhat.com" not in user_email'
+    - 'cicd_user not in user_email'
 - name: Set Up UPN for Red Hat Associate
   when:
-    - '"@redhat.com" in requester_email'
+    - '"@redhat.com" in user_email'
   set_fact:
-    upn: "{{ requester_email|replace('@redhat.com','_redhat.com#EXT#@prutledgopentlc.onmicrosoft.com') }}"
+    upn: "{{ user_email | replace('@redhat.com','_redhat.com#EXT#@prutledgopentlc.onmicrosoft.com') }}"
 - name: Set Up UPN for CICD
   when:
-    - 'cicd_user in requester_email'
+    - 'cicd_user in user_email'
   set_fact:
-    upn: "{{ requester_email|replace('@gmail.com','_gmail.com#EXT#@prutledgopentlc.onmicrosoft.com') }}"
+    upn: "{{ user_email | replace('@gmail.com','_gmail.com#EXT#@prutledgopentlc.onmicrosoft.com') }}"
 - name: Checking if user is in Active Directory
   register: azuserc
   azure.azcollection.azure_rm_aduser_info:
@@ -58,10 +59,10 @@
         status_code: 201
         body_format: json
         body:
-          invitedUserEmailAddress: "{{ requester_email }}"
+          invitedUserEmailAddress: "{{ user_email }}"
           inviteRedirectUrl: "https://portal.azure.com"
           sendInvitationMessage: true
-          invitedUserDisplayName: "OpenEnv_User_{{ requester_email }}"
+          invitedUserDisplayName: "OpenEnv_User_{{ user_email }}"
     - name: Print Open Environment Information
       agnosticd_user_info:
         msg: "{{ item }}"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
make role backwards compatible with email/requester_email
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
open-env-azure-invite-user
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
