### PR TITLE
Fix tomcat download URL, enable use of pre-installed VM templates

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/defaults/main.yaml
@@ -58,13 +58,20 @@ ocp4_workload_ama_demo_vm_user_password_length: 12
 # ------------------------------------------------
 ocp4_workload_ama_demo_oracle_vm_setup: true
 
+# Install everything from scratch (when false use a pre-installed template)
+ocp4_workload_ama_demo_oracle_vm_install_from_scratch: true
+
+# Template to use to set up the Oracle VM
+# "rhel85-empty" for a full install (ocp4_workload_ama_demo_oracle_vm_install_from_scratch == true)
+# "ama-template-oracle" to use a pre-installed template (ocp4_workload_ama_demo_oracle_vm_install_from_scratch == false)
+ocp4_workload_ama_demo_oracle_vm_template: rhel85-empty
+# ocp4_workload_ama_demo_oracle_vm_template: ama-template-oracle
+ocp4_workload_ama_demo_oracle_vm_name: "oracle-{{ guid | default(xxxxx) }}"
+
 # https://yum.oracle.com/repo/OracleLinux/OL8/appstream/x86_64/getPackage/oracle-database-preinstall-21c-1.0-1.el8.x86_64.rpm
 ocp4_workload_ama_demo_oracle_preinstall_rpm: https://gpte-public.s3.amazonaws.com/ama_demo/oracle-database-preinstall-21c-1.0-1.el8.x86_64.rpm
 # https://download.oracle.com/otn-pub/otn_software/db-express/oracle-database-xe-21c-1.0-1.ol8.x86_64.rpm
 ocp4_workload_ama_demo_oracle_rpm: https://gpte-public.s3.amazonaws.com/ama_demo/oracle-database-xe-21c-1.0-1.ol8.x86_64.rpm
-
-ocp4_workload_ama_demo_oracle_vm_template: rhel85-empty
-ocp4_workload_ama_demo_oracle_vm_name: "oracle-{{ guid | default(xxxxx) }}"
 
 # Oracle Database User
 ocp4_workload_ama_demo_oracle_db_user: customer
@@ -76,7 +83,14 @@ ocp4_workload_ama_demo_oracle_db_password: customer
 # ------------------------------------------------
 ocp4_workload_ama_demo_tomcat_vm_setup: true
 
+# Install everything from scratch (when false use a pre-installed template)
+ocp4_workload_ama_demo_tomcat_vm_install_from_scratch: true
+
+# Template to use to set up the Oracle VM
+# "rhel85-empty" for a full install (ocp4_workload_ama_demo_oracle_vm_install_from_scratch == true)
+# "ama-template-tomcat" to use a pre-installed template (ocp4_workload_ama_demo_oracle_vm_install_from_scratch == false)
 ocp4_workload_ama_demo_tomcat_vm_template: rhel85-empty
+# ocp4_workload_ama_demo_tomcat_vm_template: ama-template-tomcat
 ocp4_workload_ama_demo_tomcat_vm_name: "tomcat-{{ guid | default(xxxxx) }}"
 
 # Set up /manager admin page
@@ -87,7 +101,8 @@ ocp4_workload_ama_demo_tomcat_admin_user: redhatadmin
 ocp4_workload_ama_demo_tomcat_admin_password: redhat
 
 # Tomcat Download URL
-ocp4_workload_ama_demo_tomcat_download_url: https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.62/bin/apache-tomcat-9.0.62.tar.gz
+ocp4_workload_ama_demo_tomcat_download_url: https://gpte-public.s3.amazonaws.com/apache-tomcat-9.0.64.tar.gz
+# ocp4_workload_ama_demo_tomcat_download_url: https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.64/bin/apache-tomcat-9.0.64.tar.gz
 
 # Repo to use to build the customer application
 ocp4_workload_ama_demo_tomcat_repo_name: appmod_enablement

--- a/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/tasks/vm-oracledb-install-and-configure.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/tasks/vm-oracledb-install-and-configure.yml
@@ -1,121 +1,123 @@
 ---
