### PR TITLE
Fixes for ocp4_workload_5gran_deployments_lab role

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/post_workload.yml
@@ -53,7 +53,7 @@
 
 - name: Set fact for Hypervisor public ip
   ansible.builtin.set_fact:
-    hypervisor_public_ip: "{{ lookup('dig', hypervisor) }}"
+    hypervisor_public_ip: "{{ ansible_default_ipv4.address }}"
 
 - name: Set fact /etc/hosts entry
   ansible.builtin.set_fact:

--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/pre_workload.yml
@@ -299,6 +299,13 @@
   community.crypto.openssh_keypair:
     path: /root/.ssh/id_rsa
 
+- name: Ensure sushy is listening for redfish connections
+  ansible.builtin.uri:
+    url: https://infra.5g-deployment.lab:9000/redfish/v1/Systems/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaa0101
+    method: GET
+    status_code: 200
+    validate_certs: false
+
 # Leave this as the last task in the playbook.
 - name: pre_workload tasks complete
   debug:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Fixes an error where the hypervisor public IP was not gathered.

Adds an extra verification to make sure sushy-tools are running before launching cluster deployment.
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4_workload_5gran_deployments_lab
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
