### PR TITLE
add multi pools to azure subscription

### DIFF
--- a/ansible/configs/open-environment-azure-subscription/default_vars.yml
+++ b/ansible/configs/open-environment-azure-subscription/default_vars.yml
@@ -23,6 +23,9 @@ az_function_release: "https://{{az_function_hostname}}/api/release/"
 # Azure Function that only shows an existing pool ID
 az_function_show: "https://{{az_function_hostname}}/api/show/"
 
+# Azure open env pool default
+az_pool_id: "00"
+
 # Azure Tenant
 azure_tenant: example.onmicrosoft.com
 

--- a/ansible/roles/open-env-azure-add-user-to-subscription/tasks/main.yml
+++ b/ansible/roles/open-env-azure-add-user-to-subscription/tasks/main.yml
@@ -15,7 +15,7 @@
 - name: Retrieving an available pool ID and locking it in CosmosDB
   ansible.builtin.uri:
     return_content: yes
-    url: "{{ az_function_get }}{{ project_tag }}?code={{ azure_pool_api_secret }}"
+    url: "{{ az_function_get }}{{ project_tag }}/{{ az_pool_id }}?code={{ azure_pool_api_secret }}"
   register: poolid
 
 - name: Write out the assigned pool ID

--- a/ansible/roles/open-env-azure-remove-user-from-subscription/tasks/main.yml
+++ b/ansible/roles/open-env-azure-remove-user-from-subscription/tasks/main.yml
@@ -3,7 +3,7 @@
   ansible.builtin.uri:
     return_content: yes
     status_code: [200, 404]
-    url: "{{ az_function_show }}{{ project_tag }}?code={{ azure_pool_api_secret }}"
+    url: "{{ az_function_show }}{{ project_tag }}/{{ az_pool_id }}?code={{ azure_pool_api_secret }}"
   register: poolid
 
 - name: Write out the assigned Pool ID
@@ -11,7 +11,9 @@
     msg: "{{ poolid.content }}"
 
 - name: Purge pool assignment
-  when: poolid.content
+  when:
+    - poolid.content
+    - poolid.status == 200
   block:
     - name: Get facts for the subscription by name
       azure.azcollection.azure_rm_subscription_info:
@@ -96,5 +98,5 @@
 
     - name: Remove pool allocation from the database
       ansible.builtin.uri:
-        url: "{{ az_function_release }}{{ project_tag }}?code={{ azure_pool_api_secret }}"
+        url: "{{ az_function_release }}{{ project_tag }}/{{ az_pool_id }}?code={{ azure_pool_api_secret }}"
       ignore_errors: yes


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
add the ability to specify a pool to the pool manager API in azure
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
./open-env-azure-add-user-to-subscription/tasks/main.yml
./open-env-azure-remove-user-from-subscription/tasks/main.yml
./open-env-azure-remove-user-from-subscription/tasks/main.yml


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
