### PR TITLE
Update workloads to use fixed helm charts

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_ama_demo_shared/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ama_demo_shared/defaults/main.yaml
@@ -134,7 +134,7 @@ ocp4_workload_ama_demo_shared_demo_namespace_prefix: retail-
 # PostgreSQL Helm Chart
 ocp4_workload_ama_demo_shared_postgresql_repo: https://github.com/redhat-gpte-devopsautomation/agnosticd_workload_helm_charts.git
 ocp4_workload_ama_demo_shared_postgresql_repo_tag: main
-ocp4_workload_ama_demo_shared_postgresql_repo_path: ocp4_workload_ama_demo_shared/postgresql
+ocp4_workload_ama_demo_shared_postgresql_repo_path: postgresql
 
 # Orders PostgreSQL database
 ocp4_workload_ama_demo_shared_orders_db_app_name: postgresql-orders
@@ -173,4 +173,4 @@ ocp4_workload_ama_demo_shared_kubevirt_vm_tolerations: []
 # Location of the Helm Chart to deploy the VM
 ocp4_workload_ama_demo_shared_kubevirt_vm_repo: https://github.com/redhat-gpte-devopsautomation/agnosticd_workload_helm_charts.git
 ocp4_workload_ama_demo_shared_kubevirt_vm_repo_tag: main
-ocp4_workload_ama_demo_shared_kubevirt_vm_repo_path: ocp4_workload_ama_demo_shared/oracle-database
+ocp4_workload_ama_demo_shared_kubevirt_vm_repo_path: oracle-database

--- a/ansible/roles_ocp_workloads/ocp4_workload_codeserver/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_codeserver/defaults/main.yaml
@@ -89,3 +89,4 @@ ocp4_workload_codeserver_multi_user_namespace_base: codeserver
 # Helm Chart location
 ocp4_workload_code_server_repo: https://github.com/redhat-gpte-devopsautomation/agnosticd_workload_helm_charts.git
 ocp4_workload_code_server_repo_tag: main
+ocp4_workload_code_server_repo_path: codeserver

--- a/ansible/roles_ocp_workloads/ocp4_workload_codeserver/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_codeserver/tasks/workload.yml
@@ -110,13 +110,6 @@
     debug:
       msg: "{{ _ocp4_workload_codeserver_repos }}"
 
-  # - name: Debug template
-  #   template:
-  #     src: applicationset.yaml.j2
-  #     dest: /home/ec2-user/appset-codeserver.yaml
-  #     owner: ec2-user
-  #     mode: 0664
-
   - name: Install code server (multi user)
     kubernetes.core.k8s:
       state: present

--- a/ansible/roles_ocp_workloads/ocp4_workload_codeserver/templates/application.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_codeserver/templates/application.yaml.j2
@@ -13,64 +13,47 @@ spec:
     server: 'https://kubernetes.default.svc'
   project: default
   syncPolicy:
+    syncOptions:
+    - CreateNamespace=true
     automated:
       prune: false
       selfHeal: false
   source:
-    path: ocp4_workload_codeserver
     repoURL: {{ ocp4_workload_code_server_repo }}
     targetRevision: {{ ocp4_workload_code_server_repo_tag }}
+    path: {{ ocp4_workload_code_server_repo_path }}
     helm:
