### PR TITLE
Fix roles symlink creation for sap-smart to create locally

### DIFF
--- a/ansible/configs/sap-smart/post_software.yml
+++ b/ansible/configs/sap-smart/post_software.yml
@@ -48,6 +48,8 @@
           src: infra-ansible/roles/ansible
           dest: "{{ __agnosticd_roles_install_path }}/ansible"
           state: link
+        delegate_to: localhost
+        run_once: true
         vars:
           __agnosticd_roles_install_path: >-
             {%- if requirements_content is defined and requirements_content | length > 0 -%}


### PR DESCRIPTION
##### SUMMARY

Symlink must be created locally, not on the towers.

##### ISSUE TYPE

- Bugfix Pull Request