### PR TITLE
Increase retry for RGW deployment to fix issue

### DIFF
--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/tasks/workload.yml
@@ -28,7 +28,7 @@
     - rgw_deployment.resources[0].status is defined
     - rgw_deployment.resources[0].status.readyReplicas is defined
     - rgw_deployment.resources[0].status.readyReplicas | int > 0
-  retries: 18
+  retries: 36
   delay: 10
 
 - name: Get the ceph rgw service


### PR DESCRIPTION
##### SUMMARY
Increase retry for RGW deployment to fix issue

```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "WARNING: key_name is DEPRECATED and should not be defined when using new create_ssh_provision_key role."}
...ignoring
FAILED - RETRYING: Wait for the RGW deployment (1 retries left).
fatal: [bastion.67f65.internal]: FAILED! => {"attempts": 18, "changed": false, "resources": []}
FAIL sandboxes-gpte-OCP4_WORKSHOP_DATA_ENGINEERING-prod-eb8d run_babylon provision
FAIL tower status: failed
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-workload-rhte-analytics_data_ocp_workshop role
