### PR TITLE
Change ~{{ ansible_user }} to {{ ocp4_workload_vscode_bastion_home_di…

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_vscode_bastion/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_vscode_bastion/defaults/main.yaml
@@ -3,6 +3,9 @@ become_override: false
 ocp_username: opentlc-mgr
 silent: false
 
+# Home directory to install the configuration to
+ocp4_workload_vscode_bastion_home_directory: "/home/ec2-user"
+
 # Package version and download location for the vscode RPM
 ocp4_workload_vscode_bastion_vscode_package_version: "4.4.0"
 ocp4_workload_vscode_bastion_vscode_package_url: >-

--- a/ansible/roles_ocp_workloads/ocp4_workload_vscode_bastion/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_vscode_bastion/tasks/workload.yml
@@ -27,7 +27,7 @@
   get_url:
     url: >-
       {{ ocp4_workload_vscode_bastion_vscode_package_url }}
-    dest: "~{{ ansible_user }}/code-server.rpm"
+    dest: "{{ ocp4_workload_vscode_bastion_home_directory }}/code-server.rpm"
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
     mode: 0664
@@ -40,16 +40,16 @@
     group: "{{ ansible_user }}"
     mode: 0770
   loop:
-  - "~{{ ansible_user }}/.config"
-  - "~{{ ansible_user }}/.config/code-server"
-  - "~{{ ansible_user }}/.local"
-  - "~{{ ansible_user }}/.local/share"
-  - "~{{ ansible_user }}/.local/share/code-server"
+  - "{{ ocp4_workload_vscode_bastion_home_directory }}/.config"
+  - "{{ ocp4_workload_vscode_bastion_home_directory }}/.config/code-server"
+  - "{{ ocp4_workload_vscode_bastion_home_directory }}/.local"
+  - "{{ ocp4_workload_vscode_bastion_home_directory }}/.local/share"
+  - "{{ ocp4_workload_vscode_bastion_home_directory }}/.local/share/code-server"
 
 - name: Copy VSCode configuration file
   ansible.builtin.template:
     src: code-server-config.yaml.j2
-    dest: "~{{ ansible_user }}/.config/code-server/config.yaml"
+    dest: "{{ ocp4_workload_vscode_bastion_home_directory }}/.config/code-server/config.yaml"
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
     mode: 0664
@@ -57,7 +57,7 @@
 - name: Copy VSCode coder file
   ansible.builtin.template:
     src: code-server-coder.json.j2
-    dest: "~{{ ansible_user }}/.local/share/code-server/coder.json"
+    dest: "{{ ocp4_workload_vscode_bastion_home_directory }}/.local/share/code-server/coder.json"
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
     mode: 0664
@@ -86,7 +86,7 @@
 
   - name: Install VSCode server RPM
     ansible.builtin.command:
-      cmd: "dnf -y install ~{{ ansible_user }}/code-server.rpm"
+      cmd: "dnf -y install {{ ocp4_workload_vscode_bastion_home_directory }}/code-server.rpm"
 
   - name: "Enable and start code-server@{{ ansible_user }} system service"
     ansible.builtin.service:
@@ -98,7 +98,7 @@
 - name: Remove rpm file
   ansible.builtin.file:
     state: absent
-    path: "~{{ ansible_user }}/code-server.rpm"
+    path: "{{ ocp4_workload_vscode_bastion_home_directory }}/code-server.rpm"
 
 - name: Print User Info
   agnosticd_user_info:


### PR DESCRIPTION
…rectory }}

##### SUMMARY

Circumvent bug where `~{{ ansible_user }}` evaluates to `/root`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_vscode_bastion