### PR TITLE
ocp4_workload_paloalto_prismacloud / tasks / workload.yaml

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_paloalto_prismacloud/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_paloalto_prismacloud/tasks/workload.yml
@@ -37,10 +37,10 @@
   args:
     chdir: ~{{ansible_user}}/twistlock
 
-- name: Deploy the console to the cluster
-  command: >-
-    oc create -f ~{{ansible_user}}/twistlock/twistlock_console.yaml
-  ignore_errors: true
+#- name: Deploy the console to the cluster
+#  command: >-
+#    oc create -f ~{{ansible_user}}/twistlock/twistlock_console.yaml
+#  ignore_errors: true
 
 - name: Deploy Prisma Cloud route
   k8s:


### PR DESCRIPTION
Remove task -  Deploy the console to the cluster

```
Attempt to solve 

Error from server (AlreadyExists): error when creating \"/home/ec2-user/twistlock/twistlock_console.yaml\": persistentvolumeclaims \"twistlock-console\" already exists"],

https://tower.dark-tower-prod.infra.open.redhat.com/#/jobs/playbook/603537/host-event/302891412/json?job_search=page_size:20;order_by:-finished;not__launch_type:sync 
```
