### PR TITLE
[ocp4_workload_le_certificates] Change wait time to be configurable instead of a hardcode

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_le_certificates/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_le_certificates/defaults/main.yml
@@ -11,3 +11,11 @@ ocp4_workload_le_certificates_install_api: false
 
 # Option allow continue without certificates on failure
 ocp4_workload_le_certificates_failure_is_fatal: true
+
+# It takes about 4 minutes per API Server to
+# restart with certificates (due to AWS
+# Load Balancer). Therefore sleep
+# 12 minutes by default to give the kube-apiserver
+# cluster operator enough time to progress.
+# Wait time may be extended if it's needed
+ocp4_workload_le_certificates_wait_after_cert_setup: 12

--- a/ansible/roles_ocp_workloads/ocp4_workload_le_certificates/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_le_certificates/tasks/workload.yml
@@ -234,9 +234,10 @@
     # Load Balancer). Therefore sleep
     # 12 minutes to give the kube-apiserver
     # cluster operator enough time to progress.
-    - name: Wait 12m for all APIservers to be back up
+    # Wait time may be extended if it's needed
+    - name: Wait for some time for all APIservers to be back up (default 12 minutes)
       pause:
-        minutes: 12
+        minutes: "{{ ocp4_workload_le_certificates_wait_after_cert_setup }}"
 
     - name: Find all Kube Configs
       become: true


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

This change removes a hardcoded wait time on ocp4_workload_le_certificates role in favor of configurable one, with default being set to previously hardcoded value. Sleep is there to allow kube-apiserver employ the new certificates, but in specific conditions a time longer than 12 minutes may be needed for the things to settle down.

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
ocp4_workload_le_certificates role

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below
BEFORE:

TASK [ocp4_workload_le_certificates : Wait 12m for all APIservers to be back up] ***
Pausing for 1200 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)

AFTER:
TASK [ocp4_workload_le_certificates : Wait for some time for all APIservers to be back up (default 12 minutes)] ***
Pausing for 2000 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)

```
