### PR TITLE
Allow for insecure Gitea connections

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/files/gitconfig
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/files/gitconfig
@@ -1,0 +1,5 @@
+[user]
+  name = AMA Demo User
+  email = amademo@opentlc.com
+[http]
+  sslVerify = false

--- a/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/tasks/setup-gitops.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/tasks/setup-gitops.yml
@@ -27,6 +27,14 @@
     _ocp4_workload_ama_demo_gitea_repo_route_url: >-
       {{ r_gitea.resources[0].status.giteaRoute }}
 
+- name: Set up .gitconfig
+  ansible.builtin.copy:
+    src: gitconfig
+    dest: "{{ ocp4_workload_ama_demo_home_directory }}/.gitconfig"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: 0664
+
 - name: Make sure cloned repo directory does not exist
   ansible.builtin.file:
     path: "{{ ocp4_workload_ama_demo_home_directory }}/{{ ocp4_workload_ama_demo_gitea_repo }}"
@@ -40,7 +48,7 @@
     dest: "{{ ocp4_workload_ama_demo_home_directory }}/{{ ocp4_workload_ama_demo_gitea_repo }}"
     version: "{{ ocp4_workload_ama_demo_gitea_repo_branch }}"
   environment:
-    GIT_TERMINAL_PROMPT: "false"
+    GIT_SSL_NO_VERIFY: "true"
 
 - name: Update ~/{{ ocp4_workload_ama_demo_gitea_repo }}/argocd/customers-application.yaml
   lineinfile:

--- a/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/tasks/vm-tomcat-install-and-configure.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/tasks/vm-tomcat-install-and-configure.yml
@@ -18,6 +18,13 @@
     - maven
     - git
 
+- name: Set up .gitconfig
+  ansible.builtin.copy:
+    src: gitconfig
+    dest: "/home/{{ ocp4_workload_ama_demo_vm_user_name }}//.gitconfig"
+    owner: "{{ ocp4_workload_ama_demo_vm_user_name }}"
+    mode: 0664
+
 # Configure and build the customer legacy application
 - name: Make sure cloned repo directory does not exist
   ansible.builtin.file:
@@ -37,7 +44,7 @@
     dest: "/home/{{ ocp4_workload_ama_demo_vm_user_name }}/{{ ocp4_workload_ama_demo_tomcat_repo_name }}"
     version: "{{ ocp4_workload_ama_demo_tomcat_repo_branch }}"
   environment:
-    GIT_TERMINAL_PROMPT: "false"
+    GIT_SSL_NO_VERIFY: "true"
 
 - name: Fix repository ownership
   ansible.builtin.file:

--- a/ansible/roles_ocp_workloads/ocp4_workload_big_demo/files/gitconfig
+++ b/ansible/roles_ocp_workloads/ocp4_workload_big_demo/files/gitconfig
@@ -1,3 +1,5 @@
 [user]
 	name = Big Demo User
 	email = bigdemo@opentlc.com
+[http]
+  sslVerify = false

--- a/ansible/roles_ocp_workloads/ocp4_workload_big_demo/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_big_demo/tasks/workload.yml
@@ -8,21 +8,12 @@
     group: root
     mode: 0775
 
-- name: Save python environment variable
-  set_fact:
-    _ocp4_workload_big_demo_python_interpreter: "{{ ansible_python_interpreter }}"
-
-- name: Use default python
-  set_fact:
-    ansible_python_interpreter: /usr/bin/python
-
 - name: Install software on Bastion
   become: true
   block:
   - name: Install JDK 11
-    package:
-      state: present
-      name: java-11-openjdk-devel
+    command:
+      cmd: dnf -y install java-11-openjdk-devel
 
   - name: Create /usr/local/maven directory
     file:
@@ -49,10 +40,6 @@
       dest: /usr/bin/mvn
       owner: root
       group: root
-
-- name: Use previous python
-  set_fact:
-    ansible_python_interpreter: "{{ _ocp4_workload_big_demo_python_interpreter }}"
 
 - name: Retrieve Gitea instance
   kubernetes.core.k8s_info:
