### PR TITLE
Add support for machinesets on AWS to specify iops for disks

### DIFF
--- a/ansible/roles/ocp4_machineset_config/README.adoc
+++ b/ansible/roles/ocp4_machineset_config/README.adoc
@@ -33,6 +33,7 @@ this Ansible role redundant.
       role: compute
       aws_instance_type: m5a.4xlarge
       aws_root_volume_size: 80
+      aws_root_volume_iops: 200
       autoscale: true
       total_replicas_min: 3
       total_replicas_max: 30
@@ -70,6 +71,10 @@ this Ansible role redundant.
 | `ocp4_machineset_config_default_aws_root_volume_size`
 | `120`
 | AWS root volume size default in GB
+
+| `ocp4_machineset_config_default_aws_root_volume_iops`
+| `0`
+| AWS root volume iops
 
 | `ocp4_machineset_config_disable_base_worker_machinesets`
 | `false`

--- a/ansible/roles/ocp4_machineset_config/defaults/main.yml
+++ b/ansible/roles/ocp4_machineset_config/defaults/main.yml
@@ -7,6 +7,7 @@ ocp4_machineset_config_disable_base_worker_machinesets: false
 ocp4_machineset_config_default_aws_instance_type: m5a.4xlarge
 ocp4_machineset_config_default_aws_root_volume_size: 120
 ocp4_machineset_config_default_aws_root_volume_type: gp2
+ocp4_machineset_config_default_aws_root_volume_iops: 0
 
 ocp4_machineset_config_default_osp_instance_type: "4c12g30d"
 ocp4_machineset_config_default_osp_root_volume_size: 120

--- a/ansible/roles/ocp4_machineset_config/tasks/machineset-group-aws.yml
+++ b/ansible/roles/ocp4_machineset_config/tasks/machineset-group-aws.yml
@@ -20,6 +20,8 @@
       {{ machineset_group.root_volume_size | default(default_aws_root_volume_size) }}
     aws_root_volume_type: >-
       {{ machineset_group.root_volume_type | default(default_aws_root_volume_type) }}
+    aws_root_volume_iops: >-
+      {{ machineset_group.root_volume_iops | default(default_aws_root_volume_iops) }}
     machineset_name: >-
       {{ [cluster_label, machineset_group.name, availability_zone] | join('-') }}
     machineset_group_node_labels: >-

--- a/ansible/roles/ocp4_machineset_config/templates/machineset-aws.j2
+++ b/ansible/roles/ocp4_machineset_config/templates/machineset-aws.j2
@@ -41,7 +41,7 @@ spec:
           apiVersion: {{ cloud_provider_api_version }}
           blockDevices:
           - ebs:
-              iops: 0
+              iops: {{ aws_root_volume_iops }}
               volumeSize: {{ aws_root_volume_size }}
               volumeType: {{ aws_root_volume_type }}
           credentialsSecret:

--- a/ansible/roles/ocp4_machineset_config/vars/main.yml
+++ b/ansible/roles/ocp4_machineset_config/vars/main.yml
@@ -12,6 +12,8 @@ default_aws_root_volume_size: >-
   {{ ocp4_machineset_config_default_aws_root_volume_size }}
 default_aws_root_volume_type: >-
   {{ ocp4_machineset_config_default_aws_root_volume_type }}
+default_aws_root_volume_iops: >-
+  {{ ocp4_machineset_config_default_aws_root_volume_iops }}
 
 default_osp_instance_type: >-
   {{ ocp4_machineset_config_default_osp_instance_type }}

--- a/ansible/roles_ocp_workloads/ocp4_workload_machinesets/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_machinesets/defaults/main.yml
@@ -54,6 +54,8 @@ ocp4_workload_machinesets_machineset_groups:
   instance_type: "m5a.2xlarge"
 # root_volume_size is only available for AWS it is ignored for OpenStack
 #   root_volume_size: "150"
+# root_volume_iops is only available for AWS it is ignored for OpenStack
+#   root_volume_iops: "0"
 # instance_type for OpenStack
 #   instance_type: "4c16g30d"
 


### PR DESCRIPTION
##### SUMMARY

When creating MachineSets with disk type io1 it is necessary to specify the iops for that disk as well.
This PR adds that variable to the MachineSet Group definition and the role implementing that.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_machineset_config
ocp4_workload_machinesets