### PR TITLE
We're having issues with the FIP not being accessible in OSP

### DIFF
--- a/ansible/cloud_providers/osp_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/osp_infrastructure_deployment.yml
@@ -105,6 +105,10 @@
           -F {{ output_dir }}/{{ env_type }}_{{ guid }}_ssh_conf
           -o ControlPath=/tmp/{{ guid }}-%r-%h-%p
 
+    - name: Wait for IBM Router and OVN Gratitous ARP to have time to sync FIP to routing-table
+      pause:
+        minutes: 7
+
     - name: Run infra-generic-wait_for_linux_hosts Role
       import_role:
         name: infra-generic-wait_for_linux_hosts


### PR DESCRIPTION
##### SUMMARY

Add delay for OSP linux to allow router table and OVN to sync FIP (7 minutes hardcoded)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

ansible/cloud_providers/osp_infrastructure_deployment.yml


##### ADDITIONAL INFORMATION
High Failure rate due to FIP inaccessible on OSP VM's, but manual connection works almost immediately.

```
