### PR TITLE
infra_osp_lifecycle: Use consistent variable name

### DIFF
--- a/ansible/roles-infra/infra_osp_lifecycle/tasks/get-servers.yml
+++ b/ansible/roles-infra/infra_osp_lifecycle/tasks/get-servers.yml
@@ -3,16 +3,16 @@
 - name: Get server info using guid & env_type
   openstack.cloud.server_info:
     all_projects: false
-  register: r_os_server_info
+  register: r_osp_facts
 
 - name: Debug openstack.cloud.server_info var, use -v to display
   debug:
     verbosity: 3
-    var: r_os_server_info
+    var: r_osp_facts
 
 - name: Create openstack_servers fact
   set_fact:
-    openstack_servers: "{{ r_os_server_info.openstack_servers }}"
+    openstack_servers: "{{ r_osp_facts.openstack_servers }}"
 
 - name: Debug osp_servers fact, use -v to display
   debug:


### PR DESCRIPTION
Use same variable name as infra-osp-create-inventory role

Try to fix the lifecycle error:

```
    'r_osp_facts' is undefined
```

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION

Can't test locally, need someone to test this code.
