### PR TITLE
Add generate passwords for sap-smart config

### DIFF
--- a/ansible/configs/sap-smart/default_vars.yml
+++ b/ansible/configs/sap-smart/default_vars.yml
@@ -325,6 +325,12 @@ cf_template_description: "{{ env_type }}-{{ guid }} Ansible Agnostic Deployer "
 
 ansible_tower_password: "{{ tower_password }}"
 
+# Generate passwords if not provided
+tower_password: >-
+  {{ lookup('ansible.builtin.password', output_dir ~ '/tower_password.txt length=8 chars=ascii_letters,digits') }}
+master_sap_password:
+  {{ lookup('ansible.builtin.password', output_dir ~ '/master_sap_password.txt length=8 chars=ascii_letters,digits') }}
+
 tower_cli_config: |
   [general]
   username = admin

--- a/ansible/configs/sap-smart/default_vars.yml
+++ b/ansible/configs/sap-smart/default_vars.yml
@@ -328,7 +328,7 @@ ansible_tower_password: "{{ tower_password }}"
 # Generate passwords if not provided
 tower_password: >-
   {{ lookup('ansible.builtin.password', output_dir ~ '/tower_password.txt length=8 chars=ascii_letters,digits') }}
-master_sap_password:
+master_sap_password: >-
   {{ lookup('ansible.builtin.password', output_dir ~ '/master_sap_password.txt length=8 chars=ascii_letters,digits') }}
 
 tower_cli_config: |


### PR DESCRIPTION
##### SUMMARY

Add generate passwords for sap-smart config. The value for `tower_password` and `master_sap_password` should be generated dynamically and stored in the output directory.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Config sap-smart