### PR TITLE
Adding dynamic vars to cnvlab

### DIFF
--- a/ansible/configs/ocp4-equinix-aio/post_software.yml
+++ b/ansible/configs/ocp4-equinix-aio/post_software.yml
@@ -89,6 +89,8 @@
     - name: Setting up Openshift Virtualisation Lab
       include_role:
         name: ocp4_aio_workload_cnvlab
+      vars:
+        - ocp4_aio_console_url: "https://console-openshift-console.apps.{{ guid }}.{{ cluster_dns_zone }}"
       when: ocp4_aio_deploy_cnvlab
 
 - name: Print informations

--- a/ansible/configs/ocp4-equinix-aio/requirements.yml
+++ b/ansible/configs/ocp4-equinix-aio/requirements.yml
@@ -63,7 +63,7 @@ roles:
   - name: ocp4_aio_workload_cnvlab
     src: https://github.com/RHFieldProductManagement/ocp4_aio_role_deploy_cnvlab.git
     scm: git
-    version: v0.0.14
+    version: v0.0.16
 
 collections:
   - name: community.general


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

Adding dynamically passed vars from the roles to the CNV Lab + fixing the lab for 4.12

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
ocp4-equinix-aio

##### ADDITIONAL INFORMATION
Allows to get the generated root password in the bookbag instructions as well as the openshift console URL and kubeadmin password 
Fixes lab instructions for Openshift Virtualization 4.12 