### PR TITLE
build-ee-dispatch: remove redundant input

### DIFF
--- a/.github/workflows/build-ee-dispatch.yml
+++ b/.github/workflows/build-ee-dispatch.yml
@@ -12,13 +12,6 @@ on:
         default: ''
         required: false
         type: string
-      ref:
-        description: |-
-          Git ref of agnosticd repo to use to build.
-          (ex: development)
-        required: false
-        type: string
-        default: ''
 
 jobs:
   build-and-push:
@@ -31,4 +24,3 @@ jobs:
     with:
       tag: ${{ inputs.tag }}
       labels: ${{ inputs.labels }}
-      ref: ${{ inputs.ref }}

--- a/.github/workflows/build-ee.yml
+++ b/.github/workflows/build-ee.yml
@@ -13,11 +13,6 @@ on:
         default: ''
         required: false
         type: string
-      ref:
-        description: 'Git ref'
-        default: ''
-        required: false
-        type: string
 
     secrets:
       registry_username:
@@ -34,8 +29,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ref: ${{ inputs.ref }}
 
       - uses: actions/setup-python@v4
 


### PR DESCRIPTION
The branch / tag is already automatically present in the Workflow dispatch form, no need to add it in the workflows.