### PR TITLE
Add collections_paths to root ansible.cfg as well (ansible/ansible.cf…

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,6 +2,7 @@
 nocows                  = 1
 # Don't forget to update other ansible.cfg files like:  ansible/configs/linklight/ansible.cfg
 roles_path              = dynamic-roles:ansible/dynamic-roles:roles-infra:ansible/roles-infra:roles:ansible/roles:ansible/roles_studentvm:roles_studentvm:ansible/roles_ocp_workloads:roles_ocp_workloads
+collections_paths       = /tmp/ansible-collections
 
 forks                   = 50
 become                  = False


### PR DESCRIPTION
…g already had it correct)

##### SUMMARY

In order for dynamic installation of collections to work the root ansible.cfg needs to match the one in ansible/ansible.cfg. Both need a collections_path=/tmp/ansible-collections.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
AgnosticD Core