@@ -364,7 +351,6 @@
     line: "          == '{{ ocp4_workload_big_demo_gitea_user }}/{{ ocp4_workload_big_demo_gitea_repo_catalog }}')"
   - regexp: "^          == 'rh-aiservices-bu/car-rest'[.,/)]"
     line: "          == '{{ ocp4_workload_big_demo_gitea_user }}/{{ ocp4_workload_big_demo_gitea_repo_object_detection }}')"
-
 
 # Copy app-ci-pipeline, service-account, task-gitea-pull-request
 # to the bastion and add to the repo

--- a/ansible/roles_ocp_workloads/ocp4_workload_big_demo/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_big_demo/tasks/workload.yml
@@ -154,6 +154,14 @@
       path: "{{ ocp4_workload_big_demo_home_directory }}/{{ ocp4_workload_big_demo_gitea_repo_gitops }}"
       state: absent
 
+- name: Set up .gitconfig
+  ansible.builtin.copy:
+    src: gitconfig
+    dest: "~{{ ansible_user}}/.gitconfig"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: 0664
+
 # Don't loop with "~{{ ansible-user }}"
 - name: Clone application source code
   block:
@@ -164,6 +172,8 @@
       repo: "{{ _ocp4_workload_big_demo_gitea_repo_inventory_url }}"
       dest: "{{ ocp4_workload_big_demo_home_directory }}/{{ ocp4_workload_big_demo_gitea_repo_inventory }}"
       version: "{{ ocp4_workload_big_demo_gitea_repo_inventory_branch }}"
+    environment:
+      GIT_SSL_NO_VERIFY: "true"
   - name: Clone gateway repository
     ansible.builtin.git:
       accept_hostkey: true
@@ -171,6 +181,8 @@
       repo: "{{ _ocp4_workload_big_demo_gitea_repo_gateway_url }}"
       dest: "{{ ocp4_workload_big_demo_home_directory }}/{{ ocp4_workload_big_demo_gitea_repo_gateway }}"
       version: "{{ ocp4_workload_big_demo_gitea_repo_gateway_branch }}"
+    environment:
+      GIT_SSL_NO_VERIFY: "true"
   - name: Clone catalog repository
     ansible.builtin.git:
       accept_hostkey: true
@@ -178,6 +190,8 @@
       repo: "{{ _ocp4_workload_big_demo_gitea_repo_catalog_url }}"
       dest: "{{ ocp4_workload_big_demo_home_directory }}/{{ ocp4_workload_big_demo_gitea_repo_catalog }}"
       version: "{{ ocp4_workload_big_demo_gitea_repo_catalog_branch }}"
+    environment:
+      GIT_SSL_NO_VERIFY: "true"
   - name: Clone gitops repository
     ansible.builtin.git:
       accept_hostkey: true
@@ -185,6 +199,8 @@
       repo: "{{ _ocp4_workload_big_demo_gitea_repo_gitops_url }}"
       dest: "{{ ocp4_workload_big_demo_home_directory }}/{{ ocp4_workload_big_demo_gitea_repo_gitops }}"
       version: "{{ ocp4_workload_big_demo_gitea_repo_gitops_branch }}"
+    environment:
+      GIT_SSL_NO_VERIFY: "true"
   - name: Clone object-detection-rest repository
     ansible.builtin.git:
       accept_hostkey: true
@@ -192,14 +208,8 @@
       repo: "{{ _ocp4_workload_big_demo_gitea_repo_object_detection_url }}"
       dest: "{{ ocp4_workload_big_demo_home_directory }}/{{ ocp4_workload_big_demo_gitea_repo_object_detection }}"
       version: "{{ ocp4_workload_big_demo_gitea_repo_object_detection_branch }}"
-
-- name: Set up .gitconfig
-  ansible.builtin.copy:
-    src: gitconfig
-    dest: "~{{ ansible_user}}/.gitconfig"
-    owner: "{{ ansible_user }}"
-    group: "{{ ansible_user }}"
-    mode: 0664
+    environment:
+      GIT_SSL_NO_VERIFY: "true"
 
 - name: Create k8s resources
   kubernetes.core.k8s:


### PR DESCRIPTION
##### SUMMARY

Allow insecure connections to the Gitea repository. This is necessary to be able to move the Let's Encrypt and Authentication workloads towards the end of provisioning to prevent API and authentication pods from rotating while the deployment continues...

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_ama_demo
ocp4_workload_big_demo