### PR TITLE
Fix lpe amq streams default vars

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_lpe_amq_streams/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_lpe_amq_streams/tasks/remove_workload.yml
@@ -16,16 +16,16 @@
     install_operator_action: remove
     install_operator_name: amq-streams
     install_operator_namespace: "{{ ocp4_workload_lpe_amq_streams_namespace }}"
-    install_operator_channel: "{{ ocp4_workload_amq_streams_channel }}"
+    install_operator_channel: "{{ ocp4_workload_lpe_amq_streams_channel }}"
     install_operator_manage_namespaces: ["{{ ocp4_workload_lpe_amq_streams_namespace }}"]
     install_operator_catalog: redhat-operators
-    install_operator_automatic_install_plan_approval: "{{ ocp4_workload_amq_streams_automatic_install_plan_approval | default(true) }}"
-    install_operator_starting_csv: "{{ ocp4_workload_amq_streams_starting_csv }}"
-    install_operator_catalogsource_setup: "{{ ocp4_workload_amq_streams_use_catalog_snapshot | default(false)}}"
-    install_operator_catalogsource_name: "{{ ocp4_workload_amq_streams_catalogsource_name | default('') }}"
+    install_operator_automatic_install_plan_approval: "{{ ocp4_workload_lpe_amq_streams_automatic_install_plan_approval | default(true) }}"
+    install_operator_starting_csv: "{{ ocp4_workload_lpe_amq_streams_starting_csv }}"
+    install_operator_catalogsource_setup: "{{ ocp4_workload_lpe_amq_streams_use_catalog_snapshot | default(false)}}"
+    install_operator_catalogsource_name: "{{ ocp4_workload_lpe_amq_streams_catalogsource_name | default('') }}"
     install_operator_catalogsource_namespace: openshift-operators
-    install_operator_catalogsource_image: "{{ ocp4_workload_amq_streams_catalog_snapshot_image | default('') }}"
-    install_operator_catalogsource_image_tag: "{{ ocp4_workload_amq_streams_catalog_snapshot_image_tag | default('') }}"
+    install_operator_catalogsource_image: "{{ ocp4_workload_lpe_amq_streams_catalog_snapshot_image | default('') }}"
+    install_operator_catalogsource_image_tag: "{{ ocp4_workload_lpe_amq_streams_catalog_snapshot_image_tag | default('') }}"
 
 - name: Remove project created for this workload
   kubernetes.core.k8s:


### PR DESCRIPTION
##### SUMMARY
The removal of lpe_amq_streams was not working due to the wrong vars assignment.
This PR assigns the correct vars to the remove_workload.yml ansible tasks.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_lpe_amq_streams
