### PR TITLE
Write kubeconfig and password to file

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/tasks/get_cluster_credentials.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/tasks/get_cluster_credentials.yml
@@ -15,6 +15,24 @@
     namespace: local-cluster
   register: r_kubeconfig
 
+- name: Write kubeconfig file for student user
+  become: true
+  ansible.builtin.copy:
+    dest: "/home/{{ student_name }}/.kube/{{ _ocp4_workload_rhacm_hypershift_cluster_name }}.kubeconfig"
+    content: "{{ r_kubeconfig.resources[0].data.kubeconfig | b64decode }}"
+    owner: "{{ student_name }}"
+    group: users
+    mode: 0660
+
+- name: Write kubeadmin password file for student user
+  become: true
+  ansible.builtin.copy:
+    dest: "/home/{{ student_name }}/.kube/{{ _ocp4_workload_rhacm_hypershift_cluster_name }}.kubeadmin-password"
+    content: "{{ r_kubeadmin_password.resources[0].data.password | b64decode }}"
+    owner: "{{ student_name }}"
+    group: users
+    mode: 0660
+
 - name: "Save credentials for cluster {{ _ocp4_workload_rhacm_hypershift_cluster_name }}"
   agnosticd_user_info:
     data: >-


### PR DESCRIPTION
##### SUMMARY

Added logic to HyperShift workload to write kubeconfig and kubeadmin password to /home/{{ student_name }}/.kube.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_rhacm_hypershift