### PR TITLE
Fix ocp4-workload_ccnrd-stable to fix the image tag

### DIFF
--- a/ansible/roles/ocp4-workload-ccnrd-stable/templates/devfile.json.j2
+++ b/ansible/roles/ocp4-workload-ccnrd-stable/templates/devfile.json.j2
@@ -13,7 +13,7 @@
       "memoryLimit": "4Gi",
       "type": "dockerimage",
       "alias": "quarkus-tools",
-      "image": "image-registry.openshift-image-registry.svc:5000/openshift/quarkus-stack:2.13-mandrel-22",
+      "image": "image-registry.openshift-image-registry.svc:5000/openshift/quarkus-stack:2.13-ce-mandrel-22",
       "env": [
         {
           "value": "/home/jboss/.m2",


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Fix ocp4-workload_ccnrd-stable to fix the image tag
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
