### PR TITLE
Change role ocp4_workload_hands_on_rhacs to match API requirements of RHACS 3.72.1

### DIFF
--- a/ansible/roles/ocp4_workload_stackrox_demo_apps/tasks/workload.yml
+++ b/ansible/roles/ocp4_workload_stackrox_demo_apps/tasks/workload.yml
@@ -9,8 +9,9 @@
 - name: Demo application deployments
   include_tasks: deploy_demos.yml
 
-- name: Network anomalies
-  include_tasks: network_anomalies.yml
+# Commenting the network anomalies as it's not applicable to RHACS 3.72
+#- name: Network anomalies
+# include_tasks: network_anomalies.yml
 
 - name: Baseline processes
   include_tasks: baseline_processes.yml

--- a/ansible/roles_ocp_workloads/ocp4_workload_hands_on_rhacs/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_hands_on_rhacs/tasks/workload.yml
@@ -22,7 +22,7 @@
     name: microservices-demo
 
 - name: apply the yaml manifests to launch the demo
-  shell: "oc apply -n microservices-demo -f /home/ec2-user/microservices-demo/release/kubernetes-manifests.yaml"
+  shell: "oc apply -n microservices-demo -f https://raw.githubusercontent.com/GoogleCloudPlatform/microservices-demo/0974cec847a65d713f1255dbf87f2457fa2158c4/release/kubernetes-manifests.yaml"
 
 # run the two workloads for the pipeline and app demos
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_hands_on_rhacs/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_hands_on_rhacs/tasks/workload.yml
@@ -1,3 +1,4 @@
+# yamllint disable rule:line-length
 ---
 #- name: Demo app namespaces and pull secrets
 #  include_tasks: image_pull_secret.yml


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
1. This role calls the role ocp4_workload_stackrox_demo_apps, the network anomaly task is not needed for RHACS 3.72, as confirmed with SME mfoster
2. this role is running deployments from Googlecloudplatform repo, they have changed their manifests in their repo, hence our CI is breaking. I have made changes so that the working version of the manifest is used in our CI. Coincidentally these change happened last night and our monitoring system has this ticket https://gpte.statuspage.io/incidents/9yv4kn3wv5yw
This PR will fix this issue too.
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
role ocp4_workload_hands_on_rhacs

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
