### PR TITLE
Fix OpenShift Template apiVersion

### DIFF
--- a/ansible/roles/ocp4-workload-workshop-admin-storage/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-workshop-admin-storage/defaults/main.yml
@@ -5,4 +5,4 @@ silent: false
 WORKSHOP_FILE: workshop.yaml
 
 _infra_node_replicas: 3
-_infra_node_instance_type: m4.4xlarge
+_infra_node_instance_type: m5a.4xlarge

--- a/ansible/roles/ocp4-workload-workshop-admin-storage/files/production-cluster-admin.json
+++ b/ansible/roles/ocp4-workload-workshop-admin-storage/files/production-cluster-admin.json
@@ -1,6 +1,6 @@
 {
     "kind": "Template",
-    "apiVersion": "v1",
+    "apiVersion": "template.openshift.io/v1",
     "metadata": {
         "name": "workshop-dashboard-production-cluster-admin",
         "annotations": {


### PR DESCRIPTION
##### SUMMARY

Update the Openshift Template to `template.openshift.io/v1` from just `v1` to fix deployment errors on Admin Storage Workshop.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-workload-admin-storage