### PR TITLE
Removed SSLVerify for gitea repo

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_retail_aiml_workshop/templates/object-detection-rest-pipeline.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_retail_aiml_workshop/templates/object-detection-rest-pipeline.yaml.j2
@@ -40,6 +40,8 @@ spec:
       value: ""
     - name: deleteExisting
       value: "true"
+    - name: sslVerify
+      value: "false"
     taskRef:
       kind: ClusterTask
       name: git-clone


### PR DESCRIPTION
Remove SSL Verify for the gitea repo

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
Removed SSLVerify for gitea repo
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
