### PR TITLE
Add helm binary on bastion lite

### DIFF
--- a/ansible/roles/bastion-lite/tasks/main.yml
+++ b/ansible/roles/bastion-lite/tasks/main.yml
@@ -1,4 +1,16 @@
 ---
+- name: copy the user's SSH private key
+  become: true
+  copy:
+    src: "~/.ssh/{{key_name}}.pem"
+    dest: "/root/.ssh/{{key_name}}.pem"
+    owner: root
+    group: root
+    mode: 0400
+  when: not use_own_key|bool
+  tags:
+    - copy_env_private_key
+
 - name: Generate host .ssh/config Template
   become: false
   template:

--- a/ansible/roles/bastion-lite/tasks/main.yml
+++ b/ansible/roles/bastion-lite/tasks/main.yml
@@ -1,16 +1,4 @@
 ---
-- name: copy the user's SSH private key
-  become: true
-  copy:
-    src: "~/.ssh/{{key_name}}.pem"
-    dest: "/root/.ssh/{{key_name}}.pem"
-    owner: root
-    group: root
-    mode: 0400
-  when: not use_own_key|bool
-  tags:
-    - copy_env_private_key
-
 - name: Generate host .ssh/config Template
   become: false
   template:
@@ -61,6 +49,16 @@
     mode: 0775
     owner: root
     group: root
+
+- name: Install OpenShift Helm 3
+  when: install_helm | default(False) | bool
+  get_url:
+    url: "{{ bastion_lite_inst_root_url }}/openshift-v4/clients/helm/{{ bastion_lite_helm_version }}/helm-linux-amd64"
+    dest: /usr/bin/helm
+    owner: root
+    group: root
+    mode: 0775
+  ignore_errors: true
 
 - name: Add GUID to /etc/skel/.bashrc
   lineinfile:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
The change adds a step for Helm installation on bastion host on ocp4-cluster. Helm is required to set up few things on target cluster. Also replaces https://github.com/redhat-cop/agnosticd/pull/4749

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
bastion-lite role

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below
TASK [bastion-lite : Install OpenShift Helm 3] *********************************
Thursday 19 May 2022  09:43:32 +0000 (0:00:00.038)       0:05:34.276 ********** 
changed: [bastion.kerbin-rain-1.internal]
```
