### PR TITLE
Add pause task to fix svc mesh installation

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_lpe_servicemesh/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_lpe_servicemesh/tasks/workload.yml
@@ -87,9 +87,9 @@
     name: "{{ ocp4_workload_lpe_servicemesh_smcp_namespace }}"
   when: install_smcp | bool
 
-- name: pause 20 seconds until servicemesh is ready
+- name: pause 60 seconds until servicemesh is ready
   pause:
-    seconds: 20
+    seconds: 60
 
 - name: create ServiceMeshControlPlane
   kubernetes.core.k8s:

--- a/ansible/roles_ocp_workloads/ocp4_workload_lpe_servicemesh/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_lpe_servicemesh/tasks/workload.yml
@@ -87,13 +87,21 @@
     name: "{{ ocp4_workload_lpe_servicemesh_smcp_namespace }}"
   when: install_smcp | bool
 
+- name: pause 20 seconds until servicemesh is ready
+  pause:
+    seconds: 20
+
 - name: create ServiceMeshControlPlane
   kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('template', 'smcp-basic.yaml.j2') }}"
   when: install_smcp | bool
 
-- name: Wait until SMCP is ready
+- name: pause 10 seconds until SMCP is created
+  pause:
+    seconds: 10
+
+- name: wait until SMCP is ready
   kubernetes.core.k8s_info:
     api_version: maistra.io/v2
     kind: ServiceMeshControlPlane


### PR DESCRIPTION
##### SUMMARY
Fixes the deployment of the service mesh by adding time pauses to wait for the operator fully install.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_lpe_servicemesh