### PR TITLE
Install helm on bastion in ocp4-cluster

### DIFF
--- a/ansible/roles/bastion-lite/tasks/main.yml
+++ b/ansible/roles/bastion-lite/tasks/main.yml
@@ -54,6 +54,16 @@
         name: selinux
         version: 0.2.1
 
+- name: Install OpenShift Helm 3
+  when: install_helm | default(False) | bool
+  get_url:
+    url: "{{ bastion_lite_installer_root_url }}/openshift-v4/clients/helm/{{ bastion_lite_helm_version }}/helm-linux-amd64"
+    dest: /usr/local/bin/helm
+    owner: root
+    group: root
+    mode: 0775
+  ignore_errors: true
+
 - name: Install jq on the bastion
   get_url:
     url: https://gpte-public.s3.amazonaws.com/jq-linux64
@@ -62,20 +72,26 @@
     owner: root
     group: root
 
-- name: Add GUID to /etc/skel/.bashrc and ~{{ ansible_user }}/.bashrc
+- name: Add GUID to /etc/skel/.bashrc
   lineinfile:
-    path: "{{ item }}"
+    path: /etc/skel/.bashrc
     regexp: "^export GUID"
     line: "export GUID={{ guid }}"
-  loop:
-    - "/etc/skel/.bashrc"
-    - "~{{ ansible_user }}/.bashrc"
 
-- name: Add CLOUDUSER to /etc/skel/.bashrc and ~{{ ansible_user }}/.bashrc
+- name: Add GUID to ~{{ ansible_user }}/.bashrc
   lineinfile:
-    path: "{{ item }}"
+    path: "~{{ ansible_user }}/.bashrc"
+    regexp: "^export GUID"
+    line: "export GUID={{ guid }}"
+
+- name: Add CLOUDUSER to /etc/skel/.bashrc
+  lineinfile:
+    path: /etc/skel/.bashrc
     regexp: "^export CLOUDUSER"
     line: "export CLOUDUSER={{ ansible_user }}"
-  loop:
-    - "/etc/skel/.bashrc"
-    - "~{{ ansible_user }}/.bashrc"
+
+- name: Add CLOUDUSER to ~{{ ansible_user }}/.bashrc
+  lineinfile:
+    path: "~{{ ansible_user }}/.bashrc"
+    regexp: "^export CLOUDUSER"
+    line: "export CLOUDUSER={{ ansible_user }}"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

The change adds a step for Helm installation on bastion host on ocp4-cluster. Helm is required to set up few things on target cluster.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4-cluster

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below
TASK [bastion-lite : Install OpenShift Helm 3] *********************************
Thursday 19 May 2022  09:43:32 +0000 (0:00:00.038)       0:05:34.276 ********** 
changed: [bastion.kerbin-rain-1.internal]

```
