### PR TITLE
Add explicit version of pyOpenSSL for ocp4-cluster config

### DIFF
--- a/ansible/configs/ocp4-cluster/files/requirements_k8s.txt
+++ b/ansible/configs/ocp4-cluster/files/requirements_k8s.txt
@@ -31,6 +31,7 @@ pyasn1-modules==0.2.8
 pycparser==2.19
 PyJWT==1.7.1
 PyNaCl==1.3.0
+pyOpenSSL==22.0.0
 pyRFC3339==1.1
 python-dateutil==2.8.2
 python-string-utils==1.0.0


### PR DESCRIPTION
##### SUMMARY

New release of 22.1.0 is incompatible our version of python or ansible.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Config ocp4-cluster.