-- name: Open firewall port 1521
-  ansible.builtin.firewalld:
-    state: enabled
-    immediate: true
-    permanent: true
-    port: 1521/tcp
-
-- name: Install Oracle XE Preinstall RPMs
-  ansible.builtin.package:
-    state: present
-    disable_gpg_check: true
-    name: "{{ ocp4_workload_ama_demo_oracle_preinstall_rpm }}"
-
-- name: Reboot the VM
-  ansible.builtin.reboot:
-
-- name: Install Oracle XE RPMs
-  ansible.builtin.package:
-    state: present
-    disable_gpg_check: true
-    name: "{{ ocp4_workload_ama_demo_oracle_rpm }}"
-  register: r_oracle_install
-
-- name: Check if initial-configuration file exists
-  ansible.builtin.stat:
-    path: /root/initial-configuration
-  register: r_init_file
-
-# Only configure Oracle on a first install
-- name: Configure Oracle XE
-  when: not r_init_file.stat.exists | bool
+- name: Setup Oracle VM from scratch
   block:
-  - name: Copy database setup shell script to VM
-    ansible.builtin.template:
-      src: oracle/initial-configuration.j2
-      dest: /root/initial-configuration
-      owner: root
-      group: root
-      mode: 0770
+  - name: Open firewall port 1521
+    ansible.builtin.firewalld:
+      state: enabled
+      immediate: true
+      permanent: true
+      port: 1521/tcp
 
-  - name: Initial Oracle XE configuration
-    ansible.builtin.command: /root/initial-configuration
+  - name: Install Oracle XE Preinstall RPMs
+    ansible.builtin.package:
+      state: present
+      disable_gpg_check: true
+      name: "{{ ocp4_workload_ama_demo_oracle_preinstall_rpm }}"
 
-  - name: Ensure database system service is enabled
-    ansible.builtin.systemd:
-      name: oracle-xe-21c
-      enabled: true
-      state: started
-      daemon_reload: true
+  - name: Reboot the VM
+    ansible.builtin.reboot:
 
-  - name: Set up oracle user
-    ansible.builtin.blockinfile:
-      dest: "/home/oracle/.bash_profile"
-      create: true
-      mode: 0664
-      owner: oracle
-      group: oinstall
-      marker: "##### {mark} Oracle user configuration ######"
-      content: |
-        export ORACLE_HOME=/opt/oracle/product/21c/dbhomeXE
-        export PATH=$PATH:$ORACLE_HOME/bin
-        export ORACLE_SID=XE
-        export ORAENV_ASK=NO
-        . $ORACLE_HOME/bin/oraenv
+  - name: Install Oracle XE RPMs
+    ansible.builtin.package:
+      state: present
+      disable_gpg_check: true
+      name: "{{ ocp4_workload_ama_demo_oracle_rpm }}"
+    register: r_oracle_install
 
-  - name: Copy customer database setup SQL file to VM
-    ansible.builtin.template:
-      src: oracle/setup-customer-database.sql.j2
-      dest: /home/oracle/setup-customer-database.sql
-      owner: oracle
-      group: oinstall
-      mode: 0660
+  - name: Check if initial-configuration file exists
+    ansible.builtin.stat:
+      path: /root/initial-configuration
+    register: r_init_file
 
-  - name: Copy customer database setup shell script file to VM
-    ansible.builtin.template:
-      src: oracle/setup-customer-database.j2
-      dest: /home/oracle/setup-customer-database
-      owner: oracle
-      group: oinstall
-      mode: 0775
+  # Only configure Oracle on a first install
+  - name: Configure Oracle XE
+    when: not r_init_file.stat.exists | bool
+    block:
+    - name: Copy database setup shell script to VM
+      ansible.builtin.template:
+        src: oracle/initial-configuration.j2
+        dest: /root/initial-configuration
+        owner: root
+        group: root
+        mode: 0770
 
-  - name: Create customer database
-    become_user: oracle
-    ansible.builtin.command: /home/oracle/setup-customer-database
+    - name: Initial Oracle XE configuration
+      ansible.builtin.command: /root/initial-configuration
 
-  # Oracle writes a reverse IP Address service into its configuration files
-  # Create a script to be called at system boot after networking and before
-  # Oracle to update the current IP Address in the configuration files
-  # This is necessary to move the VM to OpenShift Virtualization
-  - name: Copy ip address update script to VM
-    ansible.builtin.copy:
-      src: oracle/update_ipaddress.sh
-      dest: /usr/bin/update_ipaddress.sh
-      owner: root
-      group: root
-      mode: 0770
+    - name: Ensure database system service is enabled
+      ansible.builtin.systemd:
+        name: oracle-xe-21c
+        enabled: true
+        state: started
+        daemon_reload: true
 
