### PR TITLE
Add Tackle2 workload

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/defaults/main.yml
@@ -17,7 +17,7 @@ ocp4_workload_mta_tackle2_num_users: 1
 ocp4_workload_mta_tackle2_namespace_base: tackle
 # UserID for Single User Setup
 ocp4_workload_mta_tackle2_user: admin
-# Base for multi user setup 
+# Base for multi user setup
 ocp4_workload_mta_tackle2_user_base: user
 
 # Role to grant users for the tackle namespace

--- a/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/defaults/main.yml
@@ -1,0 +1,52 @@
+---
+become_override: false
+ocp_username: opentlc-mgr
+silent: false
+
+# Helm Chart to deploy
+ocp4_workload_mta_tackle2_repo: https://github.com/redhat-gpte-devopsautomation/agnosticd_workload_helm_charts.git
+# Tag to deploy
+ocp4_workload_mta_tackle2_repo_tag: main
+
+# How many users to set up
+ocp4_workload_mta_tackle2_num_users: 1
+
+# Namespace base
+# If num_users == 1 then this will be the name of the namespace
+# If num_users > 1 the user base and user number will be appended to this base
+ocp4_workload_mta_tackle2_namespace_base: tackle
+# UserID for Single User Setup
+ocp4_workload_mta_tackle2_user: admin
+# Base for multi user setup 
+ocp4_workload_mta_tackle2_user_base: user
+
+# Role to grant users for the tackle namespace
+ocp4_workload_mta_tackle2_role: admin
+
+# Seed Tackle with information
+# When seeding is enabled authentication must be turned off
+# (until this is fixed in the operator)
+ocp4_workload_mta_tackle2_seed: false
+
+# Image for the job to seed tackle. The image must have the data to be seeded inside
+# See https://github.com/redhat-gpte-devopsautomation/tackle2-setup-container.git
+ocp4_workload_mta_tackle2_seed_image: quay.io/gpte-devops-automation/tackle2-setup
+ocp4_workload_mta_tackle2_seed_tag: latest
+ocp4_workload_mta_tackle2_seed_pull_policy: IfNotPresent
+
+# These are hardcoded and can't be changed at the moment, first login requires changing
+# Disable authentication by setting ocp4_workload_mta_tackle2_feature_auth_required: false
+# ocp4_workload_mta_tackle2_user: admin
+# ocp4_workload_mta_tackle2_password: password
+
+# --------------------------------
+# Tackle V2 specific settings
+# --------------------------------
+ocp4_workload_mta_tackle2_feature_auth_required: false
+ocp4_workload_mta_tackle2_rwx_storage_class: ocs-storagecluster-cephfs
+ocp4_workload_mta_tackle2_rwo_storage_class: ocs-storagecluster-ceph-rbd
+ocp4_workload_mta_tackle2_maven_data_volume_size: 10Gi
+ocp4_workload_mta_tackle2_hub_bucket_volume_size: 10Gi
+ocp4_workload_mta_tackle2_hub_database_volume_size: 5Gi
+ocp4_workload_mta_tackle2_keycloak_database_data_volume_size: 1Gi
+ocp4_workload_mta_tackle2_pathfinder_database_data_volume_size: 1Gi

--- a/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/meta/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/meta/main.yml
@@ -1,0 +1,15 @@
+---
+galaxy_info:
+  role_name: ocp4_workload_mta_tackle2
+  author:
+  - Wolfgang Kulhanek <wkulhane@redhat.com>
+  description: |
+    Deploys Tackle Operator on a OCP4 cluster
+  platforms: []
+  license: GNU General Public License v3.0
+  galaxy_tags:
+  - ocp4
+  - openshift
+  - mta
+  - tackle
+dependencies: []

