### PR TITLE
Add create_ssh_provision_key_enable_user_info_data flag

### DIFF
--- a/ansible/roles-infra/create_ssh_provision_key/defaults/main.yaml
+++ b/ansible/roles-infra/create_ssh_provision_key/defaults/main.yaml
@@ -8,3 +8,6 @@ ssh_provision_key_path: >-
 ssh_provision_pubkey_path: >-
   {{ output_dir }}/{{ ssh_provision_key_name
   | regex_replace('\.pem$', '') }}.pub
+
+# Option to have this role report the generated SSH private key as user info data
+create_ssh_provision_key_enable_user_info_data: false

--- a/ansible/roles-infra/create_ssh_provision_key/tasks/main.yaml
+++ b/ansible/roles-infra/create_ssh_provision_key/tasks/main.yaml
@@ -33,6 +33,12 @@
     content: "{{ ssh_provision_pubkey_content }}"
     dest: "{{ ssh_provision_pubkey_path }}"
 
+- name: Report user info for SSH provision key as user data
+  agnosticd_user_info:
+    data:
+      ssh_provision_key: "{{ lookup('file', ssh_provision_key_path) }}"
+  when: create_ssh_provision_key_enable_user_info_data | bool
+
 - include_role:
     name: agnosticd_save_output_dir
   when: r_ssh_key_gen is changed


### PR DESCRIPTION
##### SUMMARY

Add `create_ssh_provision_key_enable_user_info_data` flag to the `create_ssh_provision_key` role to have it report the generated SSH private key in user info data. Defaults to `false`.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Role `create_ssh_provision_key`