### PR TITLE
Add any_errors_fatal to ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -13,6 +13,8 @@ callback_enabled        = profile_tasks
 # Use the stdout_callback when running ad-hoc commands.
 bin_ansible_callbacks   = True
 localhost_warning       = False
+# Fail ansible-playbook run at first task failure
+any_errors_fatal        = True
 
 [privilege_escalation]
 become                  = False


### PR DESCRIPTION
##### SUMMARY

Set any_errors_fatal to prevent ansible execution from continuing after error.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ansible.cfg