### PR TITLE
change urls to upgrade calico on ocp4

### DIFF
--- a/ansible/roles/host-ocp4-installer/create-manifests.yml
+++ b/ansible/roles/host-ocp4-installer/create-manifests.yml
@@ -36,35 +36,35 @@
     dest: "/home/{{ ansible_user }}/{{ cluster_name }}/manifests/"
     mode: 0644
   loop:
-    - https://docs.projectcalico.org/manifests/ocp/crds/01-crd-apiserver.yaml
-    - https://docs.projectcalico.org/manifests/ocp/crds/01-crd-installation.yaml
-    - https://docs.projectcalico.org/manifests/ocp/crds/01-crd-imageset.yaml
-    - https://docs.projectcalico.org/manifests/ocp/crds/01-crd-tigerastatus.yaml
-    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_bgpconfigurations.yaml
-    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_bgppeers.yaml
-    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_blockaffinities.yaml
-    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_caliconodestatuses.yaml
-    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_clusterinformations.yaml
-    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_felixconfigurations.yaml
-    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_globalnetworkpolicies.yaml
-    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_globalnetworksets.yaml
-    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_hostendpoints.yaml
-    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_ipamblocks.yaml
-    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_ipamconfigs.yaml
-    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_ipamhandles.yaml
-    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_ippools.yaml
-    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_ipreservations.yaml
-    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_kubecontrollersconfigurations.yaml
-    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_networkpolicies.yaml
-    - https://docs.projectcalico.org/manifests/ocp/crds/calico/kdd/crd.projectcalico.org_networksets.yaml
-    - https://docs.projectcalico.org/manifests/ocp/tigera-operator/00-namespace-tigera-operator.yaml
-    - https://docs.projectcalico.org/manifests/ocp/tigera-operator/02-rolebinding-tigera-operator.yaml
-    - https://docs.projectcalico.org/manifests/ocp/tigera-operator/02-role-tigera-operator.yaml
-    - https://docs.projectcalico.org/manifests/ocp/tigera-operator/02-serviceaccount-tigera-operator.yaml
-    - https://docs.projectcalico.org/manifests/ocp/tigera-operator/02-configmap-calico-resources.yaml
-    - https://docs.projectcalico.org/manifests/ocp/tigera-operator/02-tigera-operator.yaml
-    - https://docs.projectcalico.org/manifests/ocp/01-cr-installation.yaml
-    - https://docs.projectcalico.org/manifests/ocp/01-cr-apiserver.yaml
+    - https://projectcalico.docs.tigera.io/manifests/ocp/crds/01-crd-apiserver.yaml
+    - https://projectcalico.docs.tigera.io/manifests/ocp/crds/01-crd-installation.yaml
+    - https://projectcalico.docs.tigera.io/manifests/ocp/crds/01-crd-imageset.yaml
+    - https://projectcalico.docs.tigera.io/manifests/ocp/crds/01-crd-tigerastatus.yaml
+    - https://projectcalico.docs.tigera.io/manifests/ocp/crds/calico/crd.projectcalico.org_bgpconfigurations.yaml
+    - https://projectcalico.docs.tigera.io/manifests/ocp/crds/calico/crd.projectcalico.org_bgppeers.yaml
+    - https://projectcalico.docs.tigera.io/manifests/ocp/crds/calico/crd.projectcalico.org_blockaffinities.yaml
+    - https://projectcalico.docs.tigera.io/manifests/ocp/crds/calico/crd.projectcalico.org_caliconodestatuses.yaml
+    - https://projectcalico.docs.tigera.io/manifests/ocp/crds/calico/crd.projectcalico.org_clusterinformations.yaml
+    - https://projectcalico.docs.tigera.io/manifests/ocp/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
+    - https://projectcalico.docs.tigera.io/manifests/ocp/crds/calico/crd.projectcalico.org_globalnetworkpolicies.yaml
+    - https://projectcalico.docs.tigera.io/manifests/ocp/crds/calico/crd.projectcalico.org_globalnetworksets.yaml
+    - https://projectcalico.docs.tigera.io/manifests/ocp/crds/calico/crd.projectcalico.org_hostendpoints.yaml
+    - https://projectcalico.docs.tigera.io/manifests/ocp/crds/calico/crd.projectcalico.org_ipamblocks.yaml
+    - https://projectcalico.docs.tigera.io/manifests/ocp/crds/calico/crd.projectcalico.org_ipamconfigs.yaml
+    - https://projectcalico.docs.tigera.io/manifests/ocp/crds/calico/crd.projectcalico.org_ipamhandles.yaml
+    - https://projectcalico.docs.tigera.io/manifests/ocp/crds/calico/crd.projectcalico.org_ippools.yaml
+    - https://projectcalico.docs.tigera.io/manifests/ocp/crds/calico/crd.projectcalico.org_ipreservations.yaml
+    - https://projectcalico.docs.tigera.io/manifests/ocp/crds/calico/crd.projectcalico.org_kubecontrollersconfigurations.yaml
+    - https://projectcalico.docs.tigera.io/manifests/ocp/crds/calico/crd.projectcalico.org_networkpolicies.yaml
+    - https://projectcalico.docs.tigera.io/manifests/ocp/crds/calico/crd.projectcalico.org_networksets.yaml
+    - https://projectcalico.docs.tigera.io/manifests/ocp/tigera-operator/00-namespace-tigera-operator.yaml
+    - https://projectcalico.docs.tigera.io/manifests/ocp/tigera-operator/02-rolebinding-tigera-operator.yaml
+    - https://projectcalico.docs.tigera.io/manifests/ocp/tigera-operator/02-role-tigera-operator.yaml
+    - https://projectcalico.docs.tigera.io/manifests/ocp/tigera-operator/02-serviceaccount-tigera-operator.yaml
+    - https://projectcalico.docs.tigera.io/manifests/ocp/tigera-operator/02-configmap-calico-resources.yaml
+    - https://projectcalico.docs.tigera.io/manifests/ocp/tigera-operator/02-tigera-operator.yaml
+    - https://projectcalico.docs.tigera.io/manifests/ocp/01-cr-installation.yaml
+    - https://projectcalico.docs.tigera.io/manifests/ocp/01-cr-apiserver.yaml
   retries: 3
   delay: 3
   register: result


### PR DESCRIPTION
rhjcd-patch-change urls to upgrade calico on ocp4

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
