### PR TITLE
azure: do not define ssh key file per host

### DIFF
--- a/ansible/roles-infra/infra-azure-create-inventory/tasks/main.yml
+++ b/ansible/roles-infra/infra-azure-create-inventory/tasks/main.yml
@@ -59,8 +59,6 @@
       - "{{ 'newnodes' if (item.tags.newnode|d()|bool) else 'all'}}"
     ansible_user: "{{ remote_user }}"
     remote_user: "{{ remote_user | d('azure') }}"
-    ansible_ssh_private_key_file: "{{ ssh_provision_key_path | default(env_authorized_key_path) }}"
-    key_name: "envkey"
     state: "{{item.powerState|d('unknown')}}"
     internaldns: "{{item.tags.internaldns | d(item.osProfile.computerName) |d(item.name)}}"
     instance_id: "{{ item.vmId | d('unknown')}}"

--- a/ansible/roles/agnosticd_save_output_dir/tasks/create-output-dir-archive.yml
+++ b/ansible/roles/agnosticd_save_output_dir/tasks/create-output-dir-archive.yml
@@ -15,9 +15,6 @@
     tar -czf {{ agnosticd_save_output_dir_archive_tempfile }} --exclude "google-cloud-sdk" .
   args:
     chdir: "{{ output_dir }}"
-    # Disable warning for using tar command rather than archive module.
-    # archive module does not support chdir type option.
-    warn: false
 
 - when: agnosticd_save_output_dir_archive_password is defined
   name: Encrypt tarball using password


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
This change, if applied, fixes the error:

```
TASK [infra-azure-create-inventory : Build inventory] **************************
fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'env_authorized_key_path' is undefined\n\nThe error appears to be in '/tmp/awx_689835_k7s97kyq/project/ansible/roles-infra/infra-azure-create-inventory/tasks/main.yml': line 50, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Build inventory\n  ^ here\n"}
```

see GPTEINFRA-4132

The key doesn't have to be saved per host, as the ssh config is generated and we populate a section for each host.

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->

Tested in Execution environment ee-multicloud:v0.0.6
