### PR TITLE
Add retries to infra-vmc-resources

### DIFF
--- a/ansible/roles-infra/infra-vmc-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-vmc-resources/tasks/create_instance.yaml
@@ -34,7 +34,9 @@
   loop: "{{ range(1, _instance.count|default(1)|int+1) | list }}"
   loop_control:
     index_var: _index
-
+  until: r_vmc_instance is success
+  retries: 5
+  delay: 10
 
 - name: Add virtual machine custom attributes
   register: r_vm_attributes
@@ -48,8 +50,12 @@
   loop: "{{ range(1, _instance.count|default(1)|int+1) | list }}"
   loop_control:
     index_var: _index
+  until: r_vmc_attributes is success
+  retries: 5
+  delay: 10
 
 - name: Restart VM after create it
+  register: r_vm_reboot
   when: r_vm_attributes.changed
   vars:
     _instance_name: "{{ _instance.name }}{{ _index+1 if _instance.count|d(1)|int > 1 }}"
@@ -61,6 +67,9 @@
   loop: "{{ range(1, _instance.count|default(1)|int+1) | list }}"
   loop_control:
     index_var: _index
+  until: r_vm_reboot is success
+  retries: 5
+  delay: 10
 
 - name: Pause 5 seconds before get information
   pause:
@@ -76,6 +85,9 @@
   loop: "{{ range(1, _instance.count|default(1)|int+1) | list }}"
   loop_control:
     index_var: _index
+  until: r_vmc_instance is success
+  retries: 5
+  delay: 10
 
 - name: Create public IP and NAT
   include_tasks: create_public_ip_and_nat.yaml


### PR DESCRIPTION
##### SUMMARY

Add retries to infra-vmc-resources role to adapt to vcenter API timeout issues.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Role infra-vmc-resources