### PR TITLE
Add support for tolerations for kubevirt workloads

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/defaults/main.yml
@@ -28,6 +28,15 @@ ocp4_workload_kubevirt_starting_csv: ""
 
 ocp4_workload_kubevirt_install_virtctl: true
 
+# Add additional tolerations to the HyperConverged components
+# This is necessary in mixed worker node environment where nodes that can run
+# VMs are tainted to prevent other pods from running on them
+ocp4_workload_kubevirt_workload_tolerations: []
+# Example: tolerate all nodes that have a taint with key 'metal'
+# ocp4_workload_kubevirt_workload_tolerations:
+# - key: metal
+#   operator: Exists
+
 # --------------------------------
 # Operator Catalog Snapshot Settings
 # --------------------------------

--- a/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/files/hyperconverged.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/files/hyperconverged.yaml
@@ -1,6 +1,0 @@
----
-apiVersion: hco.kubevirt.io/v1beta1
-kind: HyperConverged
-metadata:
-  name: kubevirt-hyperconverged
-  namespace: openshift-cnv

--- a/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/tasks/workload.yml
@@ -4,6 +4,16 @@
   debug:
     msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
 
+- name: Create the HyperConverged instance
+  template:
+    src: hyperconverged.yaml.j2
+    dest: /home/ec2-user/hcv.yaml
+    owner: ec2-user
+    mode: 0664
+
+- name: Abort
+  fail:
+
 - name: Install OpenShift Virtualization Operator
   include_role:
     name: install_operator
@@ -26,7 +36,7 @@
 - name: Create the HyperConverged instance
   kubernetes.core.k8s:
     state: present
-    definition: "{{ lookup('file', 'hyperconverged.yaml') }}"
+    definition: "{{ lookup('template', 'hyperconverged.yaml.j2') }}"
 
 - name: Wait until HyperConverged is installed
   kubernetes.core.k8s_info:

--- a/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/tasks/workload.yml
@@ -4,16 +4,6 @@
   debug:
     msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
 
-- name: Create the HyperConverged instance
-  template:
-    src: hyperconverged.yaml.j2
-    dest: /home/ec2-user/hcv.yaml
-    owner: ec2-user
-    mode: 0664
-
-- name: Abort
-  fail:
-
 - name: Install OpenShift Virtualization Operator
   include_role:
     name: install_operator

--- a/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/templates/hyperconverged.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/templates/hyperconverged.yaml.j2
@@ -1,0 +1,12 @@
+---
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+  namespace: openshift-cnv
+spec:
+{% if ocp4_workload_kubevirt_workload_tolerations | length > 0 %}
+  workloads:
+    tolerations:
+      {{ ocp4_workload_kubevirt_workload_tolerations | to_yaml }}
+{% endif %}

--- a/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/templates/applicationset.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/templates/applicationset.yaml.j2
@@ -8,7 +8,7 @@ spec:
   generators:
   - list:
       elements:
-{% for n in range(1, ocp4_workload_mta_tackle2_num_users + 1 ) %}
+{% for n in range(1, ocp4_workload_mta_tackle2_num_users | int + 1 ) %}
       - user: {{ ocp4_workload_mta_tackle2_user_base }}{{ n }}
 {% endfor %}
   template:


### PR DESCRIPTION
##### SUMMARY

When tainting nodes that should *only* run VMs the HyperConverged object needs to have a field .spec.workload.tolerations to set tolerations for the virt-handler daemon set to run on those nodes and make them available for VM scheduling.

This PR adds (optional) support to add workload tolerations to the HyperConverged custom resource.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_kubevirt