### PR TITLE
Update ocp4_workload_opentour_dach_2022 user default vars

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_opentour_dach_2022/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_opentour_dach_2022/defaults/main.yaml
@@ -3,8 +3,14 @@ become_override: false
 ocp_username: opentlc-mgr
 silent: false
 
-ocp4_workload_opentour_dach_2022_user_count: 4
-ocp4_workload_opentour_dach_2022_user_prefix: opentour-
+ocp4_workload_opentour_dach_2022_user_count: >-
+  {{ ocp4_workload_authentication_htpasswd_user_count
+   | default(user_count)
+   | default(num_users)
+   | default(4)
+  }}
+ocp4_workload_opentour_dach_2022_user_prefix: >-
+  {{ (ocp4_workload_authentication_htpasswd_user_base | default('opentour')) ~ '-' }}
 
 ocp4_workload_opentour_dach_2022_infra_repo: https://github.com/sa-mw-dach/opentour-2022-gitops-infra.git
 ocp4_workload_opentour_dach_2022_infra_repo_tag: HEAD


### PR DESCRIPTION
##### SUMMARY

Update ocp4_workload_opentour_dach_2022 role defaults to reference variables used by ocp4_workload_authentication.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Role ocp4_workload_opentour_dach_2022