### PR TITLE
Update to allow letsencrypt cert to be installed on frontend server

### DIFF
--- a/ansible/configs/ansible-middleware-workshop/README.adoc
+++ b/ansible/configs/ansible-middleware-workshop/README.adoc
@@ -17,14 +17,23 @@ On the bastion host, vs code server is deployed providing an IDE for users to ru
 
 The file sample_vars_ec2.yml contains all the variables you need to define to control the deployment of your environment.  Copy this file to my_vars.yml and edit it to your needs.  
 
+`cp ansible/configs/ansible-middleware-workshop/sample_vars_ec2.yml  ansible/configs/ansible-middleware-workshop/my_vars.yml`
 
 == Deploying the Ansible Middleware Workshop Config
 
-You can deploy this config by running the following command from the `ansible`
+You can deploy this config by running the following commands from the `ansible`
 directory. You will have to provide credentials and adjust settings to your own
 environment.
 
-`ansible-playbook -e @configs/ansible-middleware-workshop/my_vars.yml main.yml`
+`export aws_access_key_id=`
+
+
+
+`export aws_secret_access_key=`
+
+`ansible-galaxy collection install -r configs/ansible-middleware-workshop/requirements.yml`
+
+ansible-playbook -e @configs/ansible-middleware-workshop/my_vars.yml main.yml --extra-vars "aws_access_key_id=$aws_access_key_id aws_secret_access_key=$aws_secret_access_key"
 
 === To Delete an environment
 ----

--- a/ansible/configs/ansible-middleware-workshop/default_vars.yml
+++ b/ansible/configs/ansible-middleware-workshop/default_vars.yml
@@ -79,6 +79,7 @@ common_packages_el8:
   - python3
   - python3-lxml
   - tree
+  - socat
 
 
 ### Vars that can be removed:

--- a/ansible/configs/ansible-middleware-workshop/default_vars_ec2.yml
+++ b/ansible/configs/ansible-middleware-workshop/default_vars_ec2.yml
@@ -100,6 +100,7 @@ instances:
       - FrontendSG
       - HostSG
       - BastionSG
+      - WebSG
 
   - name: "app"
     count: "{{ app_instance_count | default(2) }}"


### PR DESCRIPTION
These changes allow the installation of lets encrypt certs on the frontend server as part of the workshop.  It comprises of the installation of the socat library which is required by letsencrypt standalone mode and opening port 80 in the frontend security group.