### PR TITLE
Add support to MTA Tackle workload to seed the Tackle instance using …

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle/defaults/main.yml
@@ -9,6 +9,18 @@ ocp4_workload_mta_tackle_namespace: tackle
 # Print information how to access tackle
 ocp4_workload_mta_tackle_print_access_information: false
 
+# Seed Tackle with information
+ocp4_workload_mta_tackle_seed: false
+
+# URL from which to download the seed script
+# When empty the default script from the templates
+# directory of this workload is used
+ocp4_workload_mta_tackle_seed_script_url: ""
+
+# These are hardcoded and can't be changed at the moment
+ocp4_workload_mta_tackle_user: tackle
+ocp4_workload_mta_tackle_password: password
+
 # Default values below are for Tackle Operator v1.2.0
 
 # Channel to use for the Tackle subscription

--- a/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle/tasks/remove_workload.yml
@@ -2,7 +2,17 @@
 - name: Delete Tackle
   kubernetes.core.k8s:
     state: absent
-    definition: "{{ lookup('file', 'tackle.yaml') }}"
+    definition: "{{ lookup('template', 'tackle.yaml.j2') }}"
+
+- name: Wait until Tackle instance is gone
+  kubernetes.core.k8s_info:
+    api_version: tackle.io/v1alpha1
+    kind: Tackle
+    name: tackle
+    namespace: "{{ ocp4_workload_mta_tackle_namespace }}"
+  register: r_tackle
+  until: r_tackle.resources | length == 0
+  retries: 10
 
 - name: Remove Tackle Operator
   include_role:

--- a/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle/tasks/workload.yml
@@ -43,21 +43,63 @@
   - r_tackle.resources[0].status.conditions | length > 0
   - r_tackle.resources[0].status.conditions[0].status is match( "True" )
 
+- name: Get Tackle route
+  kubernetes.core.k8s_info:
+    api_version: route.openshift.io/v1
+    kind: Route
+    name: tackle
+    namespace: "{{ ocp4_workload_mta_tackle_namespace }}"
+  register: r_tackle_route
+
+- name: Set Tackle host variable
+  set_fact:
+    _ocp4_workload_mta_tackle_host: "{{ r_tackle_route.resources[0].spec.host }}"
+
+- name: Seed Tackle
+  when: ocp4_workload_mta_tackle_seed | bool
+  block:
+  - name: Copy default seed shell script
+    when: ocp4_workload_mta_tackle_seed_script_url | length == 0
+    become: true
+    template:
+      src: seed-tackle.sh.j2
+      dest: /usr/bin/seed-tackle.sh
+      owner: root
+      group: root
+      mode: 0775
+
+  - name: Download seed script from URL
+    when: ocp4_workload_mta_tackle_seed_script_url | length > 0
+    block:
+    - name: Download seed script template
+      delegate_to: localhost
+      get_url:
+        url: "{{ ocp4_workload_mta_tackle_seed_script_url }}"
+        dest: /tmp/seed-tackle.sh.j2
+        mode: 0664
+
+    - name: Install seed script
+      become: true
+      template:
+        src: /tmp/seed-tackle.sh.j2
+        dest: /usr/bin/seed-tackle.sh
+        owner: root
+        group: root
+        mode: 0775
+
+    - name: Remove downloaded template script
+      delegate_to: localhost
+      file:
+        state: absent
+        path: /tmp/seed-tackle.sh/j2
+
+  - name: Execute seed shell script
+    shell:
+      cmd: /usr/bin/seed-tackle.sh
+
 - name: Print access information
   when: ocp4_workload_mta_tackle_print_access_information | bool
   block:
-  - name: Get Tackle route
-    kubernetes.core.k8s_info:
-      api_version: route.openshift.io/v1
-      kind: Route
-      name: tackle
-      namespace: "{{ ocp4_workload_mta_tackle_namespace }}"
-    register: r_tackle_route
-
-  - name: Set Tackle host variable
-    set_fact:
-      _ocp4_workload_mta_tackle_host: "{{ r_tackle_route.resources[0].spec.host }}"
-
   - name: Print access information
     agnosticd_user_info:
       msg: "{{ item }}"
