### PR TITLE
Add requirements.yml for rhel-container-security

### DIFF
--- a/ansible/configs/rhel-container-security/requirements.yml
+++ b/ansible/configs/rhel-container-security/requirements.yml
@@ -1,0 +1,8 @@
+---
+collections:
+- name: amazon.aws
+  version: 2.2.0
+- name: community.general
+  version: 4.6.1
+- name: ansible.posix
+  version: 1.3.0


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

Fixes the following error:

```
TASK [infra-ec2-ssh-key : include_tasks] ***************************************
14:35:45
204
fatal: [localhost]: FAILED! => {"reason": "couldn't resolve module/action 'amazon.aws.ec2_key'. This often indicates a misspelling, missing collection, or incorrect module path.\n\nThe error appears to be in '/tmp/awx_598475_a21j0zef/project/ansible/roles-infra/infra-ec2-ssh-key/tasks/create.yaml': line 9, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n  block:\n    - name: Create infra key\n      ^ here\n"}
```
