### PR TITLE
Change route to edge for system argocd

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/templates/openshift-gitops.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/templates/openshift-gitops.yaml.j2
@@ -66,11 +66,11 @@ spec:
         memory: "{{ ocp4_workload_openshift_gitops_server_requests_memory }}"
 {% endif %}
 {% if ocp4_workload_openshift_gitops_update_route_tls | bool %}
-    insecure: false
+    insecure: true
     route:
       enabled: true
       tls:
-        termination: reencrypt
+        termination: edge
         insecureEdgeTerminationPolicy: Redirect
 {% endif %}
 {% if ocp4_workload_openshift_gitops_resource_customizations | length > 0 %}


### PR DESCRIPTION
##### SUMMARY

Changed system ArgoCD route TLS configuration to use edge instead of reencryopt - which caused problems.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_openshift_gitops