### PR TITLE
Set ocp4-cluster version of pyOpenSSL

### DIFF
--- a/ansible/configs/ocp4-cluster/files/requirements_k8s.txt
+++ b/ansible/configs/ocp4-cluster/files/requirements_k8s.txt
@@ -31,6 +31,7 @@ pyasn1-modules==0.2.8
 pycparser==2.19
 PyJWT==1.7.1
 PyNaCl==1.3.0
+pyOpenSSL==22.0.0
 pyRFC3339==1.1
 python-dateutil==2.8.2
 python-string-utils==1.0.0


### PR DESCRIPTION
##### SUMMARY

The new version of pyOpenSSL (22.1.0) is incompatible with our version of ansible or python. It produces an error:

```
... from OpenSSL.crypto import (
  File "/opt/virtualenvs/k8s/lib64/python3.6/site-packages/OpenSSL/crypto.py", line 3232, in <module>
    name="load_pkcs7_data\",\r\nTypeError: deprecated() got an unexpected keyword argument 'name'",
```

This PR explicitly declares the previous version.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ocp4-cluster python k8s virtual env