### PR TITLE
Remove confusing defaults. Set in AgnosticV as per environment.

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_ama_demo_shared/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ama_demo_shared/defaults/main.yaml
@@ -176,39 +176,45 @@ ocp4_workload_ama_demo_shared_kubevirt_vm_repo_tag: main
 ocp4_workload_ama_demo_shared_kubevirt_vm_repo_path: oracle-database
 
 # ----------------------------------------
-# Dev Track - Guides and User distribution
+# Lab Guides
 # ----------------------------------------
-ocp4_workload_ama_demo_shared_guides_deploy: true
+ocp4_workload_ama_demo_shared_guides_deploy: false
 ocp4_workload_ama_demo_shared_guides_num_users: 2
-ocp4_workload_ama_demo_shared_guides_namespace: dev-guides
-ocp4_workload_ama_demo_shared_guides_namespace_display: Dev Track Guides
+ocp4_workload_ama_demo_shared_guides_namespace: labguides
+ocp4_workload_ama_demo_shared_guides_namespace_display: Lab Guides Guides
+# Lab guides are expected to be in their own repository under the main organization and end with the module name
+# So for the example below the repos should be:
+# https://github.com/rh-mad-workshop/mad-dev-guides-m1
+# https://github.com/rh-mad-workshop/mad-dev-guides-m2
+# etc.
 ocp4_workload_ama_demo_shared_guides_repo: https://github.com/rh-mad-workshop
 ocp4_workload_ama_demo_shared_guides_repo_name_prefix: mad-dev-guides
 
-ocp4_workload_ama_demo_shared_guides_module_type: m1;m2;m3;m4;m5
-ocp4_workload_ama_demo_shared_guides_module_titles:
-- name: m1
-  title: "Assessment and Analysis"
-  path: "/{{ ocp4_workload_ama_demo_shared_guides_repo_name_prefix }}-m1/main/introduction.html"
-- name: m2
-  title: "Refactor and Deployment"
-  path: "/{{ ocp4_workload_ama_demo_shared_guides_repo_name_prefix }}-m3/main/1-introduction.html"
-- name: m3
-  title: "Enable CI/CD Pipeline and GitOps"
-  path: "/{{ ocp4_workload_ama_demo_shared_guides_repo_name_prefix }}-m4/main/1-introduction.html"
-- name: m4
-  title: "Manage and Secure APIs"
-  path: "/{{ ocp4_workload_ama_demo_shared_guides_repo_name_prefix }}-m2/main/1-introduction.html"
-- name: m5
-  title: "Build Event-driven Architecture"
-  path: "/{{ ocp4_workload_ama_demo_shared_guides_repo_name_prefix }}-m5/main/introduction.html"
+# Which lab modules to deploy. Semi-colon separated list.
+ocp4_workload_ama_demo_shared_guides_module_type: ""
+# e.g.
+# ocp4_workload_ama_demo_shared_guides_module_type: m1;m2;m3;m4;m5
 
-ocp4_workload_ama_demo_shared_guides_user_selector_title: "Modern App Development - Dev Track"
+# Array of lab guides. Must match the module_type names
+ocp4_workload_ama_demo_shared_guides_module_titles: []
+# E.g.
+# ocp4_workload_ama_demo_shared_guides_module_titles:
+# - name: m1
+#   title: "Assessment and Analysis"
+#   path: "/{{ ocp4_workload_ama_demo_shared_guides_repo_name_prefix }}-m1/main/introduction.html"
+
+# ----------------------------------------
+# User distribution
+# ----------------------------------------
+ocp4_workload_ama_demo_shared_guides_user_selector_title: "Lab Guides"
 ocp4_workload_ama_demo_shared_guides_user_selector_lab_duration: 1week
-ocp4_workload_ama_demo_shared_guides_user_selector_lab_user_access_token: openshift
-ocp4_workload_ama_demo_shared_guides_user_selector_lab_user_password: openshift
+
+# Set these to something specific in AgnosticV
 ocp4_workload_ama_demo_shared_guides_user_selector_lab_user_prefix: user
-ocp4_workload_ama_demo_shared_guides_user_selector_lab_admin_password: openshift
+ocp4_workload_ama_demo_shared_guides_user_selector_lab_user_password: ""
+ocp4_workload_ama_demo_shared_guides_user_selector_lab_admin_password: "="
+ocp4_workload_ama_demo_shared_guides_user_selector_lab_user_access_token: ""
+
 ocp4_workload_ama_demo_shared_guides_user_selector_redis_name: redis
 ocp4_workload_ama_demo_shared_guides_user_selector_redis_namespace: "{{ ocp4_workload_ama_demo_shared_guides_namespace }}"
 ocp4_workload_ama_demo_shared_guides_user_selector_redis_image: image-registry.openshift-image-registry.svc:5000/openshift/redis


### PR DESCRIPTION
##### SUMMARY

ama shared demo workload had confusing defaults for the lab guides.
Removing defaults (which on top of being confusing were just wrong).
Set values now in AgnosticV (already there).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_ama_demo_shared