### PR TITLE
Add support for catalogsnapshots to MTA6 workload

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_mta6/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta6/defaults/main.yml
@@ -59,3 +59,11 @@ ocp4_workload_mta6_hub_bucket_volume_size: 10Gi
 ocp4_workload_mta6_hub_database_volume_size: 5Gi
 ocp4_workload_mta6_keycloak_database_data_volume_size: 1Gi
 ocp4_workload_mta6_pathfinder_database_data_volume_size: 1Gi
+
+# --------------------------------
+# Use a Catalog Snapshot
+# --------------------------------
+ocp4_workload_mta6_catalogsource_setup: false
+ocp4_workload_mta6_catalogsource_name: redhat-operators-snapshot-mta6
+ocp4_workload_mta6_catalogsource_image: quay.io/gpte-devops-automation/olm_snapshot_redhat_catalog
+ocp4_workload_mta6_catalogsource_image_tag: v4.11_2022_11_21

--- a/ansible/roles_ocp_workloads/ocp4_workload_mta6/templates/application.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta6/templates/application.yaml.j2
@@ -31,6 +31,12 @@ spec:
         seedTackle: {{ ocp4_workload_mta6_seed }}
         deployOperator: {{ ocp4_workload_mta6_deploy_operator }}
         operatorChannel: {{ ocp4_workload_mta6_channel }}
+        useCatalogSnapshot: {{ ocp4_workload_mta6_catalogsource_setup }}
+        catalogSource:
+          name: {{ ocp4_workload_mta6_catalogsource_name }}
+          namespace: {{ ocp4_workload_mta6_namespace_base }}
+          image: {{ ocp4_workload_mta6_catalogsource_image }}
+          tag: {{ ocp4_workload_mta6_catalogsource_image_tag }}
 {% if ocp4_workload_mta6_seed | bool %}
         seedJob:
           repository: {{ ocp4_workload_mta6_seed_image }}

--- a/ansible/roles_ocp_workloads/ocp4_workload_mta6/templates/applicationset.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta6/templates/applicationset.yaml.j2
@@ -42,6 +42,12 @@ spec:
             seedTackle: {{ ocp4_workload_mta6_seed }}
             deployOperator: {{ ocp4_workload_mta6_deploy_operator }}
             operatorChannel: {{ ocp4_workload_mta6_channel }}
+            useCatalogSnapshot: {{ ocp4_workload_mta6_catalogsource_setup }}
+            catalogSource:
+              name: {{ ocp4_workload_mta6_catalogsource_name }}
+              namespace: "{{ ocp4_workload_mta6_namespace_base }}-{% raw %}{{ user }}{% endraw %}"
+              image: {{ ocp4_workload_mta6_catalogsource_image }}
+              tag: {{ ocp4_workload_mta6_catalogsource_image_tag }}
 {% if ocp4_workload_mta6_seed | bool %}
             seedJob:
               repository: {{ ocp4_workload_mta6_seed_image }}


### PR DESCRIPTION
##### SUMMARY

MTA6 is now a Red Hat Operator. Add support to use a catalogsource snapshot for deploying the operator.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_mta6