### PR TITLE
Introduce ocp4_workload_openshift_gitops_argo_cr_additional_values

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_gitops_workshop/templates/argocd_cr.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitops_workshop/templates/argocd_cr.yaml.j2
@@ -61,3 +61,6 @@ spec:
         memory: 128Mi
     route:
       enabled: true
+{%- if ocp4_workload_openshift_gitops_argo_cr_additional_values is defined %}
+  {{ ocp4_workload_openshift_gitops_argo_cr_additional_values | to_nice_yaml(indent=2) | indent(width=2) }}
+{% endif %}


### PR DESCRIPTION
##### SUMMARY

Added the ability to add more non defaults to argocd CR like:
```yaml
ocp4_workload_openshift_gitops_argo_cr_additional_values: |
  resourceTrackingMethod: annotation
```

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

Adjust ocp4_workload_openshift_gitops

##### ADDITIONAL INFORMATION
nothing
