### PR TITLE
Add test_empty_config_passthrough_user_data to test-empty-config

### DIFF
--- a/ansible/configs/test-empty-config/post_software.yml
+++ b/ansible/configs/test-empty-config/post_software.yml
@@ -33,6 +33,14 @@
       random_string: >-
         {{ lookup('password', '/dev/null length=15 chars=ascii_letters') }}
 
+  - name: Pass-through agnosticd_user_info data
+    when: test_empty_config_passthrough_user_data is defined
+    agnosticd_user_info:
+      data: >-
+       {{ test_empty_config_passthrough_user_data | from_yaml
+       if test_empty_config_passthrough_user_data is string
+       else test_empty_config_passthrough_user_data }}
+
   - when: test_empty_config_multi_user | bool
     block:
     - name: Test set agnosticd_user_info for users

--- a/ansible/configs/test-empty-config/sample_vars.yml
+++ b/ansible/configs/test-empty-config/sample_vars.yml
@@ -2,4 +2,8 @@
 guid: test-config-00
 env_type: test-empty-config
 cloud_provider: test
+
+test_empty_config_passthrough_user_data: |
+  hello: world
+  foo: bar
 ...


### PR DESCRIPTION
##### SUMMARY

Add ability to set `test_empty_config_passthrough_user_data` to have test-empty-config set arbirtary values in its user data.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Config test-empty-config