### PR TITLE
Add admin group to gcp sandboxes

### DIFF
--- a/ansible/roles/open-env-gcp-add-user-to-project/README.md
+++ b/ansible/roles/open-env-gcp-add-user-to-project/README.md
@@ -23,6 +23,7 @@ Role Variables
 
 guid - the guid to use for the deployment
 requester_email - the user's email address (must match GCP principal)
+gcp_admin_group - group in GCP that has admin access to all projects, must start with group:
 
 Dependencies
 ------------

--- a/ansible/roles/open-env-gcp-add-user-to-project/tasks/main.yml
+++ b/ansible/roles/open-env-gcp-add-user-to-project/tasks/main.yml
@@ -38,11 +38,11 @@
 
 - name: Create add user string
   set_fact:
-    add_user: "user:{{ requester_email }}"
+    user_to_add: "user:{{ requester_email }}"
 
-- name: Add user to members
+- name: Add user and admin group to members
   set_fact:
-    new_members: "{{ current_members + [ add_user ] }}" 
+    new_members: "{{ current_members + [ user_to_add, gcp_admin_group ] }}"
 
 - name: Create new policy
   set_fact:

--- a/ansible/roles/open-env-gcp-remove-project/tasks/main.yml
+++ b/ansible/roles/open-env-gcp-remove-project/tasks/main.yml
@@ -33,11 +33,11 @@
 
     - name: Create user string
       set_fact:
-        add_user: "user:{{ requester_email }}"
+        user_to_delete: "user:{{ requester_email }}"
 
     - name: Remove user from members
       set_fact:
-        new_members: "{{ current_members | reject('search', add_user) | list }}"
+        new_members: "{{ current_members | reject('search', user_to_delete) | list }}"
 
     - name: Create new policy
       set_fact:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Add admin group to gcp sandboxes
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
open-env-gcp

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
