### PR TITLE
Fix location of secrets for hypershift

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/tasks/get_cluster_credentials.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/tasks/get_cluster_credentials.yml
@@ -3,8 +3,8 @@
   kubernetes.core.k8s_info:
     api_version: v1
     kind: Secret
-    name: "{{ _ocp4_workload_rhacm_hypershift_cluster_name }}-kubeadmin-password"
-    namespace: local-cluster
+    name: kubeadmin-password
+    namespace: "clusters-{{ _ocp4_workload_rhacm_hypershift_cluster_name }}"
   register: r_kubeadmin_password
   retries: 60
   delay: 5
@@ -18,8 +18,8 @@
   kubernetes.core.k8s_info:
     api_version: v1
     kind: Secret
-    name: "{{ _ocp4_workload_rhacm_hypershift_cluster_name }}-admin-kubeconfig"
-    namespace: local-cluster
+    name: admin-kubeconfig
+    namespace: "clusters-{{ _ocp4_workload_rhacm_hypershift_cluster_name }}"
   register: r_kubeconfig
   retries: 60
   delay: 5


### PR DESCRIPTION
##### SUMMARY
Secret location for hypershift credentials moved in the latest operator update...

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_rhacm_hypershift