### PR TITLE
Fixes a bug on argocd wait for role ocp4_workload_5gran_deployments_lab

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/workload.yml
@@ -89,12 +89,12 @@
     namespace: openshift-gitops
     label_selectors:
       - app.kubernetes.io/name = openshift-gitops-repo-server
-    wait: true
-    wait_sleep: 10
-    wait_timeout: 300
-    wait_condition:
-      status: "True"
-      type: "Ready"
+  register: result
+  until:
+    - result.resources[0].status.phase == "Running"
+    - result.resources[0].status.containerStatuses[0].ready == true
+  retries: 25
+  delay: 5
 
 - name: Apply ArgoCD ClusterRoleBinding manifest to the cluster
   kubernetes.core.k8s:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Fixes an issue with a wait being done with the k8s_info module that sometimes fails to wait for the pod to be ready.
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4_workload_5gran_deployments_lab
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