-  - name: Create ip address update systemd service
-    ansible.builtin.copy:
-      src: oracle/update_ipaddress.service
-      dest: /etc/systemd/system/update_ipaddress.service
-      owner: root
-      group: root
-      mode: 0644
+    - name: Set up oracle user
+      ansible.builtin.blockinfile:
+        dest: "/home/oracle/.bash_profile"
+        create: true
+        mode: 0664
+        owner: oracle
+        group: oinstall
+        marker: "##### {mark} Oracle user configuration ######"
+        content: |
+          export ORACLE_HOME=/opt/oracle/product/21c/dbhomeXE
+          export PATH=$PATH:$ORACLE_HOME/bin
+          export ORACLE_SID=XE
+          export ORAENV_ASK=NO
+          . $ORACLE_HOME/bin/oraenv
 
-  - name: Enable ip address update systemd service
-    ansible.builtin.systemd:
-      name: update_ipaddress
-      enabled: true
-      state: started
-      daemon_reload: true
+    - name: Copy customer database setup SQL file to VM
+      ansible.builtin.template:
+        src: oracle/setup-customer-database.sql.j2
+        dest: /home/oracle/setup-customer-database.sql
+        owner: oracle
+        group: oinstall
+        mode: 0660
 
-  - name: Execute the ip address update script
-    ansible.builtin.command: /usr/bin/update_ipaddress.sh nowait
+    - name: Copy customer database setup shell script file to VM
+      ansible.builtin.template:
+        src: oracle/setup-customer-database.j2
+        dest: /home/oracle/setup-customer-database
+        owner: oracle
+        group: oinstall
+        mode: 0775
 
-  - name: Restart database system service
-    ansible.builtin.systemd:
-      name: oracle-xe-21c
-      state: restarted
-      daemon_reload: true
+    - name: Create customer database
+      become_user: oracle
+      ansible.builtin.command: /home/oracle/setup-customer-database
+
+    # Oracle writes a reverse IP Address service into its configuration files
+    # Create a script to be called at system boot after networking and before
+    # Oracle to update the current IP Address in the configuration files
+    # This is necessary to move the VM to OpenShift Virtualization
+    - name: Copy ip address update script to VM
+      ansible.builtin.copy:
+        src: oracle/update_ipaddress.sh
+        dest: /usr/bin/update_ipaddress.sh
+        owner: root
+        group: root
+        mode: 0770
+
+    - name: Create ip address update systemd service
+      ansible.builtin.copy:
+        src: oracle/update_ipaddress.service
+        dest: /etc/systemd/system/update_ipaddress.service
+        owner: root
+        group: root
+        mode: 0644
+
+    - name: Enable ip address update systemd service
+      ansible.builtin.systemd:
+        name: update_ipaddress
+        enabled: true
+        state: started
+        daemon_reload: true
+
+    - name: Execute the ip address update script
+      ansible.builtin.command: /usr/bin/update_ipaddress.sh nowait
+
+    - name: Restart database system service
+      ansible.builtin.systemd:
+        name: oracle-xe-21c
+        state: restarted
+        daemon_reload: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/tasks/vm-tomcat-install-and-configure.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/tasks/vm-tomcat-install-and-configure.yml
@@ -1,173 +1,196 @@
 ---
