### PR TITLE
Rename deprecated ec2_ami_facts

### DIFF
--- a/ansible/roles-infra/infra-ec2-template-create/tasks/detect_custom_images.yml
+++ b/ansible/roles-infra/infra-ec2-template-create/tasks/detect_custom_images.yml
@@ -4,7 +4,7 @@
     AWS_ACCESS_KEY_ID: "{{aws_access_key_id}}"
     AWS_SECRET_ACCESS_KEY: "{{aws_secret_access_key}}"
     AWS_DEFAULT_REGION: "{{aws_region_loop|d(aws_region)}}"
-  ec2_ami_facts:
+  ec2_ami_info:
     owner: self
     filters:
       tag:env_type: "{{ env_type }}"
@@ -34,7 +34,7 @@
     AWS_ACCESS_KEY_ID: "{{aws_access_key_id}}"
     AWS_SECRET_ACCESS_KEY: "{{aws_secret_access_key}}"
     AWS_DEFAULT_REGION: "{{aws_region_loop|d(aws_region)}}"
-  ec2_ami_facts:
+  ec2_ami_info:
     owner: self
     filters:
       name: "*{{ custom_image_filter }}*"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Rename deprecated ec2_ami_facts to its alias ec2_ami_info.

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
- [infra-ec2-template-create/tasks/detect_custom_images.yml](https://github.com/redhat-cop/agnosticd/compare/jbon-ee-fix?expand=1#diff-780ac3766ca42bd7c29497083b8f469ab357e8eea7f7bc374ee374d08b2219eb)
##### ADDITIONAL INFORMATION
tested with `ee-multicloud:v0.0.10`
