### PR TITLE
adding     ignore_errors: true

### DIFF
--- a/ansible/roles-infra/infra-osp-create-inventory/tasks/main.yml
+++ b/ansible/roles-infra/infra-osp-create-inventory/tasks/main.yml
@@ -54,6 +54,7 @@
     loop_control:
       label: "{{ server | json_query(_name_selector) | default(server.name) }}"
       loop_var: server
+    ignore_errors: true      
     tags:
     - create_inventory
     - must
@@ -73,6 +74,7 @@
     vars:
       private_ip_query: >
         [?"OS-EXT-IPS:type"=='fixed'].addr|[0]
+    ignore_errors: true    
 
   - add_host:
       name: "{{ server | json_query(_name_selector) | default(server.name) }}"
@@ -82,6 +84,7 @@
       label: "{{ server | json_query(_name_selector) | default(server.name) }}"
       loop_var: server
     when: server.metadata.AnsibleGroup | default('') != ''
+    ignore_errors: true
     tags:
     - create_inventory
     - must


### PR DESCRIPTION
TASK [infra-osp-create-inventory : Find the bastion in this batch of host] ***** task path: /tmp/awx_959721_jk41q7sk/project/ansible/roles-infra/infra-osp-create-inventory/tasks/main.yml:18 fatal: [localhost]: FAILED! => {
    "msg": "'r_osp_facts' is undefined"
}
...ignoring
TASK [infra-osp-create-inventory : Add hosts to inventory] ********************* task path: /tmp/awx_959721_jk41q7sk/project/ansible/roles-infra/infra-osp-create-inventory/tasks/main.yml:35 fatal: [localhost]: FAILED! => {
    "msg": "'r_osp_facts' is undefined"
}


https://tower.dark-tower-prod.infra.open.redhat.com/#/jobs/playbook/959721?job_search=page_size:20;order_by:-finished;not__launch_type:sync

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
