### PR TITLE
BUGFIX - Migration Toolkit for Containers OCP4 Lab

### DIFF
--- a/ansible/roles/ocp-workload-migration/templates/operator.yml.j2
+++ b/ansible/roles/ocp-workload-migration/templates/operator.yml.j2
@@ -288,7 +288,7 @@ spec:
       serviceAccountName: migration-operator
       containers:
       - name: operator
-        image: registry.redhat.io/rhmtc/{{ mig_migration_namespace }}-legacy-rhel8-operator:v1.5.1-13
+        image: registry.redhat.io/rhmtc/{{ mig_migration_namespace }}-legacy-rhel8-operator:v1.7.3
         imagePullPolicy: Always
         volumeMounts:
         - mountPath: /tmp/ansible-operator/runner
@@ -311,51 +311,51 @@ spec:
         - name: RSYNC_TRANSFER_REPO
           value: {{ mig_migration_namespace }}-rsync-transfer-rhel8
         - name: RSYNC_TRANSFER_TAG
-          value: v1.5.1-3
+          value: v1.7.3
         - name: HOOK_RUNNER_REPO
           value: {{ mig_migration_namespace }}-hook-runner-rhel7
         - name: HOOK_RUNNER_TAG
-          value: v1.5.1-3
+          value: v1.7.3
         - name: MIG_CONTROLLER_REPO
           value: {{ mig_migration_namespace }}-controller-rhel8
         - name: MIG_CONTROLLER_TAG
-          value: v1.5.1-4
+          value: v1.7.3
         - name: MIG_UI_REPO
           value: {{ mig_migration_namespace }}-ui-rhel8
         - name: MIG_UI_TAG
-          value: v1.5.1-4
+          value: v1.7.3
         - name: MIG_LOG_READER_REPO
           value: {{ mig_migration_namespace }}-log-reader-rhel8
         - name: MIG_LOG_READER_TAG
-          value: v1.5.1-3
+          value: v1.7.3
         - name: MIGRATION_REGISTRY_REPO
           value: {{ mig_migration_namespace }}-registry-rhel8
         - name: MIGRATION_REGISTRY_TAG
-          value: v1.5.1-4
+          value: v1.7.3
         - name: VELERO_REPO
           value: {{ mig_migration_namespace }}-velero-rhel8
         - name: VELERO_TAG
-          value: v1.5.1-4
+          value: v1.7.3
         - name: VELERO_PLUGIN_REPO
           value: openshift-velero-plugin-rhel8
         - name: VELERO_PLUGIN_TAG
-          value: v1.5.1-4
+          value: v1.7.3
         - name: VELERO_RESTIC_RESTORE_HELPER_REPO
           value: {{ mig_migration_namespace }}-velero-restic-restore-helper-rhel8
         - name: VELERO_RESTIC_RESTORE_HELPER_TAG
-          value: v1.5.1-4
+          value: v1.7.3
         - name: VELERO_AWS_PLUGIN_REPO
           value: {{ mig_migration_namespace }}-velero-plugin-for-aws-rhel8
         - name: VELERO_AWS_PLUGIN_TAG
-          value: v1.5.1-5
+          value: v1.7.3
         - name: VELERO_GCP_PLUGIN_REPO
           value: {{ mig_migration_namespace }}-velero-plugin-for-gcp-rhel8
         - name: VELERO_GCP_PLUGIN_TAG
-          value: v1.5.1-7
+          value: v1.7.3
         - name: VELERO_AZURE_PLUGIN_REPO
           value: {{ mig_migration_namespace }}-velero-plugin-for-microsoft-azure-rhel8
         - name: VELERO_AZURE_PLUGIN_TAG
-          value: v1.5.1-4
+          value: v1.7.3
       volumes:
         - name: runner
           emptyDir: {}

--- a/ansible/roles/ocp4-workload-migration/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-migration/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # workload vars
-mig_operator_release_channel: release-v1.5
-mig_operator_starting_csv: mtc-operator.v1.5.1
+mig_operator_release_channel: release-v1.7
+mig_operator_starting_csv: mtc-operator.v1.7.3
 mig_subscription_wait: 20
 mig_expected_crds:
 - migclusters.migration.openshift.io


### PR DESCRIPTION
##### SUMMARY

Due to the removal of older versions of operator from the operator hub, the lab is failing to deploy. 
This PR updates the versions to the most recent ones. 

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
agnoticd roles: 
- ocp-workload-migration
- ocp4-workload-migration

##### ADDITIONAL INFORMATION
