### PR TITLE
Add config to externally provide private SSH key used for provision and destroy at EC2

### DIFF
--- a/ansible/cloud_providers/ec2_destroy_env.yml
+++ b/ansible/cloud_providers/ec2_destroy_env.yml
@@ -16,6 +16,8 @@
     - name: Set facts for ssh provision SSH key
       include_role:
         name: create_ssh_provision_key
+      when:
+        - ssh_provision_key_name is undefined
 
     - name: Destroy infra ec2 keypair
       include_role:

--- a/ansible/cloud_providers/ec2_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/ec2_infrastructure_deployment.yml
@@ -35,7 +35,9 @@
     - name: Create ssh provision key
       include_role:
         name: create_ssh_provision_key
-      when: instances | default([]) | length > 0
+      when:
+        - instances | default([]) | length
+        - ssh_provision_key_name is undefined
 
     - name: Locate environment SSH key
       include_role:

--- a/ansible/configs/hybrid-cloud/destroy_env_ec2.yml
+++ b/ansible/configs/hybrid-cloud/destroy_env_ec2.yml
@@ -33,6 +33,8 @@
   - name: Create local ssh provision facts (key already exists)
     include_role:
       name: create_ssh_provision_key
+    when:
+      - ssh_provision_key_name is undefined
 
   - name: SSH config setup
     when:

--- a/ansible/configs/hybrid-cloud/destroy_env_ec2.yml
+++ b/ansible/configs/hybrid-cloud/destroy_env_ec2.yml
@@ -34,7 +34,7 @@
     include_role:
       name: create_ssh_provision_key
     when:
-      - ssh_provision_key_name is undefined
+    - ssh_provision_key_name is undefined
 
   - name: SSH config setup
     when:

--- a/ansible/configs/ocp4-cluster/destroy_env_ec2.yml
+++ b/ansible/configs/ocp4-cluster/destroy_env_ec2.yml
@@ -33,6 +33,8 @@
   - name: Create local ssh provision facts (key already exists)
     include_role:
       name: create_ssh_provision_key
+    when:
+      - ssh_provision_key_name is undefined
 
   - name: SSH config setup
     when:

--- a/ansible/configs/ocp4-cluster/destroy_env_ec2.yml
+++ b/ansible/configs/ocp4-cluster/destroy_env_ec2.yml
@@ -34,7 +34,7 @@
     include_role:
       name: create_ssh_provision_key
     when:
-      - ssh_provision_key_name is undefined
+    - ssh_provision_key_name is undefined
 
   - name: SSH config setup
     when:

--- a/ansible/roles-infra/infra-ec2-ssh-key/tasks/create.yaml
+++ b/ansible/roles-infra/infra-ec2-ssh-key/tasks/create.yaml
@@ -6,6 +6,18 @@
 
 - when: stat_infra_ssh_key.stat.exists
   block:
+    - when: ssh_provision_pubkey_content is not defined
+      block:
+        - name: Generate SSH pub key content
+          command: >-
+            ssh-keygen -y -f {{ ssh_provision_key_path | quote }}
+          changed_when: false
+          register: r_ssh_provision_pubkey
+
+        - name: Save all facts for SSH
+          set_fact:
+            ssh_provision_pubkey_content: "{{ r_ssh_provision_pubkey.stdout.strip() }}"
+
     - name: Create infra key
       environment:
         AWS_ACCESS_KEY_ID: "{{ aws_access_key_id }}"

--- a/ansible/roles/control-user/tasks/ssh-config.yml
+++ b/ansible/roles/control-user/tasks/ssh-config.yml
@@ -20,7 +20,7 @@
 
     - name: copy the environment .pub key
       copy:
-        src: "{{ hostvars.localhost.env_authorized_key_path_pub }}"
+        content: "{{ hostvars.localhost.env_authorized_key_content_pub }}"
         dest: "/home/{{ control_user_name }}/.ssh/{{env_authorized_key}}.pub"
         owner: "{{ control_user_name }}"
         group: "{{ control_user_private_group }}"

--- a/ansible/roles/locate_env_authorized_key/readme.adoc
+++ b/ansible/roles/locate_env_authorized_key/readme.adoc
@@ -6,7 +6,7 @@ The main reason is to facilitate the transition of all configs and roles to a co
 
 This role, `locate_env_authorized_key`, will use the available keys if found, in order:
 
-* `ssh_provision_key` - created by `create_ssh_provision_key`
+* `ssh_provision_key` - created by `create_ssh_provision_key` or re-used existent one
 * `infra_ssh_key` - created by OSP heat template
 * defaults to `{{ output_dir }}/{{ env_authorized_key }}`
 ** generally the key is created directly in the config

--- a/ansible/roles/locate_env_authorized_key/tasks/main.yaml
+++ b/ansible/roles/locate_env_authorized_key/tasks/main.yaml
@@ -19,8 +19,16 @@
   delegate_facts: true
   set_fact:
     env_authorized_key_path_pub: >-
-      {{ hostvars.localhost.env_authorized_key_path
-      | regex_replace('\.pem$', '') }}.pub
+      {%- if hostvars.localhost.ssh_provision_pubkey_path is defined -%}
+      {{ hostvars.localhost.ssh_provision_pubkey_path }}
+      {%- else -%}
+      {{ output_dir }}/{{ hostvars.localhost.ssh_provision_key_name | regex_replace('\.pem$', '') }}.pub
+      {%- endif -%}
+
+- name: Check if env_authorized_key_pub exists
+  stat:
+    path: "{{ env_authorized_key_path_pub }}"
+  register: env_authorized_key_pub_stats
 
 - name: Generate SSH pub key content if it doesn't exist
   shell: >-
