### PR TITLE
Increase ocp4_workload_pipelines wait for tkn-cli-serve

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_pipelines/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_pipelines/tasks/workload.yml
@@ -45,8 +45,8 @@
     namespace: openshift-pipelines
     name: tkn-cli-serve
   register: r_pipeline_tkn_cli_deployment
-  retries: 40
-  delay: 10
+  retries: 60
+  delay: 30
   until:
   - r_pipeline_tkn_cli_deployment.resources | length | int > 0
   - r_pipeline_tkn_cli_deployment.resources[0].status.readyReplicas is defined


### PR DESCRIPTION
##### SUMMARY

Increase wait for tkn-cli-serve in ocp4_workload_pipelines from 6m40s to 30m. Investigation of a recent failure showed that the deployment became ready around 20m after the failure. Not sure why it takes so long, but better to wait a bit longer than to fail.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role ocp4_workload_pipelines