### PR TITLE
Fix sap-smart infra-ansible symlink to reflect agnosticd install path logic

### DIFF
--- a/ansible/configs/sap-smart/post_software.yml
+++ b/ansible/configs/sap-smart/post_software.yml
@@ -46,8 +46,15 @@
       - name: Create symlink to support internal infra-ansible role includes
         file:
           src: infra-ansible/roles/ansible
-          dest: "{{ playbook_dir }}/dynamic-roles/ansible"
+          dest: "{{ __agnosticd_roles_install_path }}/ansible"
           state: link
+        vars:
+          __agnosticd_roles_install_path: >-
+            {%- if requirements_content is defined and requirements_content | length > 0 -%}
+            {{ playbook_dir }}/dynamic-roles
+            {%- else -%}
+            {{ ANSIBLE_REPO_PATH | default(playbook_dir) | default('.') }}/configs/{{ env_type }}/roles
+            {%- endif -%}
 
       - name: Ensure Tower License is configured
         include_role:


### PR DESCRIPTION
##### SUMMARY

Logic in sap-smart config for creating infra-ansible symlink must match AgnosticD logic to select the role install path.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Config sap-smart