### PR TITLE
Ocp4 aio cnvlab

### DIFF
--- a/ansible/configs/ocp4-equinix-aio/requirements.yml
+++ b/ansible/configs/ocp4-equinix-aio/requirements.yml
@@ -2,7 +2,7 @@ roles:
   - src: https://github.com/RHFieldProductManagement/ocp4_aio_infra_role_base_software.git
     scm: git
     name: ocp4_aio_base_software
-    version: v0.0.3
+    version: v0.0.5
 
   - name: ocp4_aio_base_virt
     src: https://github.com/RHFieldProductManagement/ocp4_aio_infra_role_base_virt.git

--- a/ansible/configs/ocp4-equinix-aio/requirements.yml
+++ b/ansible/configs/ocp4-equinix-aio/requirements.yml
@@ -62,7 +62,7 @@ roles:
   - name: ocp4_aio_workload_cnvlab
     src: https://github.com/RHFieldProductManagement/ocp4_aio_role_deploy_cnvlab.git
     scm: git
-    version: v0.0.6
+    version: v0.0.8
 
 collections:
   - name: community.general


### PR DESCRIPTION
##### SUMMARY
Bumps requirement for the base_software component to get the latest version that provides a mirrorlist for the openstack-victoria repo instead of a wonky baseurl that was failing some deployments


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
CNV Lab

##### ADDITIONAL INFORMATION
