### PR TITLE
Add base domain and ignore errors to destroy

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/tasks/remove_workload.yml
@@ -23,8 +23,10 @@
       --name {{ ocp4_workload_deploy_hosted_cluster_name }}
       --infra-id {{ ocp4_workload_deploy_hosted_cluster_infra_ID }}
       --aws-creds /home/opentlc-mgr/.aws/credentials
+      --base-domain {{ ocp4_workload_deploy_hosted_cluster_base_domain }}
       --namespace local-cluster
   register: r_hypershift_destroy
+  ignore_errors: true
 
 - name: Delete htpasswd-{{ guid }} secret
   kubernetes.core.k8s:


### PR DESCRIPTION
##### SUMMARY

Make destroy of Hypershift clusters more robust (especially in case where the provision failed).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_deploy_hosted_cluster