### PR TITLE
Add retry to control plane creation on service mesh workshop role

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/create_user_workloads.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/tasks/create_user_workloads.yml
@@ -57,6 +57,8 @@
     definition: "{{ lookup('template', './templates/servicemesh_controlplane.j2' ) }}"
   vars:
     namespace: "{{ item }}-istio"
+  retries: 15
+  delay: 5
   loop: '{{ ocp4_workload_servicemesh_workshop_user_list }}'
 
 - name: Add users as members to their corresponding service mesh projects


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

Add retry to address race condition in ServiceMeshControlPlane creation
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4_workload_servicemesh_workshop

