### PR TITLE
omit cluster specific kconf_path until really needed

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm_clusters/tasks/cluster_kconf.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm_clusters/tasks/cluster_kconf.yml
@@ -1,10 +1,11 @@
 ---
 - name: Set ACM cluster variables
   set_fact:
-    kconf_cluster_name:
-      "{{ _ocp4_workload_rhacm_clusters_aws_clusters_item.managed_cluster_name }}"
-    cluster_kconf_path:
-      "{{ _ocp4_workload_rhacm_clusters_aws_clusters_item.managed_cluster_kconf_path | default('~/.kube/') }}"
+    kconf_cluster_name: >-
+      {{ _ocp4_workload_rhacm_clusters_aws_clusters_item.managed_cluster_name }}
+    cluster_kconf_path: "~/.kube/"
+    # TODO: enable reading of
+    # {{ _ocp4_workload_rhacm_clusters_aws_clusters_item.managed_cluster_kconf_path | default('~/.kube') }}
 
 - name: Create directory
   file:


### PR DESCRIPTION
I didn't see kconf_path used in any of the CIs we have now.
So disabling this seems fine.

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
