### PR TITLE
Redirect vscode server download to GPTE S3

### DIFF
--- a/ansible/configs/ansible-automation-platform/env_vars.yml
+++ b/ansible/configs/ansible-automation-platform/env_vars.yml
@@ -24,7 +24,7 @@
 
 # Version of the VSCode server as available at
 # https://github.com/coder/code-server/releases
-vscode_server_version: 4.5.1
+vscode_server_version: 4.5.2
 
 ## guid is the deployment unique identifier, it will be appended to all tags,
 ## files and anything that identifies this environment from another "just like it"

--- a/ansible/roles/vscode-server/defaults/main.yml
+++ b/ansible/roles/vscode-server/defaults/main.yml
@@ -8,7 +8,9 @@ vscode_server_default_extensions:
 # It is recommended to pin it in your configuration so that the version in the
 # role can be kept up-to-date without need to re-test all configs
 vscode_server_version: "3.4.1"
-vscode_server_rpm_url: https://github.com/cdr/code-server/releases/download/v{{ vscode_server_version }}/code-server-{{ vscode_server_version }}-amd64.rpm
+vscode_server_rpm_url: https://gpte-public.s3.amazonaws.com/CI+Assets/Ansible+Automation+Controller+for+Advanced+Users/code-server-{{ vscode_server_version }}-amd64.rpm
+# the original URL directly from GitHub is the following:
+#vscode_server_rpm_url: https://github.com/cdr/code-server/releases/download/v{{ vscode_server_version }}/code-server-{{ vscode_server_version }}-amd64.rpm
 
 # Let's Encrypt default e-mail address
 # email was the old name of the variable but wasn't specific enough


### PR DESCRIPTION
##### SUMMARY

Redirect vscode server download to GPTE S3
This can avoid DoS blocking from GitHub, especially when doing mass deployment.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
code-server role

##### ADDITIONAL INFORMATION

Necessary for Summit connect 2022