### PR TITLE
Add VM name to output of workload

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_ama_rhev_vm/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ama_rhev_vm/tasks/workload.yml
@@ -199,6 +199,7 @@
   loop:
   - ""
   - "Customer Service (Tomcat VM)"
+  - "  VM Name:     {{ ocp4_workload_ama_rhev_vm_tomcat_vm_name }}"
   - "  IP Address:  {{ _ocp4_workload_ama_rhev_vm_tomcat_ip }}"
   - "  User:        {{ ocp4_workload_ama_rhev_vm_rhev_user_name }}"
   - "  Password:    {{ ocp4_workload_ama_rhev_vm_rhev_user_password }}"
@@ -210,6 +211,7 @@
   loop:
   - ""
   - "Oracle Database VM (on RHEV):"
+  - "  VM Name:     {{ ocp4_workload_ama_rhev_vm_oracle_vm_name }}"
   - "  IP Address:  {{ _ocp4_workload_ama_rhev_vm_oracle_ip }}"
   - "  User ID:     {{ ocp4_workload_ama_rhev_vm_vm_user_name }}"
   - "  VM Password: {{ ocp4_workload_ama_rhev_vm_vm_user_password }}"


### PR DESCRIPTION
##### SUMMARY

Demo instructions need the name of the VM in RHEV. Adding to the agnosticd_info output.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_ama_rhev_vm