### PR TITLE
fixes bug with multiple csvs in installplan

### DIFF
--- a/ansible/roles/install_operator/tasks/install.yml
+++ b/ansible/roles/install_operator/tasks/install.yml
@@ -80,7 +80,7 @@
   register: r_install_plans
   vars:
     _query: >-
-      [?starts_with(spec.clusterServiceVersionNames[0], '{{ install_operator_csv_nameprefix }}' )]
+      [spec.clusterServiceVersionNames[?starts_with(@, '{{ install_operator_csv_nameprefix }}' )]]
   retries: 30
   delay: 5
   until:


### PR DESCRIPTION
##### SUMMARY
In the case where an installplan had a list of csvs, and the desired
CSV was not the first item in the list, the old code would fail. This 
changes the installplan jmespath search to check if the entire list
contains the desired text.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
install_operator