### PR TITLE
Add Billy to manage AWS image definitions

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -38,3 +38,7 @@ ansible/action_plugins/test_agnosticd_odcr.py @fridim
 ansible/*azure* @redhat-cop/agnosticd-core @rut31337
 ansible/cloud_providers/*azure* @redhat-cop/agnosticd-core @rut31337
 ansible/roles-infra/*azure* @redhat-cop/agnosticd-core @rut31337
+
+# AWS Images
+
+ansible/roles-infra/infra-images/defaults/main.yaml @redhat-cop/agnosticd-core @bbethell-1


### PR DESCRIPTION
following up on #5674

Billy knows how to test the images filters and is able to maintain that file.

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
