### PR TITLE
Fix loop_var in ocp4-workload-homeroomlab-starter-guides

### DIFF
--- a/ansible/roles/ocp4-workload-homeroomlab-starter-guides/tasks/post_workload.yml
+++ b/ansible/roles/ocp4-workload-homeroomlab-starter-guides/tasks/post_workload.yml
@@ -22,7 +22,7 @@
   when: ocp4_workload_homeroomlab_starter_guides_per_user_info_enable | bool
   loop: "{{ range(1, 1 + num_users | int) | list }}"
   loop_control:
-    loop_var: "{{ __user_number }}"
+    loop_var: __user_number
     label: "{{ __user_name }}"
   vars:
     __user_name: "{{ user_format | format(__user_number) }}"


### PR DESCRIPTION
##### SUMMARY

Fix loop_var in ocp4-workload-homeroomlab-starter-guides.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role ocp4-workload-homeroomlab-starter-guides