### PR TITLE
Add web terminal operator back and preinstall devworkspace-operator

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_gitops_workshop/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitops_workshop/tasks/workload.yml
@@ -1,6 +1,78 @@
 ---
 # Implement your Workload deployment tasks here
 # deploy individual argo instances for users
+- name: Install dev workspace operator
+  include_role:
+    name: install_operator
+  vars:
+    install_operator_action: install
+    install_operator_name: devworkspace-operator
+    install_operator_channel: "fast"
+    install_operator_catalog: redhat-operators
+    install_operator_use_catalog_snapshot: false
+
+- name: Pause for 5 minutes to let the dev workspace operator installation to settle
+  ansible.builtin.pause:
+    minutes: 5
+
+- name: Install web terminal operator
+  include_role:
+    name: install_operator
+  vars:
+    install_operator_action: install
+    install_operator_name: web-terminal
+    install_operator_channel: "fast"
+    install_operator_catalog: redhat-operators
+    install_operator_use_catalog_snapshot: false
+
+- name: Pause for 5 minutes to let the web terminal operator installation settle
+  ansible.builtin.pause:
+    minutes: 5
+
+- name: Wait for DevWorkspaceTemplate CRD to exist
+  kubernetes.core.k8s_info:
+    api_version: "apiextensions.k8s.io/v1"
+    kind: CustomResourceDefinition
+    name: devworkspacetemplates.workspace.devfile.io
+    wait: true
+    wait_condition:
+      reason: InitialNamesAccepted
+      status: 'True'
+      type: Established
+    wait_sleep: 20
+    wait_timeout: 180
+
+# modify the custom web terminal operator image
+# only needed until the image with kustomize goes GA
+- name: Modify the web terminal DevWorkspaceTemplate with a custom tools image
+  kubernetes.core.k8s:
+    definition: "{{ lookup('file', 'devworkspacetemplate.yaml' ) | from_yaml }}"
+    state: present
+  retries: 10
+  delay: 30
+
+- name: Wait for web-terminal-exec CR to exist
+  kubernetes.core.k8s_info:
+    kind: DevWorkspaceTemplate
+    namespace: openshift-operators
+    name: web-terminal-exec
+    api_version: workspace.devfile.io/v1alpha2
+  register: r_web_exec_cr
+  retries: 10
+  delay: 30
+  until: r_web_exec_cr.resources | length > 0
+
+- name: Modify the web terminal timeout
+  kubernetes.core.k8s_json_patch:
+    kind: DevWorkspaceTemplate
+    namespace: openshift-operators
+    name: web-terminal-exec
+    api_version: workspace.devfile.io/v1alpha2
+    patch:
+    - op: replace
+      path: /spec/components/0/container/env/0/value
+      value: "6h"
+
 - name: Deploy ArgoCD instances for users
   vars:
     _ocp4_workload_gitops_workshop_namespacename: >-


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

Adds back the web-terminal operator that was removed for troubeshooting. In an attempt to workaround install_operator not checking the operator properly we pre-install the devworkspace-operator first.

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
