### PR TITLE
Do not report per-user messages for ocp4_workload_authentication if user count is one

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_authentication/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_authentication/defaults/main.yml
@@ -61,5 +61,7 @@ ocp4_workload_authentication_htpasswd_admin_password_length: 16
 ocp4_workload_authentication_remove_kubeadmin: true
 
 # agnosticd_user_info controls
+# If set to false then no agnosticd_user_info will be reported
 ocp4_workload_authentication_enable_user_info_messages: true
-ocp4_workload_authentication_enable_user_info_data: true
+# Only report per-user messages if number of users is greater than one
+ocp4_workload_authentication_enable_user_info_data: "{{ ocp4_workload_authentication_htpasswd_user_count | int > 1 }}"


### PR DESCRIPTION
##### SUMMARY

Do not report per-user messages for ocp4_workload_authentication unless multiple users are configured.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Role ocp4_workload_authentication