### PR TITLE
ocp4-cluster config, support multiple zone-layout for ODCR

### DIFF
--- a/ansible/configs/ocp4-cluster/pre_infra.yml
+++ b/ansible/configs/ocp4-cluster/pre_infra.yml
@@ -63,16 +63,22 @@
           aws_availability_zone: "{{ _r.az1.availability_zone }}"
           # masters
           # Support several logical mapping (masters, masters1-3)
-          openshift_controlplane_aws_zones_odcr:
-          - "{{ _r.masters.availability_zone  | default(None) }}"
-          - "{{ _r.masters1.availability_zone | default(None) }}"
-          - "{{ _r.masters2.availability_zone | default(None) }}"
-          - "{{ _r.masters3.availability_zone | default(None) }}"
+          openshift_controlplane_aws_zones_odcr: >-
+            {{
+              [ {{ _r.masters.availability_zone  | default(None) }},
+                {{ _r.masters1.availability_zone | default(None) }},
+                {{ _r.masters2.availability_zone | default(None) }},
+                {{ _r.masters3.availability_zone | default(None) }},
+              ] | select() | list
+            }}
           # workers
           # Support up to 4 zones
-          openshift_machineset_aws_zones_odcr:
-          - "{{ _r.workers.availability_zone  | default(None) }}"
-          - "{{ _r.workers1.availability_zone | default(None) }}"
-          - "{{ _r.workers2.availability_zone | default(None) }}"
-          - "{{ _r.workers3.availability_zone | default(None) }}"
-          - "{{ _r.workers4.availability_zone | default(None) }}"
+          openshift_machineset_aws_zones_odcr: >-
+            {{
+              [ {{ _r.workers.availability_zone  | default(None) }},
+                {{ _r.workers1.availability_zone | default(None) }},
+                {{ _r.workers2.availability_zone | default(None) }},
+                {{ _r.workers3.availability_zone | default(None) }},
+                {{ _r.workers4.availability_zone | default(None) }},
+              ] | select() | list
+            }}

--- a/ansible/configs/ocp4-cluster/pre_infra.yml
+++ b/ansible/configs/ocp4-cluster/pre_infra.yml
@@ -56,20 +56,23 @@
       when: agnosticd_aws_capacity_reservation_results.reservations | default({}) | length > 0
       block:
       - name: Set availability zone for bastion, masters and workers
+        vars:
+          _r: "{{ agnosticd_aws_capacity_reservation_results.reservations }}"
         set_fact:
           # Cloudformation (bastion)
-          aws_availability_zone: "{{ agnosticd_aws_capacity_reservation_results.reservations.az1.availability_zone }}"
+          aws_availability_zone: "{{ _r.az1.availability_zone }}"
           # masters
+          # Support several logical mapping (masters, masters1-3)
           openshift_controlplane_aws_zones_odcr:
-          - "{{ agnosticd_aws_capacity_reservation_results.reservations.masters.availability_zone }}"
+          - "{{ _r.masters.availability_zone  | default(None) }}"
+          - "{{ _r.masters1.availability_zone | default(None) }}"
+          - "{{ _r.masters2.availability_zone | default(None) }}"
+          - "{{ _r.masters3.availability_zone | default(None) }}"
           # workers
+          # Support up to 4 zones
           openshift_machineset_aws_zones_odcr:
-          - "{{ agnosticd_aws_capacity_reservation_results.reservations.workers1.availability_zone }}"
-          - >-
-              {{ agnosticd_aws_capacity_reservation_results.reservations.workers2.availability_zone
-                 | default(agnosticd_aws_capacity_reservation_results.reservations.workers1.availability_zone)
-              }}
-          - >-
-              {{ agnosticd_aws_capacity_reservation_results.reservations.workers3.availability_zone
-                 | default(agnosticd_aws_capacity_reservation_results.reservations.workers1.availability_zone)
-              }}
+          - "{{ _r.workers.availability_zone  | default(None) }}"
+          - "{{ _r.workers1.availability_zone | default(None) }}"
+          - "{{ _r.workers2.availability_zone | default(None) }}"
+          - "{{ _r.workers3.availability_zone | default(None) }}"
+          - "{{ _r.workers4.availability_zone | default(None) }}"

