### PR TITLE
Change ocp4_workload_ama_demo_app_services_shared to set lab_ui_url

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_ama_demo_app_services_shared/tasks/setup-app-services-lab-bookbag.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ama_demo_app_services_shared/tasks/setup-app-services-lab-bookbag.yml
@@ -25,7 +25,7 @@
   agnosticd_user_info:
     user: "{{ ocp4_workload_ama_demo_app_services_shared_user_prefix }}{{ n }}"
     data:
-      instructions_url: >-
+      lab_ui_url: >-
         https://bookbag-bookbag-{{ ocp4_workload_ama_demo_app_services_shared_user_prefix }}{{ n }}.{{ r_openshift_subdomain }}
   loop: "{{ range(1, 1 + ocp4_workload_ama_demo_app_services_shared_user_count | int) | list }}"
   loop_control:


### PR DESCRIPTION
##### SUMMARY

Change role `ocp4_workload_ama_demo_app_services_shared` to set `lab_ui_url` rather than `instructions_url` so that the URL will be picked up by other Babylon components to display as a link.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Workload ocp4_workload_ama_demo_app_services_shared