### PR TITLE
Changing openstack ansible module to os_server_info

### DIFF
--- a/ansible/cloud_providers/osp_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/osp_infrastructure_deployment.yml
@@ -49,7 +49,7 @@
     OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"
   tasks:
     - name: Gather instance facts
-      openstack.cloud.server_info:
+      os_server_info:
         server: "*"
         filters:
           metadata:

--- a/ansible/configs/multi-cloud-capsule/infra_configs/osp_infrastructure_deployment.yml
+++ b/ansible/configs/multi-cloud-capsule/infra_configs/osp_infrastructure_deployment.yml
@@ -49,7 +49,7 @@
     OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"
   tasks:
     - name: Gather instance facts
-      openstack.cloud.server_info: 
+      os_server_info:
         server: "*"
         filters:
           metadata:

--- a/ansible/configs/osp-migration/destroy_env.yml
+++ b/ansible/configs/osp-migration/destroy_env.yml
@@ -38,7 +38,7 @@
     - name: Gather instance facts
       environment:
         OS_PROJECT_NAME: "{{ osp_project_name }}"
-      openstack.cloud.server_info:
+      os_server_info:
         server: "*"
         filters:
           metadata:

--- a/ansible/configs/osp-migration/infra.yml
+++ b/ansible/configs/osp-migration/infra.yml
@@ -202,7 +202,7 @@
         OS_PROJECT_NAME: "{{ osp_project_name }}"
         OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
         OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"
-      openstack.cloud.server_info:
+      os_server_info:
         server: "*"
         filters:
           metadata:

--- a/ansible/configs/osp-satellite-vm/destroy_env.yml
+++ b/ansible/configs/osp-satellite-vm/destroy_env.yml
@@ -38,7 +38,7 @@
     - name: Gather instance facts
       environment:
         OS_PROJECT_NAME: "{{ osp_project_name }}"
-      openstack.cloud.server_info:
+      os_server_info:
         server: "*"
         filters:
           metadata:

--- a/ansible/configs/osp-satellite-vm/infra.yml
+++ b/ansible/configs/osp-satellite-vm/infra.yml
@@ -142,7 +142,7 @@
         OS_PROJECT_NAME: "{{ osp_project_name }}"
         OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
         OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"
-      openstack.cloud.server_info:
+      os_server_info:
         server: "*"
         filters:
           metadata:

--- a/ansible/lifecycle_osp.yml
+++ b/ansible/lifecycle_osp.yml
@@ -10,7 +10,7 @@
     - when: ACTION == 'stop'
       block:
         - name: Gather instance facts
-          openstack.cloud.server_info:
+          os_server_info:
             filters:
               metadata:
                 guid: "{{ guid }}"
@@ -37,7 +37,7 @@
     - when: ACTION == 'start'
       block:
         - name: Gather instance facts
-          openstack.cloud.server_info:
+          os_server_info:
             filters:
               metadata:
                 guid: "{{ guid }}"
@@ -67,7 +67,7 @@
     - when: ACTION == 'status'
       block:
         - name: Get OSP facts using (guid, env_type) metadata
-          openstack.cloud.server_info:
+          os_server_info:
             filters:
               metadata:
                 guid: "{{ guid }}"

--- a/ansible/roles-infra/infra-osp-dry-run/tasks/main.yml
+++ b/ansible/roles-infra/infra-osp-dry-run/tasks/main.yml
@@ -34,6 +34,6 @@
         - validate_heat_template
 
     - name: Gather instance facts
-      openstack.cloud.server_info:
+      os_server_info:
         server: "*"
       register: r_osp_facts


### PR DESCRIPTION
Changing Openstack configs to use the "os_server_info" module instead of the openstack.cloud collection.


<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
