### PR TITLE
Centralize project name definition and remove username from project n…

### DIFF
--- a/ansible/configs/open-environment-gcp/README.adoc
+++ b/ansible/configs/open-environment-gcp/README.adoc
@@ -14,7 +14,6 @@ ansible-playbook ansible/main.yml \
   -e@/home/opentlc-mgr/secrets/gcp.yml \
   -e env_type=open-environment-gcp -e cloud_provider=gcp -e platform=RHPDS \
   -e requester_email=prutledg@redhat.com \
-  -e requester_name=prutledg \
   -e guid=$guid
 ----
 
@@ -24,6 +23,5 @@ ansible-playbook ansible/destroy.yml \
   -e@/home/opentlc-mgr/secrets/gcp.yml \
   -e env_type=open-environment-gcp -e cloud_provider=gcp -e platform=RHPDS \
   -e requester_email=prutledg@redhat.com \
-  -e requester_name=prutledg \
   -e guid=$guid
 ----

--- a/ansible/configs/open-environment-gcp/default_vars.yml
+++ b/ansible/configs/open-environment-gcp/default_vars.yml
@@ -8,4 +8,5 @@ project_tag: "{{ env_type }}-{{ guid }}"
 # Temporary directory for playbook operations
 output_dir: "/tmp/output-dir-{{ guid }}"
 
-requester_name: "{{ requester_username | default(student_name) | regex_replace('@.*') }}"
+# Name of GCP project to manage
+project_name: "openenv-{{ guid }}"

--- a/ansible/roles/open-env-gcp-add-user-to-project/README.md
+++ b/ansible/roles/open-env-gcp-add-user-to-project/README.md
@@ -22,8 +22,7 @@ Role Variables
 --------------
 
 guid - the guid to use for the deployment
-requester_email - an email address to invite
-requester_name - login name of user
+requester_email - the user's email address (must match GCP principal)
 
 Dependencies
 ------------

--- a/ansible/roles/open-env-gcp-add-user-to-project/tasks/main.yml
+++ b/ansible/roles/open-env-gcp-add-user-to-project/tasks/main.yml
@@ -5,10 +5,6 @@
   when:
     - '"@redhat.com" not in requester_email'
 
-- name: Create project name
-  set_fact:
-    project_name: "openenv-{{ guid }}-{{ requester_name }}"
-
 - name: Create GCP Project
   google.cloud.gcp_resourcemanager_project:
     auth_kind: serviceaccount

--- a/ansible/roles/open-env-gcp-remove-project/tasks/main.yml
+++ b/ansible/roles/open-env-gcp-remove-project/tasks/main.yml
@@ -1,8 +1,4 @@
 ---
-- name: Get project name
-  set_fact:
-    project_name: "openenv-{{ guid }}-{{ requester_name }}"
-
 - name: Call GCP get token role
   include_role:
     name: gcp-get-token


### PR DESCRIPTION


<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

Centralize project name definition and remove username from project name in GCP

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
open-env-gcp
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
