### PR TITLE
Remove check for pipelines

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/workload.yml
@@ -5,27 +5,6 @@
   debug:
     msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
 
-- name: Check that OpenShift Pipelines are installed
-  kubernetes.core.k8s_info:
-    api_version: operators.coreos.com/v1alpha1
-    kind: ClusterServiceVersion
-    namespace: openshift-operators
-  register: r_csvs
-
-- name: Set Pipelines CSV name
-  set_fact:
-    __ocp4_workload_openshift_gitops_pipelines_csv_name: "{{ r_csvs.resources | to_json | from_json | json_query(query) }}"
-  vars:
-    query: >-
-      [?starts_with(metadata.name, '{{ ocp4_workload_openshift_gitops_pipelines_csv_prefix }}' )].metadata.name
-
-- name: Assert that a CSV has been found
-  assert:
-    that:
-      __ocp4_workload_openshift_gitops_pipelines_csv_name | length > 0
-    success_msg: "Found OpenShift Pipelines operator."
-    fail_msg: "OpenShift Pipelines operator needs to be installed before the OpenShift GitOps operator."
-
 - name: Install OpenShift GitOps operator
   include_role:
     name: install_operator


### PR DESCRIPTION
##### SUMMARY

Apparently OpenShift gitops does not require pipelines any more. Removing check.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_openshift_gitops