### PR TITLE
Add user info default vars for infra-aws-open-environment

### DIFF
--- a/ansible/roles-infra/infra-aws-open-environment/defaults/main.yaml
+++ b/ansible/roles-infra/infra-aws-open-environment/defaults/main.yaml
@@ -5,3 +5,6 @@ admin_console_password_gen: >-
   {{- lookup('password', '/dev/null length=1 chars=digits') -}}
 
 sandbox_enable_ui: false
+
+sandbox_user_info_data_enable: true
+sandbox_user_info_messages_enable: true

--- a/ansible/roles-infra/infra-aws-open-environment/tasks/print_user_info.yaml
+++ b/ansible/roles-infra/infra-aws-open-environment/tasks/print_user_info.yaml
@@ -1,5 +1,6 @@
 ---
 - name: Print Open Environment information to user
+  when: sandbox_user_info_messages_enable | bool
   agnosticd_user_info:
     msg: |
 


### PR DESCRIPTION
##### SUMMARY

Add defaults for `sandbox_user_info_data_enable` and `sandbox_user_info_messages_enable` to role `infra-aws-open-environment`.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role infra-aws-open-environment