### PR TITLE
Use cluster TLS and add Argo CD RBAC for workshop user to each instance

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_gitops_workshop/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitops_workshop/tasks/workload.yml
@@ -66,6 +66,8 @@
       user{{ item }}-argocd
     _ocp4_workload_gitops_workshop_argo_instance_name: >-
       user{{ item }}-argo
+    _ocp4_workload_gitops_workshop_user: >-
+      user{{ item }}
   kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('template', 'argocd_cr.yaml.j2' ) | from_yaml }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_gitops_workshop/templates/argocd_cr.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitops_workshop/templates/argocd_cr.yaml.j2
@@ -4,6 +4,7 @@ metadata:
   name: {{ _ocp4_workload_gitops_workshop_argo_instance_name }}
   namespace: {{ _ocp4_workload_gitops_workshop_namespacename }}
 spec:
+  disableAdmin: true
   controller:
     resources:
       limits:
@@ -33,8 +34,9 @@ spec:
   rbac:
     defaultPolicy: ''
     policy: |
-      g, system:cluster-admins, role:admin
-    scopes: '[groups]'
+      g, {{ _ocp4_workload_gitops_workshop_user }}, role:admin
+      g, opentlc-mgr, role:admin
+    scopes: '[email, groups]'
   redis:
     resources:
       limits:
@@ -59,5 +61,9 @@ spec:
       requests:
         cpu: 125m
         memory: 128Mi
+    insecure: true
     route:
       enabled: true
+      tls:
+        termination: edge
+        insecureEdgeTerminationPolicy: Redirect


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

Modifies the configuration of the user Argo CD instances for this workshop as follows:
- Uses edge termination instead of passthrough so it will use the wildcard TLS certificate, avoids problem of users having to accept a private certificate
- Adds RBAC to enable logging into Argo CD using the OpenShift credential instead of requiring users to lookup the Argo CD certificate
- Adds RBAC to all instances for the opentlc-mgr user so the workshop owner can easily assist users with problems.
- Disables login via the secret to avoid confusion

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

Changes to ocp4_workload_gitops_workshop role to support the OpenShift GitOps workshop

##### ADDITIONAL INFORMATION

Additional changes required in Workshop material, only merge into development for now (i.e. no test or prod environments)