### PR TITLE
omit the jinja2 loop for azure zones

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm_clusters/templates/azure/install_config_azure.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm_clusters/templates/azure/install_config_azure.yaml.j2
@@ -23,9 +23,9 @@ compute:
       osDisk:
         diskSizeGB: 128
       zones:
-      {% for i in range(_ocp4_workload_rhacm_clusters_azure_worker_replica_count|int) %}
-      - "{{ i }}"
-      {% endfor %}
+      - "1"
+      - "2"
+      - "3"
 networking:
   networkType: OpenShiftSDN
   clusterNetwork:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
ocp4_workload_rhacm_clusters - jinja2 for loop was failing.  Omitting.
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