-      parameters:
-      # Common parameters
-      - name: namespace
-        value: {{ ocp4_workload_codeserver_namespace }}
-      - name: user
-        value: {{ ocp4_workload_codeserver_repos_user }}
-      - name: role
-        value: {{ ocp4_workload_codeserver_repos_user_role }}
-      - name: name
-        value: {{ ocp4_workload_codeserver_name }}
-      - name: workspaceName
-        value: {{ ocp4_workload_codeserver_workspace_name }}
-      - name: password
-        value: "{{ ocp4_workload_codeserver_password }}"
-      - name: storage.pvcSize
-        value: {{ ocp4_workload_codeserver_pvc_size }}
-{% if ocp4_workload_codeserver_storageclass | default("") | length > 0 %}
-      - name: storage.storageClass
-        value: {{ ocp4_workload_codeserver_storageclass }}
-{% endif %}
-
-      # Main Container
-      - name: mainContainer.repository
-        value: {{ ocp4_workload_codeserver_image }}
-      - name: mainContainer.tag
-        value: {{ ocp4_workload_codeserver_image_tag }}
-      - name: mainContainer.pullPolicy
-        value: {{ ocp4_workload_codeserver_image_pull_policy }}
-      - name: mainContainer.requests.cpu
-        value: {{ ocp4_workload_codeserver_request_cpu }}
-      - name: mainContainer.requests.memory
-        value: {{ ocp4_workload_codeserver_request_memory }}
-
-      # Init Container
-      - name: initContainer.repository
-        value: {{ ocp4_workload_codeserver_init_image }}
-      - name: initContainer.tag
-        value: {{ ocp4_workload_codeserver_init_image_tag }}
-      - name: initContainer.pullPolicy
-        value: {{ ocp4_workload_codeserver_init_image_pull_policy }}
-      - name: initContainer.requests.cpu
-        value: {{ ocp4_workload_codeserver_init_request_cpu }}
-      - name: initContainer.requests.memory
-        value: {{ ocp4_workload_codeserver_init_request_memory }}
-
+      values: |
+        fullnameOverride: {{ ocp4_workload_codeserver_name }}
+        workspaceName: {{ ocp4_workload_codeserver_workspace_name }}
+        password: {{ ocp4_workload_codeserver_password }}
 {% if _ocp4_workload_codeserver_repos | length > 0 %}
-      - name: repositoryList
-        value: '{{ _ocp4_workload_codeserver_repos | to_json }}'
+        repositoryList:
+          "{{ _ocp4_workload_codeserver_repos }}"
 {% endif %}
 {% if ocp4_workload_codeserver_extensions | length > 0 %}
-      - name: extensionList
-        value: '{{ ocp4_workload_codeserver_extensions | to_json }}'
+        extensionList:
+          "{{ ocp4_workload_codeserver_extensions }}"
 {% endif %}
+        namespacePermissions:
+          user: {{ ocp4_workload_codeserver_repos_user }}
+          role: {{ ocp4_workload_codeserver_repos_user_role }}
+        storage:
+          pvcSize: {{ ocp4_workload_codeserver_pvc_size }}
+{% if ocp4_workload_codeserver_storageclass | default("") | length > 0 %}
+          storageClass: {{ ocp4_workload_codeserver_storageclass }}
+{% endif %}
+        mainContainer:
+          repository: {{ ocp4_workload_codeserver_image }}
+          tag: {{ ocp4_workload_codeserver_image_tag }}
+          pullPolicy: {{ ocp4_workload_codeserver_image_pull_policy }}
+          requests:
+            cpu: {{ ocp4_workload_codeserver_request_cpu }}
+            memory: {{ ocp4_workload_codeserver_request_memory }}
+        initContainer:
+          repository: {{ ocp4_workload_codeserver_init_image }}
+          tag: {{ ocp4_workload_codeserver_init_image_tag }}
+          pullPolicy: {{ ocp4_workload_codeserver_init_image_pull_policy }}
+          requests:
+            cpu: {{ ocp4_workload_codeserver_init_request_cpu }}
+            memory: {{ ocp4_workload_codeserver_init_request_memory }}

--- a/ansible/roles_ocp_workloads/ocp4_workload_codeserver/templates/applicationset.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_codeserver/templates/applicationset.yaml.j2
@@ -19,68 +19,52 @@ spec:
       - resources-finalizer.argocd.argoproj.io
     spec:
       destination:
-        name: ''
+        name: ""
         namespace: "{{ ocp4_workload_codeserver_multi_user_namespace_base }}-{% raw %}{{ user }}{% endraw %}"
         server: 'https://kubernetes.default.svc'
       project: default
       syncPolicy:
+        syncOptions:
+        - CreateNamespace=true
         automated:
           prune: false
           selfHeal: false
       source:
-        path: ocp4_workload_codeserver
         repoURL: {{ ocp4_workload_code_server_repo }}
         targetRevision: {{ ocp4_workload_code_server_repo_tag }}
