### PR TITLE
Fix ocp4_workload_ama_demo_shared for the vscode URL and add namespace param

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_ama_demo_shared/tasks/dev-module-guides-install.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ama_demo_shared/tasks/dev-module-guides-install.yml
@@ -10,14 +10,14 @@
 - name: Create a new app for the guides-{{ guide }}
   when: r_guide_dc.resources | list | length == 0
   shell: |
-    oc new-app  https://github.com/RedHat-Middleware-Workshops/mad-dev-guides-{{ guide }}.git --strategy=docker
+    oc new-app https://github.com/RedHat-Middleware-Workshops/mad-dev-guides-{{ guide }}.git --strategy=docker -n dev-guides
 
 - name: Expose the deployment for the guides-{{ guide }}
   when: r_guide_dc.resources | list | length == 0
   shell: |
-    oc expose deploy mad-dev-guides-{{ guide }} --port 3000
+    oc expose deploy mad-dev-guides-{{ guide }} --port 3000 -n dev-guides
 
 - name: Create an edge route for the guides-{{ guide }}
   when: r_guide_dc.resources | list | length == 0
   shell: |
-    oc create route edge mad-dev-guides-{{ guide }} --service=mad-dev-guides-{{ guide }}
+    oc create route edge mad-dev-guides-{{ guide }} --service=mad-dev-guides-{{ guide }} -n dev-guides

--- a/ansible/roles_ocp_workloads/ocp4_workload_ama_demo_shared/tasks/dev-username-distribution-install.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ama_demo_shared/tasks/dev-username-distribution-install.yml
@@ -59,7 +59,7 @@
     -e LAB_USER_PAD_ZERO=false
     -e LAB_ADMIN_PASS=openshift
     -e LAB_MODULE_URLS={{ guides_urls | join(',') | quote }}
-    -e LAB_EXTRA_URLS={{ ( console_url + ';OpenShift Console,https://codeready-dev-guides.' + route_subdomain + ';VS Code Server' ) | quote }}
+    -e LAB_EXTRA_URLS={{ ( console_url + ';OpenShift Console,https://codeserver-codeserver-.%USERNAME%.' + route_subdomain + ';VS Code Server' ) | quote }}
 
 - name: expose username distribution tool
   when: r_gau_dc.resources | list | length == 0
@@ -89,7 +89,5 @@
 - name: output workshop info URL
   agnosticd_user_info:
     msg: |
-    
       URL for attendees to get a username assigned to them and links to labs:
-      
       https://get-a-username-dev-guides.{{ route_subdomain }}


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Fix ocp4_workload_ama_demo_shared for the vscode URL and add namespace param
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
