### PR TITLE
Update workload removal tasks for ocp4 cluster to also allow workload…

### DIFF
--- a/ansible/configs/ocp4-cluster/default_vars.yml
+++ b/ansible/configs/ocp4-cluster/default_vars.yml
@@ -153,5 +153,9 @@ infra_workloads: []
 student_workloads: []
 
 # Some workloads create infrastructure that needs to be removed
-# when deleting the software or infrastructure
+# when deleting the software or infrastructure. These workloads run on the controller
 remove_workloads: []
+
+# Some workloads create infrastructure that needs to be removed
+# when deleting the software or infrastructure. These workloads run on the bastion
+remove_workloads_bastion: []

--- a/ansible/configs/ocp4-cluster/destroy_env_ec2.yml
+++ b/ansible/configs/ocp4-cluster/destroy_env_ec2.yml
@@ -64,7 +64,7 @@
   - include_tasks: ec2_instances_start.yaml
 
 # Call Remove Workloads for workloads that need to clean up "other" infrastructure.
-# Those removal playbooks need to be able to be run on the provisioning host (aka not a Bastion)
+# Workloads that need to be able to be run on the provisioning host (aka not a Bastion)
 - name: Remove workloads
   hosts: localhost
   connection: local
@@ -82,7 +82,35 @@
       vars:
         ocp_username: "system:admin"
         ACTION: "remove"
+        silent: false
       loop: "{{ remove_workloads }}"
+      loop_control:
+        loop_var: workload_loop_var
+
+# Call Remove Workloads for workloads that need to clean up "other" infrastructure.
+# Workloads that need to be run on the bastion
+- name: Remove workloads
+  hosts: bastions
+  gather_facts: false
+  run_once: true
+  become: false
+  tasks:
+  - name: Set Ansible Python interpreter to k8s virtualenv
+    set_fact:
+      ansible_python_interpreter: /opt/virtualenvs/k8s/bin/python
+
+  - name: Remove ocp workloads on bastion
+    when:
+    - remove_workloads_bastion | default("") | length > 0
+    block:
+    - name: Invoke roles to remove ocp workloads
+      include_role:
+        name: "{{ workload_loop_var }}"
+      vars:
+        ocp_username: "system:admin"
+        ACTION: "remove"
+        silent: false
+      loop: "{{ remove_workloads_bastion }}"
       loop_control:
         loop_var: workload_loop_var
 


### PR DESCRIPTION
…s to be run on bastion

##### SUMMARY

Existing `remove_workloads` logic runs on localhost (provisioner). Needed to add a way to specify removal workloads to be run on the bastion. Added `remove_workloads_bastion` variable.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4-cluster