--- a/ansible/configs/ocp4-cluster/pre_infra.yml
+++ b/ansible/configs/ocp4-cluster/pre_infra.yml
@@ -65,4 +65,11 @@
           # workers
           openshift_machineset_aws_zones_odcr:
           - "{{ agnosticd_aws_capacity_reservation_results.reservations.workers1.availability_zone }}"
-          - "{{ agnosticd_aws_capacity_reservation_results.reservations.workers2.availability_zone }}"
+          - >-
+              {{ agnosticd_aws_capacity_reservation_results.reservations.workers2.availability_zone
+                 | default(agnosticd_aws_capacity_reservation_results.reservations.workers1.availability_zone)
+              }}
+          - >-
+              {{ agnosticd_aws_capacity_reservation_results.reservations.workers3.availability_zone
+                 | default(agnosticd_aws_capacity_reservation_results.reservations.workers1.availability_zone)
+              }}

--- a/ansible/configs/ocp4-cluster/pre_infra.yml
+++ b/ansible/configs/ocp4-cluster/pre_infra.yml
@@ -64,21 +64,19 @@
           # masters
           # Support several logical mapping (masters, masters1-3)
           openshift_controlplane_aws_zones_odcr: >-
-            {{
-              [ {{ _r.masters.availability_zone  | default(None) }},
-                {{ _r.masters1.availability_zone | default(None) }},
-                {{ _r.masters2.availability_zone | default(None) }},
-                {{ _r.masters3.availability_zone | default(None) }},
-              ] | select() | list
-            }}
+            {{ [
+              _r.masters.availability_zone | default(None),
+              _r.masters1.availability_zone | default(None),
+              _r.masters2.availability_zone | default(None),
+              _r.masters3.availability_zone | default(None),
+            ] | select() | list }}
           # workers
           # Support up to 4 zones
           openshift_machineset_aws_zones_odcr: >-
-            {{
-              [ {{ _r.workers.availability_zone  | default(None) }},
-                {{ _r.workers1.availability_zone | default(None) }},
-                {{ _r.workers2.availability_zone | default(None) }},
-                {{ _r.workers3.availability_zone | default(None) }},
-                {{ _r.workers4.availability_zone | default(None) }},
-              ] | select() | list
-            }}
+            {{ [
+              _r.workers.availability_zone | default(None),
+              _r.workers1.availability_zone | default(None),
+              _r.workers2.availability_zone | default(None),
+              _r.workers3.availability_zone | default(None),
+              _r.workers4.availability_zone | default(None),
+            ] | select() | list }}

--- a/ansible/roles-infra/infra-aws-capacity-reservation/readme.adoc
+++ b/ansible/roles-infra/infra-aws-capacity-reservation/readme.adoc
@@ -164,3 +164,112 @@ The role would be executed if:
 
 * `agnosticd_aws_capacity_reservations` is defined and not empty
 * `agnosticd_aws_capacity_reservation_enable` is true (default is true)
