### PR TITLE
Add variable to have ocp4-host-installer report kubeadmin password

### DIFF
--- a/ansible/roles/host-ocp4-installer/defaults/main.yml
+++ b/ansible/roles/host-ocp4-installer/defaults/main.yml
@@ -58,6 +58,10 @@ ocp_use_single_network: false
 host_ocp4_installer_set_user_data: true
 host_ocp4_installer_show_user_info: true
 
+# Set user data for kubedamin password.
+# Usually the kubeadmin is disabled so this must be explicitly enabled.
+host_ocp4_installer_set_user_data_kubeadmin_password: false
+
 # When master_storage_type == io1 or io2,
 # calculate the IOPS:
 # IOPS = 2000 << number of worker * 100 << 32000

--- a/ansible/roles/host-ocp4-installer/tasks/print_cluster_info.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/print_cluster_info.yml
@@ -1,7 +1,14 @@
+---
 - name: Get kubeadmin password
-  slurp:
+  ansible.builtin.slurp:
     path: /home/{{ ansible_user }}/{{ cluster_name }}/auth/kubeadmin-password
-  register: kubeadminr
+  register: r_slurp_kubeadmin_password
+
+- name: Set user data for kubeadmin password
+  when: host_ocp4_installer_set_user_data_kubeadmin_password | bool
+  agnosticd_user_info:
+    data:
+      openshift_kubeadmin_password: "{{ r_slurp_kubeadmin_password.content | b64decode }}"
 
 - name: Get console route
   environment:


### PR DESCRIPTION
##### SUMMARY

Add `host_ocp4_installer_set_user_data_kubeadmin_password` variable to have host-ocp4-installer role report the kubeadmin password as `agnosticd_user_info` data. Defaults to false.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Role host-ocp4-installer.