### PR TITLE
Add option to use own ssh keys in bastion-lite role

### DIFF
--- a/ansible/roles/bastion-lite/defaults/main.yml
+++ b/ansible/roles/bastion-lite/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
 # defaults file for bastion
+# by default, do not copy over the user's private key
+use_own_key: false

--- a/ansible/roles/bastion-lite/tasks/main.yml
+++ b/ansible/roles/bastion-lite/tasks/main.yml
@@ -1,4 +1,16 @@
 ---
+- name: copy the user's SSH private key
+  become: true
+  copy:
+    src: "~/.ssh/{{key_name}}.pem"
+    dest: "/root/.ssh/{{key_name}}.pem"
+    owner: root
+    group: root
+    mode: 0400
+  when: not use_own_key|bool
+  tags:
+    - copy_env_private_key
+
 - name: Generate host .ssh/config Template
   become: false
   template:

--- a/ansible/roles/bastion-lite/templates/bastion_ssh_config.j2
+++ b/ansible/roles/bastion-lite/templates/bastion_ssh_config.j2
@@ -4,7 +4,11 @@ Host ec2* *.internal
 Host *.example.com
 {% endif %}	
   User {{remote_user | default(hostvars.localhost.remote_user) }}
-  IdentityFile ~/.ssh/{{ env_authorized_key }}.pem
+{% if use_own_key|bool %}
+  IdentityFile ~/.ssh/{{env_authorized_key}}.pem
+{% else %}
+  IdentityFile ~/.ssh/{{key_name}}.pem
+{% endif %}
   ForwardAgent yes
   StrictHostKeyChecking no
   ConnectTimeout 60


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
This PR is a  partial revert of https://github.com/redhat-cop/agnosticd/pull/4534, with the aim to add back the option to use our own key pair in bastion-lite role. Only real difference from the previous approach is that now `use_own_key` is by default set to `false` .


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
bastion-lite role

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