@@ -65,8 +107,8 @@
     - ""
     - "Konveyor Tackle (Migration Toolkit for Applications Upstream):"
     - "  URL:      https://{{ _ocp4_workload_mta_tackle_host }}"
-    - "  User:     tackle"
-    - "  Password: password"
+    - "  User:     {{ ocp4_workload_mta_tackle_user }}"
+    - "  Password: {{ ocp4_workload_mta_tackle_password }}"
 
 # Leave this as the last task in the playbook.
 - name: workload tasks complete

--- a/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle/templates/seed-tackle.sh.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle/templates/seed-tackle.sh.j2
@@ -1,0 +1,248 @@
+# Set the BASE URL of TACKLE
+TACKLE_URL=https://{{ _ocp4_workload_mta_tackle_host }}
+REALM_NAME="tackle"
+USERNAME="{{ ocp4_workload_mta_tackle_user }}"
+PASSWORD="{{ ocp4_workload_mta_tackle_password }}"
+SECRET="secret"
+
+access_token=$(
+  curl -s -X POST "$TACKLE_URL/auth/realms/${REALM_NAME}/protocol/openid-connect/token" \
+    --user "backend-service:${SECRET}" \
+    -H 'content-type: application/x-www-form-urlencoded' \
+    -d "username=${USERNAME}&password=${PASSWORD}&grant_type=password" | jq --raw-output '.access_token'
+)
+
+function getOrCreateEntity() {
+  endpoint=$1
+  fieldKey=$2
+  json=$3
+
+  # Extract "fieldValue" from JSON
+  fieldValue=$(echo $json | jq -r --arg key "$fieldKey" '.[$key]')
+
+  # Search by "fieldKey"
+  search_response=$(
+    curl -s -X GET -G "$TACKLE_URL/$endpoint?page=0&size=10" \
+      --data-urlencode "$fieldKey=$fieldValue" \
+      -H 'Accept: application/json' \
+      -H 'Content-Type: application/json;charset=UTF-8' \
+      -H 'Authorization: Bearer '$access_token
+  )
+
+  # Extract an element, from array response, that has "fieldKey" equals to "fieldValue"
+  result=$(echo $search_response | jq --arg key "$fieldKey" --arg value "$fieldValue" '.[] | select(.[$key]==$value)')
+
+  # If no result is found then create a new entity
+  if [ -z "$result" ]; then
+    result=$(
+      curl -s -X POST "$TACKLE_URL/$endpoint" \
+        -H 'Accept: application/json' \
+        -H 'Content-Type: application/json;charset=UTF-8' \
+        -H 'Authorization: Bearer '$access_token \
+        -d "$json"
+    )
+  fi
+
+  echo "$result"
+}
+
+function getOrCreateStakeholder() {
+  getOrCreateEntity "api/controls/stakeholder" "email" "$1"
+}
+
+function getOrCreateStakeholderGroup() {
+  getOrCreateEntity "api/controls/stakeholder-group" "name" "$1"
+}
+
+function getOrCreateBusinessService() {
+  getOrCreateEntity "api/controls/business-service" "name" "$1"
+}
+
+function getOrCreateTagType() {
+  getOrCreateEntity "api/controls/tag-type" "name" "$1"
+}
+
+function getOrCreateTag() {
+  getOrCreateEntity "api/controls/tag" "name" "$1"
+}
+
+function getOrCreateApplication() {
+  getOrCreateEntity "api/application-inventory/application" "name" "$1"
+}
+
+function getOrCreateAssessment() {
+  application_id=$1
+
+  assessment=$(
+    curl -s "$TACKLE_URL/api/pathfinder/assessments?applicationId=$application_id" \
+      -H 'Accept: application/json' \
+      -H 'Content-Type: application/json;charset=UTF-8' \
+      -H 'Authorization: Bearer '$access_token
+  )
+  assessment_id=$(echo "$assessment" | jq '.[].id')
+
+  if [ -z "$assessment_id" ]; then
+    assessment=$(
+      curl -s "$TACKLE_URL/api/pathfinder/assessments" \
+        -H 'Accept: application/json' \
+        -H 'Content-Type: application/json;charset=UTF-8' \
+        -H 'Authorization: Bearer '$access_token \
+        -d '{"applicationId":'$application_id'}'
+    )
+    assessment_id=$(echo "$assessment" | jq '.id')
+  fi
+
+  result=$(
+    curl -s "$TACKLE_URL/api/pathfinder/assessments/$assessment_id" \
+      -H 'Accept: application/json' \
+      -H 'Content-Type: application/json;charset=UTF-8' \
+      -H 'Authorization: Bearer '$access_token
+  )
+
+  echo "$result"
+}
+
+fillAssessment() {
+  assessment=$1
+  category_index=$2
+  question_index=$3
+  option_index=$4
+
+  options=$(echo "$assessment" | jq '.questionnaire.categories | (.[] | select(.order == '$category_index') | .questions) | (.[] | select(.order == '$question_index') | .options) | (.[] | select(.order == '$option_index') | .checked) |= true')
+  question=$(echo "$assessment" | jq --argjson newval "$options" '.questionnaire.categories | (.[] | select(.order == '$category_index') | .questions) | (.[] | select(.order == '$question_index') | .options) |= $newval')
+  questions=$(echo "$assessment" | jq --argjson newval "$question" '.questionnaire.categories | (.[] | select(.order == '$category_index') | .questions) |= $newval')
+
+  filledAssessment=$(echo "$assessment" | jq --argjson newval "$questions" '.questionnaire.categories |= $newval')
+  echo "$filledAssessment"
+}
+
+# START CREATING OBJECTS THROUGH THE API:
+
+#
+## Upload a CSV
+#
+
+# Create Stakeholders
+stakeholder1=$(getOrCreateStakeholder '{"email": "hscorpio@globex.com","displayName": "Hank Scorpio"}')
+stakeholder2=$(getOrCreateStakeholder '{"email": "hsimpson@globex.com","displayName": "Homer Simpson"}')
+
+echo "Created Stakeholder:" $stakeholder1
+echo "Created Stakeholder:" $stakeholder2
+
+# Create StakeholderGroups
+stakeholderGroup1=$(getOrCreateStakeholderGroup '{"name": "IT Management"}')
+stakeholderGroup2=$(getOrCreateStakeholderGroup '{"name": "Retail Management"}')
+
+echo "Created StakeholderGroup:" $stakeholderGroup1
+echo "Created StakeholderGroup:" $stakeholderGroup2
+
+# Create BusinessServices
+businessService1=$(getOrCreateBusinessService '{"name": "Retail"}')
+businessService2=$(getOrCreateBusinessService '{"name": "Finance and HR"}')
+
+echo "Created BusinessService:" $businessService1
+echo "Created BusinessService:" $businessService2
+
+# Create TagType
+tagType1=$(getOrCreateTagType '{"name":"Corporate Libraries","colour":"#6ec664"}')
+
+echo "Created TagType:" $tagType1
+
+# Create Tag
+tag1=$(echo '{"name":"Corporate Custom Configuration Library","tagType":'$tagType1'}')
+tag1=$(getOrCreateTag "$tag1")
+
+echo "Created Tag:" $tag1
+
+# Upload CSV file
+
+curl -s "$TACKLE_URL/api/application-inventory/file/upload" \
+  -F "fileName=myFileName.csv" \
+  -F "file=@/home/rroman/Downloads/applications-konveyor-noglobex.csv" \
+  -H 'Authorization: Bearer '$access_token
+
+echo "Imported CSV File"
+
+# Find Customers application
+customers_application=$(echo '{"name":"Customers"}')
+customers_application=$(getOrCreateApplication "$customers_application")
+
+echo "Found customers application: " $customers_application
+
+# Assess Customers application (fill Pathfinder questionnaire)
+#
+application_id=$(echo "$customers_application" | jq '.id') # Get the applicationID we want to assess
+stakeholder_id=$(echo "$stakeholder2" | jq '.id')          # Get the stakeholderID we want to associate with the assessment
+
+application_assesment=$(getOrCreateAssessment $application_id)
+application_assesment_id=$(echo "$application_assesment" | jq '.id')
+
+# Fill Stakeholders and set final status
+application_assesment=$(echo "$application_assesment" | jq '.stakeholders=['$stakeholder_id']')
+application_assesment=$(echo "$application_assesment" | jq '.status="COMPLETE"')
+
+# Fill "Application details"
+application_assesment=$(fillAssessment "$application_assesment" 1 1 4)
+application_assesment=$(fillAssessment "$application_assesment" 1 2 4)
+application_assesment=$(fillAssessment "$application_assesment" 1 3 5)
+application_assesment=$(fillAssessment "$application_assesment" 1 4 4)
+application_assesment=$(fillAssessment "$application_assesment" 1 5 5)
+application_assesment=$(fillAssessment "$application_assesment" 1 6 4)
+application_assesment=$(fillAssessment "$application_assesment" 1 7 4)
+
+# Fill "Application dependencies"
+application_assesment=$(fillAssessment "$application_assesment" 2 1 4)
+application_assesment=$(fillAssessment "$application_assesment" 2 2 5)
+application_assesment=$(fillAssessment "$application_assesment" 2 3 6)
+application_assesment=$(fillAssessment "$application_assesment" 2 4 5)
+application_assesment=$(fillAssessment "$application_assesment" 2 5 5)
+
+# Fill "Application architecture"
+application_assesment=$(fillAssessment "$application_assesment" 3 1 4)
+application_assesment=$(fillAssessment "$application_assesment" 3 2 5)
+application_assesment=$(fillAssessment "$application_assesment" 3 3 5)
+application_assesment=$(fillAssessment "$application_assesment" 3 4 1)
+application_assesment=$(fillAssessment "$application_assesment" 3 5 4)
+
+# Fill "Application observability"
+application_assesment=$(fillAssessment "$application_assesment" 4 1 6)
+application_assesment=$(fillAssessment "$application_assesment" 4 2 4)
+application_assesment=$(fillAssessment "$application_assesment" 4 3 4)
+application_assesment=$(fillAssessment "$application_assesment" 4 4 5)
+application_assesment=$(fillAssessment "$application_assesment" 4 5 4)
+
+# Fill "Application cross-cutting concerns"
+application_assesment=$(fillAssessment "$application_assesment" 5 1 4)
+application_assesment=$(fillAssessment "$application_assesment" 5 2 3)
+application_assesment=$(fillAssessment "$application_assesment" 5 3 7)
+application_assesment=$(fillAssessment "$application_assesment" 5 4 5)
+application_assesment=$(fillAssessment "$application_assesment" 5 5 2)
+application_assesment=$(fillAssessment "$application_assesment" 5 6 3)
+
+patch_assessment_response=$(
+  curl -s -X PATCH "$TACKLE_URL/api/pathfinder/assessments/$application_assesment_id" \
+    -H 'Accept: application/json' \
+    -H 'Content-Type: application/json;charset=UTF-8' \
+    -H 'Authorization: Bearer '$access_token \
+    -d "$application_assesment"
+)
+
+echo "Created Assessment:" $patch_assessment_response
+
+# Copy assessment from application "Customers" to "Orders" and "RetailFrontend"
+sourceApp_id=$application_assesment_id
+
+targetApp1_id1=$(getOrCreateApplication '{"name":"Orders"}' | jq '.id')
+targetApp1_id2=$(getOrCreateApplication '{"name":"RetailFrontend"}' | jq '.id')
+
+bulkCopy=$(jq -n --argjson source "$sourceApp_id" --argjson target1 "$targetApp1_id1" --argjson target2 "$targetApp1_id2" '{"fromAssessmentId":$source,"applications":[{"applicationId":$target1},{"applicationId":$target2}]}')
+
+bulkCopy=$(
+  curl -s -X POST "$TACKLE_URL/api/pathfinder/assessments/bulk" \
+    -H 'Accept: application/json' \
+    -H 'Content-Type: application/json;charset=UTF-8' \
+    -H 'Authorization: Bearer '$access_token \
+    -d "$bulkCopy"
+)
+
+echo "Copy bulk created" $bulkCopy


### PR DESCRIPTION
…a shell script

##### SUMMARY

Added ability to see the deployed tackle instance using a seed script - which can be the included default script or be downloaded from a remote location.

Also fixed destroy logic.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_mta_tackle