### PR TITLE
Add setting openshift_cluster_ingress_domain in ocp4_workload_authentication

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_authentication/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_authentication/tasks/workload.yml
@@ -9,17 +9,20 @@
       ocp4_workload_authentication_idm_type == "ldap"
     fail_msg: "ocp4_workload_authentication_idm_type is not defined or not in ('none', 'htpasswd', 'ldap')."
 
-- name: Retrieve OpenShift console route
+- name: Retrieve OpenShift ingress config
   kubernetes.core.k8s_info:
-    api_version:
-    kind: Route
-    name: console
-    namespace: openshift-console
-  register: r_console_route
+    api_version: config.openshift.io/v1
+    kind: Ingress
+    name: cluster
+  register: r_ingress_config
+  failed_when: r_ingress_config.resources | length != 1
 
 - name: Save OpenShift console route
+  vars:
+    _ingress_config: "{{ r_ingress_config.resources[0] }}"
   set_fact:
-    _ocp4_workload_authentication_console_route: "https://{{ r_console_route.resources[0].spec.host }}"
+    _ocp4_workload_authentication_cluster_ingress_domain: "{{ _ingress_config.spec.domain }}"
+    _ocp4_workload_authentication_console_route: "https://console-openshift-console.{{ _ingress_config.spec.domain }}"
 
 - name: Setup HTPasswd Authentication
   when: ocp4_workload_authentication_idm_type == "htpasswd"
@@ -147,6 +150,7 @@
       user: "{{ ocp4_workload_authentication_htpasswd_user_base }}{{ n }}"
       data:
         console_url: "{{ _ocp4_workload_authentication_console_route }}"
+        openshift_cluster_ingress_domain: "{{ _ocp4_workload_authentication_cluster_ingress_domain }}"
         password: "{{ ocp4_workload_authentication_user_password }}"
         login_command: >-
           oc login -u {{ ocp4_workload_authentication_htpasswd_user_base }}{{ n }}


### PR DESCRIPTION
##### SUMMARY

It will be common in labs to require the cluster ingress domain in the per-user information.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ocp4_workload_authentication