### PR TITLE
Support new version of ansible-runner

### DIFF
--- a/ansible/install_galaxy_roles.yml
+++ b/ansible/install_galaxy_roles.yml
@@ -64,7 +64,11 @@
 
     - name: Install collections from requirements.yml
       vars:
-        __from_ee: "{{ lookup('env', 'LAUNCHED_BY_RUNNER') == '1' }}"
+        __from_ee: >-
+          {{ lookup('env', 'LAUNCHED_BY_RUNNER') == '1'
+          or
+          lookup('env', 'HOME') == '/home/runner'
+          }}
         __collections_path: "{{ lookup('config', 'COLLECTIONS_PATHS')[0] }}"
       command: >-
         ansible-galaxy collection install


### PR DESCRIPTION
LAUNCHED_BY_RUNNER is not available anymore with new version of the runner.

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below
❯ ansible-navigator --version
ansible-navigator 2.1.0

agnosticd on  fix-collections-ee [$!?] via 🐍 v3.10.6 (ee)
❯ ansible-runner --version
2.2.1

```
