### PR TITLE
Save output dir to s3 when OCP4 installer fails

### DIFF
--- a/ansible/roles/host-ocp4-installer/tasks/main.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/main.yml
@@ -76,6 +76,11 @@
       dest: "{{ output_dir }}/{{ env_type }}_{{ guid }}_log/"
       flat: true
 
+  - name: Save output_dir archive
+    when: agnosticd_save_output_dir_archive is defined
+    include_role:
+      name: agnosticd_save_output_dir
+
 # OpenStack does not have a way to add userTags via the install-config.yaml
 # https://bugzilla.redhat.com/show_bug.cgi?id=1868517
 # Find all created active instances (name contains the GUID)


### PR DESCRIPTION
When the OCP4 installer fails, there is a `always` ansible block to fetch the installer log.

This change, if applied, adds a step to run the `agnosticd_save_output_dir` role so the installer logs will be found in the outputdir archive for our production environments when this happens.

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
- host-ocp4-installer role

