### PR TITLE
Add ocp4_workload_le_certs_cert_manager role

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_le_certs_cert_manager/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_le_certs_cert_manager/defaults/main.yml
@@ -1,0 +1,82 @@
+---
+become_override: false
+ocp_username: opentlc-mgr
+silent: false
+
+cert_manager_ns: "cert-mgmt"
+cert_configs_ns: "cert-mgmt"
+cert_manager_helm_ver: "v1.6.1"
+cert_configs_helm_ver: "v0.1.1"
+
+cert_configs_route53:
+  accessKeyId: "example"
+  secretAccessKey: "example"
+  region: "us-east-1"
+
+cert_configs_cert_manager_certificates:
+  apiServer:
+    name: api-letsencrypt-cert
+    namespace: openshift-config
+    issuerRef: letsencrypt-staging
+    issuerKind: ClusterIssuer
+    dnsNames:
+      - api.cluster.example.com
+  ingressController:
+    name: ingress-letsencrypt-cert
+    namespace: openshift-ingress
+    issuerRef: letsencrypt-staging
+    issuerKind: ClusterIssuer
+    dnsNames:
+      - '*.apps.cluster.example.com'
+
+cert_configs_cluster:
+  apiServer:
+    enabled: false
+    name: api.example.com
+    tlsSecret: api-letsencrypt-cert
+
+  ingressController:
+    enabled: false
+  caBundle: |
+        -----BEGIN CERTIFICATE-----
+        MIIFFjCCAv6gAwIBAgIRAJErCErPDBinU/bWLiWnX1owDQYJKoZIhvcNAQELBQAw
+        TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh
+        cmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMjAwOTA0MDAwMDAw
+        WhcNMjUwOTE1MTYwMDAwWjAyMQswCQYDVQQGEwJVUzEWMBQGA1UEChMNTGV0J3Mg
+        RW5jcnlwdDELMAkGA1UEAxMCUjMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
+        AoIBAQC7AhUozPaglNMPEuyNVZLD+ILxmaZ6QoinXSaqtSu5xUyxr45r+XXIo9cP
+        R5QUVTVXjJ6oojkZ9YI8QqlObvU7wy7bjcCwXPNZOOftz2nwWgsbvsCUJCWH+jdx
+        sxPnHKzhm+/b5DtFUkWWqcFTzjTIUu61ru2P3mBw4qVUq7ZtDpelQDRrK9O8Zutm
+        NHz6a4uPVymZ+DAXXbpyb/uBxa3Shlg9F8fnCbvxK/eG3MHacV3URuPMrSXBiLxg
+        Z3Vms/EY96Jc5lP/Ooi2R6X/ExjqmAl3P51T+c8B5fWmcBcUr2Ok/5mzk53cU6cG
+        /kiFHaFpriV1uxPMUgP17VGhi9sVAgMBAAGjggEIMIIBBDAOBgNVHQ8BAf8EBAMC
+        AYYwHQYDVR0lBBYwFAYIKwYBBQUHAwIGCCsGAQUFBwMBMBIGA1UdEwEB/wQIMAYB
+        Af8CAQAwHQYDVR0OBBYEFBQusxe3WFbLrlAJQOYfr52LFMLGMB8GA1UdIwQYMBaA
+        FHm0WeZ7tuXkAXOACIjIGlj26ZtuMDIGCCsGAQUFBwEBBCYwJDAiBggrBgEFBQcw
+        AoYWaHR0cDovL3gxLmkubGVuY3Iub3JnLzAnBgNVHR8EIDAeMBygGqAYhhZodHRw
+        Oi8veDEuYy5sZW5jci5vcmcvMCIGA1UdIAQbMBkwCAYGZ4EMAQIBMA0GCysGAQQB
+        gt8TAQEBMA0GCSqGSIb3DQEBCwUAA4ICAQCFyk5HPqP3hUSFvNVneLKYY611TR6W
+        PTNlclQtgaDqw+34IL9fzLdwALduO/ZelN7kIJ+m74uyA+eitRY8kc607TkC53wl
+        ikfmZW4/RvTZ8M6UK+5UzhK8jCdLuMGYL6KvzXGRSgi3yLgjewQtCPkIVz6D2QQz
+        CkcheAmCJ8MqyJu5zlzyZMjAvnnAT45tRAxekrsu94sQ4egdRCnbWSDtY7kh+BIm
+        lJNXoB1lBMEKIq4QDUOXoRgffuDghje1WrG9ML+Hbisq/yFOGwXD9RiX8F6sw6W4
+        avAuvDszue5L3sz85K+EC4Y/wFVDNvZo4TYXao6Z0f+lQKc0t8DQYzk1OXVu8rp2
+        yJMC6alLbBfODALZvYH7n7do1AZls4I9d1P4jnkDrQoxB3UqQ9hVl3LEKQ73xF1O
+        yK5GhDDX8oVfGKF5u+decIsH4YaTw7mP3GFxJSqv3+0lUFJoi5Lc5da149p90Ids
+        hCExroL1+7mryIkXPeFM5TgO9r0rvZaBFOvV2z0gp35Z0+L4WPlbuEjN/lxPFin+
+        HlUjr8gRsI3qfJOQFy/9rKIJR0Y/8Omwt/8oTWgy1mdeHmmjk7j1nYsvC9JSQ6Zv
+        MldlTTKB3zhThV1+XWYp6rjd5JW1zbVWEkLNxE7GJThEUG3szgBVGP7pSWTUTsqX
+        nLRbwHOoq7hHwg==
+        -----END CERTIFICATE-----
+
+cert_configs_acme_cluster_issuer:
+  dns:
+    enabled: true
+  solver: DNS01
+  provider: route53
+  acme:
+    emailAddress: jfilipcz@redhat.com
+    selectorZones:
+      - cluster.example.com
+    env: staging
+    issuerKind: ClusterIssuer

