### PR TITLE
Fix sap-smart usage of playbook_dir when determining roles path

### DIFF
--- a/ansible/configs/sap-smart/post_software.yml
+++ b/ansible/configs/sap-smart/post_software.yml
@@ -53,7 +53,7 @@
             {%- if requirements_content is defined and requirements_content | length > 0 -%}
             {{ playbook_dir }}/dynamic-roles
             {%- else -%}
-            {{ ANSIBLE_REPO_PATH | default(playbook_dir) | default('.') }}/configs/{{ env_type }}/roles
+            {{ ANSIBLE_REPO_PATH | default(playbook_dir) }}/roles
             {%- endif -%}
 
       - name: Ensure Tower License is configured


### PR DESCRIPTION
##### SUMMARY

Last attempt duplicated `configs/sap-smart`.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Config sap-smart