### PR TITLE
Remove domain from username

### DIFF
--- a/ansible/configs/open-environment-gcp/default_vars.yml
+++ b/ansible/configs/open-environment-gcp/default_vars.yml
@@ -8,4 +8,4 @@ project_tag: "{{ env_type }}-{{ guid }}"
 # Temporary directory for playbook operations
 output_dir: "/tmp/output-dir-{{ guid }}"
 
-requester_name: "{{ requester_username | default(student_name) }}"
+requester_name: "{{ requester_username | default(student_name) | regex_replace('@.*') }}"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Remove email domain from username if it exists.  This breaks GCP as project names cannot have an @ in them.

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
open-environment-gcp
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
