### PR TITLE
Add option to ocp4_workload_le_certificates to not fail on error

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_le_certificates/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_le_certificates/defaults/main.yml
@@ -8,3 +8,6 @@ ocp4_workload_le_certificates_install_certificates: true
 
 # Install certificates for API Endpoint
 ocp4_workload_le_certificates_install_api: false
+
+# Option allow continue without certificates on failure
+ocp4_workload_le_certificates_failure_is_fatal: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_le_certificates/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_le_certificates/tasks/workload.yml
@@ -233,6 +233,13 @@
       delay: 10
       until: not r_ingress_config.failed
 
+  rescue:
+  - name: Fail if certificates are required
+    when: ocp4_workload_le_certificates_failure_is_fatal | bool
+    fail:
+      msg: >-
+        Let's Encrypt certificate workload failed.
+
 # Leave this as the last task in the playbook.
 - name: workload tasks complete
   debug:


### PR DESCRIPTION
##### SUMMARY

Add `ocp4_workload_le_certificates_failure_is_fatal` flag to `ocp4_workload_le_certificates` workload.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Role `ocp4_workload_le_certificates`