### PR TITLE
Change pipelines logic to download from cluster

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_pipelines/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_pipelines/defaults/main.yml
@@ -3,21 +3,10 @@ become_override: false
 ocp_username: opentlc-mgr
 silent: false
 
-# Defaults values below are for OpenShift Pipelines 1.0.1 (Tech Preview)
-
-# Where to download the OpenShift client binaries from
-# Only used if the ocp4_installer_url and ocp4_client_url are not defined
-# Official Mirror
-# ocp4_installer_root_url: https://mirror.openshift.com/pub/openshift-v4/clients
-# CloudFront Mirror
-ocp4_installer_root_url: http://d3s3zqyaz8cp2d.cloudfront.net/pub/openshift-v4/clients
-
-# Version of tkn to be installed on the bastion host
-# tkn 0.15.0 maps to OpenShift Pipelines 1.3.0
-ocp4_workload_pipelines_tkn_version: 0.15.0
+# Defaults values below are for latest channel
 
 # Channel to use for the OpenShift pipelines subscription
-ocp4_workload_pipelines_channel: stable
+ocp4_workload_pipelines_channel: latest
 
 # Set automatic InstallPlan approval. If set to false it is also suggested
 # to set the starting_csv to pin a specific version
@@ -32,12 +21,12 @@ ocp4_workload_pipelines_automatic_install_plan_approval: true
 # the catalog snapshot got created.
 # Match the first part of the CSV name to the nameprefix below
 ocp4_workload_pipelines_starting_csv: ""
-# ocp4_workload_pipelines_starting_csv: "openshift-pipelines-operator.v1.0.1"
+# ocp4_workload_pipelines_starting_csv: "openshift-pipelines-operator-rh.v1.8.0"
 
 # The name of the CSV to be installed
 # redhat-openshift-pipelines for v1.5.2 and earlier
 # openshift-pipelines-operator-rh for 1.6.0 and later
-ocp4_workload_pipelines_csv_nameprefix: redhat-openshift-pipelines
+ocp4_workload_pipelines_csv_nameprefix: openshift-pipelines-operator-rh
 
 # --------------------------------
 # Operator Catalog Snapshot Settings
@@ -56,4 +45,4 @@ ocp4_workload_pipelines_catalogsource_name: redhat-operators-snapshot-pipelines
 ocp4_workload_pipelines_catalog_snapshot_image: quay.io/gpte-devops-automation/olm_snapshot_redhat_catalog
 
 # Catalog snapshot image tag
-ocp4_workload_pipelines_catalog_snapshot_image_tag: v4.7_2021_02_24
+ocp4_workload_pipelines_catalog_snapshot_image_tag: v4.11_2022_09_05

--- a/ansible/roles_ocp_workloads/ocp4_workload_pipelines/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_pipelines/tasks/remove_workload.yml
@@ -62,6 +62,7 @@
     path: "{{ item }}"
   loop:
   - /usr/local/bin/tkn
+  - /usr/local/bin/tkn-pac
   - /etc/bash_completion.d/tkn
 
 - name: Remove Tekton CRDs

--- a/ansible/roles_ocp_workloads/ocp4_workload_pipelines/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_pipelines/tasks/workload.yml
@@ -24,29 +24,8 @@
     install_operator_catalogsource_image: "{{ ocp4_workload_pipelines_catalog_snapshot_image | default('') }}"
     install_operator_catalogsource_image_tag: "{{ ocp4_workload_pipelines_catalog_snapshot_image_tag }}"
 