+        path: {{ ocp4_workload_code_server_repo_path }}
         helm:
-          parameters:
-          - name: namespace
-            value: "{{ ocp4_workload_codeserver_multi_user_namespace_base }}-{% raw %}{{ user }}{% endraw %}"
-          - name: user
-            value: "{% raw %}{{ user }}{% endraw %}"
-          - name: role
-            value: "{{ ocp4_workload_codeserver_repos_user_role }}"
-          - name: name
-            value: "{{ ocp4_workload_codeserver_name }}"
-          - name: workspaceName
-            value: "{{ ocp4_workload_codeserver_workspace_name }}"
-          - name: password
-            value: "{{ ocp4_workload_codeserver_password }}"
-          - name: storage.pvcSize
-            value: "{{ ocp4_workload_codeserver_pvc_size }}"
-{% if ocp4_workload_codeserver_storageclass | default("") | length > 0 %}
-          - name: storage.storageClass
-            value: "{{ ocp4_workload_codeserver_storageclass }}"
-{% endif %}
-
-          # Main Container
-          - name: mainContainer.repository
-            value: "{{ ocp4_workload_codeserver_image }}"
-          - name: mainContainer.tag
-            value: "{{ ocp4_workload_codeserver_image_tag }}"
-          - name: mainContainer.pullPolicy
-            value: "{{ ocp4_workload_codeserver_image_pull_policy }}"
-          - name: mainContainer.requests.cpu
-            value: "{{ ocp4_workload_codeserver_request_cpu }}"
-          - name: mainContainer.requests.memory
-            value: "{{ ocp4_workload_codeserver_request_memory }}"
-
-          # Init Container
-          - name: initContainer.repository
-            value: "{{ ocp4_workload_codeserver_init_image }}"
-          - name: initContainer.tag
-            value: "{{ ocp4_workload_codeserver_init_image_tag }}"
-          - name: initContainer.pullPolicy
-            value: "{{ ocp4_workload_codeserver_init_image_pull_policy }}"
-          - name: initContainer.requests.cpu
-            value: "{{ ocp4_workload_codeserver_init_request_cpu }}"
-          - name: initContainer.requests.memory
-            value: "{{ ocp4_workload_codeserver_init_request_memory }}"
-
+          values: |
+            fullnameOverride: {{ ocp4_workload_codeserver_name }}
+            workspaceName: {{ ocp4_workload_codeserver_workspace_name }}
+            password: {{ ocp4_workload_codeserver_password }}
 {% if _ocp4_workload_codeserver_repos | length > 0 %}
-          - name: repositoryList
-            value: '{{ _ocp4_workload_codeserver_repos | to_json }}'
+            repositoryList:
+              "{{ _ocp4_workload_codeserver_repos }}"
 {% endif %}
 {% if ocp4_workload_codeserver_extensions | length > 0 %}
-          - name: extensionList
-            value: "{{ ocp4_workload_codeserver_extensions }}"
+            extensionList:
+              "{{ ocp4_workload_codeserver_extensions }}"
 {% endif %}
+            namespacePermissions:
+              user: "{% raw %}{{ user }}{% endraw %}"
+              role: {{ ocp4_workload_codeserver_repos_user_role }}
+            storage:
+              pvcSize: {{ ocp4_workload_codeserver_pvc_size }}
+{% if ocp4_workload_codeserver_storageclass | default("") | length > 0 %}
+              storageClass: {{ ocp4_workload_codeserver_storageclass }}
+{% endif %}
+            mainContainer:
+              repository: {{ ocp4_workload_codeserver_image }}
+              tag: {{ ocp4_workload_codeserver_image_tag }}
+              pullPolicy: {{ ocp4_workload_codeserver_image_pull_policy }}
+              requests:
+                cpu: {{ ocp4_workload_codeserver_request_cpu }}
+                memory: {{ ocp4_workload_codeserver_request_memory }}
+            initContainer:
+              repository: {{ ocp4_workload_codeserver_init_image }}
+              tag: {{ ocp4_workload_codeserver_init_image_tag }}
+              pullPolicy: {{ ocp4_workload_codeserver_init_image_pull_policy }}
+              requests:
+                cpu: {{ ocp4_workload_codeserver_init_request_cpu }}
+                memory: {{ ocp4_workload_codeserver_init_request_memory }}

