### PR TITLE
Made requesting certificates optional for VSCode

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_vscode_bastion/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_vscode_bastion/defaults/main.yaml
@@ -28,3 +28,5 @@ ocp4_workload_vscode_bastion_vscode_repo_directories:
 
 ocp4_workload_vscode_bastion_workspace_name: Workspace
 ocp4_workload_vscode_bastion_workspace: "/home/ec2-user/.local/share/code-server/User/Workspaces/bigdemo.code-workspace"
+
+ocp4_workload_vscode_bastion_ec2_certificates: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_vscode_bastion/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_vscode_bastion/tasks/workload.yml
@@ -5,23 +5,59 @@
     ocp4_workload_vscode_bastion_vscode_password: >-
       {{ lookup('password', '/dev/null length={{ ocp4_workload_vscode_bastion_vscode_password_length }} chars=ascii_letters,digits') }}
 
-- name: Validate that certbot virtualenv directory exists
-  ansible.builtin.stat:
-    path: "{{ ocp4_workload_vscode_bastion_vscode_certbot_virtualenv }}/bin/activate"
-  register: r_certbot_virtualenv
+- name: Set http URL for VSCode server
+  when: ocp4_workload_vscode_bastion_ec2_certificates | bool
+  set_fact:
+    _ocp4_workload_vscode_bastion_url: http://bastion.{{ guid }}{{ subdomain_base_suffix }}:8080"
 
-- name: Fail if certbot virtualenv directoroy does not exist
-  when: not r_certbot_virtualenv.stat.exists
-  ansible.builtin.fail:
-    msg: "Virtualenv for Certbot does not exist in {{ ocp4_workload_vscode_bastion_vscode_certbot_virtualenv }}"
+- name: Request Let's Encrypt certificates for EC2
+  when: ocp4_workload_vscode_bastion_ec2_certificates | bool
+  block:
+  - name: Override variable with https URL for VSCode server
+    when: ocp4_workload_vscode_bastion_ec2_certificates | bool
+    set_fact:
+      _ocp4_workload_vscode_bastion_url: https://bastion.{{ guid }}{{ subdomain_base_suffix }}:8443"
 
-- name: Ensure the VS Code certs directory exists
-  ansible.builtin.file:
-    state: directory
-    owner: "{{ ansible_user }}"
-    group: "{{ ansible_user }}"
-    path: "{{ ocp4_workload_vscode_bastion_vscode_cert_directory }}"
-    mode: 0770
+  - name: Validate that certbot virtualenv directory exists
+    ansible.builtin.stat:
+      path: "{{ ocp4_workload_vscode_bastion_vscode_certbot_virtualenv }}/bin/activate"
+    register: r_certbot_virtualenv
+
+  - name: Fail if certbot virtualenv directoroy does not exist
+    when: not r_certbot_virtualenv.stat.exists
+    ansible.builtin.fail:
+      msg: "Virtualenv for Certbot does not exist in {{ ocp4_workload_vscode_bastion_vscode_certbot_virtualenv }}"
+
+  - name: Ensure the VS Code certs directory exists
+    ansible.builtin.file:
+      state: directory
+      owner: "{{ ansible_user }}"
+      group: "{{ ansible_user }}"
+      path: "{{ ocp4_workload_vscode_bastion_vscode_cert_directory }}"
+      mode: 0770
+
+- name: Run Let's Encrypt configuration actions as root
+  when: ocp4_workload_vscode_bastion_ec2_certificates | bool
+  become: true
+  block:
+  - name: Copy run_vscode_certbot shell script
+    ansible.builtin.template:
+      src: run_vscode_certbot.j2
+      dest: /usr/bin/run_vscode_certbot
+      owner: root
+      group: root
+      mode: 0775
+
+  - name: Run certbot to get a certificate
+    ansible.builtin.command: /usr/bin/run_vscode_certbot
+
+  - name: Change Ownership of generated certs to {{ ansible_user }}
+    file:
+      state: directory
+      recurse: true
+      path: "{{ ocp4_workload_vscode_bastion_vscode_cert_directory }}"
+      owner: "{{ ansible_user }}"
+      group: "{{ ansible_user }}"
 
 - name: Download VScode server RPM
   get_url:
@@ -138,25 +174,6 @@
 - name: Run code-server configuration actions as root
   become: true
   block:
-  - name: Copy run_vscode_certbot shell script
-    ansible.builtin.template:
-      src: run_vscode_certbot.j2
-      dest: /usr/bin/run_vscode_certbot
-      owner: root
-      group: root
-      mode: 0775
-
-  - name: Run certbot to get a certificate
-    ansible.builtin.command: /usr/bin/run_vscode_certbot
-
-  - name: Change Ownership of generated certs to {{ ansible_user }}
-    file:
-      state: directory
-      recurse: true
-      path: "{{ ocp4_workload_vscode_bastion_vscode_cert_directory }}"
-      owner: "{{ ansible_user }}"
-      group: "{{ ansible_user }}"
-
   - name: Install VSCode server RPM
     ansible.builtin.command:
       cmd: "dnf -y install {{ ocp4_workload_vscode_bastion_home_directory }}/code-server.rpm"
@@ -179,6 +196,6 @@
   loop:
   - ""
   - "Visual Studio Code Server is available on the Bastion VM."
-  - "  URL:      https://bastion.{{ guid }}{{ subdomain_base_suffix }}:8443"
+  - "  URL:      {{ _ocp4_workload_vscode_bastion_url }}"
   - "  Password: {{ ocp4_workload_vscode_bastion_vscode_password }}"
   - ""

--- a/ansible/roles_ocp_workloads/ocp4_workload_vscode_bastion/templates/code-server-config.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_vscode_bastion/templates/code-server-config.yaml.j2
@@ -1,5 +1,9 @@
+  {% if ocp4_workload_vscode_bastion_ec2_certificates | bool %}
   bind-addr: 0.0.0.0:8443
-  auth: password
-  password: {{ ocp4_workload_vscode_bastion_vscode_password }}
   cert: {{ ocp4_workload_vscode_bastion_vscode_cert_directory }}/config/live/bastion.{{ guid }}{{ subdomain_base_suffix }}/fullchain.pem
   cert-key: {{ ocp4_workload_vscode_bastion_vscode_cert_directory}}/config/live/bastion.{{ guid }}{{ subdomain_base_suffix }}/privkey.pem
+  {% else %}
+  bind-addr: 0.0.0.0:8080
+  {% endif %}
+  auth: password
+  password: {{ ocp4_workload_vscode_bastion_vscode_password }}


### PR DESCRIPTION
##### SUMMARY

Let's Encrypt certificates are only implemented for AWS (Route53). Add variable to make requesting certificates optional (e.g. for OSP deployments).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_vscode_bastion