### PR TITLE
Add logic to wait for secrets to be populated

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/tasks/get_cluster_credentials.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/tasks/get_cluster_credentials.yml
@@ -6,6 +6,13 @@
     name: "{{ _ocp4_workload_rhacm_hypershift_cluster_name }}-kubeadmin-password"
     namespace: local-cluster
   register: r_kubeadmin_password
+  retries: 60
+  delay: 5
+  until:
+  - r_kubeadmin_password is defined
+  - r_kubeadmin_password.resources | length > 0
+  - r_kubeadmin_password.resources[0].data.password is defined
+  - r_kubeadmin_password.resources[0].data.password | length > 0
 
 - name: Get kubeconfig
   kubernetes.core.k8s_info:
@@ -14,6 +21,13 @@
     name: "{{ _ocp4_workload_rhacm_hypershift_cluster_name }}-admin-kubeconfig"
     namespace: local-cluster
   register: r_kubeconfig
+  retries: 60
+  delay: 5
+  until:
+  - r_kubeconfig is defined
+  - r_kubeconfig.resources | length > 0
+  - r_kubeconfig.resources[0].data.kubeconfig is defined
+  - r_kubeconfig.resources[0].data.kubeconfig | length > 0
 
 - name: Write kubeconfig file for student user
   become: true


### PR DESCRIPTION
##### SUMMARY

Need to wait for the secrets with kubeadmin password and kubeconfig to be populated before trying to save the contents...

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_rhacm_hypershift