### PR TITLE
Fixed domain variable for bastion VM, generate VSCode password when n…

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_vscode_bastion/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_vscode_bastion/defaults/main.yaml
@@ -10,7 +10,10 @@ ocp4_workload_vscode_bastion_vscode_package_url: >-
   }}/code-server-{{ ocp4_workload_vscode_bastion_vscode_package_version }}-amd64.rpm
 
 # Password for the VSCode Server
-ocp4_workload_vscode_bastion_vscode_password: openshift
+# Set via config or secret
+# If not specified it is being generated with ocp4_workload_vscode_bastion_vscode_password_length characters
+ocp4_workload_vscode_bastion_vscode_password: ""
+ocp4_workload_vscode_bastion_vscode_password_length: 16
 
 # Use pre-installed certbot (by Let's Encrypt workload) to create a certificate for code server
 ocp4_workload_vscode_bastion_vscode_certbot_virtualenv: /home/ec2-user/virtualenvs/certbot

--- a/ansible/roles_ocp_workloads/ocp4_workload_vscode_bastion/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_vscode_bastion/tasks/workload.yml
@@ -1,4 +1,10 @@
 ---
+- name: Generate VSCode server password if no password specified
+  when: ocp4_workload_vscode_bastion_vscode_password | default('') | length == 0
+  ansible.builtin.set_fact:
+    ocp4_workload_vscode_bastion_vscode_password: >-
+      {{ lookup('password', '/dev/null length={{ ocp4_workload_vscode_bastion_vscode_password_length }} chars=ascii_letters,digits') }}
+
 - name: Validate that certbot virtualenv directory exists
   ansible.builtin.stat:
     path: "{{ ocp4_workload_vscode_bastion_vscode_certbot_virtualenv }}/bin/activate"

--- a/ansible/roles_ocp_workloads/ocp4_workload_vscode_bastion/templates/run_vscode_certbot.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_vscode_bastion/templates/run_vscode_certbot.j2
@@ -3,7 +3,7 @@ source {{ ocp4_workload_vscode_bastion_vscode_certbot_virtualenv }}/bin/activate
 
 certbot certonly -n --agree-tos --standalone \
     --email {{ ocp4_workload_vscode_bastion_vscode_cert_email }} \
-    -d bastion.{{ guid }}.{{ subdomain_base }} \
+    -d bastion.{{ guid }}{{ subdomain_base_suffix }} \
     --config-dir={{ ocp4_workload_vscode_bastion_vscode_cert_directory }}/config \
     --work-dir={{ ocp4_workload_vscode_bastion_vscode_cert_directory }}/work \
     --logs-dir={{ ocp4_workload_vscode_bastion_vscode_cert_directory }}/logs


### PR DESCRIPTION
…ot specified

##### SUMMARY

Bugfix. Used the wrong base domain variable.
Feature: generate VSCode password if no password specified.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_vscode_bastion