### PR TITLE
Added version check to ssh_authorized_keys

### DIFF
--- a/ansible/roles/ssh_authorized_keys/tasks/main.yaml
+++ b/ansible/roles/ssh_authorized_keys/tasks/main.yaml
@@ -6,6 +6,7 @@
     key: "{{ item.key }}"
     key_options: "{{ item.key_options | default(omit) }}"
   loop: "{{ ssh_authorized_keys }}"
+  when: "ansible_version.full is compare('2.10', '>=')"
 
 - name: Add all authorized keys (legacy var all_ssh_authorized_keys)
   ansible.posix.authorized_key:
@@ -13,4 +14,23 @@
     state: present
     key: "{{ item }}"
   loop: "{{ all_ssh_authorized_keys | default([]) }}"
+  when: "ansible_version.full is compare('2.10', '>=')"
+
+- name: Add all authorized keys
+  uthorized_key:
+    user: "{{ remote_user | default(ansible_user) }}"
+    state: present
+    key: "{{ item.key }}"
+    key_options: "{{ item.key_options | default(omit) }}"
+  loop: "{{ ssh_authorized_keys }}"
+  when: "ansible_version.full is compare('2.10', '<')"
+
+- name: Add all authorized keys (legacy var all_ssh_authorized_keys)
+  authorized_key:
+    user: "{{ remote_user | default(ansible_user) }}"
+    state: present
+    key: "{{ item }}"
+  loop: "{{ all_ssh_authorized_keys | default([]) }}"
+  when: "ansible_version.full is compare('2.10', '<')"
+
 ...


### PR DESCRIPTION
** DO NOT MERGE WITHOUT REVIEW et DISCUSSION please **

Updating the ssh_authorized_keys role to support both ansible.posix.authorized_key for versions >= 2.10 and use the deprecated authorized_key for ansible versions < 2.10