### PR TITLE
ACS removed some fields in policy API in 3.70

### DIFF
--- a/ansible/roles/ocp4_workload_stackrox_demo_apps/templates/openshift_policy_fix/policy.json.j2
+++ b/ansible/roles/ocp4_workload_stackrox_demo_apps/templates/openshift_policy_fix/policy.json.j2
@@ -6,9 +6,7 @@
     "remediation": {{ item.json.remediation | tojson }},
     "disabled": {{ item.json.disabled | lower }},
     "categories": {{ item.json.categories | tojson }},
-    "fields": {{ item.json.fields | tojson }},
     "lifecycleStages": {{ item.json.lifecycleStages | tojson }},
-    "whitelists": {{ item.json.whitelists | tojson  }},
     "exclusions": [
         {% for exclusion in item.json.exclusions %}{{ exclusion | tojson }},{% endfor %}
         {% for namespace in item.item.namespaces %}


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

Red Hat ACS 3.70 deprecated some API fields in the /v1/policies endpoint
https://docs.openshift.com/acs/3.70/release_notes/370-release-notes.html#deprecation-notices-370

The ansible playbook for updating policies expects these values to be present, and the failure results from these being missing. Since the two fields aren't required for any functionality, I just removed them. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4_workload_stackrox_demo_apps

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
