### PR TITLE
Fix ocp4_workload_gitea_operator user name format

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/defaults/main.yml
@@ -111,9 +111,9 @@ ocp4_workload_gitea_operator_create_users: false
 # Format for the users to create. E.g. user1, user2, ...
 # When ocp4_workload_gitea_operator_user_number=1 specify just the
 # user name: e.g. lab-user
-ocp4_workload_gitea_operator_generate_user_format: user%d
+ocp4_workload_gitea_operator_generate_user_format: "{{ ocp4_workload_authentication_htpasswd_user_base | default('user') }}%d"
 ocp4_workload_gitea_operator_user_email_domain: opentlc.com
-ocp4_workload_gitea_operator_user_number: "{{ num_users }}"
+ocp4_workload_gitea_operator_user_number: "{{ ocp4_workload_authentication_htpasswd_user_count | default(user_count) | default(num_users) | default(10) }}"
 # Set the password for the users to be created
 # If empty then a random password with the specified
 # length will be created for all users (same for all users)

--- a/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/tasks/workload.yml
@@ -202,9 +202,9 @@
     - name: Print user details per created user
       when: ocp4_workload_gitea_operator_user_number | int > 1
       agnosticd_user_info:
-        user: "{{ ocp4_workload_gitea_operator_generate_user_format }}{{ n }}"
+        user: "{{ ocp4_workload_gitea_operator_generate_user_format | format(n) }}"
         data:
-          gitea_user: "{{ ocp4_workload_gitea_operator_generate_user_format }}{{ n }}"
+          gitea_user: "{{ ocp4_workload_gitea_operator_generate_user_format | format(n) }}"
           gitea_password: "{{ ocp4_workload_gitea_operator_user_password }}"
           gitea_console_url: "{{ _ocp4_workload_gitea_operator_gitea_route }}"
       loop: "{{ range(1, 1 + ocp4_workload_gitea_operator_user_number | int) | list }}"


### PR DESCRIPTION
##### SUMMARY

Fix `ocp4_workload_gitea_operator` use of `ocp4_workload_gitea_operator_generate_user_format` in user info.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role ocp4_workload_gitea_operator