### PR TITLE
ocp_cleanup_failed_pod: enable best effort mode

### DIFF
--- a/ansible/roles/ocp_cleanup_failed_pods/tasks/main.yaml
+++ b/ansible/roles/ocp_cleanup_failed_pods/tasks/main.yaml
@@ -24,6 +24,8 @@
     name: "{{ __owner.name }}"
     namespace: "{{ __pod.metadata.namespace }}"
     state: absent
+  # Best effort
+  ignore_errors: true
 
 - name: Delete failed pods
   loop: "{{ r_failed_pods.resources | default([]) }}"
@@ -36,3 +38,5 @@
     name: "{{ __pod.metadata.name }}"
     namespace: "{{ __pod.metadata.namespace }}"
     state: absent
+  # Best effort
+  ignore_errors: true


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Start is broken because of that role.

Can we enable best-effort for that?
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp_cleanup_failed_pod role

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