+
+
+=== Examples ===
+
+==== example 1 ====
+
+ocp4-cluster with everything in a single zone
+
+[source,yaml]
+----
+agnosticd_aws_capacity_reservation_single_zone: true
+----
+
+==== example 2 ====
+
+ocp4-cluster with:
+* 1 zone for the masters
+* 1 zone for the workers
+* 1 zone for the bastion
+
+with best-effort, meaning, the zone are not necessarly distinct.
+This is the layout that will have the best chance to successfuly provision.
+
+[source,yaml]
+----
+agnosticd_aws_capacity_reservation_single_zone: false
+agnosticd_aws_capacity_reservation_distinct: false
+agnosticd_aws_capacity_reservations:
+  # Bastion can have its own AZ
+  az1:
+  - instance_type: "{{ bastion_instance_type }}"
+    instance_count: 1
+    instance_platform: "{{ bastion_instance_platform }}"
+
+  # Workers: all in one
+  masters:
+  - instance_type: "{{ master_instance_type }}"
+    instance_count: 3
+    instance_platform: Linux/UNIX
+
+  # Workers: all in one
+  workers:
+  - instance_type: "{{ worker_instance_type }}"
+    instance_count: "{{ worker_instance_count }}"
+    instance_platform: Linux/UNIX
+----
+
+==== example 3 ====
+
+HA ocp4-cluster on 3 different zones:
+* masters in 3 different zones (HA)
+* workers spread in 2 zones
+* bastion on the first zone with 1 master
+
+[source,yaml]
+----
+agnosticd_aws_capacity_reservation_distinct: true
+agnosticd_aws_capacity_reservations:
+  az1:
+  - instance_type: "{{ bastion_instance_type }}"
+    instance_count: 1
+    instance_platform: "{{ bastion_instance_platform }}"
+
+  # 1/3 master
+  - instance_type: "{{ master_instance_type }}"
+    instance_count: 1
+    instance_platform: Linux/UNIX
+
+  az2:
+  # 1/3 master
+  - instance_type: "{{ master_instance_type }}"
+    instance_count: 1
+    instance_platform: Linux/UNIX
+
+  - instance_type: "{{ worker_instance_type }}"
+    instance_count: >-
+      {{ ( worker_instance_count | int / 2 )
+      | round(0, 'ceil')
+      | int }}
+    instance_platform: Linux/UNIX
+
+  az3:
+  # 1/3 master
+  - instance_type: "{{ master_instance_type }}"
+    instance_count: 1
+    instance_platform: Linux/UNIX
+
+  # half the nodes
+  - instance_type: "{{ worker_instance_type }}"
+    instance_count: >-
+      {{ ( worker_instance_count | int / 2 )
+      | round(0, 'ceil')
+      | int }}
+    instance_platform: Linux/UNIX
+
+
+aws_availability_zone: "{{ agnosticd_aws_capacity_reservation_results.reservations.az1.availability_zone }}"
+
+# masters, how to use the results from the reservation layout
+openshift_controlplane_aws_zones_odcr:
+- "{{ agnosticd_aws_capacity_reservation_results.reservations.az1.availability_zone }}"
+- "{{ agnosticd_aws_capacity_reservation_results.reservations.az2.availability_zone }}"
+- "{{ agnosticd_aws_capacity_reservation_results.reservations.az3.availability_zone }}"
+
+# workers
+openshift_machineset_aws_zones_odcr:
+- "{{ agnosticd_aws_capacity_reservation_results.reservations.az2.availability_zone }}"
+- "{{ agnosticd_aws_capacity_reservation_results.reservations.az3.availability_zone }}"
+----

--- a/ansible/roles-infra/infra-aws-capacity-reservation/readme.adoc
+++ b/ansible/roles-infra/infra-aws-capacity-reservation/readme.adoc
@@ -180,6 +180,7 @@ agnosticd_aws_capacity_reservation_single_zone: true
 ==== example 2 ====
 
 ocp4-cluster with:
+
 * 1 zone for the masters
 * 1 zone for the workers
 * 1 zone for the bastion
@@ -214,6 +215,7 @@ agnosticd_aws_capacity_reservations:
 ==== example 3 ====
 
 HA ocp4-cluster on 3 different zones:
+
 * masters in 3 different zones (HA)
 * workers spread in 2 zones
 * bastion on the first zone with 1 master

--- a/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
+++ b/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
@@ -18,7 +18,7 @@ controlPlane:
     aws:
       type: {{ master_instance_type | to_json }}
 {%   if hostvars.localhost.openshift_controlplane_aws_zones_odcr | default([]) | length > 0 %}
-      zones: {{ hostvars.localhost.openshift_controlplane_aws_zones_odcr | flatten | select() | unique | to_json }}
+      zones: {{ hostvars.localhost.openshift_controlplane_aws_zones_odcr | unique | to_json }}
 {%   endif %}
       rootVolume:
         type: {{ master_storage_type | to_json }}
