### PR TITLE
Add user info message for kubeadmin password

### DIFF
--- a/ansible/roles/host-ocp4-installer/tasks/print_cluster_info.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/print_cluster_info.yml
@@ -47,10 +47,12 @@
   when: host_ocp4_installer_set_user_data | bool
 
 - name: Show user messages for OpenShift access
-  agnosticd_user_info:
-    msg: "{{ item }}"
-  loop:
-    - "Openshift Console: {{ openshift_console_url }}"
-    - "Openshift API for command line 'oc' client: {{ openshift_api_url }}"
-    - "Download oc client from {{ ocp4_client_url }}"
   when: host_ocp4_installer_show_user_info | bool
+  agnosticd_user_info:
+    msg: |-
+      OpenShift Console: {{ openshift_console_url }}
+      OpenShift API for command line 'oc' client: {{ openshift_api_url }}
+      {% if host_ocp4_installer_set_user_data_kubeadmin_password | bool %}
+      OpenShift kubeadmin password: {{ r_slurp_kubeadmin_password.content | b64decode }}
+      {% endif %}
+      Download oc client from {{ ocp4_client_url }}


### PR DESCRIPTION
##### SUMMARY

Print kubeadmin user password from `host-ocp4-installer` when also storing it as user info.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Role `host-ocp4-installer`