### PR TITLE
Make curl commands insecure in tackle workload

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle/tasks/workload.yml
@@ -72,6 +72,29 @@
   set_fact:
     _ocp4_workload_mta_tackle_host: "{{ r_tackle_route.resources[0].spec.host }}"
 
+# - name: Wait until retrieving a token succeeds
+#   uri:
+#     url: "https://{{ _ocp4_workload_mta_tackle_host }}/auth/realms/tackle/protocol/openid-connect/token"
+#     method: POST
+#     body:
+#       username: tackle
+#       password: password
+#       grant_type: password
+#     status_code: 200
+#     body_format: form-urlencoded
+#     validate_certs: false
+#     user: backend-service
+#     password: secret
+#     force_basic_auth: true
+#   register: r_token
+#   until: r_token is not failed
+#   retries: 30
+#   delay: 5
+
+# - name: Print access token
+#   debug:
+#     msg: "Access Token: {{ r_token.json.access_token }}"
+
 - name: Seed Tackle
   when: ocp4_workload_mta_tackle_seed | bool
   block:

--- a/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle/templates/seed-tackle.sh.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle/templates/seed-tackle.sh.j2
@@ -6,7 +6,7 @@ PASSWORD="{{ ocp4_workload_mta_tackle_password }}"
 SECRET="secret"
 
 access_token=$(
-  curl -s -X POST "$TACKLE_URL/auth/realms/${REALM_NAME}/protocol/openid-connect/token" \
+  curl -k -s -X POST "$TACKLE_URL/auth/realms/${REALM_NAME}/protocol/openid-connect/token" \
     --user "backend-service:${SECRET}" \
     -H 'content-type: application/x-www-form-urlencoded' \
     -d "username=${USERNAME}&password=${PASSWORD}&grant_type=password" | jq --raw-output '.access_token'
@@ -22,7 +22,7 @@ function getOrCreateEntity() {
 
   # Search by "fieldKey"
   search_response=$(
-    curl -s -X GET -G "$TACKLE_URL/$endpoint?page=0&size=10" \
+    curl -k -s -X GET -G "$TACKLE_URL/$endpoint?page=0&size=10" \
       --data-urlencode "$fieldKey=$fieldValue" \
       -H 'Accept: application/json' \
       -H 'Content-Type: application/json;charset=UTF-8' \
@@ -35,7 +35,7 @@ function getOrCreateEntity() {
   # If no result is found then create a new entity
   if [ -z "$result" ]; then
     result=$(
-      curl -s -X POST "$TACKLE_URL/$endpoint" \
+      curl -k -s -X POST "$TACKLE_URL/$endpoint" \
         -H 'Accept: application/json' \
         -H 'Content-Type: application/json;charset=UTF-8' \
         -H 'Authorization: Bearer '$access_token \
@@ -74,7 +74,7 @@ function getOrCreateAssessment() {
   application_id=$1
 
   assessment=$(
-    curl -s "$TACKLE_URL/api/pathfinder/assessments?applicationId=$application_id" \
+    curl -k -s "$TACKLE_URL/api/pathfinder/assessments?applicationId=$application_id" \
       -H 'Accept: application/json' \
       -H 'Content-Type: application/json;charset=UTF-8' \
       -H 'Authorization: Bearer '$access_token
@@ -83,7 +83,7 @@ function getOrCreateAssessment() {
 
   if [ -z "$assessment_id" ]; then
     assessment=$(
-      curl -s "$TACKLE_URL/api/pathfinder/assessments" \
+      curl -k -s "$TACKLE_URL/api/pathfinder/assessments" \
         -H 'Accept: application/json' \
         -H 'Content-Type: application/json;charset=UTF-8' \
         -H 'Authorization: Bearer '$access_token \
@@ -93,7 +93,7 @@ function getOrCreateAssessment() {
   fi
 
   result=$(
-    curl -s "$TACKLE_URL/api/pathfinder/assessments/$assessment_id" \
+    curl -k -s "$TACKLE_URL/api/pathfinder/assessments/$assessment_id" \
       -H 'Accept: application/json' \
       -H 'Content-Type: application/json;charset=UTF-8' \
       -H 'Authorization: Bearer '$access_token
@@ -156,7 +156,7 @@ echo "Created Tag:" $tag1
 
 # Upload CSV file
 
-curl -s "$TACKLE_URL/api/application-inventory/file/upload" \
+curl -k -s "$TACKLE_URL/api/application-inventory/file/upload" \
   -F "fileName=myFileName.csv" \
   -F "file=@/home/rroman/Downloads/applications-konveyor-noglobex.csv" \
   -H 'Authorization: Bearer '$access_token
@@ -220,7 +220,7 @@ application_assesment=$(fillAssessment "$application_assesment" 5 5 2)
 application_assesment=$(fillAssessment "$application_assesment" 5 6 3)
 
 patch_assessment_response=$(
-  curl -s -X PATCH "$TACKLE_URL/api/pathfinder/assessments/$application_assesment_id" \
+  curl -k -s -X PATCH "$TACKLE_URL/api/pathfinder/assessments/$application_assesment_id" \
     -H 'Accept: application/json' \
     -H 'Content-Type: application/json;charset=UTF-8' \
     -H 'Authorization: Bearer '$access_token \
@@ -238,7 +238,7 @@ targetApp1_id2=$(getOrCreateApplication '{"name":"RetailFrontend"}' | jq '.id')
 bulkCopy=$(jq -n --argjson source "$sourceApp_id" --argjson target1 "$targetApp1_id1" --argjson target2 "$targetApp1_id2" '{"fromAssessmentId":$source,"applications":[{"applicationId":$target1},{"applicationId":$target2}]}')
 
 bulkCopy=$(
-  curl -s -X POST "$TACKLE_URL/api/pathfinder/assessments/bulk" \
+  curl -k -s -X POST "$TACKLE_URL/api/pathfinder/assessments/bulk" \
     -H 'Accept: application/json' \
     -H 'Content-Type: application/json;charset=UTF-8' \
     -H 'Authorization: Bearer '$access_token \


### PR DESCRIPTION
##### SUMMARY

In case the mta_tackle workload runs before certificates exist the seeing of tackle fails.
Added -k to all curl commands in the seed script to ignore.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_mta_tackle