### PR TITLE
trust default workspace

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_vscode_bastion/files/user_settings.json
+++ b/ansible/roles_ocp_workloads/ocp4_workload_vscode_bastion/files/user_settings.json
@@ -5,5 +5,7 @@
   "workbench.enableExperiments": false,
   "update.mode": "none",
   "update.showReleaseNotes": false,
-  "telemetry.telemetryLevel": "off"
+  "telemetry.telemetryLevel": "off",
+  "security.workspace.trust.enabled": false,
+  "security.workspace.trust.untrustedFiles": "open"  
 }


### PR DESCRIPTION
##### SUMMARY
Disable trust prompt for workspaces in VSCode.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_vscode_bastion