### PR TITLE
Feature: dynamically define galaxy requirements

### DIFF
--- a/ansible/install_galaxy_roles.yml
+++ b/ansible/install_galaxy_roles.yml
@@ -11,21 +11,45 @@
     ## Needs to be validated
     ## var is called from main.yml
     requirements_path: "configs/{{ env_type }}/requirements.yml"
+    requirements_content: {}
   tasks:
+    - name: requirements_content is provided
+      when: requirements_content | length > 0
+      block:
+        - name: Use requirements_content
+          set_fact:
+            requirements_path_final: "{{ output_dir }}/custom_requirements.yml"
+
+        - name: Copy requirements content to output_dir
+          copy:
+            dest: "{{ requirements_path_final }}"
+            content: "{{ requirements_content | to_yaml }}"
+
+    - when: requirements_content | length == 0
+      name: Use requirements_path from the config
+      set_fact:
+        requirements_path_final: "{{ requirements_path }}"
+
     - name: Check if requirements.yml exists
       stat:
-        path: "{{ requirements_path }}"
+        path: "{{ requirements_path_final }}"
       register: r_requirements_stat
 
     - set_fact:
-        r_requirements_content: "{{ lookup('file', requirements_path) | from_yaml }}"
+        r_requirements_content: "{{ lookup('file', requirements_path_final) | from_yaml }}"
       when: r_requirements_stat.stat.exists
 
     - name: Install roles from requirements.yml
       command: >-
         ansible-galaxy install
-        -r "{{ requirements_path }}"
-        -p "{{ ANSIBLE_REPO_PATH | default('.') }}/configs/{{ env_type }}/roles"
+        -r "{{ requirements_path_final }}"
+        -p "{%- if requirements_content | length > 0 -%}
+        {{ playbook_dir }}/dynamic-roles
+        {%- else -%}
+        {{ ANSIBLE_REPO_PATH
+        | default(playbook_dir)
+        | default('.') }}/configs/{{ env_type }}/roles
+        {%- endif -%}"
       when: >-
         r_requirements_stat.stat.exists
         and r_requirements_content | length > 0
@@ -44,7 +68,7 @@
         __collections_path: "{{ lookup('config', 'COLLECTIONS_PATHS')[0] }}"
       command: >-
         ansible-galaxy collection install
-        -r "{{ requirements_path }}"
+        -r "{{ requirements_path_final }}"
         -p "{{ __collections_path | quote }}"
         --force-with-deps
       when: >-


### PR DESCRIPTION
Sometimes, a catalog item needs additional ansible collection, depending
on the workloads it installs.

This change, if applied, adds the ability to define the entire content
of requirements.yml file that is usually in the config directory.

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Code is taken from https://github.com/redhat-cop/agnosticd/pull/3054

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
agnosticd core
