### PR TITLE
Image tags need quotes to prevent tag manipulation

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_codeserver/templates/application.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_codeserver/templates/application.yaml.j2
@@ -45,14 +45,14 @@ spec:
 {% endif %}
         mainContainer:
           repository: {{ ocp4_workload_codeserver_image }}
-          tag: {{ ocp4_workload_codeserver_image_tag }}
+          tag: "{{ ocp4_workload_codeserver_image_tag }}"
           pullPolicy: {{ ocp4_workload_codeserver_image_pull_policy }}
           requests:
             cpu: {{ ocp4_workload_codeserver_request_cpu }}
             memory: {{ ocp4_workload_codeserver_request_memory }}
         initContainer:
           repository: {{ ocp4_workload_codeserver_init_image }}
-          tag: {{ ocp4_workload_codeserver_init_image_tag }}
+          tag: "{{ ocp4_workload_codeserver_init_image_tag }}"
           pullPolicy: {{ ocp4_workload_codeserver_init_image_pull_policy }}
           requests:
             cpu: {{ ocp4_workload_codeserver_init_request_cpu }}

--- a/ansible/roles_ocp_workloads/ocp4_workload_codeserver/templates/applicationset.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_codeserver/templates/applicationset.yaml.j2
@@ -56,14 +56,14 @@ spec:
 {% endif %}
             mainContainer:
               repository: {{ ocp4_workload_codeserver_image }}
-              tag: {{ ocp4_workload_codeserver_image_tag }}
+              tag: "{{ ocp4_workload_codeserver_image_tag }}"
               pullPolicy: {{ ocp4_workload_codeserver_image_pull_policy }}
               requests:
                 cpu: {{ ocp4_workload_codeserver_request_cpu }}
                 memory: {{ ocp4_workload_codeserver_request_memory }}
             initContainer:
               repository: {{ ocp4_workload_codeserver_init_image }}
-              tag: {{ ocp4_workload_codeserver_init_image_tag }}
+              tag: "{{ ocp4_workload_codeserver_init_image_tag }}"
               pullPolicy: {{ ocp4_workload_codeserver_init_image_pull_policy }}
               requests:
                 cpu: {{ ocp4_workload_codeserver_init_request_cpu }}

--- a/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/templates/application.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/templates/application.yaml.j2
@@ -34,7 +34,7 @@ spec:
 {% if ocp4_workload_mta_tackle2_seed | bool %}
         seedJob:
           repository: {{ ocp4_workload_mta_tackle2_seed_image }}
-          tag: {{ ocp4_workload_mta_tackle2_seed_tag }}
+          tag: "{{ ocp4_workload_mta_tackle2_seed_tag }}"
           pullPolicy: {{ ocp4_workload_mta_tackle2_seed_pull_policy }}
 {% endif %}
         tackleInstance:

--- a/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/templates/applicationset.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta_tackle2/templates/applicationset.yaml.j2
@@ -45,7 +45,7 @@ spec:
 {% if ocp4_workload_mta_tackle2_seed | bool %}
             seedJob:
               repository: {{ ocp4_workload_mta_tackle2_seed_image }}
-              tag: {{ ocp4_workload_mta_tackle2_seed_tag }}
+              tag: "{{ ocp4_workload_mta_tackle2_seed_tag }}"
               pullPolicy: {{ ocp4_workload_mta_tackle2_seed_pull_policy }}
 {% endif %}
             tackleInstance:


### PR DESCRIPTION
##### SUMMARY

Tags need quotes around them to prevent 1.0 becoming 1 - and resulting in ImagePull errors.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_mta_tackle2
ocp4_workload_codeserver