### PR TITLE
Add support for hyphens in ec2 instances names

### DIFF
--- a/ansible/roles-infra/infra-ec2-template-generate/templates/cloud_template.j2
+++ b/ansible/roles-infra/infra-ec2-template-generate/templates/cloud_template.j2
@@ -166,7 +166,9 @@ Resources:
 {%       endif %}
 {%     endfor %}
     Properties:
-{%     if aws_dns_create_public_zone | bool %}
+{%     if instance.public_dns_zone is defined %}
+      HostedZoneName: {{ instance.public_dns_zone }}
+{%     elif aws_dns_create_public_zone | bool %}
 {%       if secondary_stack is defined %}
       HostedZoneName: "{{ aws_dns_zone_public }}"
 {%       else %}
@@ -177,7 +179,7 @@ Resources:
       HostedZoneName: "{{ aws_dns_zone_root }}"
 {%     endif %}
       RecordSets:
-      - Name: "{{instance['name']}}.{{aws_dns_zone_public_prefix|d('')}}{{ aws_dns_zone_public }}"
+      - Name: {{ instance.name }}.{{ instance.public_dns_zone | default(aws_dns_zone_public_prefix | default('') ~ aws_dns_zone_public) }}
         Type: A
         TTL: {{ aws_dns_ttl_public }}
         ResourceRecords:
@@ -297,7 +299,9 @@ Resources:
     DependsOn:
       - {{instance['name']}}{{loop.index}}EIP
     Properties:
-{%     if aws_dns_create_public_zone | bool %}
+{%     if instance.public_dns_zone is defined %}
+      HostedZoneName: {{ instance.public_dns_zone }}
+{%     elif aws_dns_create_public_zone | bool %}
 {%       if secondary_stack is defined %}
       HostedZoneName: "{{ aws_dns_zone_public }}"
 {%       else %}
@@ -309,9 +313,9 @@ Resources:
 {%     endif %}
       RecordSets:
 {%       if instance['unique'] | d(false) | bool %}
-        - Name: "{{instance['name']}}.{{aws_dns_zone_public_prefix|d('')}}{{ aws_dns_zone_public }}"
+        - Name: {{ instance.name }}.{{ instance.public_dns_zone | default(aws_dns_zone_public_prefix | default('') ~ aws_dns_zone_public) }}
 {%       else %}
-        - Name: "{{instance['name']}}{{loop.index}}.{{aws_dns_zone_public_prefix|d('')}}{{ aws_dns_zone_public }}"
+        - Name: {{ instance.name }}{{ loop.index }}.{{ instance.public_dns_zone | default(aws_dns_zone_public_prefix | default('') ~ aws_dns_zone_public) }}
 {%       endif %}
           Type: A
           TTL: {{ aws_dns_ttl_public }}

--- a/ansible/roles-infra/infra-ec2-template-generate/templates/cloud_template.j2
+++ b/ansible/roles-infra/infra-ec2-template-generate/templates/cloud_template.j2
@@ -286,7 +286,7 @@ Resources:
               - PrivateIp
 
 {%     if instance['public_dns'] %}
-  {{instance['name']}}{{loop.index}}EIP:
+  {{ instance.name | replace('-', '') }}{{ loop.index }}EIP:
     Type: "AWS::EC2::EIP"
     DependsOn:
     - VpcGA
@@ -297,7 +297,7 @@ Resources:
   {{ instance.name | replace('-', '') }}{{ loop.index }}PublicDns:
     Type: "AWS::Route53::RecordSetGroup"
     DependsOn:
-      - {{instance['name']}}{{loop.index}}EIP
+      - {{ instance.name | replace('-', '') }}{{ loop.index }}EIP
     Properties:
 {%     if instance.public_dns_zone is defined %}
       HostedZoneName: {{ instance.public_dns_zone }}

--- a/ansible/roles-infra/infra-ec2-template-generate/templates/cloud_template.j2
+++ b/ansible/roles-infra/infra-ec2-template-generate/templates/cloud_template.j2
@@ -156,13 +156,13 @@ Resources:
 {% for instance in instances %}
 {%   if instance['dns_loadbalancer'] | default(false) | bool
      and not instance['unique'] | default(false) | bool %}
