### PR TITLE
Add retries to automation-controller-config-job workflow launch

### DIFF
--- a/ansible/roles/automation-controller-config/tasks/job_workflow_template.yml
+++ b/ansible/roles/automation-controller-config/tasks/job_workflow_template.yml
@@ -50,3 +50,7 @@
   awx.awx.workflow_launch:
     workflow_template: "HMI-demo-workflow"
     wait: no
+  register: r_workflow_launch
+  until: r_workflow_launch is successful
+  retries: 5
+  delay: 3


### PR DESCRIPTION
##### SUMMARY

Add retries to automation-controller-config-job role to attempt to deal with sporadic 403 errors we have encountered after workflow template creation.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role automation-controller-config-job