--- a/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/readme.adoc
@@ -1,0 +1,68 @@
+= ocp4_workload_mta_tackle2 - Deploy Konveyer Tackle2 (Upstream for Migration Toolkit for Applications) to an OpenShift Cluster
+
+== Role overview
+
+* This role installs Konveyor Tackle into an OpenShift Cluster.
+
+It consists of following tasks files:
+** Tasks: pre_workload.yml - Sets up an environment for the workload environment.
+*** Debug task will print out: `Pre-Workload tasks completed successfully.`
+
+** Tasks: workload.yml - Used to deploy Konveyor Tackle
+*** This playbook creates following OCP resources:
+**** namespace (project) `openshift-cnv`. The mandatory namespace for installing CNV to
+**** subscription to CNV
+**** KubeVrit HCO
+
+** Tasks: post_workload.yml - Used to configure the workload after deployment
+*** This role doesn't do anything here
+*** Debug task will print out: workload Tasks completed successfully.
+
+** Tasks: remove_workload.yml - Used to delete the workload
+*** This role removes Konveyor Tackle and its subscription.
+*** Debug task will print out: `remove_workload Tasks completed successfully.`
+
+== The defaults variable file
+
+* This file ./defaults/main.yml contains all the variables you need to define to control the deployment of your workload.
+* The variable ocp_username is mandatory to assign the workload to the correct OpenShift user.
+* A variable silent=True can be passed to suppress debug messages.
+* You can modify any of these default values by adding -e "variable_name=variable_value" to the command line
+
+== Deploy a Workload with the `ocp-workload` playbook [Mostly for testing]
+
+----
+TARGET_HOST="bastion.na4.openshift.opentlc.com"
+OCP_USERNAME="wkulhane-redhat.com"
+WORKLOAD="ocp4_workload_mta_tackle2"
+GUID=1001
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=ec2-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"silent=False" \
+    -e"guid=${GUID}" \
+    -e"_quay_dockerconfigjson=${QUAY_DOCKERCONFIGJSON}" \
+    -e"ACTION=create"
+----
+
+=== To Delete an environment
+
+----
+TARGET_HOST="bastion.na4.openshift.opentlc.com"
+OCP_USERNAME="wkulhane-redhat.com"
+WORKLOAD="ocp4_workload_mta_tackle2"
+GUID=1002
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=ec2-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"guid=${GUID}" \
+    -e"ACTION=remove"
+----

