### PR TITLE
Move OpenStack lifecycle to infra role

### DIFF
--- a/ansible/configs/tech-desktop-901/requirements.yml
+++ b/ansible/configs/tech-desktop-901/requirements.yml
@@ -1,0 +1,4 @@
+---
+collections:
+- name: openstack.cloud
+  version: 1.7.2

--- a/ansible/lifecycle_osp.yml
+++ b/ansible/lifecycle_osp.yml
@@ -1,74 +1,8 @@
----
-- environment:
-    OS_AUTH_URL: "{{ osp_auth_url }}"
-    OS_USERNAME: "{{ osp_auth_username }}"
-    OS_PASSWORD: "{{ osp_auth_password }}"
-    OS_PROJECT_NAME: "{{ osp_project_name }}"
-    OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
-    OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"
-  block:
-  - debug:
-      msg: Entering lifecycle_osp playbook
+- name: Debug ACTION, use -v to display
+  debug:
+    verbosity: 1
+    var: ACTION
 
-  - name: Debug ACTION, use -v to display
-    debug:
-      verbosity: 1
-      var: ACTION
-
-  - name: Gather Instances using guid & env_type
-    os_server_info:
-      filters:
-        metadata:
-          guid: "{{ guid }}"
-          env_type: "{{ env_type }}"
-    register: osp_info
-  - name: Debug osp_info var, use -v to display
-    debug:
-      verbosity: 3
-      var: osp_info
-  - name: Create all_instances fact
-    set_fact:
-      all_instances: >-
-        {{ osp_info.openstack_servers
-        | json_query('[*].id') }}
-
-  - name: Debug all_instances fact, use -v to display
-    debug:
-      verbosity: 1
-      var: all_instances
-  - name: Creating instance status report
-    when: ACTION == 'status'
-    block:
-      - name: Report status in user info
-        agnosticd_user_info:
-           msg: |-
-             {{ "%-30s %s" | format('Instance', 'State') }}
-             -------------------------------------------
-             {% for instance in osp_info.openstack_servers %}
-             {{ "%-30s %s" | format(instance.name, instance.vm_state) }}
-             {% endfor %}
-      - name: Print status information to a file
-        copy:
-          dest: "{{ output_dir }}/status.txt"
-          content: |-
-            {{ "%-30s %s" | format('Instance', 'State') }}
-            -------------------------------------------
-            {% for instance in osp_info.openstack_servers %}
-            {{ "%-30s %s" | format(instance.name, instance.vm_state) }}
-            {% endfor %}
-  - name: Start all Instances
-    when: ACTION == 'start'
-    os_server_action:
-      action: unshelve
-      server: "{{ item }}"
-      timeout: "{{ osp_timeout | default(300) }}"
-    register: start_results
-    loop: "{{ all_instances }}"
-  - name: Stop all Instances
-    when: ACTION == 'stop'
-    os_server_action:
-      action: shelve
-      server: "{{ item }}"
-      timeout: "{{ osp_timeout | default(300) }}"
-    register: stop_results
-    loop: "{{ all_instances }}"
+- name: Include OpenStack lifecycle role
+  include_role:
+    name: infra_osp_lifecycle

--- a/ansible/roles-infra/infra_osp_lifecycle/tasks/get-servers.yml
+++ b/ansible/roles-infra/infra_osp_lifecycle/tasks/get-servers.yml
@@ -1,0 +1,23 @@
+---
+# FIXME? - Get all server in project rather than restrict by guid?
+- name: Get server info using guid & env_type
+  openstack.cloud.server_info:
+    filters:
+      metadata:
+        guid: "{{ guid }}"
+        env_type: "{{ env_type }}"
+  register: r_os_server_info
+
+- name: Debug openstack.cloud.server_info var, use -v to display
+  debug:
+    verbosity: 3
+    var: r_os_server_info
+
+- name: Create openstack_servers fact
+  set_fact:
+    openstack_servers: "{{ r_os_server_info.openstack_servers }}"
+
+- name: Debug osp_servers fact, use -v to display
+  debug:
+    verbosity: 1
+    var: openstack_servers

--- a/ansible/roles-infra/infra_osp_lifecycle/tasks/main.yml
+++ b/ansible/roles-infra/infra_osp_lifecycle/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: Include tasks for ACTION
+  include_tasks:
+    file: "{{ ACTION }}.yml"
+    apply:
+      environment:
+        OS_AUTH_URL: "{{ osp_auth_url }}"
+        OS_USERNAME: "{{ osp_auth_username }}"
+        OS_PASSWORD: "{{ osp_auth_password }}"
+        OS_PROJECT_NAME: "{{ osp_project_name }}"
+        OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
+        OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"

--- a/ansible/roles-infra/infra_osp_lifecycle/tasks/start.yml
+++ b/ansible/roles-infra/infra_osp_lifecycle/tasks/start.yml
@@ -1,0 +1,14 @@
+---
+- name: Get server info
+  include_tasks:
+    file: get-servers.yml
+
+- name: Unshelve all servers
+  openstack.cloud.server_action:
+    action: unshelve
+    server: "{{ __server.id }}"
+    timeout: "{{ osp_timeout | default(300) }}"
+  loop: "{{ openstack_servers }}"
+  loop_control:
+    loop_var: __server
+    label: "{{ __server.id }}"

--- a/ansible/roles-infra/infra_osp_lifecycle/tasks/status.yml
+++ b/ansible/roles-infra/infra_osp_lifecycle/tasks/status.yml
@@ -1,0 +1,22 @@
+---
+- name: Get server info
+  include_tasks:
+    file: get-servers.yml
+
+- name: Report status
+  vars:
+    __status_text: |-
+     {{ "%-30s %s" | format('Instance', 'State') }}
+     -------------------------------------------
+     {% for __server in openstack_servers %}
+     {{ "%-30s %s" | format(__server.name, __server.vm_state) }}
+     {% endfor %}
+  block:
+  - name: Report status in user info
+    agnosticd_user_info:
+       msg: "{{ __status_text }}"
+
+  - name: Print status information to a file
+    copy:
+      dest: "{{ output_dir }}/status.txt"
+      content: "{{ __status_text }}"

--- a/ansible/roles-infra/infra_osp_lifecycle/tasks/stop.yml
+++ b/ansible/roles-infra/infra_osp_lifecycle/tasks/stop.yml
@@ -1,0 +1,14 @@
+---
+- name: Get server info
+  include_tasks:
+    file: get-servers.yml
+
+- name: Shelve all servers
+  openstack.cloud.server_action:
+    action: shelve
+    server: "{{ __server.id }}"
+    timeout: "{{ osp_timeout | default(300) }}"
+  loop: "{{ openstack_servers }}"
+  loop_control:
+    loop_var: __server
+    label: "{{ __server.id }}"


### PR DESCRIPTION
##### SUMMARY

Change OpenStack lifecycle to use infra role.

This allows us to support use of the `openstack.cloud` collection.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

OpenStack lifecycle