### PR TITLE
fix order of setting default vars

### DIFF
--- a/ansible/roles/set-repositories/defaults/main.yaml
+++ b/ansible/roles/set-repositories/defaults/main.yaml
@@ -5,8 +5,8 @@
 # Preferred variable name uses role name as prefix with compatibility for older variable names
 set_repositories_satellite_ca_rpm_url: "https://{{ set_repositories_satellite_hostname }}/pub/katello-ca-consumer-latest.noarch.rpm"
 set_repositories_satellite_activationkey: "{{ satellite_activationkey | default('') }}"
-set_repositories_satellite_ca_cert: "{{ lookup('file', set_repositories_satellite_hostname ~ '.ca.crt') }}"
 set_repositories_satellite_hostname: "{{ set_repositories_satellite_url | default(satellite_url) | default('') }}"
+set_repositories_satellite_ca_cert: "{{ lookup('file', set_repositories_satellite_hostname ~ '.ca.crt') }}"
 # pattern matching a pool name for attachment via Satellite
 #set_repositories_satellite_pool: "^$"
 


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
if satellite_hostname is not set the crt location is not set right.  the order of the variables being set were out of order.
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
set-repositories
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
