### PR TITLE
Adds default workshop file var (for later override)

### DIFF
--- a/ansible/roles/ocp4-workload-workshop-admin-storage/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-workshop-admin-storage/defaults/main.yml
@@ -2,6 +2,7 @@
 become_override: false
 ocp_username: kubeadmin
 silent: false
+WORKSHOP_FILE: workload.yaml
 
 _infra_node_replicas: 3
 _infra_node_instance_type: m4.4xlarge

--- a/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/workload.yml
@@ -57,6 +57,7 @@
     --param TERMINAL_IMAGE="quay.io/openshiftroadshow/lab-ocp-ocs:{{ HOMEROOM_IMAGE }}"
     --param PROJECT_NAME="lab-ocp-cns"
     --param WORKSHOP_ENVVARS="`cat /tmp/workshop-settings.sh`"
+    --param WORKSHOP_FILE="{{ WORKSHOP_FILE}}"
     --param OC_VERSION="4.3"
 
 - name: add kubeadmin to RoleBinding admin enabling route access

--- a/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/workload.yml
@@ -57,7 +57,7 @@
     --param TERMINAL_IMAGE="quay.io/openshiftroadshow/lab-ocp-ocs:{{ HOMEROOM_IMAGE }}"
     --param PROJECT_NAME="lab-ocp-cns"
     --param WORKSHOP_ENVVARS="`cat /tmp/workshop-settings.sh`"
-    --param WORKSHOP_FILE="{{ WORKSHOP_FILE}}"
+    --param WORKSHOP_FILE="{{ WORKSHOP_FILE }}"
     --param OC_VERSION="4.3"
 
 - name: add kubeadmin to RoleBinding admin enabling route access


### PR DESCRIPTION

##### SUMMARY
The OCP4 Admin/Storage workshop got some updates for 2022, which requires a new workshop definition file. This change to the role adds a variable which will support overriding which workshop file to load via AgnosticV.

##### ISSUE TYPE
- Feature Pull Request

Technically this is a role modification and not much of a new feature.

##### COMPONENT NAME
ocp4-workload-workshop-admin-storage