### PR TITLE
Add a flag to omit waiting for MTV deployment, fix wait condition

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_mtv/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mtv/defaults/main.yml
@@ -5,6 +5,11 @@ silent: false
 
 # Default values below are for Migration Toolkit for OpenShift Virtualization v4.9.3
 
+# Wait for the ForkliftController instance to be ready
+# This takes a long time so for multi user environments
+# it is disabled by default
+ocp4_workload_mtv_wait_for_forkliftcontroller: true
+
 # Channel to use for the Migration Toolkit for OpenShift Virtualization subscription
 # When not set (or set to "") use the default channel for the
 # OpenShift version this operator is installed on. If there is

--- a/ansible/roles_ocp_workloads/ocp4_workload_mtv/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mtv/tasks/workload.yml
@@ -29,19 +29,19 @@
     definition: "{{ lookup('file', 'forkliftcontroller.yaml') }}"
 
 - name: Wait until ForkliftController is installed
+  when: ocp4_workload_mtv_wait_for_forkliftcontroller | bool
   kubernetes.core.k8s_info:
     api_version: forklift.konveyor.io/v1beta1
     kind: ForkliftController
     name: forklift-controller
     namespace: openshift-mtv
-  register: r_forkliftcontroller
-  retries: 120
-  delay: 10
-  until:
-  - r_forkliftcontroller.resources | length > 0
-  - r_forkliftcontroller.resources[0].status is defined
-  - r_forkliftcontroller.resources[0].status.conditions | length > 0
-  - r_forkliftcontroller.resources[0].status.conditions[0].reason is match( "Successful" )
+    wait: true
+    wait_condition:
+      reason: Successful
+      status: 'True'
+      type: Successful
+    wait_sleep: 10
+    wait_timeout: 600
 
 # Leave this as the last task in the playbook.
 - name: workload tasks complete


### PR DESCRIPTION
##### SUMMARY

It takes a long time for the operator to report success on the forkliftcontroller installation. Optionally turn off waiting for success. Also fix wait condition (which seems to have changed recently).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_mtv