### PR TITLE
agnosticd_save_output_dir: run only on localhost

### DIFF
--- a/ansible/roles/agnosticd_save_output_dir/tasks/main.yml
+++ b/ansible/roles/agnosticd_save_output_dir/tasks/main.yml
@@ -7,7 +7,9 @@
       file: create-output-dir-archive.yml
       apply:
         delegate_to: localhost
+        delegate_facts: true
         run_once: true
+        become: false
 
   - name: Upload output_dir archive to S3
     when: agnosticd_save_output_dir_s3_bucket is defined
@@ -15,7 +17,9 @@
       file: upload-archive-s3.yml
       apply:
         delegate_to: localhost
+        delegate_facts: true
         run_once: true
+        become: false
 
   always:
   - name: Remove output_dir archive tempfile
@@ -25,6 +29,7 @@
       state: absent
     delegate_to: localhost
     run_once: true
+    become: false
 
   - name: Remove output_dir encrypted archive tempfile
     when: agnosticd_save_output_dir_archive_password is defined
@@ -33,4 +38,5 @@
       state: absent
     delegate_to: localhost
     run_once: true
+    become: false
 ...

--- a/ansible/roles/agnosticd_save_output_dir/tasks/main.yml
+++ b/ansible/roles/agnosticd_save_output_dir/tasks/main.yml
@@ -5,11 +5,17 @@
   - name: Create output_dir archive
     include_tasks:
       file: create-output-dir-archive.yml
+      apply:
+        delegate_to: localhost
+        run_once: true
 
   - name: Upload output_dir archive to S3
     when: agnosticd_save_output_dir_s3_bucket is defined
     include_tasks:
       file: upload-archive-s3.yml
+      apply:
+        delegate_to: localhost
+        run_once: true
 
   always:
   - name: Remove output_dir archive tempfile
@@ -17,10 +23,14 @@
     file:
       path: "{{ agnosticd_save_output_dir_archive_tempfile }}"
       state: absent
+    delegate_to: localhost
+    run_once: true
 
   - name: Remove output_dir encrypted archive tempfile
     when: agnosticd_save_output_dir_archive_password is defined
     file:
       path: "{{ agnosticd_save_output_dir_archive_tempfile }}.gpg"
       state: absent
+    delegate_to: localhost
+    run_once: true
 ...

--- a/ansible/roles/host-ocp4-installer/tasks/main.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/main.yml
@@ -76,6 +76,11 @@
       dest: "{{ output_dir }}/{{ env_type }}_{{ guid }}_log/"
       flat: true
 
+  - name: Save output_dir archive
+    when: agnosticd_save_output_dir_archive is defined
+    include_role:
+      name: agnosticd_save_output_dir
+
 # OpenStack does not have a way to add userTags via the install-config.yaml
 # https://bugzilla.redhat.com/show_bug.cgi?id=1868517
 # Find all created active instances (name contains the GUID)


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
This change includes https://github.com/redhat-cop/agnosticd/pull/5571 and adds:

- `become: false`: ensure the tasks are run as normal user. This way the agnosticd dev can call `agnosticd_save_output_dir` from any play without surprises or too much thinking.
- `delegate_facts: true`: There are `set_facts` in included tasks and included role. `upload-archive-s3.yml` calls the role `infra-clouds-tags` which set some facts. We want to save facts on localhost.


<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request


##### COMPONENT NAME

- `agnosticd_save_output_dir`

##### ADDITIONAL INFORMATION

Tested the behavior using the following playbook and test role:

test.yaml
```
- hosts:
    - opi
  become: true
  gather_facts: false
  tasks:
    - include_role:
        name: test

- hosts: localhost
  gather_facts: false
  tasks:
    - debug:
        var: hostvars.localhost.bla

    - debug:
        var: hostvars.localhost.ibla

```

roles/test/tasks/main.yaml
```
---
- include_tasks:
    file: bla.yaml
    apply:
      delegate_to: localhost
      delegate_facts: true
      run_once: true
      become: false
```

roles/test/tasks/bla.yaml
```
- set_fact:
    bla: OK from include_tasks

- command: whoami
  register: r
  failed_when: r.stdout == "root"

- include_role:
    name: ibla
```

roles/ibla/tasks/main.yaml:

```
- command: whoami
  register: r
  failed_when: r.stdout == "root"

- set_fact:
    ibla: OK from include_role within include_tasks

```

Run:

`ansible-playbook -i opi, test.yaml`

Output:

```
PLAY [opi] ************************************************************************************************************************************************************************************************************************************

TASK [include_role : test] ********************************************************************************************************************************************************************************************************************

TASK [test : include_tasks] *******************************************************************************************************************************************************************************************************************
included: /tmp/roles/test/tasks/bla.yaml for opi

TASK [test : set_fact] ************************************************************************************************************************************************************************************************************************
ok: [opi -> localhost]

TASK [test : command] *************************************************************************************************************************************************************************************************************************
changed: [opi -> localhost]

TASK [include_role : ibla] ********************************************************************************************************************************************************************************************************************

TASK [ibla : command] *************************************************************************************************************************************************************************************************************************
changed: [opi -> localhost]

TASK [ibla : set_fact] ************************************************************************************************************************************************************************************************************************
ok: [opi -> localhost]

PLAY [localhost] ******************************************************************************************************************************************************************************************************************************

TASK [debug] **********************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "hostvars.localhost.bla": "OK from include_tasks"
}

TASK [debug] **********************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "hostvars.localhost.ibla": "OK from include_role within include_tasks"
}

PLAY RECAP ************************************************************************************************************************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
opi                        : ok=5    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```

With the following ansible version:
<!--- Write the short name of the config, roles, task or feature below -->
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below
ansible-playbook 2.9.27
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/fridim/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/fridim/virtualenvs/ansible2.9-python3.6-2021-11-30/lib/python3.10/site-packages/ansible
  executable location = /home/fridim/virtualenvs/ansible2.9-python3.6-2021-11-30/bin/ansible-playbook
  python version = 3.10.8 (main, Oct 13 2022, 21:13:48) [GCC 12.2.0]
```

And

```
ansible-playbook [core 2.13.5]
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/fridim/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.10/site-packages/ansible
  ansible collection location = /home/fridim/.ansible/collections:/usr/share/ansible/collections
  executable location = /bin/ansible-playbook
  python version = 3.10.8 (main, Oct 13 2022, 21:13:48) [GCC 12.2.0]
  jinja version = 3.1.2
  libyaml = True
```
