### PR TITLE
add validation if the resource group is already deleted

### DIFF
--- a/ansible/roles-infra/infra-azure-create-inventory/tasks/main.yml
+++ b/ansible/roles-infra/infra-azure-create-inventory/tasks/main.yml
@@ -29,13 +29,15 @@
     AZURE_CONFIG_DIR: "{{ output_dir }}/.azure-{{project_tag}}"
   changed_when: false
   register: result_list
-  ignore_errors: yes
+  failed_when:
+    - result_list.rc != 0
+    - "'ResourceGroupNotFound' not in result_list.stderr"
   tags:
     - create_inventory
     - must
 
 - name: Translate JSON output from 'az vm list' to ansible variable
-  when: result_list is defined
+  when: result_list is succeeded
   set_fact:
     vm_list: "{{ result_list.stdout | from_json }}"
   tags:

--- a/ansible/roles-infra/infra-azure-create-inventory/tasks/main.yml
+++ b/ansible/roles-infra/infra-azure-create-inventory/tasks/main.yml
@@ -29,11 +29,13 @@
     AZURE_CONFIG_DIR: "{{ output_dir }}/.azure-{{project_tag}}"
   changed_when: false
   register: result_list
+  ignore_errors: yes
   tags:
     - create_inventory
     - must
 
 - name: Translate JSON output from 'az vm list' to ansible variable
+  when: result_list is defined
   set_fact:
     vm_list: "{{ result_list.stdout | from_json }}"
   tags:
@@ -41,6 +43,7 @@
     - must
 
 - debug:
+  when: vm_list is defined
     var: vm_list
     verbosity: 2
   tags:
@@ -48,6 +51,7 @@
     - must
 
 - name: Build inventory
+  when: vm_list is defined
   add_host:
     name: "{{item.osProfile.computerName|default(item.name)}}"
     shortname: "{{item.tags.Name|default(item.name)}}"
@@ -84,6 +88,7 @@
 
 # AnsibleGroup tag can have several comma-separated values. Ex: activedirectories,windows
 - add_host:
+  when: vm_list is defined
     name: "{{item.osProfile.computerName|default(item.name)}}"
     groups: "{{item.tags.AnsibleGroup}}"
   with_items: "{{vm_list}}"

--- a/ansible/roles-infra/infra-azure-create-inventory/tasks/main.yml
+++ b/ansible/roles-infra/infra-azure-create-inventory/tasks/main.yml
@@ -7,19 +7,30 @@
     - must
 
 - name: Login to Azure
-  command: >-
-    az login --service-principal
-    -u {{ azure_service_principal | quote }}
-    -p {{ azure_password | quote }}
-    --tenant {{ azure_tenant | quote }}
   environment:
     AZURE_CONFIG_DIR: "{{ output_dir }}/.azure-{{project_tag}}"
   tags:
     - validate_azure_template
     - create_inventory
     - must
+  command: >-
+    az login --service-principal
+    -u {{ azure_service_principal | quote }}
+    -p {{ azure_password | quote }}
+    --tenant {{ azure_tenant | quote }}
+
+- name: Switch Subscriptions
+  environment:
+    AZURE_CONFIG_DIR: "{{ output_dir }}/.azure-{{project_tag}}"
+  tags:
+    - validate_azure_template
+    - create_inventory
+    - must
+  command: az account set -s "{{azure_subscription_id}}"
 
 - name: Check if Resource Group exists
+  environment:
+    AZURE_CONFIG_DIR: "{{ output_dir }}/.azure-{{project_tag}}"
   tags:
     - create_inventory
     - must
@@ -27,18 +38,19 @@
     auth_source: cli
     name: "{{ az_resource_group }}"
     tenant: "{{ azure_tenant }}"
-  ignore_errors: true
   register: azrg
 
 - name: If Resource Group exists, create inventory
-  when: azrg.result is not failed
+  when: azrg.resourcegroups|length>0
+  environment:
+    AZURE_CONFIG_DIR: "{{ output_dir }}/.azure-{{project_tag}}"
   tags:
     - create_inventory
     - must
   block:
     - name: Get list of VMs
       command: >-
-        az vm list --resource-group "{{az_resource_group}}"
+        az vm list --resource-group "{{ az_resource_group }}"
         --show-details
       environment:
         AZURE_CONFIG_DIR: "{{ output_dir }}/.azure-{{project_tag}}"

--- a/ansible/roles-infra/infra-azure-create-inventory/tasks/main.yml
+++ b/ansible/roles-infra/infra-azure-create-inventory/tasks/main.yml
@@ -44,8 +44,9 @@
     - create_inventory
     - must
 
-- debug:
+- name: Dump VM List
   when: vm_list is defined
+  debug:
     var: vm_list
     verbosity: 2
   tags:
@@ -53,7 +54,11 @@
     - must
 
 - name: Build inventory
