### PR TITLE
Add variable to omit delete of namespaces upon workload destroy

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/defaults/main.yaml
@@ -3,6 +3,11 @@ become_override: false
 ocp_username: opentlc-mgr
 silent: false
 
+# Do not delete OpenShift resources when running the destroy
+# Useful when the cluster is being destroyed anyway
+# Otherwise destroy may fail if the nodes were shut down
+ocp4_workload_ama_demo_destroy_projects: false
+
 # ------------------------------------------------
 # RHV Environment
 # ------------------------------------------------

--- a/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/tasks/remove_workload.yml
@@ -70,6 +70,7 @@
     path: /tmp/rhev.pem
 
 - name: Delete demo namespaces
+  when: ocp4_workload_ama_demo_destroy_projects | bool
   kubernetes.core.k8s:
     state: absent
     definition: "{{ lookup('template', item ) | from_yaml }}"


### PR DESCRIPTION
##### SUMMARY

Bugfix: when destroying an AMA environment this workload deletes the RHV VMs and then tries to clean up OpenShift. The OCP cleanup can fail if the cluster node(s) had not been running upon deletion because the cluster may not be ready yet.

Add variable (defaults to false) to not destroy OpenShift resources - which is usually fine because the cluster gets deleted anyway.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_ama_demo