### PR TITLE
Update ocp4_workload_servicemesh_workshop to run on OCP 4.10

### DIFF
--- a/ansible/configs/open-environment-azure-subscription/post_software.yml
+++ b/ansible/configs/open-environment-azure-subscription/post_software.yml
@@ -17,7 +17,7 @@
           Ansible Automation Platform on Azure - Open Environment.
 
           Welcome to the Red Hat Ansible Automation Platform on Microsoft Azure RHPDS.
-          This Environment gives Red Hatters on demand access to an Azure environment with access to the Ansible Automation Platform on Azure service offering. This time bound sandbox offers access to experience the Ansible Automation Platform on Azure - Managed Application.  You as a Red Hat associate will be enabled to to test, create, and demo this offering!  YOU will help make our customers and account teams successful. 
+          This Environment gives Red Hatters on demand access to an Azure environment with access to the Ansible Automation Platform on Azure service offering. This time bound sandbox offers access to experience the Ansible Automation Platform on Azure - Managed Application.  You as a Red Hat associate will be enabled to test, create, and demo this offering!  YOU will help make our customers and account teams successful. 
 
           The demo guide is available here https://docs.google.com/document/d/1TFFVL5-gcX7FeeIXItr1LxiUAeTb2aHevyNZPt1rucs/edit?usp=sharing
 
@@ -48,7 +48,7 @@
           Login using web authentication:
           az login --tenant $TENANT
           ...Follow the instructions that appear next...
-          az set --subscription $SUBSCRIPTION
+          az account set --subscription $SUBSCRIPTION
 
           See https://docs.microsoft.com/en-us/cli/azure/install-azure-cli for more info on installing the azure CLI
           See https://docs.microsoft.com/en-us/cli/azure/ for full documentation of the azure CLI

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/defaults/main.yml
@@ -21,12 +21,12 @@ ocp4_workload_servicemesh_workshop_elasticsearch_channel: "4.6"
 ocp4_workload_servicemesh_workshop_jaeger_channel: stable
 ocp4_workload_servicemesh_workshop_kiali_channel: stable
 ocp4_workload_servicemesh_workshop_servicemesh_channel: stable
-ocp4_workload_servicemesh_workshop_rhsso_channel: alpha
+ocp4_workload_servicemesh_workshop_rhsso_channel: stable
 ocp4_workload_servicemesh_workshop_elasticsearch_starting_csv: "elasticsearch-operator.4.6.0-202103010126.p0"
-ocp4_workload_servicemesh_workshop_jaeger_starting_csv: "jaeger-operator.v1.20.3"
-ocp4_workload_servicemesh_workshop_kiali_starting_csv: "kiali-operator.v1.24.7"
-ocp4_workload_servicemesh_workshop_servicemesh_starting_csv: "servicemeshoperator.v2.0.5"
-ocp4_workload_servicemesh_workshop_rhsso_starting_csv: "rhsso-operator.7.4.7"
+ocp4_workload_servicemesh_workshop_jaeger_starting_csv: "jaeger-operator.v1.30.2"
+ocp4_workload_servicemesh_workshop_kiali_starting_csv: "kiali-operator.v1.36.8"
+ocp4_workload_servicemesh_workshop_servicemesh_starting_csv: "servicemeshoperator.v2.1.2"
+ocp4_workload_servicemesh_workshop_rhsso_starting_csv: "rhsso-operator.7.5.1-opr-011"
 
 ## Operator Catalog Snapshot Settings
 ocp4_workload_servicemesh_workshop_catalogsource_name: redhat-operators-snapshot-servicemesh-workshop

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/defaults/main.yml
@@ -26,7 +26,7 @@ ocp4_workload_servicemesh_workshop_elasticsearch_starting_csv: "elasticsearch-op
 ocp4_workload_servicemesh_workshop_jaeger_starting_csv: "jaeger-operator.v1.30.2"
 ocp4_workload_servicemesh_workshop_kiali_starting_csv: "kiali-operator.v1.36.8"
 ocp4_workload_servicemesh_workshop_servicemesh_starting_csv: "servicemeshoperator.v2.1.2"
-ocp4_workload_servicemesh_workshop_rhsso_starting_csv: "rhsso-operator.7.5.1-opr-011"
+ocp4_workload_servicemesh_workshop_rhsso_starting_csv: "rhsso-operator.7.5.2-opr-001"
 
 ## Operator Catalog Snapshot Settings
 ocp4_workload_servicemesh_workshop_catalogsource_name: redhat-operators-snapshot-servicemesh-workshop

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/homeroom.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/homeroom.yaml
@@ -55,7 +55,7 @@
           -p SPAWNER_NAMESPACE=homeroom \
           -p CLUSTER_SUBDOMAIN={{ CLUSTER_SUBDOMAIN }} \
           -p WORKSHOP_NAME=service-mesh-workshop \
