### PR TITLE
Revert for ROSA to explicit awscli-bundle-1.18.200.zip - python 3.6 fix

### DIFF
--- a/ansible/roles/host-ocp4-provisioner/defaults/main.yml
+++ b/ansible/roles/host-ocp4-provisioner/defaults/main.yml
@@ -1,5 +1,11 @@
----
 # By default, the latest version of the "aws-bundle.zip" is downloaded.
 # In order to override a specific version, set the following variable:
-#aws_cli_bundle_filename: "awscli-bundle-1.18.200.zip"
-aws_cli_bundle_filename: "awscli-bundle.zip"
+#
+# AWS has just deprecated python 3.6 in the 1.25.0 release of v1
+# This has caused severe issues - OCP instructors should learn
+# to factor out and isolate dependencies!
+#
+# See: https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/
+#
+#aws_cli_bundle_filename: "awscli-bundle.zip"
+aws_cli_bundle_filename: "awscli-bundle-1.18.200.zip"


### PR DESCRIPTION

##### SUMMARY

Fix rosa config to use explicit version aws-cli for python 3.6 support

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
rosa

##### ADDITIONAL INFORMATION
