### PR TITLE
rosa: fix fail destroy when cluster doesn't exist

### DIFF
--- a/ansible/configs/rosa/destroy_env.yml
+++ b/ansible/configs/rosa/destroy_env.yml
@@ -106,8 +106,13 @@
     block:
     - set_fact:
         rosa_cluster_name: "rosa-{{ guid }}"
+
     - name: Destroy ROSA Cluster
       command: "/usr/local/bin/rosa delete cluster -y --cluster={{ rosa_cluster_name }}"
+      register: r_rosa_delete
+      failed_when: >-
+        r_rosa_delete.rc != 0
+        and 'ERR: There is no cluster with identifier or name' not in r_rosa_delete.stderr
 
     - name: Wait for ROSA deletion to complete
       command: "/usr/local/bin/rosa describe cluster -c {{ rosa_cluster_name }}"


### PR DESCRIPTION
```
TASK [Destroy ROSA Cluster] ****************************************************
fatal: [bastion.tn6q6.internal]: FAILED! => {"changed": true, "cmd": ["/usr/local/bin/rosa", "delete", "cluster", "-y", "--cluster=rosa-tn6q6"], "delta": "0:00:02.335637", "end": "2022-09-30 03:33:22.355779", "msg": "non-zero return code", "rc": 1, "start": "2022-09-30 03:33:20.020142", "stderr": "ERR: There is no cluster with identifier or name 'rosa-tn6q6'", "stderr_lines": ["ERR: There is no cluster with identifier or name 'rosa-tn6q6'"], "stdout": "", "stdout_lines": []}
```

see GPTEINFRA-4538

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

- config/rosa