--- a/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: Running Pre Workload Tasks
+  include_tasks:
+    file: ./pre_workload.yml
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload Tasks
+  include_tasks:
+    file: ./workload.yml
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  include_tasks:
+    file: ./post_workload.yml
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload removal Tasks
+  include_tasks:
+    file: ./remove_workload.yml
+  when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/tasks/post_workload.yml
@@ -1,0 +1,5 @@
+---
+- name: post_workload tasks complete
+  debug:
+    msg: "Post-Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/tasks/pre_workload.yml
@@ -1,0 +1,5 @@
+---
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/tasks/workload.yml
@@ -1,0 +1,84 @@
+---
+# Implement your Workload deployment tasks here
+- name: Setting up workload for user
+  debug:
+    msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
+
+- name: Determine cluster wildcard domain
+  k8s_info:
+    api_version: operator.openshift.io/v1
+    kind: IngressController
+    name: default
+    namespace: openshift-ingress-operator
+  register: r_ingress_controller
+
+- name: Set wildcard domain variable
+  set_fact:
+    _ocp4_workload_mta_tackle2_wildcard_domain: "{{ r_ingress_controller.resources[0].status.domain }}"
+
+# -----------------------------------------------------------------------------
+- name: Single user installation
+  when: ocp4_workload_mta_tackle2_num_users | int == 1
+  block:
+  - name: Install Tackle2 (single user)
+    kubernetes.core.k8s:
+      state: present
+      definition: "{{ lookup('template', 'application.yaml.j2') }}"
+
+  - name: Save Tackle2 user info (single user, auth enabled)
+    when: ocp4_workload_mta_tackle2_feature_auth_required | default(true)
+    agnosticd_user_info:
+      data:
+        tackle_url: >-
+          https://tackle-{{ ocp4_workload_mta_tackle2_namespace_base }}.{{
+          _ocp4_workload_mta_tackle2_wildcard_domain }}
+        tackle_user: "{{ ocp4_workload_mta_tackle2_user }}"
+        tackle_password: "{{ ocp4_workload_mta_tackle2_password }}"
+
+  - name: Save Tackle2 user info (single user, auth disabled)
+    when: not ocp4_workload_mta_tackle2_feature_auth_required | default(true)
+    agnosticd_user_info:
+      data:
+        tackle_url: >-
+          https://tackle-{{ ocp4_workload_mta_tackle2_namespace_base }}.{{
+          _ocp4_workload_mta_tackle2_wildcard_domain }}
+
+# -----------------------------------------------------------------------------
+- name: Multi user installation
+  when: ocp4_workload_mta_tackle2_num_users | int > 1
+  block:
+  - name: Install Tackle2 (multi user)
+    kubernetes.core.k8s:
+      state: present
+      definition: "{{ lookup('template', 'applicationset.yaml.j2') }}"
+
+  - name: Save Tackle2 user information for each user (authentication enabled)
+    when: ocp4_workload_mta_tackle2_feature_auth_required | default(true)
+    agnosticd_user_info:
+      user: "{{ ocp4_workload_mta_tackle2_user_base }}{{ item }}"
+      data:
+        tackle_url: >-
+          https://tackle-{{ ocp4_workload_mta_tackle2_namespace_base }}-{{
+          ocp4_workload_mta_tackle2_user_base }}{{ item }}.{{
+          _ocp4_workload_mta_tackle2_wildcard_domain }}
+        tackle_user: "{{ ocp4_workload_mta_tackle2_user }}"
+        tackle_password: "{{ ocp4_workload_mta_tackle2_password }}"
+    loop: "{{ range(1, 1 + ocp4_workload_mta_tackle2_num_users | int) | list }}"
+
+  - name: Save Tackle user information for each user (authentication disabled)
+    when: not ocp4_workload_mta_tackle2_feature_auth_required | default(true)
+    agnosticd_user_info:
+      user: "{{ ocp4_workload_mta_tackle2_user_base }}{{ item }}"
+      data:
+        tackle_url: >-
+          https://tackle-{{ ocp4_workload_mta_tackle2_namespace_base }}-{{
+          ocp4_workload_mta_tackle2_user_base }}{{ item }}.{{
+          _ocp4_workload_mta_tackle2_wildcard_domain }}
+    loop: "{{ range(1, 1 + ocp4_workload_mta_tackle2_num_users | int) | list }}"
+
+# -----------------------------------------------------------------------------
+# Leave this as the last task in the playbook.
+- name: workload tasks complete
+  debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/templates/application.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/templates/application.yaml.j2
@@ -1,0 +1,68 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ ocp4_workload_mta_tackle2_namespace_base }}
+  namespace: openshift-gitops
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    name: ''
+    namespace: {{ ocp4_workload_mta_tackle2_namespace_base }}
+    server: 'https://kubernetes.default.svc'
+  source:
+    path: ocp4_workload_mta_tackle2
+    repoURL: {{ ocp4_workload_mta_tackle2_repo }}
+    targetRevision: {{ ocp4_workload_mta_tackle2_repo_tag }}
+    helm:
+      parameters:
+      - name: namespace
+        value: "{{ ocp4_workload_mta_tackle2_namespace_base }}"
+      - name: user
+        value: "{{ ocp4_workload_mta_tackle2_user }}"
+      - name: role
+        value: "{{ ocp4_workload_mta_tackle2_role }}"
+      - name: seedTackle
+        value: "{{ ocp4_workload_mta_tackle2_seed }}"
+{% if ocp4_workload_mta_tackle2_seed | bool %}
+      - name: seedJob.repository
+        value: "{{ ocp4_workload_mta_tackle2_seed_image }}"
+      - name: seedJob.tag
+        value: "{{ ocp4_workload_mta_tackle2_seed_tag }}"
+      - name: seedJob.pullPolicy
+        value: "{{ ocp4_workload_mta_tackle2_seed_pull_policy }}"
+{% endif %}
+{% if ocp4_workload_mta_tackle2_feature_auth_required is defined %}
+      - name: tackle.featureAuthRequired
+        value: "{{ ocp4_workload_mta_tackle2_feature_auth_required }}"
+{% endif %}
+{% if ocp4_workload_mta_tackle2_rwx_storage_class | default("") | length > 0 %}
+      - name: tackle.rwxStorageClass
+        value: "{{ ocp4_workload_mta_tackle2_rwx_storage_class }}"
+{% endif %}
+{% if ocp4_workload_mta_tackle2_rwo_storage_class | default("") | length > 0 %}
+      - name: tackle.rwoStorageClass
+        value: "{{ ocp4_workload_mta_tackle2_rwo_storage_class }}"
+{% endif %}
+{% if ocp4_workload_mta_tackle2_maven_data_volume_size | default("") | length > 0 %}
+      - name: tackle.mavenDataVolumeSize
+        value: "{{ ocp4_workload_mta_tackle2_maven_data_volume_size }}"
+{% endif %}
+{% if ocp4_workload_mta_tackle2_hub_database_volume_size | default("") | length > 0 %}
+      - name: tackle.hubDatabaseVolumeSize
+        value: "{{ ocp4_workload_mta_tackle2_hub_database_volume_size }}"
+{% endif %}
+{% if ocp4_workload_mta_tackle2_keycloak_database_data_volume_size | default("") | length > 0 %}
+      - name: tackle.keycloakDatabaseDataVolumesize
+        value: "{{ ocp4_workload_mta_tackle2_keycloak_database_data_volume_size }}"
+{% endif %}
+{% if ocp4_workload_mta_tackle2_pathfinder_database_data_volume_size | default("") | length > 0 %}
+      - name: tackle.pathfinderDatabaseDataVolumeSize
+        value: "{{ ocp4_workload_mta_tackle2_pathfinder_database_data_volume_size }}"
+{% endif %}
+  project: default
+  syncPolicy:
+    automated:
+      prune: false
+      selfHeal: false