-- name: Open firewall ports 8080, 8443
-  ansible.builtin.firewalld:
-    state: enabled
-    immediate: true
-    permanent: true
-    port: "{{ item }}"
-  loop:
-  - "8080/tcp"
-  - "8443/tcp"
-
-- name: Install Tomcat prerequisites
-  ansible.builtin.package:
-    state: present
-    name:
-    - java-1.8.0-openjdk
-    - java-1.8.0-openjdk-devel
-    - maven
-    - git
-
-- name: Set up .gitconfig
-  ansible.builtin.copy:
-    src: gitconfig
-    dest: "/home/{{ ocp4_workload_ama_demo_vm_user_name }}//.gitconfig"
-    owner: "{{ ocp4_workload_ama_demo_vm_user_name }}"
-    mode: 0664
-
-# Configure and build the customer legacy application
-- name: Make sure cloned repo directory does not exist
-  ansible.builtin.file:
-    path: "/home/{{ ocp4_workload_ama_demo_vm_user_name }}/{{ ocp4_workload_ama_demo_tomcat_repo_name }}"
-    state: absent
-
-- name: Clone application source code
-  ansible.builtin.git:
-    accept_hostkey: true
-    force: true
-    repo: >-
-      {{ ocp4_workload_ama_demo_tomcat_repo_ssl | bool | ternary( 'https', 'http' ) }}://{{
-      ocp4_workload_ama_demo_tomcat_repo_user | urlencode }}:{{
-      ocp4_workload_ama_demo_tomcat_repo_user_password | urlencode }}@gitea.{{
-      _ocp4_workload_ama_demo_apps_domain }}/{{
-      ocp4_workload_ama_demo_vm_user_name }}/{{ ocp4_workload_ama_demo_tomcat_repo_name }}.git
-    dest: "/home/{{ ocp4_workload_ama_demo_vm_user_name }}/{{ ocp4_workload_ama_demo_tomcat_repo_name }}"
-    version: "{{ ocp4_workload_ama_demo_tomcat_repo_branch }}"
-  environment:
-    GIT_SSL_NO_VERIFY: "true"
-
-- name: Fix repository ownership
-  ansible.builtin.file:
-    state: directory
-    recurse: true
-    path: "/home/{{ ocp4_workload_ama_demo_vm_user_name }}/{{ ocp4_workload_ama_demo_tomcat_repo_name }}"
-    owner: "{{ ocp4_workload_ama_demo_vm_user_name }}"
-
-- name: Remove persistence.properties from source repository
-  ansible.builtin.file:
-    state: absent
-    path: >-
-      /home/{{ ocp4_workload_ama_demo_vm_user_name }}/{{
-      ocp4_workload_ama_demo_tomcat_repo_name }}/customers-tomcat-legacy/src/main/resources/persistence.properties"
-
-- name: Build customer application
-  become: true
-  become_user: "{{ ocp4_workload_ama_demo_vm_user_name }}"
+- name: Setup Tomcat VM from pre-installed template
+  when: not ocp4_workload_ama_demo_oracle_vm_install_from_scratch | bool
   block:
-  - name: Build config-utils library
-    ansible.builtin.command:
-      chdir: "/home/{{ ocp4_workload_ama_demo_vm_user_name }}/{{ ocp4_workload_ama_demo_tomcat_repo_name }}/config-utils"
-      cmd: "mvn install"
+  # "Legacy" app reads connections properties from /opt/config/persistence.properties
+  # Update properties from the template
+  - name: Copy persistence.properties template
+    ansible.builtin.template:
+      src: tomcat/persistence.properties
+      dest: /opt/config/persistence.properties
+      owner: tomcat
+      group: tomcat
+      mode: 0664
 
-  - name: Build application WAR file
-    ansible.builtin.command:
-      chdir: "/home/{{ ocp4_workload_ama_demo_vm_user_name }}/{{ ocp4_workload_ama_demo_tomcat_repo_name }}/customers-tomcat-legacy"
-      cmd: "mvn package"
+  - name: Enable and start Tomcat systemd service
+    ansible.builtin.systemd:
+      name: tomcat
+      enabled: true
+      state: restarted
+      daemon_reload: true
 
-# Now install and configure Tomcat Server
-- name: Create group tomcat
-  ansible.builtin.group:
-    name: tomcat
-    state: present
-
-- name: Create tomcat user
-  ansible.builtin.user:
-    name: tomcat
-    group: tomcat
-    shell: /sbin/nologin
-    create_home: false
-
-- name: Ensure necessary directories exist
-  ansible.builtin.file:
-    path: "{{ item }}"
-    state: directory
-    owner: tomcat
-    group: tomcat
-    mode: 0775
-  loop:
-  - /usr/local/tomcat
-  - /opt/config
-
-- name: Download and install Tomcat
-  ansible.builtin.unarchive:
-    src: "{{ ocp4_workload_ama_demo_tomcat_download_url }}"
-    remote_src: true
-    dest: /usr/local/tomcat
-    owner: tomcat
-    group: tomcat
-    mode: 0775
-    extra_opts: --strip-components=1
-  args:
-    creates: /usr/local/tomcat/bin/startup.sh
-
-- name: Set up admin interface
-  when: ocp4_workload_ama_demo_tomcat_admin_enabled | bool
+- name: Setup Tomcat VM from scratch
+  when: ocp4_workload_ama_demo_oracle_vm_install_from_scratch | bool
   block:
