### PR TITLE
Force AWS CLI version to 1.18.200

### DIFF
--- a/ansible/roles/host-ocp4-provisioner/defaults/main.yml
+++ b/ansible/roles/host-ocp4-provisioner/defaults/main.yml
@@ -3,7 +3,7 @@
 # In order to override a specific version, set the following variable:
 #
 # AWS has just deprecated python 3.6 in the 1.25.0 release of v1
-# This has caused severe issues - OCP instructors should learn 
+# This has caused severe issues - OCP instructors should learn
 # to factor out and isolate dependencies!
 #
 # See: https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/

--- a/ansible/roles/host-ocp4-provisioner/defaults/main.yml
+++ b/ansible/roles/host-ocp4-provisioner/defaults/main.yml
@@ -1,5 +1,12 @@
 ---
 # By default, the latest version of the "aws-bundle.zip" is downloaded.
 # In order to override a specific version, set the following variable:
-#aws_cli_bundle_filename: "awscli-bundle-1.18.200.zip"
-aws_cli_bundle_filename: "awscli-bundle.zip"
+#
+# AWS has just deprecated python 3.6 in the 1.25.0 release of v1
+# This has caused severe issues - OCP instructors should learn 
+# to factor out and isolate dependencies!
+#
+# See: https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/
+#
+#aws_cli_bundle_filename: "awscli-bundle.zip"
+aws_cli_bundle_filename: "awscli-bundle-1.18.200.zip"


### PR DESCRIPTION
##### SUMMARY
As of today, AWS has deprecated python 3.6 in awscli-latest.tar by
moving to 1.25.0 which removes 3.6 support.

As a quick fix, we are forcing all OCP deploys to use a python 3.6
supported version of awscli until a longer term fix can be implemented.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-installer

##### ADDITIONAL INFORMATION
(https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/)

Deploys are now failing with 

```
fatal: [bastion.internal]: FAILED! => {"changed": true, "cmd": ["/tmp/awscli-bundle/install", "-i", "/usr/local/aws", "-b", "/bin/aws"], "delta": "0:00:00.054218", "end": "2022-05-31 22:38:55.021126", "msg": "non-zero return code", "rc": 1, "start": "2022-05-31 22:38:54.966908", "stderr": "Unsupported Python version detected: Python 3.6\nTo continue using this installer you must use Python 3.7 or later.\nFor more information see the following blog post: https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-python-2-7-in-aws-sdk-for-python-and-aws-cli-v1/", "stderr_lines": ["Unsupported Python version detected: Python 3.6", "To continue using this installer you must use Python 3.7 or later.", "For more information see the following blog post: https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-python-2-7-in-aws-sdk-for-python-and-aws-cli-v1/"], "stdout": "", "stdout_lines": []}
```