### PR TITLE
error in double role call - omit

### DIFF
--- a/ansible/configs/hybrid-cloud/pre_infra.yml
+++ b/ansible/configs/hybrid-cloud/pre_infra.yml
@@ -11,22 +11,6 @@
   - debug:
       msg: "Step 000 Pre Infrastructure"
 
-- name: Step 000.1 - Add the Azure user to the Subscription
-  hosts: localhost
-  connection: local
-  gather_facts: false
-  become: false
-  environment:
-    AZURE_CLIENT_ID: "{{ azure_service_principal }}"
-    AZURE_SUBSCRIPTION_ID: "{{ azure_subscription_id }}"
-    AZURE_SECRET: "{{ azure_password }}"
-    AZURE_TENANT: "{{ azure_tenant }}"
-    AZURE_CONFIG_DIR: "{{ azure_config_dir }}"
-  tasks:
-  - name: Run the azure add user to subscription
-    include_role:
-      name: open-env-azure-add-user-to-subscription
-
 - name: Step 000.2 - Pre Infrastructure
   hosts: localhost
   connection: local


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

I accidentally called the azure subscriptions role twice.

Omitting the first.

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
