### PR TITLE
Added toleration support to ODF workload

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/defaults/main.yml
@@ -27,3 +27,11 @@ ocp4_workload_openshift_data_foundation_install_toolbox: false
 ocp4_workload_openshift_data_foundation_update_default_storage_class: false
 ocp4_workload_openshift_data_foundation_old_default_storage_class_name: gp2
 ocp4_workload_openshift_data_foundation_new_default_storage_class_name: ocs-storagecluster-ceph-rbd
+
+# --------------------------------
+# Tolerations for ODF Pods
+# --------------------------------
+ocp4_workload_openshift_data_foundation_tolerations: []
+# ocp4_workload_openshift_data_foundation_tolerations:
+# - key: metal
+#   operator: Exists

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/templates/storagecluster.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/templates/storagecluster.yaml.j2
@@ -5,6 +5,12 @@ metadata:
   namespace: openshift-storage
   name: ocs-storagecluster
 spec:
+{% if ocp4_workload_openshift_data_foundation_tolerations | length > 0 %}
+  placement:
+    all:
+      tolerations:
+        {{ ocp4_workload_openshift_data_foundation_tolerations | to_yaml }}
+{% endif %}
   manageNodes: false
   storageDeviceSets:
   - name: ocs-deviceset


### PR DESCRIPTION
##### SUMMARY

When Nodes are tainted ODF components don't get scheduled on those nodes.
Add optional support to add tolerations to all ODF components.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_openshift_data_foundations