### PR TITLE
Add new workload to fix argocd deployments

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops_fix_argocd/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops_fix_argocd/defaults/main.yml
@@ -1,0 +1,19 @@
+---
+become_override: false
+ocp_username: opentlc-mgr
+silent: false
+
+# Create a namespace to deploy the fix argocd job in
+ocp4_workload_openshift_gitops_fix_argocd_create_namespace: false
+
+# Which namespace to deploy the fix argocd job in - if create_namespace
+# is false this namespace must already exist
+ocp4_workload_openshift_gitops_fix_argocd_namespace: openshift-gitops
+
+# How long to sleep in minutes before the job will delete all argocd-dex-server
+# and openshift-gitops-repo-server pods
+ocp4_workload_openshift_gitops_fix_argocd_delay: "2"
+
+# Image and tag for the container
+ocp4_workload_openshift_gitops_fix_argocd_image: quay.io/gpte-devops-automation/fix-argocd
+ocp4_workload_openshift_gitops_fix_argocd_tag: v1.0.0

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops_fix_argocd/meta/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops_fix_argocd/meta/main.yml
@@ -1,0 +1,15 @@
+---
+galaxy_info:
+  role_name: ocp4_workload_openshift_gitops_fix_argocd
+  author: Red Hat GPTE, Wolfgang Kulhanek (wkulhane@redhat.com)
+  description: |
+    Set up OpenShift GitOps (Operator).
+  license: MIT
+  min_ansible_version: "2.9"
+  platforms: []
+  galaxy_tags:
+  - ocp
+  - openshift
+  - gitops
+  - argocd
+dependencies: []

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops_fix_argocd/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops_fix_argocd/readme.adoc
@@ -1,0 +1,65 @@
+= ocp4_workload_openshift_gitops_fix_argocd - Deploy a Job to fix ArgoCD DEX pods
+
+[WARNING]
+This role is dependent on the OpenShift GitOps Operator. Make sure to install the gitops operator *BEFORE* installing this one.
+
+== Role overview
+
+* This role installs a job to delete all ArgoCD DEX Pods and the OpenShift GitOps repo server pod. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+ environment for the workload deployment.
+*** Debug task will print out: `pre_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy the job
+*** Debug task will print out: `workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+ configure the workload after deployment
+*** This role doesn't do anything here
+*** Debug task will print out: `post_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+ delete the workload
+*** This role removes the job
+*** Debug task will print out: `remove_workload Tasks completed successfully.`
+
+== Review the defaults variable file
+
+* This file link:./defaults/main.yml[./defaults/main.yml] contains all the variables you need to define to control the deployment of your workload.
+* The variable *ocp_username* is mandatory to assign the workload to the correct OpenShift user.
+* A variable *silent=True* can be passed to suppress debug messages.
+
+
+=== Deploy a Workload with the `ocp-workload` config [Mostly for testing]
+
+Create a file `workload_vars.yaml` with your variables:
+----
+cloud_provider: none
+env_type: ocp-workloads
+target_host: bastion.dev4.openshift.opentlc.com
+
+ocp_workloads:
+- ocp4_workload_openshift_gitops_fix_argocd
+
+#become_override: false
+
+# If the ocp-workload supports it, you should specify the OCP user:
+ocp_username: system:admin
+
+# Usually the ocp-workloads want a GUID also:
+guid: changeme
+----
+
+From the Agnosticd/ansible directory run the playbook:
+
+----
+ansible-playbook main.yml -e @workload_vars.yml -e ACTION="create"
+----
+
+=== To Delete an environment
+
+From the Agnosticd/ansible directory run the playbook:
+
+----
+ansible-playbook main.yml -e @workload_vars.yml -e ACTION="remove"
+----

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops_fix_argocd/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops_fix_argocd/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+
+# Do not modify this file
+
+- name: Running Pre Workload Tasks
+  include_tasks:
+    file: ./pre_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload Tasks
+  include_tasks:
+    file: ./workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  include_tasks:
+    file: ./post_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload removal Tasks
+  include_tasks:
+    file: ./remove_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+  when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops_fix_argocd/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops_fix_argocd/tasks/post_workload.yml
@@ -1,0 +1,9 @@
+---
+# Implement your Post Workload deployment tasks here
+
+
+# Leave this as the last task in the playbook.
+- name: post_workload tasks complete
+  debug:
+    msg: "Post-Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops_fix_argocd/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops_fix_argocd/tasks/pre_workload.yml
@@ -1,0 +1,8 @@
+---
+# Implement your Pre Workload deployment tasks here
+
+# Leave this as the last task in the playbook.
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops_fix_argocd/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops_fix_argocd/tasks/remove_workload.yml
@@ -1,0 +1,36 @@
+---
+# Implement your Workload removal tasks here
+
+- name: Install OpenShift GitOps operator
+  include_role:
+    name: install_operator
+  vars:
+    install_operator_action: remove
+    install_operator_name: openshift-gitops-operator
+    install_operator_namespace: openshift-operators
+    install_operator_channel: preview
+    install_operator_catalog: redhat-operators
+    install_operator_catalogsource_setup: "{{ ocp4_workload_openshift_gitops_use_catalog_snapshot | default(false)}}"
+    install_operator_catalogsource_name: "{{ ocp4_workload_openshift_gitops_catalogsource_name | default('') }}"
+    install_operator_catalogsource_namespace: openshift-operators
+    install_operator_catalogsource_image: "{{ ocp4_workload_openshift_gitops_catalog_snapshot_image | default('') }}"
+    install_operator_catalogsource_image_tag: "{{ ocp4_workload_openshift_gitops_catalog_snapshot_image_tag | default('') }}"
+
+- name: Remove cluster-admin permissions from Gitops Service account
+  when: ocp4_workload_openshift_gitops_setup_cluster_admin | bool
+  kubernetes.core.k8s:
+    state: absent
+    definition: "{{ lookup('file', 'clusterrolebinding.yaml' ) | from_yaml }}"
+
+- name: Remove openshift-gitops namespace
+  kubernetes.core.k8s:
+    state: absent
+    api_version: v1
+    kind: namespace
+    name: openshift-gitops
+
+# Leave this as the last task in the playbook.
+- name: remove_workload tasks complete
+  debug:
+    msg: "Remove Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops_fix_argocd/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops_fix_argocd/tasks/workload.yml
@@ -1,0 +1,27 @@
+---
+# Implement your Workload deployment tasks here
+
+- name: Setting up workload for user
+  debug:
+    msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
+
+- name: Create namespace
+  when: ocp4_workload_openshift_gitops_fix_argocd_create_namespace | bool
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('template', 'namespace.yaml.j2' ) | from_yaml }}"
+
+- name: Deploy fix-argocd job
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('template', item ) | from_yaml }}"
+  loop:
+  - serviceaccount.yaml.j2
+  - clusterrolebinding.yaml.j2
+  - job.yaml.j2
+
+# Leave this as the last task in the playbook.
+- name: workload tasks complete
+  debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops_fix_argocd/templates/clusterrolebinding.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops_fix_argocd/templates/clusterrolebinding.yaml.j2
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: fix-argocd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: fix-argocd
+  namespace: {{ ocp4_workload_openshift_gitops_fix_argocd_namespace }}

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops_fix_argocd/templates/job.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops_fix_argocd/templates/job.yaml.j2
@@ -1,0 +1,32 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: fix-argocd
+  namespace: {{ ocp4_workload_openshift_gitops_fix_argocd_namespace }}
+spec:
+  backoffLimit: 6
+  completionMode: NonIndexed
+  completions: 1
+  parallelism: 1
+  selector:
+    matchLabels:
+      job-name: fix-argocd
+  suspend: false
+  template:
+    metadata:
+      labels:
+        job-name: fix-argocd
+    spec:
+      serviceAccountName: fix-argocd
+      containers:
+      - image: "{{ ocp4_workload_openshift_gitops_fix_argocd_image }}:{{ ocp4_workload_openshift_gitops_fix_argocd_tag }}"
+        imagePullPolicy: IfNotPresent
+        name: fix-argocd
+        env:
+        - name: SETUP_DELAY
+          value: "{{ ocp4_workload_openshift_gitops_fix_argocd_delay }}"
+        resources: {}
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never
+      terminationGracePeriodSeconds: 30

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops_fix_argocd/templates/namespace.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops_fix_argocd/templates/namespace.yaml.j2
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ ocp4_workload_openshift_gitops_fix_argocd_namespace }}

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops_fix_argocd/templates/serviceaccount.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops_fix_argocd/templates/serviceaccount.yaml.j2
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fix-argocd
+  namespace: {{ ocp4_workload_openshift_gitops_fix_argocd_namespace }}


### PR DESCRIPTION
##### SUMMARY

Sometimes ArgoCD DEX servers can't connect to the OpenShift API - and then users can not login. Fix is to just restart every argocd-dex-server pod on the cluster.

Also sometimes the OpenShift GitOps repo server pod has locks in its ephemeral storage that prevent rollout of all applications. Fix is to restart that pod as well.

This workload deploys a job that does all that.

##### ISSUE TYPE
- New role Pull Request

##### COMPONENT NAME
ocp4_workload_openshift_gitops_fix_argocd