### PR TITLE
Add pause for node to come up in ocp windows node role

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/tasks/workload.yml
@@ -247,6 +247,10 @@
   until:
     - windocr.resources[0].status.ingress[0].host is defined
 
+- name: Wait 10 minutes for the node to spin up
+  pause:
+    minutes: 10
+
 # Get the running Windows Node
 - name: Get the running Windows Node
   k8s_info:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Add pause for node to come up in ocp windows node role
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4_workload_windows_node

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