--- a/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/defaults/main.yml
@@ -7,6 +7,7 @@ silent: false
 ocp4_workload_mta_tackle2_repo: https://github.com/redhat-gpte-devopsautomation/agnosticd_workload_helm_charts.git
 # Tag to deploy
 ocp4_workload_mta_tackle2_repo_tag: main
+ocp4_workload_mta_tackle2_repo_path: tackle2
 
 # How many users to set up
 ocp4_workload_mta_tackle2_num_users: 1

--- a/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/templates/application.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/templates/application.yaml.j2
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: {{ ocp4_workload_mta_tackle2_namespace_base }}
+  name: tackle2
   namespace: openshift-gitops
   finalizers:
   - resources-finalizer.argocd.argoproj.io
@@ -11,58 +11,49 @@ spec:
     name: ''
     namespace: {{ ocp4_workload_mta_tackle2_namespace_base }}
     server: 'https://kubernetes.default.svc'
-  source:
-    path: ocp4_workload_mta_tackle2
-    repoURL: {{ ocp4_workload_mta_tackle2_repo }}
-    targetRevision: {{ ocp4_workload_mta_tackle2_repo_tag }}
-    helm:
-      parameters:
-      - name: namespace
-        value: "{{ ocp4_workload_mta_tackle2_namespace_base }}"
-      - name: user
-        value: "{{ ocp4_workload_mta_tackle2_user }}"
-      - name: role
-        value: "{{ ocp4_workload_mta_tackle2_role }}"
-      - name: seedTackle
-        value: "{{ ocp4_workload_mta_tackle2_seed }}"
-{% if ocp4_workload_mta_tackle2_seed | bool %}
-      - name: seedJob.repository
-        value: "{{ ocp4_workload_mta_tackle2_seed_image }}"
-      - name: seedJob.tag
-        value: "{{ ocp4_workload_mta_tackle2_seed_tag }}"
-      - name: seedJob.pullPolicy
-        value: "{{ ocp4_workload_mta_tackle2_seed_pull_policy }}"
-{% endif %}
-{% if ocp4_workload_mta_tackle2_feature_auth_required is defined %}
-      - name: tackle.featureAuthRequired
-        value: "{{ ocp4_workload_mta_tackle2_feature_auth_required }}"
-{% endif %}
-{% if ocp4_workload_mta_tackle2_rwx_storage_class | default("") | length > 0 %}
-      - name: tackle.rwxStorageClass
-        value: "{{ ocp4_workload_mta_tackle2_rwx_storage_class }}"
-{% endif %}
-{% if ocp4_workload_mta_tackle2_rwo_storage_class | default("") | length > 0 %}
-      - name: tackle.rwoStorageClass
-        value: "{{ ocp4_workload_mta_tackle2_rwo_storage_class }}"
-{% endif %}
-{% if ocp4_workload_mta_tackle2_maven_data_volume_size | default("") | length > 0 %}
-      - name: tackle.mavenDataVolumeSize
-        value: "{{ ocp4_workload_mta_tackle2_maven_data_volume_size }}"
-{% endif %}
-{% if ocp4_workload_mta_tackle2_hub_database_volume_size | default("") | length > 0 %}
-      - name: tackle.hubDatabaseVolumeSize
-        value: "{{ ocp4_workload_mta_tackle2_hub_database_volume_size }}"
-{% endif %}
-{% if ocp4_workload_mta_tackle2_keycloak_database_data_volume_size | default("") | length > 0 %}
-      - name: tackle.keycloakDatabaseDataVolumesize
-        value: "{{ ocp4_workload_mta_tackle2_keycloak_database_data_volume_size }}"
-{% endif %}
-{% if ocp4_workload_mta_tackle2_pathfinder_database_data_volume_size | default("") | length > 0 %}
-      - name: tackle.pathfinderDatabaseDataVolumeSize
-        value: "{{ ocp4_workload_mta_tackle2_pathfinder_database_data_volume_size }}"
-{% endif %}
   project: default
   syncPolicy:
+    syncOptions:
+    - CreateNamespace=true
     automated:
       prune: false
       selfHeal: false
+  source:
+    repoURL: {{ ocp4_workload_mta_tackle2_repo }}
+    targetRevision: {{ ocp4_workload_mta_tackle2_repo_tag }}
+    path: {{ ocp4_workload_mta_tackle2_repo_path }}
+    helm:
+      values: |
+        fullNameOverride: {{ ocp4_workload_mta_tackle2_namespace_base }}
+        namespacePermissions:
+          user: {{ ocp4_workload_mta_tackle2_user }}
+          role: {{ ocp4_workload_mta_tackle2_role }}
+        seedTackle: {{ ocp4_workload_mta_tackle2_seed }}
+{% if ocp4_workload_mta_tackle2_seed | bool %}
+        seedJob:
+          repository: {{ ocp4_workload_mta_tackle2_seed_image }}
+          tag: {{ ocp4_workload_mta_tackle2_seed_tag }}
+          pullPolicy: {{ ocp4_workload_mta_tackle2_seed_pull_policy }}
+{% endif %}
+        tackleInstance:
+{% if ocp4_workload_mta_tackle2_feature_auth_required is defined %}
+          featureAuthRequired: {{ ocp4_workload_mta_tackle2_feature_auth_required }}
+{% endif %}
+{% if ocp4_workload_mta_tackle2_rwx_storage_class | default("") | length > 0 %}
+          rwxStorageClass: {{ ocp4_workload_mta_tackle2_rwx_storage_class }}
+{% endif %}
+{% if ocp4_workload_mta_tackle2_rwo_storage_class | default("") | length > 0 %}
+          rwoStorageClass: {{ ocp4_workload_mta_tackle2_rwo_storage_class }}
+{% endif %}
+{% if ocp4_workload_mta_tackle2_maven_data_volume_size | default("") | length > 0 %}
+          mavenDataVolumeSize: {{ ocp4_workload_mta_tackle2_maven_data_volume_size }}
+{% endif %}
+{% if ocp4_workload_mta_tackle2_hub_database_volume_size | default("") | length > 0 %}
+          hubDatabaseVolumeSize: {{ ocp4_workload_mta_tackle2_hub_database_volume_size }}
+{% endif %}
+{% if ocp4_workload_mta_tackle2_keycloak_database_data_volume_size | default("") | length > 0 %}
+          keycloakDatabaseDataVolumesize: {{ ocp4_workload_mta_tackle2_keycloak_database_data_volume_size }}
+{% endif %}
+{% if ocp4_workload_mta_tackle2_pathfinder_database_data_volume_size | default("") | length > 0 %}
+          pathfinderDatabaseDataVolumeSize: {{ ocp4_workload_mta_tackle2_pathfinder_database_data_volume_size }}
+{% endif %}

--- a/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/templates/applicationset.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/templates/applicationset.yaml.j2
@@ -24,56 +24,47 @@ spec:
         server: 'https://kubernetes.default.svc'
       project: default
       syncPolicy:
+        syncOptions:
+        - CreateNamespace=true
         automated:
           prune: false
           selfHeal: false
       source:
-        path: ocp4_workload_mta_tackle2
         repoURL: {{ ocp4_workload_mta_tackle2_repo }}
         targetRevision: {{ ocp4_workload_mta_tackle2_repo_tag }}
+        path: {{ ocp4_workload_mta_tackle2_repo_path }}
         helm:
-          parameters:
-          - name: namespace
-            value: "{{ ocp4_workload_mta_tackle2_namespace_base }}-{% raw %}{{ user }}{% endraw %}"
-          - name: user
-            value: "{% raw %}{{ user }}{% endraw %}"
-          - name: role
-            value: "{{ ocp4_workload_mta_tackle2_role }}"
-          - name: seedTackle
-            value: "{{ ocp4_workload_mta_tackle2_seed }}"
+          values: |
+            fullNameOverride: {{ ocp4_workload_mta_tackle2_namespace_base }}
+            namespacePermissions:
+              user: "{% raw %}{{ user }}{% endraw %}"
+              role: {{ ocp4_workload_mta_tackle2_role }}
+            seedTackle: {{ ocp4_workload_mta_tackle2_seed }}
 {% if ocp4_workload_mta_tackle2_seed | bool %}