--- a/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/templates/applicationset.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/templates/applicationset.yaml.j2
@@ -1,0 +1,79 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: tackle2
+  namespace: openshift-gitops
+spec:
+  generators:
+  - list:
+      elements:
+{% for n in range(1, ocp4_workload_mta_tackle2_num_users + 1 ) %}
+      - user: {{ ocp4_workload_mta_tackle2_user_base }}{{ n }}
+{% endfor %}
+  template:
+    metadata:
+      name: "{{ ocp4_workload_mta_tackle2_namespace_base }}-{% raw %}{{ user }}{% endraw %}"
+      namespace: openshift-gitops
+      finalizers:
+      - resources-finalizer.argocd.argoproj.io
+    spec:
+      destination:
+        name: ''
+        namespace: "{{ ocp4_workload_mta_tackle2_namespace_base }}-{% raw %}{{ user }}{% endraw %}"
+        server: 'https://kubernetes.default.svc'
+      project: default
+      syncPolicy:
+        automated:
+          prune: false
+          selfHeal: false
+      source:
+        path: ocp4_workload_mta_tackle2
+        repoURL: {{ ocp4_workload_mta_tackle2_repo }}
+        targetRevision: {{ ocp4_workload_mta_tackle2_repo_tag }}
+        helm:
+          parameters:
+          - name: namespace
+            value: "{{ ocp4_workload_mta_tackle2_namespace_base }}-{% raw %}{{ user }}{% endraw %}"
+          - name: user
+            value: "{% raw %}{{ user }}{% endraw %}"
+          - name: role
+            value: "{{ ocp4_workload_mta_tackle2_role }}"
+          - name: seedTackle
+            value: "{{ ocp4_workload_mta_tackle2_seed }}"
+{% if ocp4_workload_mta_tackle2_seed | bool %}
+          - name: seedJob.repository
+            value: "{{ ocp4_workload_mta_tackle2_seed_image }}"
+          - name: seedJob.tag
+            value: "{{ ocp4_workload_mta_tackle2_seed_tag }}"
+          - name: seedJob.pullPolicy
+            value: "{{ ocp4_workload_mta_tackle2_seed_pull_policy }}"
+{% endif %}
+{% if ocp4_workload_mta_tackle2_feature_auth_required is defined %}
+          - name: tackle.featureAuthRequired
+            value: "{{ ocp4_workload_mta_tackle2_feature_auth_required }}"
+{% endif %}
+{% if ocp4_workload_mta_tackle2_rwx_storage_class | default("") | length > 0 %}
+          - name: tackle.rwxStorageClass
+            value: "{{ ocp4_workload_mta_tackle2_rwx_storage_class }}"
+{% endif %}
+{% if ocp4_workload_mta_tackle2_rwo_storage_class | default("") | length > 0 %}
+          - name: tackle.rwoStorageClass
+            value: "{{ ocp4_workload_mta_tackle2_rwo_storage_class }}"
+{% endif %}
+{% if ocp4_workload_mta_tackle2_maven_data_volume_size | default("") | length > 0 %}
+          - name: tackle.mavenDataVolumeSize
+            value: "{{ ocp4_workload_mta_tackle2_maven_data_volume_size }}"
+{% endif %}
+{% if ocp4_workload_mta_tackle2_hub_database_volume_size | default("") | length > 0 %}
+          - name: tackle.hubDatabaseVolumeSize
+            value: "{{ ocp4_workload_mta_tackle2_hub_database_volume_size }}"
+{% endif %}
+{% if ocp4_workload_mta_tackle2_keycloak_database_data_volume_size | default("") | length > 0 %}
+          - name: tackle.keycloakDatabaseDataVolumesize
+            value: "{{ ocp4_workload_mta_tackle2_keycloak_database_data_volume_size }}"
+{% endif %}
+{% if ocp4_workload_mta_tackle2_pathfinder_database_data_volume_size | default("") | length > 0 %}
+          - name: tackle.pathfinderDatabaseDataVolumeSize
+            value: "{{ ocp4_workload_mta_tackle2_pathfinder_database_data_volume_size }}"
+{% endif %}


### PR DESCRIPTION
##### SUMMARY

Added workload to deploy Tackle2 to a cluster. Either for a single user or for multiple users.

This workload requires OpenShift Gitops to be installed - and the gitops controller service account to have cluster-admin permissions.

It depends on the following repos:
https://github.com/redhat-gpte-devopsautomation/agnosticd_workload_helm_charts

And this container image:
https://quay.io/repository/gpte-devops-automation/tackle2-setup

Source for the container image:
https://github.com/redhat-gpte-devopsautomation/tackle2-setup-container

##### ISSUE TYPE
- New role Pull Request

##### COMPONENT NAME
ocp4_workload_mta_tackle2