### PR TITLE
Update ocp4-cluster requirements amazon.aws to 5.2.0

### DIFF
--- a/ansible/configs/ocp4-cluster/requirements.yml
+++ b/ansible/configs/ocp4-cluster/requirements.yml
@@ -6,19 +6,19 @@ roles:
   version: v0.17
 
 collections:
-- name: kubernetes.core
-  version: 2.3.0
-- name: openstack.cloud
-  version: 1.7.2
 - name: amazon.aws
-  version: 2.2.0
-- name: community.general
-  version: 4.6.1
+  version: 5.2.0
 - name: ansible.posix
   version: 1.3.0
+- name: community.aws
+  version: 4.1.1
+- name: community.general
+  version: 4.6.1
 - name: community.vmware
   version: 2.7.0
 - name: google.cloud
   version: 1.0.2
-- name: community.aws
-  version: 4.1.1
+- name: kubernetes.core
+  version: 2.3.0
+- name: openstack.cloud
+  version: 1.7.2


### PR DESCRIPTION
##### SUMMARY

- Update ocp4-cluster config requirements.yml to update amazon.aws collection from 2.2.0 to 5.2.0 to fix issue with community.aws 4.1.1.
- Sort requirements.yml content.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Config ocp4-cluster