### PR TITLE
SSH doc: Add deprecated vars and roles

### DIFF
--- a/docs/SSH_keys_and_access.adoc
+++ b/docs/SSH_keys_and_access.adoc
@@ -100,10 +100,10 @@ ssh_provision_pubkey_content: ssh-rsa AAAAB3NzaC1 ...rest of the key... JjQ==
 
 * link:../ansible/roles-infra/create_ssh_provision_key[`create_ssh_provision_key`]
 +
-Generate locally a private SSH key, in `output_dir`. The resulting public key is used to provision the instances
+Generate locally a private SSH key in `output_dir` and set the facts for later use. The resulting public key is used to provision the instances. The role is idempotent and can be run multiple times.
 * `infra-{{ cloud_provider }}-ssh-key`
 +
-Create the key resource in the cloud provider so it can be attached to instances. For example link:../ansible/roles-infra/infra-ec2-ssh-key[`infra-ec2-ssh-key`]
+Create the key resource in the cloud provider so it can be attached to instances. For example link:../ansible/roles-infra/infra-ec2-ssh-key[`infra-ec2-ssh-key`].
 * link:../ansible/roles-infra/infra-common-ssh-config-generate[`infra-common-ssh-config-generate`]
 +
 Generate the SSH configuration in `output_dir`

--- a/docs/SSH_keys_and_access.adoc
+++ b/docs/SSH_keys_and_access.adoc
@@ -14,7 +14,7 @@ Long-term, we want all cloud providers to comply.
 == Workflow ==
 
 . PRE-INFRA cloud-agnostic role `create_ssh_provision_key` generates a per-environment, for infra, local SSH key
-** output file: private and public key in output_dir
+** output file: private and public key in `output_dir`
 ** output facts:
 *** `ssh_provision_key_name`        ex: `ssh_provision_{{ guid }}`
 *** `ssh_provision_key_path`        ex: `/tmp/output_dir/ssh_provision_{{ guid }}`
@@ -48,7 +48,39 @@ all_ssh_authorized_keys:
 ----
 . DESTROY role `infra-{{ cloud_provider }}-ssh-key` to delete the keypair in the cloud provider
 
-== Bring your own provision key ==
+=== Lifecycle and destroy ===
+
+The private key and SSH config are stored in `output_dir`.
+In order to access the instances after provision you need access to `output_dir`.
+If you're developping from your laptop, that should be transparent since `output_dir` will be persistent across calls of `ansible-playbook`.
+
+On the other hand, when you're provisioning from Tower or Controller (or from RHPDS), you need `output_dir` to be persistent across jobs and that is done by the 2 following roles:
+
+* link:../ansible/roles/agnosticd_save_output_dir[`agnosticd_save_output_dir`] Save `output_dir` and push it to S3
+* link:../ansible/roles/agnosticd_restore_output_dir[`agnosticd_restore_output_dir`] Restore `output_dir` from S3
+
+Make sure the secrets and variables are set so those roles are executed:
+[source,yaml]
+----
+# PROD bucket
+# Archive object to create in S3 storage.
+agnosticd_save_output_dir_archive: "{{ guid }}_{{ uuid }}.tar.gz"
+# If you want to protect the archive with a password:
+# it can be useful if the S3 bucket is shared between multiple users.
+# agnosticd_save_output_dir_archive_password: ...
+
+# S3 storage bucket access information, should be provided by a secret.
+agnosticd_save_output_dir_s3_bucket: agnosticd-output-dir
+agnosticd_save_output_dir_s3_region: us-east-1
+agnosticd_save_output_dir_s3_access_key_id: "..."
+agnosticd_save_output_dir_s3_secret_access_key: "..."
+----
+
+
+== Bring your own provision key (optional) ==
+
+NOTE: Most of the time you don't need to bring your own key as it is generated automatically.
+
 In some cases the SSH key generation described above is not working well (e.g., the key pair can be lost if not stored at persistent storage and destroy job will fail).
 It is possible to specify an existing SSH key which will be used for the environment provisioning and destroy by setting the following variables:
 
@@ -66,15 +98,46 @@ ssh_provision_pubkey_content: ssh-rsa AAAAB3NzaC1 ...rest of the key... JjQ==
 
 == Roles ==
 
-* `create_ssh_provision_key`
+* link:../ansible/roles-infra/create_ssh_provision_key[`create_ssh_provision_key`]
 +
 Generate locally a private SSH key, in `output_dir`. The resulting public key is used to provision the instances
 * `infra-{{ cloud_provider }}-ssh-key`
 +
-Create the key resource in the cloud provider so it can be attached to instances
-* `infra-common-ssh-config-generate`
+Create the key resource in the cloud provider so it can be attached to instances. For example link:../ansible/roles-infra/infra-ec2-ssh-key[`infra-ec2-ssh-key`]
+* link:../ansible/roles-infra/infra-common-ssh-config-generate[`infra-common-ssh-config-generate`]
 +
 Generate the SSH configuration in `output_dir`
-* `ssh_authorized_keys`
+* link:../ansible/roles/ssh_authorized_keys[`ssh_authorized_keys`]
 +
 Populate `authorized_keys` files on the instances for additional access.
+* link:../ansible/roles/locate_env_authorized_key[`locate_env_authorized_key`]
++
+Compatibility role to facilitate migration from deprecated roles. See link:../ansible/roles/locate_env_authorized_key/readme.adoc[readme].
+
+=== Deprecated roles and variables ===
+
+Roles:
+[cols="1,1"]
+|=====================
+| DEPRECATED
+| Use instead
+
+| `infra-local-create-ssh_key`
+| `create_ssh_provision_key`
+
+| `set_env_authorized_key`
+| `bastion-lite`
+|=====================
+
+Variables:
+[cols="1,1"]
+|=====================
+| DEPRECATED
+| Use instead
+
+| `env_authorized_key`
+| `ssh_provision_key_name` or `hostvars.localhost.ssh_provision_key_name`
+
+| `"{{ output_dir }}/{{ env_authorized_key }}"`
+| `ssh_provision_key_path` or `hostvars.localhost.ssh_provision_key_path`
+|=====================


### PR DESCRIPTION
* add section about `output_dir` storage which is important for SSH access as the output_dir is not persistent in Tower and Controller.

See GPTEINFRA-4470


<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
SSH Doc

