### PR TITLE
Create a hook for lifecycle for empty-config

### DIFF
--- a/ansible/configs/test-empty-config/lifecycle_hook.yml
+++ b/ansible/configs/test-empty-config/lifecycle_hook.yml
@@ -1,0 +1,20 @@
+- name: Step lifecycle
+  hosts: localhost
+  connection: local
+  become: false
+  gather_facts: false
+  tasks:
+    - when: cloud_provider == 'osp'
+      name: Include AWS dry-run read-only role
+      include_role:
+        name: infra-osp-dry-run
+
+    - when: cloud_provider == 'ec2'
+      name: Include AWS dry-run read-only role
+      include_role:
+        name: infra-aws-dry-run
+
+    - when: cloud_provider == 'equinix_metal'
+      name: Include Equinix Metal dry-run read-only role
+      include_role:
+        name: infra-equinix-metal-dry-run


### PR DESCRIPTION
empty-config not creating any resource, the start/stop should just
ensure the connection to the cloud-provider is working

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
