### PR TITLE
Fix missing storage size on AWS

### DIFF
--- a/ansible/configs/ocp4-cluster/default_vars_ec2.yml
+++ b/ansible/configs/ocp4-cluster/default_vars_ec2.yml
@@ -116,6 +116,8 @@ master_instance_count: 3
 master_storage_type: >-
   {{ 'io1' if worker_instance_count|int >= 10
   else 'gp2' }}
+# Size in Gigabytes (as an integer)
+master_storage_size: 100
 
 # When master_storage_type is io1 or io2, you can set the IOPS.
 # You usually want to leave it as the default IOPS value is calculated in the role host-ocp4-installer
@@ -130,6 +132,8 @@ worker_instance_type_family: >-
 worker_instance_type: "{{ master_instance_type_family }}.4xlarge"
 worker_instance_count: 2
 worker_storage_type: "gp2"
+# Size in Gigabytes (as an integer)
+worker_storage_size: 100
 
 # Instances to be provisioned
 # Provide these as a list.

--- a/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
+++ b/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
@@ -22,6 +22,7 @@ controlPlane:
 {%   endif %}
       rootVolume:
         type: {{ master_storage_type | to_json }}
+        size: {{ master_storage_size | int }}
 {%   if master_storage_type in ['io1', 'io2'] %}
         iops: {{ master_storage_iops | default(host_ocp4_installer_master_storage_iops) | int | to_json }}
 {%   endif %}
@@ -59,6 +60,7 @@ compute:
       type: {{ worker_instance_type | to_json }}
       rootVolume:
         type: {{ worker_storage_type | to_json }}
+        size: {{ worker_storage_size | int }}
 {%   if openshift_machineset_aws_zones | default([]) | length > 0 %}
       zones: {{ openshift_machineset_aws_zones | unique | to_json }}
 {%   elif hostvars.localhost.openshift_machineset_aws_zones_odcr | default([]) | length > 0 %}


### PR DESCRIPTION
##### SUMMARY

OCP 4.11 Installer now checks if the rootVolume.storage.size is set. This has been a required variable since at least 4.6 - but it hasn't been checked so far.

Adding a default rootVolume for AWS for 100 (Gigabytes).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-cluster
host-ocp4-installer