### PR TITLE
Add execution nodes optionally to AAP config

### DIFF
--- a/ansible/configs/ansible-automation-platform/env_vars.yml
+++ b/ansible/configs/ansible-automation-platform/env_vars.yml
@@ -102,7 +102,9 @@ pah_instance_count: 0
 pah_instance_type: "t2.large"
 pah_instance_image: "RHEL84GOLD"
 
-isosupport_instance_count: 0
+exec_instance_count: 0  # increase also tower_expected_instances accordingly!
+exec_instance_type: "t2.medium"
+exec_instance_image: "RHEL84GOLD"
 
 subnets:
 - name: PublicSubnet
@@ -369,19 +371,19 @@ instances:
     value: "rhel"
   subnet: PublicSubnet
 
-# isolated support hosts
-- name: "isosupport"  # name must be strictly alphanumeric!
-  count: "{{isosupport_instance_count}}"
+# execution hosts
+- name: "exec"  # name must be strictly alphanumeric!
+  count: "{{exec_instance_count}}"
   public_dns: false
   security_groups:
   - TowerSG
   - HostSG
-  image: "{{ support_instance_image }}"
+  image: "{{ exec_instance_image }}"
   flavor:
-    "ec2": "{{support_instance_type}}"
+    "ec2": "{{exec_instance_type}}"
   tags:
   - key: "AnsibleGroup"
-    value: "support"
+    value: "execution_nodes"
   - key: "ostype"
     value: "rhel"
   subnet: PublicSubnet  #PrivateSubnet
@@ -557,6 +559,7 @@ tower_run: false
 
 ### Variables to check against in the tower_validate role, they must be aligned with what you expect
 # Set to "1" if single-instance Tower, "3" for Tower cluster
+# Execution hosts also need to be counted
 tower_expected_instances: 3           # number of instances in the cluster
 tower_expected_instance_groups: 2     # number of instance groups in the cluster
 # AAP 2.2+ doesn't care too much about subscription count, hence 1 managed node

--- a/ansible/configs/ansible-automation-platform/files/hosts_template.j2
+++ b/ansible/configs/ansible-automation-platform/files/hosts_template.j2
@@ -17,6 +17,13 @@
 {% endfor %}
 {% endif %}
 
+{% if 'execution_nodes' in groups %}
+[execs]
+{% for host in groups['execution_nodes'] %}
+{{ host }}
+{% endfor %}
+{% endif %}
+
 {% if 'support' in groups %}
 [supports]
 {% for host in groups['support'] %}

--- a/ansible/roles/aap_deploy/defaults/main.yml
+++ b/ansible/roles/aap_deploy/defaults/main.yml
@@ -12,6 +12,11 @@ deploy_automationcontroller_admin_password: "{{ automationcontroller_admin_passw
 
 # packages, libraries, installer vars
 
+# Which type should the controllers be, hybrid or only control?
+# Only used if there is at least one execution host in the execution_nodes
+# group.
+aap_deploy_controller_type: hybrid
+
 deploy_automationcontroller_pip_packages:
   - pip
   - setuptools

--- a/ansible/roles/aap_deploy/templates/automationcontroller_inventory.j2
+++ b/ansible/roles/aap_deploy/templates/automationcontroller_inventory.j2
@@ -17,7 +17,16 @@
 {% endfor %}
 {% endif %}
 
-[servicescatalog_workers]
+{% if groups['execution_nodes'] is defined %}
+[execution_nodes]
+{% for host in groups['execution_nodes'] %}
+{{ host }}
+{% endfor %}
+
+[automationcontroller:vars]
+node_type={{ aap_deploy_controller_type }}
+peers=execution_nodes
+{% endif %}
 
 [all:vars]
 admin_password='{{ deploy_automationcontroller_admin_password }}'


### PR DESCRIPTION
##### SUMMARY

Add execution nodes optionally to AAP config
Allows to decide if the control nodes are hybrid or only control.

##### ISSUE TYPE

- Feature Pull Request
- New config Pull Request

##### COMPONENT NAME

configs/ansible-automation-platform
roles/aap_deploy

##### ADDITIONAL INFORMATION

It is required for Summit Connect 2022 because we found out that the deployment of a single execution node takes too long during a lab (30 minutes out of 2 hours!). Linked to https://github.com/redhat-gpe/agnosticv/pull/6414