### PR TITLE
workload mta: add user data for single user

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_mta/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta/tasks/workload.yml
@@ -27,6 +27,18 @@
     when: not ocp4_workload_mta_install_operator | bool
     include_tasks: install_manifests_single_user.yml
 
+  - name: Print access data (Operator)
+    when:
+    - ocp4_workload_mta_print_access_information | bool
+    - ocp4_workload_mta_install_operator | bool
+    agnosticd_user_info:
+      data:
+        mta_url: >-
+          https://secure-{{ ocp4_workload_mta_namespace }}-mta.{{
+          _ocp4_workload_mta_wildcard_domain }}"
+        mta_user: mta
+        mta_password: password
+
   - name: Print access information (Operator)
     when:
     - ocp4_workload_mta_print_access_information | bool
@@ -40,6 +52,18 @@
           _ocp4_workload_mta_wildcard_domain }}"
     - "  User:     mta"
     - "  Password: password"
+
+  - name: Print access data (Manifests)
+    when:
+    - ocp4_workload_mta_print_access_information | bool
+    - not ocp4_workload_mta_install_operator | bool
+    agnosticd_user_info:
+      data:
+        mta_url: >-
+          https://secure-mta-{{ ocp4_workload_mta_namespace }}.{{
+          _ocp4_workload_mta_wildcard_domain }}"
+        mta_user: mta
+        mta_password: password
 
   - name: Print access information (Manifests)
     when:

--- a/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle/tasks/workload.yml
@@ -29,6 +29,14 @@
   - name: Print access information (single user)
     when: ocp4_workload_mta_tackle_print_access_information | bool
     block:
+    - name: Print user data (authentication enabled)
+      when: ocp4_workload_mta_tackle_feature_auth_required | default(true)
+      agnosticd_user_info:
+        data:
+          tackle_url: "https://{{ _ocp4_workload_mta_tackle_host }}"
+          tackle_user: "{{ ocp4_workload_mta_tackle_user }}"
+          tackle_password: "{{ ocp4_workload_mta_tackle_password }}"
+
     - name: Print access information (authentication enabled)
       when: ocp4_workload_mta_tackle_feature_auth_required | default(true)
       agnosticd_user_info:
@@ -48,6 +56,13 @@
       - ""
       - "Konveyor Tackle (Migration Toolkit for Applications Upstream):"
       - "  URL: https://tackle-{{ ocp4_workload_mta_tackle_namespace }}.{{ _ocp4_workload_mta_tackle_wildcard_domain }}"
+
+    - name: Print user data infromation
+      when: not ocp4_workload_mta_tackle_feature_auth_required | default(true)
+      agnosticd_user_info:
+        data:
+          tackle_url: >-
+            https://tackle-{{ ocp4_workload_mta_tackle_namespace }}.{{ _ocp4_workload_mta_tackle_wildcard_domain }}
 
 - name: Multi user installation
   when: ocp4_workload_mta_tackle_multi_user_install | bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle/tasks/workload.yml
@@ -57,7 +57,7 @@
       - "Konveyor Tackle (Migration Toolkit for Applications Upstream):"
       - "  URL: https://tackle-{{ ocp4_workload_mta_tackle_namespace }}.{{ _ocp4_workload_mta_tackle_wildcard_domain }}"
 
-    - name: Print user data infromation
+    - name: Print user data infromation (authentication disabled)
       when: not ocp4_workload_mta_tackle_feature_auth_required | default(true)
       agnosticd_user_info:
         data:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

user.data was missing for MTA single-user workload 
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
