### PR TITLE
Remove filters for server_info module

### DIFF
--- a/ansible/roles-infra/infra_osp_lifecycle/tasks/get-servers.yml
+++ b/ansible/roles-infra/infra_osp_lifecycle/tasks/get-servers.yml
@@ -2,6 +2,7 @@
 # FIXME? - Get all server in project rather than restrict by guid?
 - name: Get server info using guid & env_type
   openstack.cloud.server_info:
+    all_projects: false
   register: r_os_server_info
 
 - name: Debug openstack.cloud.server_info var, use -v to display

--- a/ansible/roles-infra/infra_osp_lifecycle/tasks/get-servers.yml
+++ b/ansible/roles-infra/infra_osp_lifecycle/tasks/get-servers.yml
@@ -2,10 +2,6 @@
 # FIXME? - Get all server in project rather than restrict by guid?
 - name: Get server info using guid & env_type
   openstack.cloud.server_info:
-    filters:
-      metadata:
-        guid: "{{ guid }}"
-        env_type: "{{ env_type }}"
   register: r_os_server_info
 
 - name: Debug openstack.cloud.server_info var, use -v to display


### PR DESCRIPTION
VMs created outside of the stack is most probably they don't have the correct tags, so the VMs are never stopped.