### PR TITLE
Add version to ServiceMeshControlPlane spec in service mesh workshop …

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/servicemesh_controlplane.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/servicemesh_controlplane.j2
@@ -4,6 +4,7 @@ metadata:
   name: workshop-install
   namespace: {{ namespace }}
 spec:
+  version: v2.2
   proxy:
     networking:
       trafficControl:


### PR DESCRIPTION
…role

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

`version` field is now required in the `ServiceMeshControlPlane` spec. This fixes failed deployments in the `ocp4_workload_servicemesh_workshop` role.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4_workload_servicemesh_workshop

