### PR TITLE
Fixed jquery to wait for InstallPlan is created

### DIFF
--- a/ansible/roles/install_operator/tasks/install.yml
+++ b/ansible/roles/install_operator/tasks/install.yml
@@ -80,7 +80,7 @@
   register: r_install_plans
   vars:
     _query: >-
-      [spec.clusterServiceVersionNames[?starts_with(@, '{{ install_operator_csv_nameprefix }}' )]]
+      [?starts_with(spec.clusterServiceVersionNames[0], '{{ install_operator_csv_nameprefix }}') && status.phase ]
   retries: 30
   delay: 10
   until:


### PR DESCRIPTION
##### SUMMARY

The jquery to wait for installplan was always true. So that meats it doesn't wait on the installplan. Useally it fails later the the "Wait for CSV" stept becasuse if scipts also the installplan approval. No Approved installplan -> no csv... Installation fails.

The fixed based on
ansible/roles_ocp_workloads/ocp4_workload_servicemesh/tasks/install_servicemesh_operator.yml, line 15:
```
- name: Wait until InstallPlan is created k8s_info: api_version: operators.coreos.com/v1alpha1 kind: InstallPlan namespace: openshift-operators register: r_install_plans vars: _query: >- [?starts_with(spec.clusterServiceVersionNames[0], 'servicemesh') && status.phase] retries: 30 delay: 5 until:
  - r_install_plans.resources | length > 0
  - r_install_plans.resources | to_json | from_json | json_query(_query)
```


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

`ansible/role/install_operator`

##### ADDITIONAL INFORMATION

<details>
  <summary>Here a small playbook to test the jquery:</summary>



```yaml
#!/usr/bin/env ansible-playbook
---

- hosts: localhost
  gather_facts: false
  vars:
    install_operator_csv_nameprefix: "kiali"
    r_install_plans:
      resources: [
        {
            "spec": {
                "clusterServiceVersionNames": [
                    "servicemeshoperator.v2.2.3"
                ],
                "generation": 1
            },
            "status": {
                "phase": "Complete"
            }
        },
        {
            "spec": {
                "clusterServiceVersionNames": [
                    "jaeger-operator.v1.38.0-2"
                ],
                "generation": 2
            },
            "status": {
                "phase": "Complete"
            }
        },
        {
            "spec": {
                "clusterServiceVersionNames": [
                    "kiali-operator.v1.48.3"
                ],
                "generation": 3
            },
            "status": {
                "phase": "Complete"
            }

        }
    ]
  
  tasks:
    - name: "{{ install_operator_name }} - Set InstallPlan name"
      set_fact:
        install_operator_install_plan_name: "{{ r_install_plans.resources | to_json | from_json | json_query(query) }}"
      vars:
        query: >-
          [?starts_with(spec.clusterServiceVersionNames[0], '{{ install_operator_csv_nameprefix }}' )].metadata.name|[0]

    - debug:
        msg: "Installplan name: {{ install_operator_install_plan_name }}"

    - name: "{{ install_operator_name }} - Wait until InstallPlan is created"
      debug:
        msg: "{{ r_install_plans.resources | to_json | from_json | json_query(_query2) }}"
      vars: 
        _query2: >-
          [?starts_with(spec.clusterServiceVersionNames[0], '{{ install_operator_csv_nameprefix }}') && status.phase ]
      when:
      - r_install_plans.resources | length > 0
      - r_install_plans.resources | to_json | from_json | json_query(_query2)

```
</details>