@@ -60,9 +60,9 @@ compute:
       rootVolume:
         type: {{ worker_storage_type | to_json }}
 {%   if openshift_machineset_aws_zones | default([]) | length > 0 %}
-      zones: {{ openshift_machineset_aws_zones | flatten | select() | unique | to_json }}
+      zones: {{ openshift_machineset_aws_zones | unique | to_json }}
 {%   elif hostvars.localhost.openshift_machineset_aws_zones_odcr | default([]) | length > 0 %}
-      zones: {{ hostvars.localhost.openshift_machineset_aws_zones_odcr | flatten | select() | unique | to_json }}
+      zones: {{ hostvars.localhost.openshift_machineset_aws_zones_odcr | unique | to_json }}
 {%   endif %}
 {% endif %}
 {% if cloud_provider == 'azure' %}

--- a/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
+++ b/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
@@ -18,7 +18,7 @@ controlPlane:
     aws:
       type: {{ master_instance_type | to_json }}
 {%   if hostvars.localhost.openshift_controlplane_aws_zones_odcr | default([]) | length > 0 %}
-      zones: {{ hostvars.localhost.openshift_controlplane_aws_zones_odcr | unique | to_json }}
+      zones: {{ hostvars.localhost.openshift_controlplane_aws_zones_odcr | flatten | select() | unique | to_json }}
 {%   endif %}
       rootVolume:
         type: {{ master_storage_type | to_json }}
@@ -60,9 +60,9 @@ compute:
       rootVolume:
         type: {{ worker_storage_type | to_json }}
 {%   if openshift_machineset_aws_zones | default([]) | length > 0 %}
-      zones: {{ openshift_machineset_aws_zones | unique | to_json }}
+      zones: {{ openshift_machineset_aws_zones | flatten | select() | unique | to_json }}
 {%   elif hostvars.localhost.openshift_machineset_aws_zones_odcr | default([]) | length > 0 %}
-      zones: {{ hostvars.localhost.openshift_machineset_aws_zones_odcr | unique | to_json }}
+      zones: {{ hostvars.localhost.openshift_machineset_aws_zones_odcr | flatten | select() | unique | to_json }}
 {%   endif %}
 {% endif %}
 {% if cloud_provider == 'azure' %}


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
This change, if applied, allows more ways to arrange the clusters in different zones.

###### Before change

By default:
* 2 zones for workers
* 1 zone for masters
* 1 zone for bastion

Supported names for logical zones:
* workers1, workers2
* masters
* az1 for bastion

We can force zones to be distinct with `agnosticd_aws_capacity_reservation_distinct: true`.
It's possible to force everything into a single zone (costs effective, less HA) with `agnosticd_aws_capacity_reservation_single_zone: true`.

No flexibility to change the number of zone as the configs expects `masters` `workers1` and `workers2` logical zones.

It's always possible to change the layout by also changing the variables to specify how to use the new layout:

```yaml
openshift_controlplane_aws_zones_odcr
openshift_machineset_aws_zones_odcr
aws_availability_zone
```

But it's cumbersome for common use-cases.

###### After change

By default, same:
* 2 zones for workers
* 1 zone for masters
* 1 zone for bastion

It's now possible to change the layout a bit. Supported names for logical zones are now:
* workers, workers1, workers2
* masters, masters1, masters2, masters3
* az1 for bastion

 For example, this will now work:

* masters in the same zone   A
* workers in the same zone   B

Same as before: we can force zones to be distinct with `agnosticd_aws_capacity_reservation_distinct: true`.
Same as before: it's possible to force everything into a single zone (costs effective, less HA) with `agnosticd_aws_capacity_reservation_single_zone: true`.


###### Examples

This change also adds  examples to the readme of the reservation role, including examples that need to change the layout entirely. This can be done by overriding the variables that use the result of the role:

```yaml
openshift_controlplane_aws_zones_odcr
openshift_machineset_aws_zones_odcr
aws_availability_zone
```

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
* infra-aws-capacity-reservation role (doc)
* ocp4-cluster config

