### PR TITLE
[Equinix-AiO] bumping requirements for 4.12 support

### DIFF
--- a/ansible/configs/ocp4-equinix-aio/requirements.yml
+++ b/ansible/configs/ocp4-equinix-aio/requirements.yml
@@ -8,7 +8,7 @@ roles:
   - name: ocp4_aio_base_virt
     src: https://github.com/RHFieldProductManagement/ocp4_aio_infra_role_base_virt.git
     scm: git
-    version: v0.1.2
+    version: v0.1.5
 
   - name: ocp4_aio_prepare_bastion
     src: https://github.com/RHFieldProductManagement/ocp4_aio_infra_role_prepare_bastion.git
@@ -63,7 +63,7 @@ roles:
   - name: ocp4_aio_workload_cnvlab
     src: https://github.com/RHFieldProductManagement/ocp4_aio_role_deploy_cnvlab.git
     scm: git
-    version: v0.0.12
+    version: v0.0.14
 
 collections:
   - name: community.general


### PR DESCRIPTION
##### SUMMARY

Bumping requirements to enhance security (bastion host now gets upgraded before being started to make sure we avoid any OpenSSH CVEs) and 4.12 compatibility (update in instructions) 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request
- Security fix Pull Request
- 
##### COMPONENT NAME
ocp4-equinix-aio

##### ADDITIONAL INFORMATION
Fixed lots of instructions due to changes in 4.12' CNV
Trying to get the whole env more secure to avoid issues with Equinix sec team