### PR TITLE
Add openshift_cluster_admin_service_account for ocp4-cluster config

### DIFF
--- a/ansible/configs/ocp4-cluster/default_vars.yml
+++ b/ansible/configs/ocp4-cluster/default_vars.yml
@@ -133,6 +133,9 @@ ocp4_cluster_show_default_user_info: true
 ocp4_cluster_show_flight_check_user_info: "{{ ocp4_cluster_show_default_user_info }}"
 ocp4_cluster_show_access_user_info: "{{ ocp4_cluster_show_default_user_info }}"
 
+# Set to true to enable creating a cluster-admin service account during installation
+openshift_cluster_admin_service_account_enable: false
+
 # YAML List of Infrastructure Workloads.
 # REQUIRES Ansible 2.7+ on the deployer host
 # Empty by default - to be set by specific configurations

--- a/ansible/configs/ocp4-cluster/post_software.yml
+++ b/ansible/configs/ocp4-cluster/post_software.yml
@@ -9,6 +9,15 @@
   - debug:
       msg: "Post-Software Steps starting"
 
+  - name: Set Ansible Python interpreter to k8s virtualenv
+    set_fact:
+      ansible_python_interpreter: /opt/virtualenvs/k8s/bin/python
+
+  - name: Setup cluster-admin service account
+    when: openshift_cluster_admin_service_account_enable | bool
+    include_role:
+      name: openshift_cluster_admin_service_account
+
 # Deploy Workloads
 - name: Step 005.2 - Deploy Infra and Student Workloads
   import_playbook: workloads.yml
@@ -26,9 +35,6 @@
     - install_ocp4 | default( false ) | bool
     - ocp4_enable_cluster_shutdown | default( false ) | bool
     block:
-    - name: Set Ansible Python interpreter to k8s virtualenv
-      set_fact:
-        ansible_python_interpreter: /opt/virtualenvs/k8s/bin/python
     - name: Create Daemon Set to renew Bootstrap Credentials
       k8s:
         state: present
@@ -54,10 +60,6 @@
   - name: Run fio tests for etcd performance
     when: test_deploy_results | default( false ) | bool
     block:
-    - name: Set Ansible Python interpreter to k8s virtualenv
-      set_fact:
-        ansible_python_interpreter: /opt/virtualenvs/k8s/bin/python
-
     - name: Get metadata.json
       stat:
         path: /home/{{ ansible_user }}/{{ cluster_name }}/metadata.json

--- a/ansible/roles/openshift_cluster_admin_service_account/.yamllint
+++ b/ansible/roles/openshift_cluster_admin_service_account/.yamllint
@@ -1,0 +1,2 @@
+---
+extends: ../../../tests/static/.yamllint

--- a/ansible/roles/openshift_cluster_admin_service_account/README.adoc
+++ b/ansible/roles/openshift_cluster_admin_service_account/README.adoc
@@ -1,0 +1,29 @@
+:role: openshift_cluster_admin_service_account
+:author1: Johnathan Kupferer <jkupfere@redhat.com>
+:team: Red Hat Product Demo System
+
+
+Role: {role}
+============
+
+The role {role} creates a service account with cluster-admin rights on the cluster.
+
+Requirements
+------------
+
+* A running OpenShift cluster with authentication configured
+* Virtualenv with kubernetes.core collection
+
+Role Variables
+--------------
+
+See defaults.yaml
+
+Author Information
+------------------
+
+* Author/owner/maintainer:
+** {author1}
+
+* Team:
+** {team}

--- a/ansible/roles/openshift_cluster_admin_service_account/README.adoc
+++ b/ansible/roles/openshift_cluster_admin_service_account/README.adoc
@@ -17,7 +17,7 @@ Requirements
 Role Variables
 --------------
 
-See defaults.yaml
+See defaults/main.yml
 
 Author Information
 ------------------

--- a/ansible/roles/openshift_cluster_admin_service_account/defaults/main.yml
+++ b/ansible/roles/openshift_cluster_admin_service_account/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# Control for creating a cluster-admin service account
+openshift_cluster_admin_service_account_name: cluster-admin
+openshift_cluster_admin_service_account_namespace: openshift-config

--- a/ansible/roles/openshift_cluster_admin_service_account/tasks/main.yml
+++ b/ansible/roles/openshift_cluster_admin_service_account/tasks/main.yml
@@ -1,0 +1,72 @@
+---
+- name: Create cluster-admin service account
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: "{{ openshift_cluster_admin_service_account_name }}"
+        namespace: "{{ openshift_cluster_admin_service_account_namespace }}"
+
+- name: Grant cluster-admin service account cluster-admin privileges
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: >-
+          {{ 'cluster-admin:serviceaccount:%s:%s' | format(
+            openshift_cluster_admin_service_account_namespace,
+            openshift_cluster_admin_service_account_name
+          ) }}
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: cluster-admin
+      subjects:
+      - kind: ServiceAccount
+        name: "{{ openshift_cluster_admin_service_account_name }}"
+        namespace: "{{ openshift_cluster_admin_service_account_namespace }}"
+
+- name: Wait for cluster-admin service account token
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: ServiceAccount
+    name: "{{ openshift_cluster_admin_service_account_name }}"
+    namespace: "{{ openshift_cluster_admin_service_account_namespace }}"
+  register: r_cluster_admin_service_account
+  failed_when: >-
+    r_cluster_admin_service_account.resources[0].secrets is undefined or
+    r_cluster_admin_service_account.resources[0].secrets | selectattr(
+      'name', 'regex', '^' ~ openshift_cluster_admin_service_account_name ~ '-token-'
+    ) | list | length < 1
+  until: r_cluster_admin_service_account is success
+  retries: 5
+  delay: 1
+
+- name: Get cluster-admin service account token
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    name: >-
+      {{ (r_cluster_admin_service_account.resources[0].secrets | selectattr(
+        'name', 'regex', '^' ~ openshift_cluster_admin_service_account_name ~ '-token-'
+      ) | first).name }}
+    namespace: "{{ openshift_cluster_admin_service_account_namespace }}"
+  register: r_cluster_admin_service_account_token
+  failed_when: r_cluster_admin_service_account_token.resources | length != 1
+
+- name: Set openshift_api_ca_cert and openshift_cluster_admin_token
+  set_fact:
+    openshift_api_ca_cert: >-
+      {{ r_cluster_admin_service_account_token.resources[0].data['ca.crt'] | b64decode }}
+    openshift_cluster_admin_token: >-
+      {{ r_cluster_admin_service_account_token.resources[0].data.token | b64decode }}
+
+- name: Report openshift_api_ca_cert and openshift_cluster_admin_token as user data
+  agnosticd_user_info:
+    data:
+      openshift_api_ca_cert: "{{ openshift_api_ca_cert }}"
+      openshift_cluster_admin_token: "{{ openshift_cluster_admin_token }}"


### PR DESCRIPTION
##### SUMMARY

Add ability to create a service account with cluster-admin privileges to ocp4-cluster config. By default this feature is disabled but may be enabled by setting `openshift_cluster_admin_service_account_create` to `true`.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

- Config ocp4-cluster
- New role openshift_cluster_admin_service_account

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
