### PR TITLE
Fix delegate_facts issue in agnosticd_save_output_dir

### DIFF
--- a/ansible/roles/agnosticd_save_output_dir/tasks/main.yml
+++ b/ansible/roles/agnosticd_save_output_dir/tasks/main.yml
@@ -1,42 +1,10 @@
 ---
 - name: Save output dir if archive file is defined
   when: agnosticd_save_output_dir_archive is defined
-  block:
-  - name: Create output_dir archive
-    include_tasks:
-      file: create-output-dir-archive.yml
-      apply:
-        delegate_to: localhost
-        delegate_facts: true
-        run_once: true
-        become: false
-
-  - name: Upload output_dir archive to S3
-    when: agnosticd_save_output_dir_s3_bucket is defined
-    include_tasks:
-      file: upload-archive-s3.yml
-      apply:
-        delegate_to: localhost
-        delegate_facts: true
-        run_once: true
-        become: false
-
-  always:
-  - name: Remove output_dir archive tempfile
-    when: agnosticd_save_output_dir_archive_tempfile is defined
-    file:
-      path: "{{ agnosticd_save_output_dir_archive_tempfile }}"
-      state: absent
-    delegate_to: localhost
-    run_once: true
-    become: false
-
-  - name: Remove output_dir encrypted archive tempfile
-    when: agnosticd_save_output_dir_archive_password is defined
-    file:
-      path: "{{ agnosticd_save_output_dir_archive_tempfile }}.gpg"
-      state: absent
-    delegate_to: localhost
-    run_once: true
-    become: false
+  include_tasks:
+    file: save-output-dir.yml
+    apply:
+      delegate_to: localhost
+      run_once: true
+      become: false
 ...

--- a/ansible/roles/agnosticd_save_output_dir/tasks/save-output-dir.yml
+++ b/ansible/roles/agnosticd_save_output_dir/tasks/save-output-dir.yml
@@ -1,0 +1,24 @@
+---
+- block:
+  - name: Create output_dir archive
+    include_tasks:
+      file: create-output-dir-archive.yml
+
+  - name: Upload output_dir archive to S3
+    when: agnosticd_save_output_dir_s3_bucket is defined
+    include_tasks:
+      file: upload-archive-s3.yml
+
+  always:
+  - name: Remove output_dir archive tempfile
+    when: agnosticd_save_output_dir_archive_tempfile is defined
+    file:
+      path: "{{ agnosticd_save_output_dir_archive_tempfile }}"
+      state: absent
+
+  - name: Remove output_dir encrypted archive tempfile
+    when: agnosticd_save_output_dir_archive_password is defined
+    file:
+      path: "{{ agnosticd_save_output_dir_archive_tempfile }}.gpg"
+      state: absent
+...


### PR DESCRIPTION
##### SUMMARY

Remove use of `delegate_facts` in `agnosticd_save_output_dir` role. `set_fact` does not work with `delegate_facts`.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role agnosticd_save_output_dir