### PR TITLE
Remove default hostedzoneid and url from StudentVM config to enable S…

### DIFF
--- a/ansible/configs/studentvm/default_vars_ec2.yml
+++ b/ansible/configs/studentvm/default_vars_ec2.yml
@@ -14,16 +14,16 @@ key_name: "default_key_name"
 #
 # HostedZoneId needs to come from the account that is being used. It also needs to match
 # subdomain_base_suffix
-HostedZoneId: Z3IHLWJZOU9SRT
+# HostedZoneId: Z3IHLWJZOU9SRT
+# subdomain_base_suffix: ".example.opentlc.com"
 
 subdomain_base_short: "{{ guid }}"
-subdomain_base_suffix: ".example.opentlc.com"
 subdomain_base: "{{subdomain_base_short}}{{subdomain_base_suffix}}"
 
 ## Environment Sizing
 
-studentvm_instance_type: "t2.medium"
-studentvm_instance_image: RHEL82GOLD
+studentvm_instance_type: "t3a.medium"
+studentvm_instance_image: RHEL84GOLD-latest
 studentvm_rootfs_size: 30
 
 ###### VARIABLES YOU SHOULD ***NOT*** CONFIGURE FOR YOUR DEPLOYEMNT


### PR DESCRIPTION
…andbox deployment

##### SUMMARY

StudentVM Config had a default HostedZoneID and basedomain suffix URL set. This prevented deployment of StudentVM into Sandboxes.

Remove the defaults (and update a few settings to current ones).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
studentvm