### PR TITLE
[infra-vmc-resources] Delete project even if is empty.

### DIFF
--- a/ansible/roles-infra/infra-vmc-resources/tasks/delete_instances.yaml
+++ b/ansible/roles-infra/infra-vmc-resources/tasks/delete_instances.yaml
@@ -27,8 +27,6 @@
     parent_folder: "Workloads"
     folder_type: vm
     state: absent
-  when: "{{ r_vmc_vms.virtual_machines|default([])|length > 0 }}"
-
 
 - name: Delete additional public ips
   include_tasks: delete_additional_public_ips.yaml


### PR DESCRIPTION
When a provision fails, the cleanup was not deleting the project because the folder was empty.