-  {{instance['name']}}DnsLoadBalancer:
+  {{ instance.name | replace('-', '') }}DnsLoadBalancer:
     Type: "AWS::Route53::RecordSetGroup"
     DependsOn:
 {%     for c in range(1, (instance['count']|int)+1) %}
-      - {{instance['name']}}{{c}}
+      - {{ instance.name | replace('-', '') }}{{c}}
 {%       if instance['public_dns'] %}
-      - {{instance['name']}}{{c}}EIP
+      - {{ instance.name | replace('-', '') }}{{c}}EIP
 {%       endif %}
 {%     endfor %}
     Properties:
@@ -183,13 +183,13 @@ Resources:
         ResourceRecords:
 {%     for c in range(1,(instance['count'] |int)+1) %}
           - "Fn::GetAtt":
-            - {{instance['name']}}{{c}}
+            - {{ instance.name | replace('-', '') }}{{c}}
             - PublicIp
 {%     endfor %}
 {%   endif %}
 
 {%   for c in range(1,(instance['count'] |int)+1) %}
-  {{instance['name']}}{{loop.index}}:
+  {{ instance.name | replace('-', '') }}{{ loop.index }}:
     Type: "AWS::EC2::Instance"
     Properties:
 {%     if instance.name in agnosticd_images | default({}) %}
@@ -265,7 +265,7 @@ Resources:
             VolumeSize: "{{ vol.size }}"
 {%     endfor %}
 
-  {{instance['name']}}{{loop.index}}InternalDns:
+  {{ instance.name | replace('-', '') }}{{loop.index}}InternalDns:
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
       HostedZoneId:
@@ -292,7 +292,7 @@ Resources:
       InstanceId:
         Ref: {{instance['name']}}{{loop.index}}
 
-  {{instance['name']}}{{loop.index}}PublicDns:
+  {{ instance.name | replace('-', '') }}{{ loop.index }}PublicDns:
     Type: "AWS::Route53::RecordSetGroup"
     DependsOn:
       - {{instance['name']}}{{loop.index}}EIP
@@ -317,7 +317,7 @@ Resources:
           TTL: {{ aws_dns_ttl_public }}
           ResourceRecords:
           - "Fn::GetAtt":
-            - {{instance['name']}}{{loop.index}}
+            - {{ instance.name | replace('-', '') }}{{loop.index}}
             - PublicIp
 {%     endif %}
 {%   endfor %}

--- a/ansible/roles-infra/infra-ec2-template-generate/templates/cloud_template.j2
+++ b/ansible/roles-infra/infra-ec2-template-generate/templates/cloud_template.j2
@@ -292,7 +292,7 @@ Resources:
     - VpcGA
     Properties:
       InstanceId:
-        Ref: {{instance['name']}}{{loop.index}}
+        Ref: {{ instance.name | replace('-', '') }}{{ loop.index }}
 
   {{ instance.name | replace('-', '') }}{{ loop.index }}PublicDns:
     Type: "AWS::Route53::RecordSetGroup"

--- a/ansible/roles-infra/infra-ec2-template-generate/templates/cloud_template.j2
+++ b/ansible/roles-infra/infra-ec2-template-generate/templates/cloud_template.j2
@@ -282,7 +282,7 @@ Resources:
           TTL: {{ aws_dns_ttl_private }}
           ResourceRecords:
             - "Fn::GetAtt":
-              - {{instance['name']}}{{loop.index}}
+              - {{ instance.name | replace('-', '') }}{{ loop.index }}
               - PrivateIp
 
 {%     if instance['public_dns'] %}


### PR DESCRIPTION
##### SUMMARY

Add support for hyphens in instance names using our ec2 cloudformation template.

Resource names in CloudFormation do not support hyphens even though instance names and dns names do support it. This PR strips any hyphens out of CloudFormation resource names.

Also adds ability to place host DNS in separate DNS zone.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ec2 cloud provider