### PR TITLE
Change package to shell

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/setup_bastion.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/setup_bastion.yml
@@ -3,12 +3,11 @@
   become: true
   block:
   - name: Install Java packages to bastion
-    package:
-      state: present
-      name:
-      - "java-{{ ocp4_workload_quarkus_super_heroes_demo_setup_bastion_java_version }}-openjdk"
-      - "java-{{ ocp4_workload_quarkus_super_heroes_demo_setup_bastion_java_version }}-openjdk-devel"
-      - podman-docker
+    ansible.builtin.shell:
+      cmd: >-
+        dnf install -y podman-docker
+          java-{{ ocp4_workload_quarkus_super_heroes_demo_setup_bastion_java_version }}-openjdk
+          java-{{ ocp4_workload_quarkus_super_heroes_demo_setup_bastion_java_version }}-openjdk-devel
 
   - name: Create /usr/local/maven directory
     file:


### PR DESCRIPTION
##### SUMMARY

ansible.builtin.package doesn't work on bastions on Tower.
Changing to ansible.builtin.shell instead.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_quarkus_superheroes_demo