-  - name: Ensure Tomcat configuration directory exists
+  - name: Open firewall ports 8080, 8443
+    ansible.builtin.firewalld:
+      state: enabled
+      immediate: true
+      permanent: true
+      port: "{{ item }}"
+    loop:
+    - "8080/tcp"
+    - "8443/tcp"
+
+  - name: Install Tomcat prerequisites
+    ansible.builtin.package:
+      state: present
+      name:
+      - java-1.8.0-openjdk
+      - java-1.8.0-openjdk-devel
+      - maven
+      - git
+
+  - name: Set up .gitconfig
+    ansible.builtin.copy:
+      src: gitconfig
+      dest: "/home/{{ ocp4_workload_ama_demo_vm_user_name }}//.gitconfig"
+      owner: "{{ ocp4_workload_ama_demo_vm_user_name }}"
+      mode: 0664
+
+  # Configure and build the customer legacy application
+  - name: Make sure cloned repo directory does not exist
     ansible.builtin.file:
-      path: /usr/local/tomcat/conf/Catalina/localhost
+      path: "/home/{{ ocp4_workload_ama_demo_vm_user_name }}/{{ ocp4_workload_ama_demo_tomcat_repo_name }}"
+      state: absent
+
+  - name: Clone application source code
+    ansible.builtin.git:
+      accept_hostkey: true
+      force: true
+      repo: >-
+        {{ ocp4_workload_ama_demo_tomcat_repo_ssl | bool | ternary( 'https', 'http' ) }}://{{
+        ocp4_workload_ama_demo_tomcat_repo_user | urlencode }}:{{
+        ocp4_workload_ama_demo_tomcat_repo_user_password | urlencode }}@gitea.{{
+        _ocp4_workload_ama_demo_apps_domain }}/{{
+        ocp4_workload_ama_demo_vm_user_name }}/{{ ocp4_workload_ama_demo_tomcat_repo_name }}.git
+      dest: "/home/{{ ocp4_workload_ama_demo_vm_user_name }}/{{ ocp4_workload_ama_demo_tomcat_repo_name }}"
+      version: "{{ ocp4_workload_ama_demo_tomcat_repo_branch }}"
+    environment:
+      GIT_SSL_NO_VERIFY: "true"
+
+  - name: Fix repository ownership
+    ansible.builtin.file:
+      state: directory
+      recurse: true
+      path: "/home/{{ ocp4_workload_ama_demo_vm_user_name }}/{{ ocp4_workload_ama_demo_tomcat_repo_name }}"
+      owner: "{{ ocp4_workload_ama_demo_vm_user_name }}"
+
+  - name: Remove persistence.properties from source repository
+    ansible.builtin.file:
+      state: absent
+      path: >-
+        /home/{{ ocp4_workload_ama_demo_vm_user_name }}/{{
+        ocp4_workload_ama_demo_tomcat_repo_name }}/customers-tomcat-legacy/src/main/resources/persistence.properties"
+
+  - name: Build customer application
+    become: true
+    become_user: "{{ ocp4_workload_ama_demo_vm_user_name }}"
+    block:
+    - name: Build config-utils library
+      ansible.builtin.command:
+        chdir: "/home/{{ ocp4_workload_ama_demo_vm_user_name }}/{{ ocp4_workload_ama_demo_tomcat_repo_name }}/config-utils"
+        cmd: "mvn install"
+
+    - name: Build application WAR file
+      ansible.builtin.command:
+        chdir: "/home/{{ ocp4_workload_ama_demo_vm_user_name }}/{{ ocp4_workload_ama_demo_tomcat_repo_name }}/customers-tomcat-legacy"
+        cmd: "mvn package"
+
+  # Now install and configure Tomcat Server
+  - name: Create group tomcat
+    ansible.builtin.group:
+      name: tomcat
+      state: present
+
+  - name: Create tomcat user
+    ansible.builtin.user:
+      name: tomcat
+      group: tomcat
+      shell: /sbin/nologin
+      create_home: false
+
+  - name: Ensure necessary directories exist
+    ansible.builtin.file:
+      path: "{{ item }}"
       state: directory
       owner: tomcat
       group: tomcat
+      mode: 0775
+    loop:
+    - /usr/local/tomcat
+    - /opt/config
 
-  # Allow remote /manager access
-  - name: Add Tomcat manager configuration file
-    ansible.builtin.copy:
-      src: tomcat/manager.xml
-      dest: /usr/local/tomcat/conf/Catalina/localhost/manager.xml
+  - name: Download and install Tomcat
+    ansible.builtin.unarchive:
+      src: "{{ ocp4_workload_ama_demo_tomcat_download_url }}"
+      remote_src: true
+      dest: /usr/local/tomcat
       owner: tomcat
       group: tomcat
-      mode: 0644
+      mode: 0775
+      extra_opts: --strip-components=1
+    args:
+      creates: /usr/local/tomcat/bin/startup.sh
 
