### PR TITLE
Change indentfirst to indent

### DIFF
--- a/ansible/configs/osp16-concepts-architecture/files/cloud_providers/osp_cloud_template_master.j2
+++ b/ansible/configs/osp16-concepts-architecture/files/cloud_providers/osp_cloud_template_master.j2
@@ -177,7 +177,7 @@ resources:
       user_data: |
         #cloud-config
         ssh_authorized_keys: {{ all_ssh_authorized_keys | to_json }}
-        {{ instance.userdata | default(omit) | indent( width=8, indentfirst=False ) }}
+        {{ instance.userdata | default(omit) | indent( width=8, indent=False ) }}
 
       user_data_format: RAW
       networks:


### PR DESCRIPTION
Before Jinja 2.10 the [indent parameter was called indentfirst](https://github.com/pallets/jinja/blob/c9593aa388a04ca6a1a15a4436269f762c36a7b5/src/jinja2/filters.py#L797).