### PR TITLE
Update main.yml

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_windows_node/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_windows_node/defaults/main.yml
@@ -16,4 +16,5 @@ ocp4_workload_windows_node_doc_svc: "winc-doc"
 ocp4_workload_windows_node_doc_route: "winc-doc"
 ocp4_workload_windows_node_doc_image: "quay.io/redhatworkshops/windows-containers-quickstart"
 ocp4_workload_windows_node_doc_image_tag: "latest"
-ocp4_workload_windows_node_windows_ami_filter: "Windows_Server-2019*English*Full*ContainersLatest-2022.08.10*"
+ocp4_workload_windows_node_windows_ami_filter: "Windows_Server-2019*English*Full*Containers*"
+


### PR DESCRIPTION
testing to see if removing the specific version resolves the deployment problem as AWS rotates out older images.

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
trying to get the deployment to work by removing the specific AMI image

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