-  when: vm_list is defined
+  when:
+    - vm_list is defined
+    - item.tags is defined
+    - item.tags.Project is defined
+    - item.tags.Project == project_tag
   add_host:
     name: "{{item.osProfile.computerName|default(item.name)}}"
     shortname: "{{item.tags.Name|default(item.name)}}"
@@ -78,10 +83,6 @@
     ansible_ssh_extra_args: "-o StrictHostKeyChecking=no"
     instance_canonical_name: "{{ item.tags.canonical_name }}"
   with_items: "{{vm_list}}"
-  when:
-    - item.tags is defined
-    - item.tags.Project is defined
-    - item.tags.Project == project_tag
   loop_control:
     label: "{{ item.name }}"
   tags:
@@ -89,15 +90,16 @@
     - must
 
 # AnsibleGroup tag can have several comma-separated values. Ex: activedirectories,windows
-- add_host:
-  when: vm_list is defined
-    name: "{{item.osProfile.computerName|default(item.name)}}"
-    groups: "{{item.tags.AnsibleGroup}}"
-  with_items: "{{vm_list}}"
+- name: Add host to inventory
   when:
+    - vm_list is defined
     - item.tags is defined
     - item.tags.Project is defined
     - item.tags.Project == project_tag
+  add_host:
+    name: "{{item.osProfile.computerName|default(item.name)}}"
+    groups: "{{item.tags.AnsibleGroup}}"
+  with_items: "{{vm_list}}"
   loop_control:
     label: "{{ item.name }}"
   tags:

--- a/ansible/roles-infra/infra-azure-create-inventory/tasks/main.yml
+++ b/ansible/roles-infra/infra-azure-create-inventory/tasks/main.yml
@@ -1,12 +1,11 @@
 ---
-# Setting the stack_tag
-- set_fact:
+- name: Set stack tag
+  set_fact:
     stack_tag: "{{env_type | replace('-', '_')}}_{{guid}}"
   tags:
     - create_inventory
     - must
 
-# use command line 'az' to validate template and deploy
 - name: Login to Azure
   command: >-
     az login --service-principal
@@ -20,98 +19,73 @@
     - create_inventory
     - must
 
-# use '--show-details' feature from the cli, it groups instances and their public IPs.
-# It saves us API calls.
-- name: Get list of VMs
-  command: az vm list --resource-group "{{az_resource_group}}" --show-details
-  # specify path to use azure-cli from system and not from python virtualenv
-  environment:
-    AZURE_CONFIG_DIR: "{{ output_dir }}/.azure-{{project_tag}}"
-  changed_when: false
-  register: result_list
-  failed_when:
-    - result_list.rc != 0
-    - "'ResourceGroupNotFound' not in result_list.stderr"
+- name: Check if Resource Group exists
   tags:
     - create_inventory
     - must
+  azure.azcollection.azure_rm_resourcegroup_info:
+    auth_source: cli
+    name: "{{ az_resource_group }}"
+    tenant: "{{ azure_tenant }}"
+  ignore_errors: true
+  register: azrg
 
-- name: Translate JSON output from 'az vm list' to ansible variable
-  when: result_list is succeeded
-  set_fact:
-    vm_list: "{{ result_list.stdout | from_json }}"
+- name: If Resource Group exists, create inventory
+  when: azrg.result is not failed
   tags:
     - create_inventory
     - must
