### PR TITLE
ec2: Fix lifecycle when there are terminated vm

### DIFF
--- a/ansible/lifecycle_ec2.yml
+++ b/ansible/lifecycle_ec2.yml
@@ -10,11 +10,6 @@
           "tag:guid": "{{ guid }}"
       register: r_instances
 
-    - when: r_instances.instances | default([]) | length == 0
-      name: Fail if no instance is found
-      fail:
-        msg: "No instance found for guid={{ guid }}"
-
     - when:
         - ACTION == 'stop'
         - _instance_ids_running | length > 0

--- a/ansible/lifecycle_ec2.yml
+++ b/ansible/lifecycle_ec2.yml
@@ -4,32 +4,53 @@
     AWS_SECRET_ACCESS_KEY: "{{aws_secret_access_key}}"
     AWS_DEFAULT_REGION: "{{aws_region_final|d(aws_region)}}"
   block:
-    - when: ACTION == 'stop'
-      name: Stop instances by (guid,env_type) tags
+    - name: Get EC2 instances filtering by guid
+      ec2_instance_info:
+        filters:
+          "tag:guid": "{{ guid }}"
+      register: r_instances
+
+    - when: r_instances.instances | default([]) | length == 0
+      name: Fail if no instance is found
+      fail:
+        msg: "No instance found for guid={{ guid }}"
+
+    - when:
+        - ACTION == 'stop'
+        - _instance_ids_running | length > 0
+      name: Stop instances
       ec2:
         state: stopped
         wait: false
-        instance_tags:
-          guid: "{{ guid }}"
+        instance_ids: "{{ _instance_ids_running }}"
+      vars:
+        _instance_ids_running: >-
+          {{ r_instances.instances
+          | default([])
+          | selectattr("state.name", "equalto", "running")
+          | map(attribute="instance_id")
+          | list
+          }}
 
-    - when: ACTION == 'start'
-      name: Start instances by (guid, env_type) tags
+    - when:
+        - ACTION == 'start'
+        - _instance_ids_stopped | length > 0
+      name: Start instances
       ec2:
         state: running
         wait: false
-        instance_tags:
-          guid: "{{ guid }}"
+        instance_ids: "{{ _instance_ids_stopped }}"
+      vars:
+        _instance_ids_stopped: >-
+          {{ r_instances.instances
+          | default([])
+          | selectattr("state.name", "equalto", "stopped")
+          | map(attribute="instance_id")
+          | list
+          }}
 
     - when: ACTION == 'status'
       block:
-        - name: Get EC2 facts using (guid, env_type) tag
-          ec2_instance_facts:
-            filters:
-              "tag:guid": "{{ guid }}"
-              # TODO: uncomment this after a few weeks
-              #"tag:env_type": "{{ env_type }}"
-          register: r_instances
-
         - name: Report status in user info
           agnosticd_user_info:
             msg: |-


### PR DESCRIPTION
This change, if applied, fixes start and stop actions for EC2 (aws) when
there are Terminating or Terminated instances.

The error message is the following:

```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Unable to change state for instance i-06641ecc4a23f3948, error: EC2ResponseError: 400 Bad Request\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Response><Errors><Error><Code>IncorrectInstanceState</Code><Message>This instance 'i-06641ecc4a23f3948' is not in a state from which it can be stopped.</Message></Error></Errors><RequestID>529e8468-0813-419c-b719-24bdbd34132a</RequestID></Response>"}
```

see GPTEINFRA-3798.

This happens because of a bug in the version of the aws collection that we use.
Since it's not easy to update the collection, this change uses another
approach to stop or start the instances:

- get the instances first using the ec2_instance_info module
- stop or start only the instances that are respectively running or stopped.

This change has been tested with ansible python virtualenv: ansible2.9-python3.6-2021-11-30

Also fix the following warning by renaming `ec2_instance_facts` to `ec2_instance_info`

```
[DEPRECATION WARNING]: The 'ec2_instance_facts' module has been renamed to 'ec2_instance_info'. This feature will be removed in version 2.13. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.
```

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ec2 lifecycle
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below
ansible-playbook 2.9.27
  config file = /home/fridim/sync/dev/aad/ansible.cfg
  configured module search path = ['/home/fridim/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/fridim/virtualenvs/ansible2.9-python3.6-2021-11-30/lib/python3.10/site-packages/ansible
  executable location = /home/fridim/virtualenvs/ansible2.9-python3.6-2021-11-30/bin/ansible-playbook
  python version = 3.10.5 (main, Jun  6 2022, 18:49:26) [GCC 12.1.0]
```
