### PR TITLE
Introduce new private var for migration host

### DIFF
--- a/ansible/configs/osp16-concepts-architecture/pre_infra.yml
+++ b/ansible/configs/osp16-concepts-architecture/pre_infra.yml
@@ -12,6 +12,7 @@
       name: "{{ import_host }}"
       ansible_become: true
       ansible_ssh_private_key_file: "{{ migration_key_path | default(omit) }}"
+      ansible_ssh_private_key_content: "{{ migration_host_ansible_ssh_private_key_content | default(omit) }}"
       ansible_user: "opentlc-mgr"
       bastion: "{{ import_host }}"
       group: "migration"

--- a/ansible/configs/osp16-concepts-architecture/pre_infra.yml
+++ b/ansible/configs/osp16-concepts-architecture/pre_infra.yml
@@ -8,14 +8,14 @@
   tasks:
   - when: migration_host_ssh_private_key_content is defined
     block:
-      - name: Prepare ssh_key from provided content
-        copy:
-          content: "{{ migration_host_ssh_private_key_content }}"
-          dest: "{{ output_dir }}/migration_key.pem"
-          mode: 0600
+    - name: Prepare ssh_key from provided content
+      copy:
+        content: "{{ migration_host_ssh_private_key_content }}"
+        dest: "{{ output_dir }}/migration_key.pem"
+        mode: 0600
 
-      - set_fact:
-          migration_host_ansible_ssh_private_key_file: "{{ output_dir }}/migration_key.pem"
+    - set_fact:
+        migration_host_ansible_ssh_private_key_file: "{{ output_dir }}/migration_key.pem"
 
   - name: Create migration host group
     when: purpose == "production" or purpose == "release"

--- a/ansible/configs/osp16-concepts-architecture/pre_infra.yml
+++ b/ansible/configs/osp16-concepts-architecture/pre_infra.yml
@@ -6,11 +6,11 @@
   - step001
   - pre_infrastructure
   tasks:
-  - when: migration_ssh_private_key_content is defined
+  - when: migration_host_ssh_private_key_content is defined
     block:
       - name: Prepare ssh_key from provided content
         copy:
-          content: "{{ migration_ssh_private_key_content }}"
+          content: "{{ migration_host_ssh_private_key_content }}"
           dest: "{{ output_dir }}/migration_key.pem"
           mode: 0600
 

--- a/ansible/configs/osp16-concepts-architecture/pre_infra.yml
+++ b/ansible/configs/osp16-concepts-architecture/pre_infra.yml
@@ -6,13 +6,26 @@
   - step001
   - pre_infrastructure
   tasks:
+  - when: migration_ssh_private_key_content is defined
+    block:
+      - name: Prepare ssh_key from provided content
+        copy:
+          content: "{{ migration_ssh_private_key_content }}"
+          dest: "{{ output_dir }}/migration_key.pem"
+          mode: 0600
+
+      - set_fact:
+          migration_host_ansible_ssh_private_key_file: "{{ output_dir }}/migration_key.pem"
+
   - name: Create migration host group
     when: purpose == "production" or purpose == "release"
     add_host:
       name: "{{ import_host }}"
       ansible_become: true
-      ansible_ssh_private_key_file: "{{ migration_key_path | default(omit) }}"
-      ansible_ssh_private_key_content: "{{ migration_host_ansible_ssh_private_key_content | default(omit) }}"
+      ansible_ssh_private_key_file: >-
+        {{ migration_host_ansible_ssh_private_key_file
+        | default(migration_key_path)
+        | default(omit) }}
       ansible_user: "opentlc-mgr"
       bastion: "{{ import_host }}"
       group: "migration"


### PR DESCRIPTION
migration_host_ansible_ssh_private_key_content will contain the private key, encrypted using ansible-vault

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request
