### PR TITLE
Use project ID instead of name when destroying

### DIFF
--- a/ansible/roles-infra/infra-equinix-metal-resources/tasks/delete_project.yaml
+++ b/ansible/roles-infra/infra-equinix-metal-resources/tasks/delete_project.yaml
@@ -2,6 +2,6 @@
 - name: Delete Equinix Metal project
   community.general.packet_project:
     auth_token: "{{ equinix_metal_api_token }}"
-    name: "{{ equinix_metal_project_name }}"
+    id: "{{ equinix_metal_project_id }}"
     org_id: "{{ equinix_metal_organization_id }}"
     state: absent


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Use project id when destroying an Equinix Metal project

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
