### PR TITLE
add authn to managed cluster workload

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_managed_cluster_workload/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_managed_cluster_workload/tasks/workload.yml
@@ -44,14 +44,12 @@
     - name: Use context #we need to figure out how to do this in each role
       shell: oc config use-context "{{ ocp4_workload_managed_cluster_name }}"
 
-    - name: Set up Authenication on the managed cluster
+    - name: Set up htpasswd authenication on the managed cluster
       vars:
         ocp4_workload_authentication_idm_type: htpasswd
         ocp4_workload_authentication_admin_user: admin
-        # When no password specified it is generated
         ocp4_workload_authentication_htpasswd_admin_password: openshfit
         ocp4_workload_authentication_htpasswd_user_base: user
-        # When no password specified it is generated
         ocp4_workload_authentication_htpasswd_user_password: openshift
         ocp4_workload_authentication_htpasswd_user_count: 5
         ocp4_workload_authentication_remove_kubeadmin: false

--- a/ansible/roles_ocp_workloads/ocp4_workload_managed_cluster_workload/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_managed_cluster_workload/tasks/workload.yml
@@ -44,6 +44,21 @@
     - name: Use context #we need to figure out how to do this in each role
       shell: oc config use-context "{{ ocp4_workload_managed_cluster_name }}"
 
+    - name: Set up Authenication on the managed cluster
+      vars:
+        ocp4_workload_authentication_idm_type: htpasswd
+        ocp4_workload_authentication_admin_user: admin
+        # When no password specified it is generated
+        ocp4_workload_authentication_htpasswd_admin_password: openshfit
+        ocp4_workload_authentication_htpasswd_user_base: user
+        # When no password specified it is generated
+        ocp4_workload_authentication_htpasswd_user_password: openshift
+        ocp4_workload_authentication_htpasswd_user_count: 5
+        ocp4_workload_authentication_remove_kubeadmin: false
+
+      ansible.builtin.include_role:
+        name: ocp4_workload_authentication
+
     - name: Install Gitea Operator
       ansible.builtin.include_role:
         name: ocp4_workload_gitea_operator


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

ocp4_workload_managed_cluster_workload didn't have credentials to actually do that labs.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
