### PR TITLE
Skip installing existing collections when using EE

### DIFF
--- a/ansible/filter_plugins/core.py
+++ b/ansible/filter_plugins/core.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from copy import deepcopy
 from ansible.errors import AnsibleFilterError
 from ansible.utils.display import Display
 from ansible.module_utils.six import string_types, integer_types
@@ -281,6 +282,7 @@ def agnosticd_filter_out_installed_collections(requirements, installed_collectio
     }
     '''
 
+    requirements = deepcopy(requirements)
     function_name = "agnosticd_remove_collection_already_installed"
 
     if not isinstance(requirements, dict):

--- a/ansible/filter_plugins/core.py
+++ b/ansible/filter_plugins/core.py
@@ -299,8 +299,10 @@ def agnosticd_filter_out_installed_collections(requirements, installed_collectio
 
     installed = {}
     for _, collections_ in installed_collections.items():
-        for collection in collections_:
-            installed[collection] = True
+        for collection, value in collections_.items():
+            if collection in installed:
+                continue
+            installed[collection] = value["version"]
 
     keep_collections = []
 
@@ -312,7 +314,13 @@ def agnosticd_filter_out_installed_collections(requirements, installed_collectio
             # collection is not installed, keep it
             keep_collections.append(collection)
         else:
-            display.display("skipping %s, already installed"%(collection['name']))
+            display.warning(
+                "skipping installation of %s==%s ; %s==%s already installed in EE"
+                %(collection['name'],
+                  collection['version'],
+                  collection['name'],
+                  installed[collection['name']])
+            )
 
 
     requirements['collections'] = keep_collections

--- a/ansible/filter_plugins/core.py
+++ b/ansible/filter_plugins/core.py
@@ -261,6 +261,63 @@ def agnosticd_get_all_images(image, predefined, done=None):
 
         return result
 
+def agnosticd_filter_out_installed_collections(requirements, installed_collections):
+    '''Remove collections from a requirement content that are already installed.
+
+    argument collections is a dict, usually output of the command:
+    ansible-galaxy collection list --format json
+    , ex:
+    {
+        "/usr/share/ansible/collections/ansible_collections": {
+            {
+                "community.general": {
+                "version": "6.3.0"
+                },
+                "openstack.cloud": {
+                "version": "2.0.0"
+                }
+            }
+        }
+    }
+    '''
+
+    function_name = "agnosticd_remove_collection_already_installed"
+
+    if not isinstance(requirements, dict):
+        raise AnsibleFilterError(
+            '%s: requirement content arg should be a dict' %(function_name)
+        )
+    if not isinstance(installed_collections, dict):
+        raise AnsibleFilterError(
+            '%s: collections arg should be a dict' %(function_name)
+        )
+
+    if 'collections' not in requirements:
+        return requirements
+
+    installed = {}
+    for _, collections_ in installed_collections.items():
+        for collection in collections_:
+            installed[collection] = True
+
+    keep_collections = []
+
+    for collection in requirements['collections']:
+        if 'name' not in collection:
+            continue
+
+        if collection['name'] not in installed:
+            # collection is not installed, keep it
+            keep_collections.append(collection)
+        else:
+            display.display("skipping %s, already installed"%(collection['name']))
+
+
+    requirements['collections'] = keep_collections
+
+    return requirements
+
+
 class FilterModule(object):
     ''' AgnosticD core jinja2 filters '''
 
@@ -272,4 +329,5 @@ class FilterModule(object):
             'equinix_metal_tags_to_dict': equinix_metal_tags_to_dict,
             'image_to_ec2_filters': image_to_ec2_filters,
             'agnosticd_get_all_images': agnosticd_get_all_images,
+            'agnosticd_filter_out_installed_collections': agnosticd_filter_out_installed_collections,
         }

--- a/ansible/filter_plugins/tests/test_core.py
+++ b/ansible/filter_plugins/tests/test_core.py
@@ -266,9 +266,9 @@ def test_dict_to_equinix_metal_tags():
     testcases = [
         [
             {
-                    "AnsibleGroup":"bastions",
-                    "ostype":"linux",
-                    "number": 2,
+                "AnsibleGroup":"bastions",
+                "ostype":"linux",
+                "number": 2,
             },
             [
                 "AnsibleGroup=bastions",
@@ -343,7 +343,6 @@ def test_agnosticd_get_all_images():
     ]
 
     for tc in testcases:
-        print("test suivant")
         assert(core.agnosticd_get_all_images(tc[0], predefined) == tc[1])
 
     error_testcases = [
@@ -353,3 +352,114 @@ def test_agnosticd_get_all_images():
     for tc in error_testcases:
         with pytest.raises(AnsibleFilterError):
             core.agnosticd_get_all_images(tc, predefined)
+
+def test_agnosticd_filter_out_installed_collections():
+    testcases = [
+        {
+            "requirements": {},
+            "installed_collections": {},
+            "result": {},
+        },
+        {
+            "requirements":
+            {
+                "collections": [
+                    {
+                        "name": "amazon.aws",
+                        "version": "2.2.0"
+                    },
+                    {
+                        "name": "ansible.posix",
+                        "version": "1.3.0"
+                    },
+                    {
+                        "name": "community.general",
+                        "version": "4.6.1"
+                    },
+                    {
+                        "name": "community.vmware",
+                        "version": "2.7.0"
+                    },
+                    {
+                        "name": "google.cloud",
+                        "version": "1.0.2"
+                    },
+                    {
+                        "name": "kubernetes.core",
+                        "version": "2.3.0"
+                    },
+                    {
+                        "name": "openstack.cloud",
+                        "version": "1.7.2"
+                    }
+                ],
+                "roles": [
+                    {
+                        "name": "ftl-injector",
+                        "src": "https://github.com/redhat-gpte-devopsautomation/ftl-injector",
+                        "version": "v0.17"
+                    }
+                ]
+            },
+            "installed_collections":
+            {
+                "/usr/share/ansible/collections/ansible_collections": {
+
+                "community.general": {
+                    "version": "6.3.0"
+                },
+                    "community.aws": {
+                        "version": "5.2.0"
+                    },
+                    "ansible.utils": {
+                        "version": "2.9.0"
+                    },
+                    "ansible.netcommon": {
+                        "version": "4.1.0"
+                    },
+                    "ansible.posix": {
+                        "version": "1.5.1"
+                    },
+                    "amazon.aws": {
+                        "version": "5.2.0"
+                    },
+                    "kubernetes.core": {
+                        "version": "2.4.0"
+                    },
+                    "azure.azcollection": {
+                        "version": "1.14.0"
+                    },
+                    "openstack.cloud": {
+                        "version": "2.0.0"
+                    }
+                }
+            }
+            ,
+            "result":
+            {
+                "collections": [
+                    {
+                        "name": "community.vmware",
+                        "version": "2.7.0"
+                    },
+                    {
+                        "name": "google.cloud",
+                        "version": "1.0.2"
+                    },
+                ],
+                "roles": [
+                    {
+                        "name": "ftl-injector",
+                        "src": "https://github.com/redhat-gpte-devopsautomation/ftl-injector",
+                        "version": "v0.17"
+                    }
+                ]
+            },
+        },
+    ]
+
+    for tc in testcases:
+        assert(
+            core.agnosticd_filter_out_installed_collections(
+                tc["requirements"], tc["installed_collections"]) == tc["result"]
+        )

--- a/ansible/install_collections_ee.yml
+++ b/ansible/install_collections_ee.yml
@@ -1,0 +1,39 @@
+---
+- name: Get the list of installed collections
+  command: >-
+    ansible-galaxy collection list --format json
+  register: r_installed_collections
+
+- name: Create temporary file for requirements.yml
+  ansible.builtin.tempfile:
+    state: file
+    suffix: temp
+  register: tempfile_1
+
+- name: Remove installed collections, rewrite requirements content
+  vars:
+    installed_collections: >-
+      {{ r_installed_collections.stdout | from_json }}
+  copy:
+    dest: "{{ tempfile_1.path }}"
+    content: >-
+      {{ r_requirements_content
+      | agnosticd_filter_out_installed_collections(installed_collections)
+      | to_yaml }}
+
+- name: Install collections from requirements.yml (EE)
+  command: >-
+    ansible-galaxy collection install
+    -r "{{ tempfile_1.path }}"
+    --force-with-deps
+
+  register: r_ee_ansible_galaxy_install_collections
+  until: r_ee_ansible_galaxy_install_collections is successful
+  retries: 10
+  delay: 30
+
+- name: Use the registered var and the file module to remove the temporary file
+  ansible.builtin.file:
+    path: "{{ tempfile_1.path }}"
+    state: absent
+  when: tempfile_1.path is defined

--- a/ansible/install_collections_ee.yml
+++ b/ansible/install_collections_ee.yml
@@ -7,7 +7,7 @@
 - name: Create temporary file for requirements.yml (EE)
   ansible.builtin.tempfile:
     state: file
-    suffix: temp
+    suffix: requirements
   register: tempfile_1
 
 - name: Rewrite requirements, filter out installed collections (EE)
@@ -22,9 +22,12 @@
       | to_yaml }}
 
 - name: Install collections from requirements.yml (EE)
+  vars:
+    __collections_path: "{{ lookup('config', 'COLLECTIONS_PATHS')[0] }}"
   command: >-
     ansible-galaxy collection install
     -r "{{ tempfile_1.path }}"
+    -p "{{ __collections_path | quote }}"
     --force-with-deps
 
   register: r_ee_ansible_galaxy_install_collections
@@ -36,4 +39,3 @@
   ansible.builtin.file:
     path: "{{ tempfile_1.path }}"
     state: absent
-  when: tempfile_1.path is defined

--- a/ansible/install_collections_ee.yml
+++ b/ansible/install_collections_ee.yml
@@ -1,16 +1,16 @@
 ---
-- name: Get the list of installed collections
+- name: Get the list of installed collections (EE)
   command: >-
     ansible-galaxy collection list --format json
   register: r_installed_collections
 
-- name: Create temporary file for requirements.yml
+- name: Create temporary file for requirements.yml (EE)
   ansible.builtin.tempfile:
     state: file
     suffix: temp
   register: tempfile_1
 
-- name: Remove installed collections, rewrite requirements content
+- name: Rewrite requirements, filter out installed collections (EE)
   vars:
     installed_collections: >-
       {{ r_installed_collections.stdout | from_json }}
@@ -32,7 +32,7 @@
   retries: 10
   delay: 30
 
-- name: Use the registered var and the file module to remove the temporary file
+- name: Cleanup tempfile (EE)
   ansible.builtin.file:
     path: "{{ tempfile_1.path }}"
     state: absent

--- a/ansible/install_galaxy_roles.yml
+++ b/ansible/install_galaxy_roles.yml
@@ -12,6 +12,11 @@
     ## var is called from main.yml
     requirements_path: "configs/{{ env_type }}/requirements.yml"
     requirements_content: {}
+    __from_ee: >-
+      {{ lookup('env', 'LAUNCHED_BY_RUNNER') == '1'
+      or
+      lookup('env', 'HOME') == '/home/runner'
+      }}
   tasks:
     - name: requirements_content is provided
       when: requirements_content | length > 0
@@ -62,13 +67,8 @@
       retries: 10
       delay: 30
 
-    - name: Install collections from requirements.yml
+    - name: Install collections from requirements.yml (Not EE)
       vars:
-        __from_ee: >-
-          {{ lookup('env', 'LAUNCHED_BY_RUNNER') == '1'
-          or
-          lookup('env', 'HOME') == '/home/runner'
-          }}
         __collections_path: "{{ lookup('config', 'COLLECTIONS_PATHS')[0] }}"
       command: >-
         ansible-galaxy collection install
@@ -76,19 +76,20 @@
         -p "{{ __collections_path | quote }}"
         --force-with-deps
       when: >-
-        r_requirements_stat.stat.exists
+        not __from_ee | bool
+        and r_requirements_stat.stat.exists
         and r_requirements_content | length > 0
         and r_requirements_content is mapping
         and "collections" in r_requirements_content
-        and
-        (
-        __collections_path.startswith('/tmp/')
-        or  __from_ee | bool
-        )
+        and __collections_path.startswith('/tmp/')
       register: r_ansible_galaxy_install_collections
       until: r_ansible_galaxy_install_collections is successful
       retries: 10
       delay: 30
+
+    - name: Get installed collections (EE)
+      when: __from_ee | bool
+      include_tasks: install_collections_ee.yml
 
     - name: Install dynamic sources
       include_role:


### PR DESCRIPTION
This change, if applied, updates the install_galaxy tasks to skip collections that are already installed when running in an execution environment.

- Always Prefer the collections baked in the EE.
- Add a WARNING when conflicts exist
- install the missing collections

![screenshot](https://i.imgur.com/5gOWmNy.png)

Create a jinja2 filter agnosticd_filter_out_installed_collections() for plumbing.

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Feature Pull Request


##### COMPONENT NAME
- core install_galaxy playbook

##### ADDITIONAL INFORMATION

This change should only impact when running ansible using an execution environment.

Tested with `ee-multicloud:v0.0.9`
