### PR TITLE
Set run_once and delegate to localhost for agnosticd_save_output_dir

### DIFF
--- a/ansible/roles/agnosticd_save_output_dir/tasks/main.yml
+++ b/ansible/roles/agnosticd_save_output_dir/tasks/main.yml
@@ -5,11 +5,17 @@
   - name: Create output_dir archive
     include_tasks:
       file: create-output-dir-archive.yml
+    apply:
+      delegate_to: localhost
+      run_once: true
 
   - name: Upload output_dir archive to S3
     when: agnosticd_save_output_dir_s3_bucket is defined
     include_tasks:
       file: upload-archive-s3.yml
+    apply:
+      delegate_to: localhost
+      run_once: true
 
   always:
   - name: Remove output_dir archive tempfile
@@ -17,10 +23,14 @@
     file:
       path: "{{ agnosticd_save_output_dir_archive_tempfile }}"
       state: absent
+    delegate_to: localhost
+    run_once: true
 
   - name: Remove output_dir encrypted archive tempfile
     when: agnosticd_save_output_dir_archive_password is defined
     file:
       path: "{{ agnosticd_save_output_dir_archive_tempfile }}.gpg"
       state: absent
+    delegate_to: localhost
+    run_once: true
 ...


### PR DESCRIPTION
##### SUMMARY

Have `agnosticd_save_output_dir` always run on localhost with `run_once`.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role `agnosticd_save_output_dir`