@@ -30,6 +38,8 @@
     creates: "{{ hostvars.localhost.env_authorized_key_path_pub }}"
   delegate_to: localhost
   become: false
+  when:
+    - not env_authorized_key_pub_stats.stat.exists
 
 - name: Save SSH pub key content as fact
   delegate_to: localhost
@@ -37,4 +47,8 @@
   become: false
   set_fact:
     env_authorized_key_content_pub: >-
+      {%- if hostvars.localhost.ssh_provision_pubkey_content is defined -%}
+      {{ hostvars.localhost.ssh_provision_pubkey_content }}
+      {%- else -%} 
       {{ lookup('file', hostvars.localhost.env_authorized_key_path_pub) }}
+      {%- endif -%}

--- a/ansible/roles/locate_env_authorized_key/tasks/main.yaml
+++ b/ansible/roles/locate_env_authorized_key/tasks/main.yaml
@@ -25,11 +25,6 @@
       {{ output_dir }}/{{ hostvars.localhost.ssh_provision_key_name | regex_replace('\.pem$', '') }}.pub
       {%- endif -%}
 
-- name: Check if env_authorized_key_pub exists
-  stat:
-    path: "{{ env_authorized_key_path_pub }}"
-  register: env_authorized_key_pub_stats
-
 - name: Generate SSH pub key content if it doesn't exist
   shell: >-
     ssh-keygen -y -f {{ hostvars.localhost.env_authorized_key_path | quote }}
@@ -38,8 +33,6 @@
     creates: "{{ hostvars.localhost.env_authorized_key_path_pub }}"
   delegate_to: localhost
   become: false
-  when:
-    - not env_authorized_key_pub_stats.stat.exists
 
 - name: Save SSH pub key content as fact
   delegate_to: localhost

--- a/ansible/roles/set_env_authorized_key/tasks/main.yml
+++ b/ansible/roles/set_env_authorized_key/tasks/main.yml
@@ -18,7 +18,7 @@
 - name: copy the environment .pub key
   become: true
   copy:
-    src: "{{ hostvars.localhost.env_authorized_key_path_pub }}"
+    content: "{{ hostvars.localhost.env_authorized_key_content_pub }}"
     dest: "/root/.ssh/{{ env_authorized_key }}.pub"
     owner: root
     group: root

--- a/docs/SSH_keys_and_access.adoc
+++ b/docs/SSH_keys_and_access.adoc
@@ -47,6 +47,22 @@ all_ssh_authorized_keys:
 ----
 . DESTROY role `infra-{{ cloud_provider }}-ssh-key` to delete the keypair in the cloud provider
 
+== Bring your own provision key ==
+In some cases the SSH key generation described above is not working well (e.g., the key pair can be lost if not stored at persistent storage and destroy job will fail).
+It is possible to specify existed SSH key which will be used for the environment provisioning and destroy by setting following variables:
+
+* `ssh_provision_key_path`
+* `ssh_provision_key_name`
+* `ssh_provision_pubkey_content` (optional)
++
+[source,yaml]
+.example setting `ssh_privision_*` variables
+----
+ssh_provision_key_name: "my_private_ssh_key.pem"
+ssh_provision_key_path: "/home/account/.ssh/{{ ssh_provision_key_name }}"
+ssh_provision_pubkey_content: ssh-rsa AAAAB3NzaC1 ...rest of the key... JjQ==
+----
+
 == Roles ==
 
 * `create_ssh_provision_key`


### PR DESCRIPTION
##### SUMMARY

The `create_ssh_provision_key` infra role generates and store new SSH
key pair for each provisioning job. Plus setting following environment
variables:
- ssh_provision_pubkey_content
- ssh_provision_pubkey_path
- ssh_provision_key_path
- ssh_provision_key_name

In some cases this algorithm is not working well (e.g., the key pair can be lost
if not stored at persistent storage and destroy job will fail). This
change allow to bring your own permanent key by setting following
variables:
- ssh_provision_key_path
- ssh_provision_key_name
- ssh_provision_pubkey_content (optional)

And this provided key will be reused by provisioning and destroy jobs.

For example set following variables at AgnosticV:
```
ssh_provision_key_name: "my_private_ssh_key.pem"
ssh_provision_key_path: "/home/account/.ssh/{{ ssh_provision_key_name }}"
ssh_provision_pubkey_content: ssh-rsa AAAAB3NzaC1 ...rest of the key... JjQ==
```

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
- cloud_providers/ec2_destroy_env
- cloud_providers/ec2_infrastructure_deployment

- configs/hybrid-cloud/destroy_env_ec2
- configs/hybrid-cloud/destroy_env_ec2
- configs/ocp4-cluster/destroy_env_ec2

- roles-infra/infra-ec2-ssh-key

- roles/control-user
- roles/locate_env_authorized_key
- roles/set_env_authorized_key

##### ADDITIONAL INFORMATION
Environment provisioning and destroy was tested at AWS EC2 with externally provided SSH key and without it. Unfortunately I don't have environment to test the `control-user` role but it has exactly same change to save public SSH key form the `ssh_provision_pubkey_content` variable that was done for `set_env_authorized_key` role and this change works. But it still better to test it if there is such opportunity.