-  # Enable Admin User for /manager URL
-  - name: Add Tomcat users configuration file
+  - name: Set up admin interface
+    when: ocp4_workload_ama_demo_tomcat_admin_enabled | bool
+    block:
+    - name: Ensure Tomcat configuration directory exists
+      ansible.builtin.file:
+        path: /usr/local/tomcat/conf/Catalina/localhost
+        state: directory
+        owner: tomcat
+        group: tomcat
+
+    # Allow remote /manager access
+    - name: Add Tomcat manager configuration file
+      ansible.builtin.copy:
+        src: tomcat/manager.xml
+        dest: /usr/local/tomcat/conf/Catalina/localhost/manager.xml
+        owner: tomcat
+        group: tomcat
+        mode: 0644
+
+    # Enable Admin User for /manager URL
+    - name: Add Tomcat users configuration file
+      ansible.builtin.template:
+        src: tomcat/tomcat-users.xml.j2
+        dest: /usr/local/tomcat/conf/tomcat-users.xml
+        owner: tomcat
+        group: tomcat
+        mode: 0644
+
+  # "Legacy" app reads connections properties from /opt/config/persistence.properties
+  - name: Copy persistence.properties template
     ansible.builtin.template:
-      src: tomcat/tomcat-users.xml.j2
-      dest: /usr/local/tomcat/conf/tomcat-users.xml
+      src: tomcat/persistence.properties
+      dest: /opt/config/persistence.properties
       owner: tomcat
       group: tomcat
+      mode: 0664
+
+  - name: Add previously built Tomcat customer application
+    ansible.builtin.copy:
+      remote_src: true
+      src: "/home/{{ ocp4_workload_ama_demo_vm_user_name }}/{{
+        ocp4_workload_ama_demo_tomcat_repo_name }}/customers-tomcat-legacy/target/customers-tomcat-0.0.1-SNAPSHOT.war"
+      dest: /usr/local/tomcat/webapps/customers-tomcat-0.0.1-SNAPSHOT.war
+      owner: tomcat
+      group: tomcat
+      mode: 0664
+
+  - name: Create Tomcat systemd service
+    ansible.builtin.copy:
+      src: tomcat/tomcat.service
+      dest: /etc/systemd/system/tomcat.service
+      owner: root
+      group: root
       mode: 0644
 
-# "Legacy" app reads connections properties from /opt/config/persistence.properties
-- name: Copy persistence.properties template
-  ansible.builtin.template:
-    src: tomcat/persistence.properties
-    dest: /opt/config/persistence.properties
-    owner: tomcat
-    group: tomcat
-    mode: 0664
-
-- name: Add previously built Tomcat customer application
-  ansible.builtin.copy:
-    remote_src: true
-    src: "/home/{{ ocp4_workload_ama_demo_vm_user_name }}/{{
-      ocp4_workload_ama_demo_tomcat_repo_name }}/customers-tomcat-legacy/target/customers-tomcat-0.0.1-SNAPSHOT.war"
-    dest: /usr/local/tomcat/webapps/customers-tomcat-0.0.1-SNAPSHOT.war
-    owner: tomcat
-    group: tomcat
-    mode: 0664
-
-- name: Create Tomcat systemd service
-  ansible.builtin.copy:
-    src: tomcat/tomcat.service
-    dest: /etc/systemd/system/tomcat.service
-    owner: root
-    group: root
-    mode: 0644
-
-- name: Enable and start Tomcat systemd service
-  ansible.builtin.systemd:
-    name: tomcat
-    enabled: true
-    state: started
-    daemon_reload: true
+  - name: Enable and start Tomcat systemd service
+    ansible.builtin.systemd:
+      name: tomcat
+      enabled: true
+      state: started
+      daemon_reload: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/tasks/workload.yml
@@ -148,6 +148,7 @@
     ansible.builtin.include_tasks: vm-common-install-and-configure.yml
 
   - name: Configure Oracle database VM
+    when: ocp4_workload_ama_demo_oracle_vm_install_from_scratch | bool
     ansible.builtin.include_tasks: vm-oracledb-install-and-configure.yml
 
 # Tomcat host gets added to inventory by rhev-setup-vm.yaml


### PR DESCRIPTION
##### SUMMARY

Apache removed the Tomcat download URL and replaced with a newer version. Update download URL to newer version and use the default download from the GPTE S3 Bucket instead.

Add two flags to use pre-installed VM templates instead of installing Oracle and Tomcat from scratch. This speeds up deployment of this workload by at least 30 minutes.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_ama_demo