### PR TITLE
Fix sealed secrets controller

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_sealed_secrets/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_sealed_secrets/defaults/main.yml
@@ -14,7 +14,7 @@ ocp4_workload_sealed_secrets_deploy_admin_role: true
 # Install kubeseal binary and version (without the leading 'v')
 # Minimum version supported: 0.17.1
 ocp4_workload_sealed_secrets_kubeseal_install: true
-ocp4_workload_sealed_secrets_kubeseal_version: "0.17.1"
+ocp4_workload_sealed_secrets_kubeseal_version: "0.17.5"
 
 # Sealed Secrets can be deployed either via Helm or by deploying the
 # sealed secrets controller manifest directly. Installing sealed secrets
@@ -34,7 +34,7 @@ ocp4_workload_sealed_secrets_name: sealed-secrets-controller
 # 2.0.1 and 2.0.2 do NOT work (service uses 'name: http' which breaks kubeseal)
 # 2.0.3 (or whatever comes next) should work again
 # https://github.com/bitnami-labs/sealed-secrets/issues/502#issuecomment-1000852121
-ocp4_workload_sealed_secrets_helm_chart_version: 2.0.0
+ocp4_workload_sealed_secrets_helm_chart_version: 2.1.6
 
 # Version of dedicated helm CLI (to be installed as /usr/local/bin/helm-sealed-secrets)
 ocp4_workload_sealed_secrets_helm_version: 3.6.2
@@ -48,5 +48,5 @@ ocp4_workload_sealed_secrets_helm_url: >-
 #####################################################################
 # Version to use from
 # https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.17.1/controller.yaml
-# Minimum version supported: v0.17.1
-ocp4_workload_sealed_secrets_version: v0.17.1
+# Minimum version supported: v0.17.5
+ocp4_workload_sealed_secrets_version: v0.17.5


### PR DESCRIPTION
##### SUMMARY

Sealed Secrets moved the image from Quay to DockerHub. This PR fixes that by updating to the latest release.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_sealed_secrets