### PR TITLE
Add support for newer Tackle2 versions

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/defaults/main.yml
@@ -9,6 +9,11 @@ ocp4_workload_mta_tackle2_repo: https://github.com/redhat-gpte-devopsautomation/
 ocp4_workload_mta_tackle2_repo_tag: main
 ocp4_workload_mta_tackle2_repo_path: tackle2
 
+# Deploy the operator into each user's namespace
+ocp4_workload_mta_tackle2_deploy_operator: true
+# Tackle subscription channel to use
+ocp4_workload_mta_tackle2_channel: stable-v2.0
+
 # How many users to set up
 ocp4_workload_mta_tackle2_num_users: 1
 
@@ -31,8 +36,11 @@ ocp4_workload_mta_tackle2_seed: false
 
 # Image for the job to seed tackle. The image must have the data to be seeded inside
 # See https://github.com/redhat-gpte-devopsautomation/tackle2-setup-container.git
+# Tag should match version of operator channel subscription
+# "stable-v2.0" -> "1.0" (legacy tag name)
+# "stable-v2.1" -> "v2.1.1" (new matching tag names)
 ocp4_workload_mta_tackle2_seed_image: quay.io/gpte-devops-automation/tackle2-setup
-ocp4_workload_mta_tackle2_seed_tag: latest
+ocp4_workload_mta_tackle2_seed_tag: "1.0"
 ocp4_workload_mta_tackle2_seed_pull_policy: IfNotPresent
 
 # These are hardcoded and can't be changed at the moment, first login requires changing

--- a/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/templates/application.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/templates/application.yaml.j2
@@ -29,6 +29,8 @@ spec:
           user: {{ ocp4_workload_mta_tackle2_user }}
           role: {{ ocp4_workload_mta_tackle2_role }}
         seedTackle: {{ ocp4_workload_mta_tackle2_seed }}
+        deployOperator: {{ ocp4_workload_mta_tackle2_deploy_operator }}
+        operatorChannel: {{ ocp4_workload_mta_tackle2_channel }}
 {% if ocp4_workload_mta_tackle2_seed | bool %}
         seedJob:
           repository: {{ ocp4_workload_mta_tackle2_seed_image }}

--- a/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/templates/applicationset.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/templates/applicationset.yaml.j2
@@ -40,6 +40,8 @@ spec:
               user: "{% raw %}{{ user }}{% endraw %}"
               role: {{ ocp4_workload_mta_tackle2_role }}
             seedTackle: {{ ocp4_workload_mta_tackle2_seed }}
+            deployOperator: {{ ocp4_workload_mta_tackle2_deploy_operator }}
+            operatorChannel: {{ ocp4_workload_mta_tackle2_channel }}
 {% if ocp4_workload_mta_tackle2_seed | bool %}
             seedJob:
               repository: {{ ocp4_workload_mta_tackle2_seed_image }}


### PR DESCRIPTION
##### SUMMARY

The workload was hardcoded to Tackle2 channel `stable-v2.0`. Added support to use newer versions as well as matching seed pods.

Defaults are the current behaviour.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_mta_tackle2