### PR TITLE
RHOIC version is currently hardcoded at 4.7 - need to upgrade to 4.11

### DIFF
--- a/ansible/configs/ibm-rhoic/default_vars.yml
+++ b/ansible/configs/ibm-rhoic/default_vars.yml
@@ -16,7 +16,7 @@ rhoic_cluster_name: rhpds
 
 # Setting the version of OpenShift to use for RHOIC
 rhoic_openshift_version_major: 4
-rhoic_openshift_version_minor: 7
+rhoic_openshift_version_minor: 11
 
 # Machine type used for RHOIC
 # bx2 is a flavor of gen 2 hardware


### PR DESCRIPTION
##### SUMMARY

Upgrading RHOIC OCP 4 minor version from 7 to 11
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
IBM_RHOIC

##### ADDITIONAL INFORMATION
Requesters are complaining that the RHOIC version is too old. I have confirmed in the IBM UI that 4.11 is supported, but there is no option to select that as it appears to be hardcoded currently.

```
