### PR TITLE
bastion-lite: Remove env_authorized_key dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ Session.vim
 
 ansible/main-artifact-*
 ansible/destroy-artifact-*
+ansible/lifecycle_entry_point-artifact-*
 main-artifact-*
 destroy-artifact-*
 artifacts

--- a/ansible/configs/just-a-bunch-of-nodes/default_vars.yml
+++ b/ansible/configs/just-a-bunch-of-nodes/default_vars.yml
@@ -122,19 +122,6 @@ install_common: true
 # here the deployment will fail
 #guid: defaultguid
 
-
-###V2WORK, these should just be set as default listed in the documentation
-# This is where the ssh_config file will be created, this file is used to
-# define the communication method to all the hosts in the deployment
-deploy_local_ssh_config_location: "{{output_dir}}/"
-
-
-### If you want a Key Pair name created and injected into the hosts,
-# set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
-# you can use the key used to create the environment or use your own self generated key
-env_authorized_key: "{{guid}}key"
-set_env_authorized_key: true
-
 ###V2WORK THIS SHOULD MOVE INTO THE ROLE
 # This var is used to identify stack (cloudformation, azure resourcegroup, ...)
 project_tag: "{{ env_type }}-{{ guid }}"

--- a/ansible/configs/just-a-bunch-of-nodes/default_vars_equinix_metal.yml
+++ b/ansible/configs/just-a-bunch-of-nodes/default_vars_equinix_metal.yml
@@ -2,20 +2,4 @@
 equinix_metal_facility: any
 hypervisor_type: c3.small.x86
 hypervisor_count: 1
-hypervisor_os: rocky_8
-
-ansible_user: root
-
-# Environment Instances
-instances:
-  - name: "hypervisor"
-    count: "{{ hypervisor_count }}"
-    public_dns: true
-    type: "{{ hypervisor_type }}"
-    os: "{{ hypervisor_os }}"
-    facility: "{{ equinix_metal_facility }}"
-    tags:
-      - key: "AnsibleGroup"
-        value: "bastions,hypervisors"
-      - key: "ostype"
-        value: "linux"
+install_common: false

--- a/ansible/configs/just-a-bunch-of-nodes/default_vars_equinix_metal.yml
+++ b/ansible/configs/just-a-bunch-of-nodes/default_vars_equinix_metal.yml
@@ -1,8 +1,8 @@
 ---
-equinix_metal_facility: am6
+equinix_metal_facility: any
 hypervisor_type: c3.small.x86
 hypervisor_count: 1
-hypervisor_os: centos_8
+hypervisor_os: rocky_8
 
 ansible_user: root
 

--- a/ansible/configs/just-a-bunch-of-nodes/pre_software.yml
+++ b/ansible/configs/just-a-bunch-of-nodes/pre_software.yml
@@ -7,10 +7,6 @@
     - debug:
         msg: "Step 003 Pre Software"
 
-    - include_role:
-        name: infra-local-create-ssh_key
-      when: set_env_authorized_key | bool
-
 - name: Configure all hosts with Repositories, Common Files and Set environment key
   hosts:
     - all:!windows
@@ -26,10 +22,6 @@
     - include_role:
         name: common
       when: install_common | bool
-
-    - include_role:
-        name: set_env_authorized_key
-      when: set_env_authorized_key | bool
 
 - name: Configuring Bastion Hosts
   hosts: bastions

--- a/ansible/configs/ocp4-equinix-aio/default_vars_equinix_metal.yml
+++ b/ansible/configs/ocp4-equinix-aio/default_vars_equinix_metal.yml
@@ -1,5 +1,5 @@
 ---
-equinix_metal_facility: da6
+equinix_metal_facility: any
 hypervisor_type: s3.xlarge.x86
 hypervisor_count: 1
 hypervisor_os: rocky_8

--- a/ansible/roles/bastion-lite/defaults/main.yml
+++ b/ansible/roles/bastion-lite/defaults/main.yml
@@ -1,2 +1,10 @@
 ---
 # defaults file for bastion
+
+ssh_bastion_key_type: rsa
+ssh_bastion_key_name: bastion_{{ guid }}
+ssh_bastion_key_path: >-
+  ~/.ssh/{{ ssh_bastion_key_name }}
+ssh_bastion_pubkey_path: >-
+  ~/.ssh/{{ ssh_bastion_key_name
+  | regex_replace('\.pem$', '') }}.pub

--- a/ansible/roles/bastion-lite/tasks/main.yml
+++ b/ansible/roles/bastion-lite/tasks/main.yml
@@ -1,23 +1,12 @@
 ---
-- name: Generate host .ssh/config Template
-  become: false
+# Generate an SSH key on the Bastion and configure access on all the hosts
+- include_tasks: create_bastion_ssh_key_and_access.yml
+
+- name: Generate .ssh/config
   template:
     src: "{{ role_path }}/templates/bastion_ssh_config.j2"
-    dest: "{{ output_dir }}/ssh-config-{{ env_type }}-{{ guid }}"
-  delegate_to: localhost
-  tags:
-    - gen_sshconfig_file
-
-- name: copy over host .ssh/config Template
-  become: true
-  copy:
-    src: "{{output_dir}}/ssh-config-{{ env_type }}-{{ guid }}"
-    dest: /root/.ssh/config
-    owner: root
-    group: root
+    dest: ~/.ssh/config
     mode: 0400
-  tags:
-    - copy_sshconfig_file
 
 - name: Stat /etc/sysconfig/iptables
   stat:

--- a/ansible/roles/bastion-lite/templates/bastion_ssh_config.j2
+++ b/ansible/roles/bastion-lite/templates/bastion_ssh_config.j2
@@ -1,11 +1,5 @@
-{% if cloud_provider == 'ec2' %}
-Host ec2* *.internal
-{% elif cloud_provider == 'osp' %}
-Host *.example.com
-{% endif %}	
-  User {{remote_user | default(hostvars.localhost.remote_user) }}
-  IdentityFile ~/.ssh/{{ env_authorized_key }}.pem
-  ForwardAgent yes
-  StrictHostKeyChecking no
-  ConnectTimeout 60
-  ConnectionAttempts 10
+IdentityFile {{ ssh_bastion_key_path }}
+ForwardAgent yes
+StrictHostKeyChecking no
+ConnectTimeout 60
+ConnectionAttempts 10


### PR DESCRIPTION
##### SUMMARY

This change, if applied, remove the dependency of env_authorized_key for
the bastion-lite role.

Instead, generate an SSH key on the bastion and use that to allow the
root@bastion user to ssh to any host.

That makes the bastion-lite role cloud-agnosticd.

- tested with just-a-bunch-of-nodes on equinix and AWS
- generate a key on the bastion and use that to setup additional access
  to all the hosts.
  The additional access is for the users when they ssh to the bastion:

```
ssh bastion...
sudo -i
ssh node1.GUID.internal
```

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

- bastion-lite role
- just-a-bunch-of-nodes  config, equinix, ec2

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->

tested using ee-multicloud:v0.0.7