--- a/ansible/roles_ocp_workloads/ocp4_workload_le_certs_cert_manager/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_le_certs_cert_manager/defaults/main.yml
@@ -37,37 +37,6 @@ cert_configs_cluster:
 
   ingressController:
     enabled: false
-  caBundle: |
-        -----BEGIN CERTIFICATE-----
-        MIIFFjCCAv6gAwIBAgIRAJErCErPDBinU/bWLiWnX1owDQYJKoZIhvcNAQELBQAw
-        TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh
-        cmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMjAwOTA0MDAwMDAw
-        WhcNMjUwOTE1MTYwMDAwWjAyMQswCQYDVQQGEwJVUzEWMBQGA1UEChMNTGV0J3Mg
-        RW5jcnlwdDELMAkGA1UEAxMCUjMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
-        AoIBAQC7AhUozPaglNMPEuyNVZLD+ILxmaZ6QoinXSaqtSu5xUyxr45r+XXIo9cP
-        R5QUVTVXjJ6oojkZ9YI8QqlObvU7wy7bjcCwXPNZOOftz2nwWgsbvsCUJCWH+jdx
-        sxPnHKzhm+/b5DtFUkWWqcFTzjTIUu61ru2P3mBw4qVUq7ZtDpelQDRrK9O8Zutm
-        NHz6a4uPVymZ+DAXXbpyb/uBxa3Shlg9F8fnCbvxK/eG3MHacV3URuPMrSXBiLxg
-        Z3Vms/EY96Jc5lP/Ooi2R6X/ExjqmAl3P51T+c8B5fWmcBcUr2Ok/5mzk53cU6cG
-        /kiFHaFpriV1uxPMUgP17VGhi9sVAgMBAAGjggEIMIIBBDAOBgNVHQ8BAf8EBAMC
-        AYYwHQYDVR0lBBYwFAYIKwYBBQUHAwIGCCsGAQUFBwMBMBIGA1UdEwEB/wQIMAYB
-        Af8CAQAwHQYDVR0OBBYEFBQusxe3WFbLrlAJQOYfr52LFMLGMB8GA1UdIwQYMBaA
-        FHm0WeZ7tuXkAXOACIjIGlj26ZtuMDIGCCsGAQUFBwEBBCYwJDAiBggrBgEFBQcw
-        AoYWaHR0cDovL3gxLmkubGVuY3Iub3JnLzAnBgNVHR8EIDAeMBygGqAYhhZodHRw
-        Oi8veDEuYy5sZW5jci5vcmcvMCIGA1UdIAQbMBkwCAYGZ4EMAQIBMA0GCysGAQQB
-        gt8TAQEBMA0GCSqGSIb3DQEBCwUAA4ICAQCFyk5HPqP3hUSFvNVneLKYY611TR6W
-        PTNlclQtgaDqw+34IL9fzLdwALduO/ZelN7kIJ+m74uyA+eitRY8kc607TkC53wl
-        ikfmZW4/RvTZ8M6UK+5UzhK8jCdLuMGYL6KvzXGRSgi3yLgjewQtCPkIVz6D2QQz
-        CkcheAmCJ8MqyJu5zlzyZMjAvnnAT45tRAxekrsu94sQ4egdRCnbWSDtY7kh+BIm
-        lJNXoB1lBMEKIq4QDUOXoRgffuDghje1WrG9ML+Hbisq/yFOGwXD9RiX8F6sw6W4
-        avAuvDszue5L3sz85K+EC4Y/wFVDNvZo4TYXao6Z0f+lQKc0t8DQYzk1OXVu8rp2
-        yJMC6alLbBfODALZvYH7n7do1AZls4I9d1P4jnkDrQoxB3UqQ9hVl3LEKQ73xF1O
-        yK5GhDDX8oVfGKF5u+decIsH4YaTw7mP3GFxJSqv3+0lUFJoi5Lc5da149p90Ids
-        hCExroL1+7mryIkXPeFM5TgO9r0rvZaBFOvV2z0gp35Z0+L4WPlbuEjN/lxPFin+
-        HlUjr8gRsI3qfJOQFy/9rKIJR0Y/8Omwt/8oTWgy1mdeHmmjk7j1nYsvC9JSQ6Zv
-        MldlTTKB3zhThV1+XWYp6rjd5JW1zbVWEkLNxE7GJThEUG3szgBVGP7pSWTUTsqX
-        nLRbwHOoq7hHwg==
-        -----END CERTIFICATE-----
 
 cert_configs_acme_cluster_issuer:
   dns:
@@ -75,7 +44,7 @@ cert_configs_acme_cluster_issuer:
   solver: DNS01
   provider: route53
   acme:
-    emailAddress: jfilipcz@redhat.com
+    emailAddress: johndoe@redhat.com
     selectorZones:
       - cluster.example.com
     env: staging

--- a/ansible/roles_ocp_workloads/ocp4_workload_le_certs_cert_manager/meta/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_le_certs_cert_manager/meta/main.yml
@@ -1,0 +1,13 @@
+---
+galaxy_info:
+  role_name: ocp4_workload_le_certs_cert_manager
+  author: Red Hat Open Innovation Labs, Jakub Filipczak (jfilipcz@redhat.com)
+  description: |
+    This workload deploys the Cert-Manager with a set of configs into a cluster.
+  license: MIT
+  min_ansible_version: 2.9
+  platforms: []
+  galaxy_tags:
+  - ocp
+  - openshift
+dependencies: []

--- a/ansible/roles_ocp_workloads/ocp4_workload_le_certs_cert_manager/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_le_certs_cert_manager/readme.adoc
@@ -1,0 +1,66 @@
+= ocp4_workload_le_certs_cert_manager - Deploy a Cert-Manager along with configuration and certificate for *.apps and api
+
+== Role overview
+
+* This role enables the Nexus Operator on an OpenShift 4 Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+ environment for the workload deployment.
+*** Debug task will print out: `pre_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the Nexus Operator and then deploy a shared Nexus instance
+*** Debug task will print out: `workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+ configure the workload after deployment
+*** This role doesn't do anything here
+*** Debug task will print out: `post_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+ delete the workload
+*** This role removes the shared Nexus and Nexus operator from OCP 4. This role does *not* remove the project - there may be other items in it.
+*** Debug task will print out: `remove_workload Tasks completed successfully.`
+
+== Review the defaults variable file
+
+* This file link:./defaults/main.yml[./defaults/main.yml] contains all the variables you need to define to control the deployment of your workload.
+* The variable *ocp_username* is mandatory to assign the workload to the correct OpenShift user.
+* A variable *silent=True* can be passed to suppress debug messages.
+* You can modify any of these default values by adding `-e "variable_name=variable_value"` to the command line
+
+
+=== Deploy a Workload with the `ocp-workload` playbook [Mostly for testing]
+
+----
+TARGET_HOST="bastion.na4.openshift.opentlc.com"
+OCP_USERNAME="jfilipcz-redhat.com"
+WORKLOAD="ocp4_workload_le_certs_cert_manager"
+GUID=1001
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=ec2-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"silent=False" \
+    -e"guid=${GUID}" \
+    -e"ACTION=create"
+----
+
+=== To Delete an environment
+
+----
+TARGET_HOST="bastion.na4.openshift.opentlc.com"
+OCP_USERNAME="jfilipcz-redhat.com"
+WORKLOAD="ocp4_workload_nexus_operator"
+GUID=1002
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=ec2-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"guid=${GUID}" \
+    -e"ACTION=remove"
+----

--- a/ansible/roles_ocp_workloads/ocp4_workload_le_certs_cert_manager/tasks/install-helm.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_le_certs_cert_manager/tasks/install-helm.yaml
@@ -1,0 +1,40 @@
+---
+- name: Check if helm is installed
+  shell: "/usr/bin/which helm  >/dev/null 2>&1"
+  register: helm_exist
+  ignore_errors: true
+
+- name: Install Helm on bastion VM
+  when: helm_exist.rc != 0
+  block:
+  - name: Get helm-download-links ConsoleCLIDownload
+    k8s_info:
+      api_version: console.openshift.io/v1
+      kind: ConsoleCLIDownload
+      name: helm-download-links
+    register: r_helm_cli_download
+    retries: 20
+    delay: 10
+    ignore_errors: true
+    until:
+    - r_helm_cli_download.resources is defined
+    - r_helm_cli_download.resources | length > 0
+
+  - name: Extract Helm download URL from ConsoleCLIDownload
+    when: r_helm_cli_download.resources | length > 0
+    set_fact:
+      _helm_download_url: >-
+        {{ r_helm_cli_download.resources[0] | to_json | from_json
+        | json_query("spec.links[?contains(href,'mirror')].href") | first }}
+
+  - name: Download Helm binary tarball
+    become: true
+    get_url:
+      url: "{{ _helm_download_url }}/helm-linux-amd64"
+      validate_certs: false
+      dest: /usr/local/bin/helm
+      mode: 0755
+    register: r_helm_download
+    until: r_helm_download is success
+    retries: 20
+    delay: 10

--- a/ansible/roles_ocp_workloads/ocp4_workload_le_certs_cert_manager/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_le_certs_cert_manager/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+# Do not modify this file
+
+- name: Running Pre Workload Tasks
+  include_tasks:
+    file: ./pre_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload Tasks
+  include_tasks:
+    file: ./workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  include_tasks:
+    file: ./post_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload removal Tasks
+  include_tasks:
+    file: ./remove_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles_ocp_workloads/ocp4_workload_le_certs_cert_manager/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_le_certs_cert_manager/tasks/post_workload.yml
@@ -1,0 +1,9 @@
+---
+# Implement your Post Workload deployment tasks here
+
+
+# Leave this as the last task in the playbook.
+- name: post_workload tasks complete
+  debug:
+    msg: "Post-Workload Tasks completed successfully."
+  when: not silent | bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_le_certs_cert_manager/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_le_certs_cert_manager/tasks/pre_workload.yml
@@ -1,0 +1,8 @@
+---
+# Implement your Pre Workload deployment tasks here
+
+# Leave this as the last task in the playbook.
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Workload tasks completed successfully."
+  when: not silent | bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_le_certs_cert_manager/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_le_certs_cert_manager/tasks/remove_workload.yml
@@ -1,0 +1,8 @@
+---
+# Implement your Workload removal tasks here
+
+# Leave this as the last task in the playbook.
+- name: remove_workload tasks complete
+  debug:
+    msg: "Remove Workload tasks completed successfully."
+  when: not silent | bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_le_certs_cert_manager/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_le_certs_cert_manager/tasks/workload.yml
@@ -1,0 +1,72 @@
+---
+# Implement your Workload deployment tasks here
+- name: Ensure directory exists
+  file:
+    path: "/tmp/{{ guid }}"
+    state: directory
+
+- name: Install helm
+  include_tasks: install-helm.yaml
+
+- name: Setting up workload for user
+  debug:
+    msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
+
+- name: Add cert-manager chart repo
+  kubernetes.core.helm_repository:
+    name: jetstack
+    repo_url: "https://charts.jetstack.io"
+
+- name: Install cert-manager chart
+  kubernetes.core.helm:
+    name: cert-manager
+    chart_ref: jetstack/cert-manager
+    chart_version: "{{ cert_manager_helm_ver }}"
+    release_namespace: "{{ cert_manager_ns}}"
+    create_namespace: true
+    skip_crds: false
+    wait: true
+    update_repo_cache: true
+    values:
+      extraArgs:
+        - "--dns01-recursive-nameservers=8.8.8.8:53,1.1.1.1:53"
+        - "--dns01-recursive-nameservers-only"
+      installCRDs: true
+
+- name: Add redhat-cop chart repo
+  kubernetes.core.helm_repository:
+    name: redhat-cop
+    repo_url: "https://redhat-cop.github.io/helm-charts"
+
+- name: Wait until cert-manager is up
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Pod
+    namespace: "{{ cert_manager_ns }}"
+  register: pod_list
+  until: pod_list|json_query('resources[*].status.phase')|unique == ["Running"]
+  retries: 20
+  delay: 10
+
+- name: Install cert-manager-configs chart
+  kubernetes.core.helm:
+    name: cert-manager-configs
+    chart_ref: redhat-cop/cert-manager-configs
+    chart_version: "{{ cert_configs_helm_ver }}"
+    release_namespace: "{{ cert_configs_ns }}"
+    create_namespace: true
+    skip_crds: no
+    wait: true
+    update_repo_cache: true
+    values:
+      namespace: "{{ cert_configs_ns }}"
+      issuer: "{{ cert_configs_acme_cluster_issuer }}"
+      aws: "{{ cert_configs_route53 }}"
+      certificates: "{{ cert_configs_cert_manager_certificates }}"
+      cluster: "{{ cert_configs_cluster }}"
+
+# Leave this as the last task in the playbook.
+- name: workload tasks complete
+  debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent | bool


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

This PR adds ocp role that includes automation to install cert-manager and a set of cert-manager configs into a target cluster with an aim of enabling automated LE certificate management
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- New role Pull Request

##### COMPONENT NAME
ocp4_workload_le_certs_cert_manager
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
