### PR TITLE
Update ODF workload to properly remove default storage classes

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/defaults/main.yml
@@ -6,11 +6,11 @@ silent: false
 # -----------------------------------
 # OpenShift Data Foundations Operator
 # -----------------------------------
-ocp4_workload_openshift_data_foundation_channel: stable-4.10
+ocp4_workload_openshift_data_foundation_channel: stable-4.12
 ocp4_workload_openshift_data_foundation_catalogsource_setup: false
 ocp4_workload_openshift_data_foundation_catalogsource_name: redhat-operators-snapshot-odf
 ocp4_workload_openshift_data_foundation_catalogsource_image: quay.io/gpte-devops-automation/olm_snapshot_redhat_catalog
-ocp4_workload_openshift_data_foundation_catalogsource_image_tag: v4.10_2022_07_04
+ocp4_workload_openshift_data_foundation_catalogsource_image_tag: v4.12_2023_02_27
 
 # --------------------------------
 # Storage System parameters
@@ -25,7 +25,6 @@ ocp4_workload_openshift_data_foundation_install_toolbox: false
 # Storage Classes
 # --------------------------------
 ocp4_workload_openshift_data_foundation_update_default_storage_class: false
-ocp4_workload_openshift_data_foundation_old_default_storage_class_name: gp2
 ocp4_workload_openshift_data_foundation_new_default_storage_class_name: ocs-storagecluster-ceph-rbd
 
 # --------------------------------

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/tasks/main.yml
@@ -2,28 +2,28 @@
 # Do not modify this file
 
 - name: Running Pre Workload Tasks
-  include_tasks:
+  ansible.builtin.include_tasks:
     file: ./pre_workload.yml
     apply:
       become: "{{ become_override | bool }}"
   when: ACTION == "create" or ACTION == "provision"
 
 - name: Running Workload Tasks
-  include_tasks:
+  ansible.builtin.include_tasks:
     file: ./workload.yml
     apply:
       become: "{{ become_override | bool }}"
   when: ACTION == "create" or ACTION == "provision"
 
 - name: Running Post Workload Tasks
-  include_tasks:
+  ansible.builtin.include_tasks:
     file: ./post_workload.yml
     apply:
       become: "{{ become_override | bool }}"
   when: ACTION == "create" or ACTION == "provision"
 
 - name: Running Workload removal Tasks
-  include_tasks:
+  ansible.builtin.include_tasks:
     file: ./remove_workload.yml
     apply:
       become: "{{ become_override | bool }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/tasks/post_workload.yml
@@ -10,7 +10,7 @@
 # cluster deployment) set workload_shared_deployment to False
 # This is the default so it does not have to be set explicitely
 - name: post_workload tasks complete
-  debug:
+  ansible.builtin.debug:
     msg: "Post-Workload tasks completed successfully."
   when:
     - not silent|bool
@@ -20,7 +20,7 @@
 # workload_shared_deployment to True
 # (in the deploy script or AgnosticV configuration)
 - name: post_workload tasks complete
-  debug:
+  ansible.builtin.debug:
     msg: "Post-Software checks completed successfully"
   when:
     - not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/tasks/pre_workload.yml
@@ -10,7 +10,7 @@
 # cluster deployment) set workload_shared_deployment to False
 # This is the default so it does not have to be set explicitely
 - name: pre_workload tasks complete
-  debug:
+  ansible.builtin.debug:
     msg: "Pre-Workload tasks completed successfully."
   when:
     - not silent|bool
@@ -20,7 +20,7 @@
 # workload_shared_deployment to True
 # (in the deploy script or AgnosticV configuration)
 - name: pre_workload tasks complete
-  debug:
+  ansible.builtin.debug:
     msg: "Pre-Software checks completed successfully"
   when:
     - not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/tasks/remove_workload.yml
@@ -6,14 +6,14 @@
   when: ocp4_workload_openshift_data_foundation_update_default_storage_class | bool
   block:
   - name: Remove annotation from current default storage class
-    command:
+    ansible.builtin.command:
       cmd: >-
         oc annotate sc {{ ocp4_workload_openshift_data_foundation_new_default_storage_class_name }}
         storageclass.kubernetes.io/is-default-class-
     ignore_errors: true
 
   - name: Set previous default storage class
-    command:
+    ansible.builtin.command:
       cmd: >-
         oc annotate sc {{ ocp4_workload_openshift_data_foundation_old_default_storage_class_name }}
         storageclass.kubernetes.io/is-default-class="true"
@@ -42,7 +42,7 @@
   delay: 10
 
 - name: Remove Operator
-  include_role:
+  ansible.builtin.include_role:
     name: install_operator
   vars:
     install_operator_action: remove
@@ -63,6 +63,6 @@
 # --------------------------------------------
 
 - name: remove_workload tasks complete
-  debug:
+  ansible.builtin.debug:
     msg: "Remove Workload tasks completed successfully."
   when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/tasks/workload.yml
