### PR TITLE
Add support for OCP 4.11 to MachineSet role

### DIFF
--- a/ansible/roles/ocp4_machineset_config/defaults/main.yml
+++ b/ansible/roles/ocp4_machineset_config/defaults/main.yml
@@ -6,6 +6,7 @@ ocp4_machineset_config_disable_base_worker_machinesets: false
 
 ocp4_machineset_config_default_aws_instance_type: m5a.4xlarge
 ocp4_machineset_config_default_aws_root_volume_size: 120
+ocp4_machineset_config_default_aws_root_volume_type: gp2
 
 ocp4_machineset_config_default_osp_instance_type: "4c12g30d"
 ocp4_machineset_config_default_osp_root_volume_size: 120

--- a/ansible/roles/ocp4_machineset_config/tasks/disable-base-worker-machinesets.yml
+++ b/ansible/roles/ocp4_machineset_config/tasks/disable-base-worker-machinesets.yml
@@ -1,6 +1,6 @@
 ---
 - name: Scale base worker machinesets to zero
-  k8s:
+  kubernetes.core.k8s:
     state: present
     definition:
       apiVersion: machine.openshift.io/v1beta1

--- a/ansible/roles/ocp4_machineset_config/tasks/enable-cluster-autoscaler.yml
+++ b/ansible/roles/ocp4_machineset_config/tasks/enable-cluster-autoscaler.yml
@@ -1,5 +1,5 @@
 ---
 - name: Define clusterautoscaler
-  k8s:
+  kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('template', 'clusterautoscaler.yml.j2') | from_yaml }}"

--- a/ansible/roles/ocp4_machineset_config/tasks/machineset-group-aws.yml
+++ b/ansible/roles/ocp4_machineset_config/tasks/machineset-group-aws.yml
@@ -1,6 +1,6 @@
 ---
 - name: Define {{ machineset_group.name }} machinesets
-  k8s:
+  kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('template', 'machineset-aws.j2') | from_yaml }}"
   # Iterate through availability zones in reverse order as it makes the math
@@ -18,6 +18,8 @@
       {{ machineset_group.instance_type | default(default_aws_instance_type) }}
     aws_root_volume_size: >-
       {{ machineset_group.root_volume_size | default(default_aws_root_volume_size) }}
+    aws_root_volume_type: >-
+      {{ machineset_group.root_volume_type | default(default_aws_root_volume_type) }}
     machineset_name: >-
       {{ [cluster_label, machineset_group.name, availability_zone] | join('-') }}
     machineset_group_node_labels: >-
@@ -36,7 +38,7 @@
       ) | int }}
 
 - name: Define {{ machineset_group.name }} machineautoscalers
-  k8s:
+  kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('template', 'machineautoscaler.yml.j2') | from_yaml }}"
   # Iterate through availability zones in reverse order as it makes the math

--- a/ansible/roles/ocp4_machineset_config/tasks/machineset-group-openstack.yml
+++ b/ansible/roles/ocp4_machineset_config/tasks/machineset-group-openstack.yml
@@ -5,7 +5,7 @@
 #          not necessary on OSP. So we create just one Machineset for each MachinesetGroup
 #          NB: The way this role is called there is always just one MachinesetGroup
 - name: Define {{ machineset_group.name }} MachineSets
-  k8s:
+  kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('template', 'machineset-openstack.j2') | from_yaml }}"
   vars:
@@ -23,7 +23,7 @@
 
 - name: Define {{ machineset_group.name }} MachineAutoscalers
   when: machineset_group.autoscale | default(false) | bool
-  k8s:
+  kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('template', 'machineautoscaler.yml.j2') | from_yaml }}"
   vars:

--- a/ansible/roles/ocp4_machineset_config/tasks/set-facts.yml
+++ b/ansible/roles/ocp4_machineset_config/tasks/set-facts.yml
@@ -1,6 +1,6 @@
 ---
 - name: Get MachineSets
-  k8s_info:
+  kubernetes.core.k8s_info:
     api_version: machine.openshift.io/v1beta1
     kind: MachineSet
     namespace: openshift-machine-api
