### PR TITLE
Capture per-user agnosticd_user_info messages in result

### DIFF
--- a/ansible/action_plugins/agnosticd_user_info.py
+++ b/ansible/action_plugins/agnosticd_user_info.py
@@ -61,13 +61,16 @@ class ActionModule(ActionBase):
             result['error'] = 'msg and body are mutually exclusive'
             return result
 
-        if not user and msg != None:
-            # Output msg in result, prepend "user.info: " to support parsing from log
-            if isinstance(msg, list):
-                result['msg'] = ['user.info: ' + m for m in msg]
+        if msg != None:
+            if user:
+                result['msg'] = msg
             else:
-                result['msg'] = 'user.info: ' + msg
-                # Force display of result like debug
+                # Output msg in result, prepend "user.info: " to support parsing from log
+                if isinstance(msg, list):
+                    result['msg'] = ['user.info: ' + m for m in msg]
+                else:
+                    result['msg'] = 'user.info: ' + msg
+                    # Force display of result like debug
 
         if not user and body != None:
             # Output msg in result, prepend "user.body: " to support parsing from log


### PR DESCRIPTION
##### SUMMARY

Put per-user messages generated by `agnosticd_user_info` in the result object so that it can be recover from the event log.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`agnosticd_user_info` action plugin