@@ -1,6 +1,6 @@
 ---
 - name: Setting up workload
-  debug:
+  ansible.builtin.debug:
     msg: "Setting up OpenShift Data Foundation"
 
 - name: Discovering worker nodes
@@ -13,22 +13,36 @@
 
 - name: Fail for less than 3 worker nodes
   when: r_worker_nodes.resources | length < 3
-  fail:
+  ansible.builtin.fail:
     msg: "Less than 3 worker nodes detected. Cannot install Ceph..."
 
 - name: Set variables
-  set_fact:
+  ansible.builtin.set_fact:
     _ocp4_workload_openshift_data_foundation_worker_nodes: "{{ r_worker_nodes | json_query('resources[*].metadata.name') }}"
 
 - name: Adding Ceph labels to worker nodes
-  shell: "oc label nodes --overwrite {{ item }} cluster.ocs.openshift.io/openshift-storage=''"
+  kubernetes.core.k8s:
+    state: patched
+    api_version: v1
+    kind: Node
+    name: "{{ worker_node }}"
+    definition:
+      apiVersion: v1
+      kind: Node
+      name: "{{ worker_node }}"
+      metadata:
+        labels:
+          cluster.ocs.openshift.io/openshift-storage: ''
   loop: "{{ _ocp4_workload_openshift_data_foundation_worker_nodes }}"
+  loop_control:
+    loop_var: worker_node
+    label: "{{ worker_node }}"
 
 - name: Create namespace openshift-storage
   kubernetes.core.k8s:
     state: present
-    kind: Namespace
     api_version: v1
+    kind: Namespace
     name: openshift-storage
 
 - name: Create CatalogSource
@@ -40,7 +54,6 @@
 - name: Create OperatorGroup
   kubernetes.core.k8s:
     state: present
-    apply: true
     definition: "{{ lookup('template', 'operatorgroup.yaml.j2' ) | from_yaml }}"
 
 - name: Create operator subscription
@@ -71,9 +84,6 @@
 - name: Enable ODF console plugin
   kubernetes.core.k8s:
     state: patched
-    merge_type:
-    - strategic-merge
-    - merge
     kind: Console
     api_version: operator.openshift.io/v1
     name: cluster
@@ -90,9 +100,6 @@
 - name: Create the ODF StorageSystem
   kubernetes.core.k8s:
     state: present
-    merge_type:
-    - strategic-merge
-    - merge
     definition: "{{ lookup('template', 'storagesystem.yaml.j2' ) | from_yaml }}"
   register: r_k8s_run
   until: r_k8s_run is not failed
@@ -150,7 +157,7 @@
     kubernetes.core.k8s:
       state: absent
       api_version: v1
-      kind: pod
+      kind: Pod
       namespace: openshift-storage
       label_selectors:
       - app = rook-ceph-operator
@@ -168,21 +175,35 @@
     delay: 10
     until: sc_crd.resources | list | length == 1
 
-  - name: Remove annotation from current default storage class
-    command:
-      cmd: >-
-        oc annotate sc {{ ocp4_workload_openshift_data_foundation_old_default_storage_class_name }}
-        storageclass.kubernetes.io/is-default-class-
-    ignore_errors: true
+  - name: Get all storage classes
+    kubernetes.core.k8s_info:
+      api_version: storage.k8s.io/v1
+      kind: StorageClass
+    register: r_sc
+
+  - name: Remove default from previous default storage class
+    when: storage_class.metadata.annotations['storageclass.kubernetes.io/is-default-class'] is defined
+    kubernetes.core.k8s:
+      api_version: storage.k8s.io/v1
+      kind: StorageClass
+      name: "{{ storage_class.metadata.name }}"
+      definition:
+        kind: StorageClass
+        apiVersion: v1
+        name: "{{ ocp4_workload_openshift_data_foundation_new_default_storage_class_name }}"
+        metadata:
+          annotations:
+            storageclass.kubernetes.io/is-default-class: "false"
+    loop: "{{ r_sc.resources }}"
+    loop_control:
+      loop_var: storage_class
+      label: "{{ storage_class.metadata.name }}"
 
   - name: Set new default storage class
     kubernetes.core.k8s:
       api_version: v1
       kind: StorageClass
       name: "{{ ocp4_workload_openshift_data_foundation_new_default_storage_class_name }}"
-      merge_type:
-      - strategic-merge
-      - merge
       definition:
         kind: StorageClass
         apiVersion: v1
@@ -200,6 +221,6 @@
 # Leave this as the last task in the playbook.
 # --------------------------------------------
 - name: workload tasks complete
-  debug:
+  ansible.builtin.debug:
     msg: "Workload Tasks completed successfully."
   when: not silent|bool


### PR DESCRIPTION
##### SUMMARY

Modernized the ODF workload. Updated all the modules. General cleanup.
Updated the way to label worker nodes.
Updated the logic to remove the default from existing storage classes - this was broken on OCP 4.12.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_openshift_data_foundation