### PR TITLE
locate_env_authorized_key: fallback to old var

### DIFF
--- a/ansible/roles/locate_env_authorized_key/tasks/main.yaml
+++ b/ansible/roles/locate_env_authorized_key/tasks/main.yaml
@@ -22,7 +22,7 @@
       {%- if hostvars.localhost.ssh_provision_pubkey_path is defined -%}
       {{ hostvars.localhost.ssh_provision_pubkey_path }}
       {%- else -%}
-      {{ output_dir }}/{{ hostvars.localhost.ssh_provision_key_name | regex_replace('\.pem$', '') }}.pub
+      {{ output_dir }}/{{ hostvars.localhost.ssh_provision_key_name | default(env_authorized_key) | regex_replace('\.pem$', '') }}.pub
       {%- endif -%}
 
 - name: Generate SSH pub key content if it doesn't exist
@@ -42,6 +42,6 @@
     env_authorized_key_content_pub: >-
       {%- if hostvars.localhost.ssh_provision_pubkey_content is defined -%}
       {{ hostvars.localhost.ssh_provision_pubkey_content }}
-      {%- else -%} 
+      {%- else -%}
       {{ lookup('file', hostvars.localhost.env_authorized_key_path_pub) }}
       {%- endif -%}


### PR DESCRIPTION
This change, if applied, fixes the error:

```
fatal: [localhost -> localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'ansible.vars.hostvars.HostVarsVars object' has no attribute 'ssh_provision_key_name'\n\nThe error appears to be in '/tmp/awx_784394_ybsdlu5a/project/ansible/roles/locate_env_authorized_key/tasks/main.yaml': line 16, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Set env_authorized_key_path_pub\n  ^ here\n"}

```
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
