### PR TITLE
default_vars_equinix_metal.yml - changing to da6 from am6

### DIFF
--- a/ansible/configs/ocp4-equinix-aio/default_vars_equinix_metal.yml
+++ b/ansible/configs/ocp4-equinix-aio/default_vars_equinix_metal.yml
@@ -1,5 +1,5 @@
 ---
-equinix_metal_facility: am6
+equinix_metal_facility: da6
 hypervisor_type: s3.xlarge.x86
 hypervisor_count: 1
 hypervisor_os: rocky_8


### PR DESCRIPTION


SUMMARY

As per Alberto's request changing to use da6 to help resolve 
Error 503: The facility am6 has no provisionable s3.xlarge.x86 servers matching your criteria 


##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
default_vars_equinix_metal.ym

