### PR TITLE
Do not generate ssh config when no bastions are deployed

### DIFF
--- a/ansible/cloud_providers/ec2_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/ec2_infrastructure_deployment.yml
@@ -95,6 +95,9 @@
         name: infra-ec2-create-inventory
 
     - name: Run Common SSH Config Generator Role
+      when:
+        - groups.bastions is defined
+        - groups.bastions | length > 0
       include_role:
         name: infra-common-ssh-config-generate
 


### PR DESCRIPTION
##### SUMMARY

The ec2 cloud provider should not generate an SSH config when the cloud formation template does not create any bastion hosts. This is required for the sandbox config.

##### ISSUE TYPE

- Bugfix Pull Request