@@ -26,33 +26,16 @@
 - name: Print current MachineSets
   debug: var=ocp4_current_machineset_names
 
-- name: Set cluster facts for AWS
-  when: cloud_provider == "ec2"
+- name: Set cluster facts
   set_fact:
     cluster_label: >-
       {{ reference_machineset.metadata.labels['machine.openshift.io/cluster-api-cluster'] }}
     cloud_provider_api_version: >-
       {{ reference_provider_spec_value.apiVersion }}
     cloud_provider_platform: >-
-      {{ reference_provider_spec_value.apiVersion
-       | regex_replace('providerconfig\.openshift\.io/v1beta1', '')
-      }}
-  vars:
-    reference_machineset: >-
-      {{ ocp4_base_worker_machinesets[0] }}
-    reference_provider_spec_value: >-
-      {{ reference_machineset.spec.template.spec.providerSpec.value }}
-
-- name: Set cluster facts for OpenStack
-  when: cloud_provider == "osp"
-  set_fact:
-    cluster_label: >-
-      {{ reference_machineset.metadata.labels['machine.openshift.io/cluster-api-cluster'] }}
-    cloud_provider_api_version: >-
-      {{ reference_provider_spec_value.apiVersion }}
-    cloud_provider_platform: >-
-      {{ reference_provider_spec_value.apiVersion
-       | regex_replace('providerconfig\.openshift\.io/v1alpha1', '')
+      {{ reference_provider_spec_value.kind
+       | regex_replace('MachineProviderConfig', '')
+       | lower
       }}
   vars:
     reference_machineset: >-
@@ -64,6 +47,9 @@
   debug:
     msg: "{{ item.label }}: {{ item.value }}"
   loop:
-  - {label: "Cluster Label", value: "{{cluster_label}}"}
-  - {label: "Cloud Provider API Version", value: "{{cloud_provider_api_version}}"}
-  - {label: "Cloud Provider Platform", value: "{{cloud_provider_platform}}"}
+  - label: "Cluster Label"
+    value: "{{ cluster_label }}"
+  - label: "Cloud Provider API Version"
+    value: "{{ cloud_provider_api_version }}"
+  - label: "Cloud Provider Platform"
+    value: "{{ cloud_provider_platform }}"

--- a/ansible/roles/ocp4_machineset_config/templates/machineset-aws.j2
+++ b/ansible/roles/ocp4_machineset_config/templates/machineset-aws.j2
@@ -38,12 +38,12 @@ spec:
         value:
           ami:
             id: {{ aws_coreos_ami_id }}
-          apiVersion: awsproviderconfig.openshift.io/v1beta1
+          apiVersion: {{ cloud_provider_api_version }}
           blockDevices:
           - ebs:
               iops: 0
               volumeSize: {{ aws_root_volume_size }}
-              volumeType: gp2
+              volumeType: {{ aws_root_volume_type }}
           credentialsSecret:
             name: aws-cloud-credentials
           deviceIndex: 0

--- a/ansible/roles/ocp4_machineset_config/vars/main.yml
+++ b/ansible/roles/ocp4_machineset_config/vars/main.yml
@@ -10,6 +10,8 @@ default_aws_instance_type: >-
   {{ ocp4_machineset_config_default_aws_instance_type }}
 default_aws_root_volume_size: >-
   {{ ocp4_machineset_config_default_aws_root_volume_size }}
+default_aws_root_volume_type: >-
+  {{ ocp4_machineset_config_default_aws_root_volume_type }}
 
 default_osp_instance_type: >-
   {{ ocp4_machineset_config_default_osp_instance_type }}


### PR DESCRIPTION
##### SUMMARY

providerSpec changed for MachineSets in OCP 4.11.

Adding support for 4.11 while supporting existing versions.
Changed check for apiVersion to check for Kind. This unifies AWS and OSP code.

Add support for storage type for AWS (e.g. gp3 instead of gp2).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_machineset_config