-          - name: seedJob.repository
-            value: "{{ ocp4_workload_mta_tackle2_seed_image }}"
-          - name: seedJob.tag
-            value: "{{ ocp4_workload_mta_tackle2_seed_tag }}"
-          - name: seedJob.pullPolicy
-            value: "{{ ocp4_workload_mta_tackle2_seed_pull_policy }}"
+            seedJob:
+              repository: {{ ocp4_workload_mta_tackle2_seed_image }}
+              tag: {{ ocp4_workload_mta_tackle2_seed_tag }}
+              pullPolicy: {{ ocp4_workload_mta_tackle2_seed_pull_policy }}
 {% endif %}
+            tackleInstance:
 {% if ocp4_workload_mta_tackle2_feature_auth_required is defined %}
-          - name: tackle.featureAuthRequired
-            value: "{{ ocp4_workload_mta_tackle2_feature_auth_required }}"
+              featureAuthRequired: {{ ocp4_workload_mta_tackle2_feature_auth_required }}
 {% endif %}
 {% if ocp4_workload_mta_tackle2_rwx_storage_class | default("") | length > 0 %}
-          - name: tackle.rwxStorageClass
-            value: "{{ ocp4_workload_mta_tackle2_rwx_storage_class }}"
+              rwxStorageClass: {{ ocp4_workload_mta_tackle2_rwx_storage_class }}
 {% endif %}
 {% if ocp4_workload_mta_tackle2_rwo_storage_class | default("") | length > 0 %}
-          - name: tackle.rwoStorageClass
-            value: "{{ ocp4_workload_mta_tackle2_rwo_storage_class }}"
+              rwoStorageClass: {{ ocp4_workload_mta_tackle2_rwo_storage_class }}
 {% endif %}
 {% if ocp4_workload_mta_tackle2_maven_data_volume_size | default("") | length > 0 %}
-          - name: tackle.mavenDataVolumeSize
-            value: "{{ ocp4_workload_mta_tackle2_maven_data_volume_size }}"
+              mavenDataVolumeSize: {{ ocp4_workload_mta_tackle2_maven_data_volume_size }}
 {% endif %}
 {% if ocp4_workload_mta_tackle2_hub_database_volume_size | default("") | length > 0 %}
-          - name: tackle.hubDatabaseVolumeSize
-            value: "{{ ocp4_workload_mta_tackle2_hub_database_volume_size }}"
+              hubDatabaseVolumeSize: {{ ocp4_workload_mta_tackle2_hub_database_volume_size }}
 {% endif %}
 {% if ocp4_workload_mta_tackle2_keycloak_database_data_volume_size | default("") | length > 0 %}
-          - name: tackle.keycloakDatabaseDataVolumesize
-            value: "{{ ocp4_workload_mta_tackle2_keycloak_database_data_volume_size }}"
+              keycloakDatabaseDataVolumesize: {{ ocp4_workload_mta_tackle2_keycloak_database_data_volume_size }}
 {% endif %}
 {% if ocp4_workload_mta_tackle2_pathfinder_database_data_volume_size | default("") | length > 0 %}
-          - name: tackle.pathfinderDatabaseDataVolumeSize
-            value: "{{ ocp4_workload_mta_tackle2_pathfinder_database_data_volume_size }}"
+              pathfinderDatabaseDataVolumeSize: {{ ocp4_workload_mta_tackle2_pathfinder_database_data_volume_size }}
 {% endif %}


### PR DESCRIPTION
##### SUMMARY

Made Helm Charts for Code Server and Tackle2 more "helm compliant". Should facilitate better re-use.
Updated workloads to use the updated charts.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_codeserver
ocp4_workload_mta_tackle2
ocp4_workload_ama_shared