-
-- name: Dump VM List
-  when: vm_list is defined
-  debug:
-    var: vm_list
-    verbosity: 2
-  tags:
-    - create_inventory
-    - must
-
-- name: Build inventory
-  when:
-    - vm_list is defined
-    - item.tags is defined
-    - item.tags.Project is defined
-    - item.tags.Project == project_tag
-  add_host:
-    name: "{{item.osProfile.computerName|default(item.name)}}"
-    shortname: "{{item.tags.Name|default(item.name)}}"
-    groups:
-      - "tag_Project_{{stack_tag}}"
-      - "tag_{{stack_tag}}_{{item.tags.AnsibleGroup | default('unknowns')}}"
-      - "tag_{{stack_tag}}_ostype_{{item.tags.ostype | default('unknown')}}"
-      - "{{item.tags.ostype | default('unknowns')}}"
-      - "{{ 'newnodes' if (item.tags.newnode|d()|bool) else 'all'}}"
-    ansible_user: "{{ remote_user }}"
-    remote_user: "{{ remote_user | d('azure') }}"
-    state: "{{item.powerState|d('unknown')}}"
-    internaldns: "{{item.tags.internaldns | d(item.osProfile.computerName) |d(item.name)}}"
-    instance_id: "{{ item.vmId | d('unknown')}}"
-    region: "{{azure_region}}"
-    public_dns_name: "{{item.fqdns|d(item.publicIps)|d('')}}"
-    private_dns_name: "{{item.tags.internaldns|d(item.name)}}"
-    private_ip_address: "{{item.privateIps}}"
-    public_ip_address: "{{item.publicIps}}"
-    placement: "{{item.zones}}"
-    image_id: "{{item.storageProfile.osDisk.image|d('unknown')}}"
-    ansible_ssh_extra_args: "-o StrictHostKeyChecking=no"
-    instance_canonical_name: "{{ item.tags.canonical_name }}"
-  with_items: "{{vm_list}}"
-  loop_control:
-    label: "{{ item.name }}"
-  tags:
-    - create_inventory
-    - must
-
-# AnsibleGroup tag can have several comma-separated values. Ex: activedirectories,windows
-- name: Add host to inventory
-  when:
-    - vm_list is defined
-    - item.tags is defined
-    - item.tags.Project is defined
-    - item.tags.Project == project_tag
-  add_host:
-    name: "{{item.osProfile.computerName|default(item.name)}}"
-    groups: "{{item.tags.AnsibleGroup}}"
-  with_items: "{{vm_list}}"
-  loop_control:
-    label: "{{ item.name }}"
-  tags:
-    - create_inventory
-    - must
-
-- name: debug hostvars
-  debug:
-    var: hostvars
-    verbosity: 2
-
-- name: debug groups
-  debug:
-    var: groups
-    verbosity: 2
+  block:
+    - name: Get list of VMs
+      command: >-
+        az vm list --resource-group "{{az_resource_group}}"
+        --show-details
+      environment:
+        AZURE_CONFIG_DIR: "{{ output_dir }}/.azure-{{project_tag}}"
+      changed_when: false
+      register: result_list
+    - name: Translate JSON output from 'az vm list' to ansible variable
+      set_fact:
+        vm_list: "{{ result_list.stdout | from_json }}"
+    - name: Build inventory
+      when:
+        - item.tags is defined
+        - item.tags.Project is defined
+        - item.tags.Project == project_tag
+      add_host:
+        name: "{{item.osProfile.computerName|default(item.name)}}"
+        shortname: "{{item.tags.Name|default(item.name)}}"
+        groups:
+          - "tag_Project_{{stack_tag}}"
+          - "tag_{{stack_tag}}_{{item.tags.AnsibleGroup | default('unknowns')}}"
+          - "tag_{{stack_tag}}_ostype_{{item.tags.ostype | default('unknown')}}"
+          - "{{item.tags.ostype | default('unknowns')}}"
+          - "{{ 'newnodes' if (item.tags.newnode|d()|bool) else 'all'}}"
+        ansible_user: "{{ remote_user }}"
+        remote_user: "{{ remote_user | d('azure') }}"
+        state: "{{item.powerState|d('unknown')}}"
+        internaldns: "{{item.tags.internaldns | d(item.osProfile.computerName) |d(item.name)}}"
+        instance_id: "{{ item.vmId | d('unknown')}}"
+        region: "{{azure_region}}"
+        public_dns_name: "{{item.fqdns|d(item.publicIps)|d('')}}"
+        private_dns_name: "{{item.tags.internaldns|d(item.name)}}"
+        private_ip_address: "{{item.privateIps}}"
+        public_ip_address: "{{item.publicIps}}"
+        placement: "{{item.zones}}"
+        image_id: "{{item.storageProfile.osDisk.image|d('unknown')}}"
+        ansible_ssh_extra_args: "-o StrictHostKeyChecking=no"
+        instance_canonical_name: "{{ item.tags.canonical_name }}"
+      with_items: "{{vm_list}}"
+      loop_control:
+        label: "{{ item.name }}"
+    - name: Add host to inventory
+      when:
+        - item.tags is defined
+        - item.tags.Project is defined
+        - item.tags.Project == project_tag
+      add_host:
+        name: "{{item.osProfile.computerName|default(item.name)}}"
+        groups: "{{item.tags.AnsibleGroup}}"
+      with_items: "{{vm_list}}"
+      loop_control:
+        label: "{{ item.name }}"

--- a/ansible/roles/open-env-azure-add-user-to-subscription/tasks/main.yml
+++ b/ansible/roles/open-env-azure-add-user-to-subscription/tasks/main.yml
@@ -81,7 +81,6 @@
         state: present
         tags:
           guid: "{{ guid }}"
-          delete: never
       register: rg_info
 
     - name: Get facts for management subscription

--- a/ansible/roles/open-env-azure-create-open-env/tasks/main.yml
+++ b/ansible/roles/open-env-azure-create-open-env/tasks/main.yml
@@ -18,7 +18,6 @@
     state: present
     tags:
       guid: "{{ guid }}"
-      delete: never
 - name: Get resource group info
   register: azrg
   azure.azcollection.azure_rm_resourcegroup_info:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
add validation if the resource group is already deleted
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4 on azure

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
