### PR TITLE
Enable custom system service for code server on bastion

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_vscode_bastion/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_vscode_bastion/defaults/main.yaml
@@ -7,10 +7,16 @@ silent: false
 ocp4_workload_vscode_bastion_home_directory: "/home/ec2-user"
 
 # Package version and download location for the vscode RPM
-ocp4_workload_vscode_bastion_vscode_package_version: "4.4.0"
+ocp4_workload_vscode_bastion_vscode_package_version: "4.7.0"
 ocp4_workload_vscode_bastion_vscode_package_url: >-
   https://github.com/coder/code-server/releases/download/v{{ ocp4_workload_vscode_bastion_vscode_package_version
   }}/code-server-{{ ocp4_workload_vscode_bastion_vscode_package_version }}-amd64.rpm
+
+# Code server comes with a system service definition. This definition does not
+# work when running podman in a terminal in code server
+# Setting to true enables a hard coded system service for just the specified user
+ocp4_workload_vscode_bastion_custom_system_service: false
+ocp4_workload_vscode_bastion_custom_system_service_user: ec2-user
 
 # Password for the VSCode Server
 # Set via config or secret

--- a/ansible/roles_ocp_workloads/ocp4_workload_vscode_bastion/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_vscode_bastion/tasks/workload.yml
@@ -217,13 +217,33 @@
     until: r_install_extension is not failed
     retries: 5
 
-- name: "Enable and start code-server@{{ ansible_user }} system service"
+- name: "Enable and start provided code-server@{{ ansible_user }} system service"
+  when: not ocp4_workload_vscode_bastion_custom_system_service | bool
   become: true
   ansible.builtin.service:
     name: "code-server@{{ ansible_user }}"
     enabled: true
     state: started
     daemon_reload: true
+
+- name: Setup, enable and start custom system service"
+  when: ocp4_workload_vscode_bastion_custom_system_service | bool
+  become: true
+  block:
+  - name: Set up system service definition
+    ansible.builtin.template:
+      src: code-server.service.j2
+      dest: /usr/lib/systemd/system/code-server.service
+      owner: root
+      group: root
+      mode: 0644
+
+  - name: Enable custom system service
+    ansible.builtin.service:
+      name: code-server
+      enabled: true
+      state: started
+      daemon_reload: true
 
 - name: Print User Info
   agnosticd_user_info:
@@ -233,7 +253,7 @@
       visual_studio_code_password: "{{ ocp4_workload_vscode_bastion_vscode_password }}"
   loop:
   - ""
-  - "Visual Studio Code Server is available on the Bastion VM."
+  - "Code Server is available on the Bastion VM."
   - "  URL:      {{ _ocp4_workload_vscode_bastion_url }}"
   - "  Password: {{ ocp4_workload_vscode_bastion_vscode_password }}"
   - ""

--- a/ansible/roles_ocp_workloads/ocp4_workload_vscode_bastion/templates/code-server.service.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_vscode_bastion/templates/code-server.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=Code server system service for user {{ ocp4_workload_vscode_bastion_custom_system_service_user }}
+After=network.target
+
+[Service]
+User={{ ocp4_workload_vscode_bastion_custom_system_service_user }}
+Group={{ ocp4_workload_vscode_bastion_custom_system_service_user }}
+
+Type=exec
+ExecStart=/usr/bin/code-server
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
##### SUMMARY

Enable a custom system service for code server on the bastion to allow for podman commands.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_vscode_bastion