-          -p CONSOLE_IMAGE=quay.io/openshift/origin-console:4.6 \
+          -p CONSOLE_IMAGE=quay.io/openshift/origin-console:4.10 \
           -p WORKSHOP_IMAGE="{{ ocp4_workload_servicemesh_workshop_image_repo }}":"{{ ocp4_workload_servicemesh_workshop_image_tag }}"
   when: homeroom_deployment.resources | length | int < 1
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/per_user_workload.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/per_user_workload.yaml
@@ -43,26 +43,12 @@
   - r_install_plans.resources | length > 0
   - r_install_plans.resources | to_json | from_json | json_query(_query)
 
-- name: Set InstallPlan Name
-  set_fact:
-    ocp4_workload_servicemesh_workshop_rhsso_install_plan_name: "{{ r_install_plans.resources | to_json | from_json | json_query(query) }}"
-  vars:
-    query: >-
-      [?starts_with(spec.clusterServiceVersionNames[0], 'rhsso')].metadata.name|[0]
-
-- name: Get InstallPlan
-  k8s_info:
-    api_version: operators.coreos.com/v1alpha1
-    kind: InstallPlan
-    name: "{{ ocp4_workload_servicemesh_workshop_rhsso_install_plan_name }}"
-    namespace: "{{ t_user_project }}"
-  register: r_install_plan
-
 - name: Approve InstallPlan if necessary
-  when: r_install_plan.resources[0].status.phase is match("RequiresApproval")
+  when: item.status.phase is defined and item.status.phase is match("RequiresApproval")
   k8s:
     state: present
     definition: "{{ lookup( 'template', './templates/rhsso_installplan.j2' ) }}"
+  loop: "{{ r_install_plans }}"
 
 - name: Get Installed CSV
   k8s_info:
@@ -167,6 +153,9 @@
     name: kiali
     namespace: "{{ t_user_servicemesh_project }}"
   register: r_kiali_cm
+  until: r_kiali_cm.resources
+  retries: 15
+  delay: 5
 
 - name: Remove DeploymentConfig from excluded workloads
   set_fact:

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/post_workload.yml
@@ -5,7 +5,7 @@
     msg: "{{ item }}"
   loop:
   - ""
-  - "Presenter's Guide available here: https://github.com/RedHatGov/service-mesh-workshop-dashboard#openshift-service-mesh-workshop"
+  - "Presenter's Guide available here: https://docs.google.com/document/d/1A9pXa_sCto0ZkfeTV07eyf0vNeyk10W-o3-0TrIGBqk/edit#heading=h.h4l969tge8a8"
 
 
 # Leave these as the last tasks in the playbook

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/jaeger_subscription.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/jaeger_subscription.j2
@@ -7,6 +7,6 @@ spec:
   channel: "{{ ocp4_workload_servicemesh_workshop_jaeger_channel }}"
   installPlanApproval: Manual
   name: jaeger-product
-  source: "{{ ocp4_workload_servicemesh_workshop_catalogsource_name }}"
-  sourceNamespace: openshift-operators
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
   startingCSV: "{{ ocp4_workload_servicemesh_workshop_jaeger_starting_csv }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/kiali_subscription.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/kiali_subscription.j2
@@ -7,6 +7,6 @@ spec:
   channel: "{{ ocp4_workload_servicemesh_workshop_kiali_channel }}"
   installPlanApproval: Manual
   name: kiali-ossm
-  source: "{{ ocp4_workload_servicemesh_workshop_catalogsource_name }}"
-  sourceNamespace: openshift-operators
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
   startingCSV: "{{ ocp4_workload_servicemesh_workshop_kiali_starting_csv }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/rhsso_installplan.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/rhsso_installplan.j2
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: InstallPlan
 metadata:
-  name: "{{ ocp4_workload_servicemesh_workshop_rhsso_install_plan_name }}"
+  name: "{{ item.metadata.name }}"
   namespace: "{{ t_user_project }}"
 spec:
   approved: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/rhsso_operator.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/rhsso_operator.j2
@@ -16,6 +16,6 @@ spec:
   channel: "{{ ocp4_workload_servicemesh_workshop_rhsso_channel }}"
   installPlanApproval: Manual
   name: rhsso-operator
-  source: "{{ ocp4_workload_servicemesh_workshop_catalogsource_name }}"
-  sourceNamespace: "{{ t_user_project }}"
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
   startingCSV: "{{ ocp4_workload_servicemesh_workshop_rhsso_starting_csv }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/servicemesh_subscription.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/servicemesh_subscription.j2
@@ -7,6 +7,6 @@ spec:
   channel: "{{ ocp4_workload_servicemesh_workshop_servicemesh_channel }}"
   installPlanApproval: Manual
   name: servicemeshoperator
-  source: "{{ ocp4_workload_servicemesh_workshop_catalogsource_name }}"
-  sourceNamespace: openshift-operators
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
   startingCSV: "{{ ocp4_workload_servicemesh_workshop_servicemesh_starting_csv }}"


### PR DESCRIPTION
##### SUMMARY

Updating Service Mesh Workshop to run on OpenShift 4.10. Add missing imagestreams and fix operator installations to avoid k8s API deprecation problems.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_servicemesh_workshop