-- name: Install OpenShift Pipelines CLI (tkn)
-  become: true
-  unarchive:
-    src: >-
-      {{ ocp4_installer_root_url }}/pipeline/{{
-      ocp4_workload_pipelines_tkn_version }}/tkn-linux-amd64-{{ ocp4_workload_pipelines_tkn_version }}.tar.gz
-    remote_src: true
-    dest: /usr/local/bin
-    mode: 0755
-    owner: root
-    group: root
-  args:
-    creates: /usr/local/bin/tkn
-
-# command: does not work here - somehow the parameters don't get passed properly
-- name: Setup tkn bash completion
-  become: true
-  shell: "/usr/local/bin/tkn completion bash >/etc/bash_completion.d/tkn"
-  args:
-    creates: /etc/bash_completion.d/tkn
-
-- name: Wait until Pipelines Pods are ready
-  k8s_info:
+- name: Wait until pipeline controller pods are ready
+  kubernetes.core.k8s_info:
     api_version: v1
     kind: Deployment
     namespace: openshift-pipelines
@@ -58,6 +37,83 @@
   - r_pipeline_controller_deployment.resources | length | int > 0
   - r_pipeline_controller_deployment.resources[0].status.readyReplicas is defined
   - r_pipeline_controller_deployment.resources[0].status.readyReplicas | int == r_pipeline_controller_deployment.resources[0].spec.replicas | int
+
+- name: Wait until tkn cli download deployment is ready
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Deployment
+    namespace: openshift-pipelines
+    name: tkn-cli-serve
+  register: r_pipeline_tkn_cli_deployment
+  retries: 30
+  delay: 10
+  until:
+  - r_pipeline_tkn_cli_deployment.resources | length | int > 0
+  - r_pipeline_tkn_cli_deployment.resources[0].status.readyReplicas is defined
+  - r_pipeline_tkn_cli_deployment.resources[0].status.readyReplicas | int == r_pipeline_controller_deployment.resources[0].spec.replicas | int
+
+- name: Get tkn ConsoleCLIDownload
+  kubernetes.core.k8s_info:
+    api_version: console.openshift.io/v1
+    kind: ConsoleCLIDownload
+    name: tkn
+  register: r_tkn_cli_download
+  retries: 20
+  delay: 5
+  ignore_errors: true
+  until:
+  - r_tkn_cli_download.resources is defined
+  - r_tkn_cli_download.resources | length > 0
+
+- name: Get tkn download URL from ConsoleCLIDownload
+  when: r_tkn_cli_download.resources | length > 0
+  set_fact:
+    _ocp4_workload_pipelines_tkn_url: >-
+      {{ r_tkn_cli_download.resources[0] | to_json | from_json
+       | json_query("spec.links[?contains(href,'-linux-amd64')].href") | first }}
+
+- name: Download tkn cli tool
+  get_url:
+    url: "{{ _ocp4_workload_pipelines_tkn_url }}"
+    validate_certs: false
+    dest: /tmp/tkn-linux-amd64.tar.gz
+    mode: 0660
+  register: r_tkn
+  until: r_tkn is success
+  retries: 10
+  delay: 10
+
+- name: Install tkn CLI on bastion
+  become: true
+  unarchive:
+    src: /tmp/tkn-linux-amd64.tar.gz
+    remote_src: true
+    dest: /usr/bin
+    mode: 0775
+    owner: root
+    group: root
+  args:
+    creates: /usr/bin/tkn
+
+- name: Remove downloaded file
+  file:
+    state: absent
+    path: /tmp/tkn-linux-amd64.tar.gz
+
+# command: does not work here - somehow the parameters don't get passed properly
+- name: Setup tkn bash completion
+  become: true
+  shell: "/usr/bin/tkn completion bash >/etc/bash_completion.d/tkn"
+  args:
+    creates: /etc/bash_completion.d/tkn
+
+- name: Setup tkn-pac bash completion
+  become: true
+  shell: "/usr/bin/tkn-pac completion bash >/etc/bash_completion.d/tkn-pac"
+  args:
+    creates: /etc/bash_completion.d/tkn-pac
+  # Ignore errors for older pipelines versions
+  ignore_errors: true
 
 # Leave this as the last task in the playbook.
 - name: workload tasks complete


### PR DESCRIPTION
##### SUMMARY

Change openshift-pipelines workload to download tkn from cluster instead of the internet. Remove now obsolete variables.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_pipelines