### PR TITLE
fix goofy issue with dns zone name

### DIFF
--- a/ansible/roles/open-env-gcp-add-user-to-project/tasks/main.yml
+++ b/ansible/roles/open-env-gcp-add-user-to-project/tasks/main.yml
@@ -153,7 +153,7 @@
     auth_kind: serviceaccount
     service_account_contents: "{{ gcp_credentials }}"
     project: "{{ new_project.projectId }}"
-    name: '{{ guid + "-dns-zone" }}'
+    name: '{{ "dns-zone-" + guid }}'
     dns_name: '{{ guid + "." + gcp_root_dns_zone + "."}}'
     description: "OPEN Env {{ guid }} DNS Zone"
     state: present


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
fix issue where dns zone names are very touchy in GCP
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
open-env-gcp

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
