### PR TITLE
Add default for sandbox_enable_ui

### DIFF
--- a/ansible/roles-infra/infra-aws-open-environment/defaults/main.yaml
+++ b/ansible/roles-infra/infra-aws-open-environment/defaults/main.yaml
@@ -4,3 +4,4 @@ admin_console_password_gen: >-
   {{- lookup('password', '/dev/null length=10') -}}
   {{- lookup('password', '/dev/null length=1 chars=digits') -}}
 
+sandbox_enable_ui: false


### PR DESCRIPTION
##### SUMMARY

Fix bug caused by lack of default for sandbox_enable_ui.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role infra-aws-open-environment