### PR TITLE
Adds sushy restart, firewalld disabled and new commit id for kcli gh

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/defaults/main.yml
@@ -3,7 +3,7 @@ become_override: true
 ocp_username: opentlc-mgr
 silent: false
 
-kcli_baremetal_plan_revision: 3b428502cc9a248598ca5cd0239366b7f36901d2
+kcli_baremetal_plan_revision: 5ca3b703fca46523ad0d6079ddade8f87d8aa284 
 ocp4_major_release: "4.11"
 lab_network_cidr: "192.168.125.0/24"
 lab_network_domain: "5g-deployment.lab"

--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/defaults/main.yml
@@ -3,7 +3,7 @@ become_override: true
 ocp_username: opentlc-mgr
 silent: false
 
-kcli_baremetal_plan_revision: 5ca3b703fca46523ad0d6079ddade8f87d8aa284 
+kcli_baremetal_plan_revision: 5ca3b703fca46523ad0d6079ddade8f87d8aa284
 ocp4_major_release: "4.11"
 lab_network_cidr: "192.168.125.0/24"
 lab_network_domain: "5g-deployment.lab"
@@ -15,6 +15,7 @@ lab_hub_vm_disk: 200
 lab_sno_vm_cpus: 12
 lab_sno_vm_memory: 24000
 lab_sno_vm_disk: 200
+extra_disk_libvirt_images: true
 
 # yamllint disable rule:line-length
 etc_hosts_records: "infra.5g-deployment.lab api.hub.5g-deployment.lab multicloud-console.apps.hub.5g-deployment.lab console-openshift-console.apps.hub.5g-deployment.lab oauth-openshift.apps.hub.5g-deployment.lab openshift-gitops-server-openshift-gitops.apps.hub.5g-deployment.lab"

--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/pre_workload.yml
@@ -143,6 +143,12 @@
   ansible.builtin.shell:
     cmd: /tmp/deploy-sushy-tools.sh
 
+- name: Ensure sushy tools are running
+  ansible.builtin.systemd:
+    state: restarted
+    enabled: true
+    name: sushy-tools
+
 - name: Ensure disconnected registry dependencies are installed
   ansible.builtin.dnf:
     name: podman, httpd-tools
@@ -197,6 +203,13 @@
 - name: Ensure trusted certs are updated
   ansible.builtin.shell:
     cmd: update-ca-trust
+
+- name: Ensure firewalld is disabled
+  ansible.builtin.systemd:
+    state: stopped 
+    masked: true
+    enabled: false
+    name: firewalld
 
 - name: Ensure registry is running by login into it
   containers.podman.podman_login:

--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/pre_workload.yml
@@ -13,6 +13,49 @@
   ansible.builtin.pip:
     name: kubernetes, passlib
 
+- name: Find an extra disk for libvirt folder
+  set_fact:
+    _disks: "{{ _disks|default([]) + [ item ] }}"
+    _diskname: "{{ '/dev/' + item.key }}"
+  when:
+    - not item.value.partitions
+    - item.key is search ("nvme*")
+    - min_value|int <= item.value.sectors|int * item.value.sectorsize|int
+    - extra_disk_libvirt_images is true
+  vars:
+    min_value: '{{ 500 * 1024 * 1024 * 1024  }}' #500GB
+  with_dict: "{{ ansible_devices }}"
+
+- name: The device selected to store libvirt files
+  debug:
+    msg: "{{ item }}"
+  with_dict: "{{ _disks }}"
+  when:
+    - _diskname is defined
+
+- name: Create a xfs filesystem on {{ _diskname }}
+  community.general.filesystem:
+    fstype: "xfs"
+    dev: "{{ _diskname }}"
+    force: true
+    state: present
+    resizefs: true
+  when:
+    - _diskname is defined
+
+- name: Mount up device in /var/lib/libvirt
+  ansible.posix.mount:
+    path: /var/lib/libvirt
+    src: "{{ _diskname }}"
+    fstype: xfs
+    state: mounted
+  when:
+    - _diskname is defined
+
+- name: Ensure libvirt file applies the proper SELinux context
+  ansible.builtin.shell:
+    cmd: restorecon /var/lib/libvirt
+
 - name: Ensure lab dependencies are installed
   ansible.builtin.dnf:
     name: libvirt, libvirt-daemon-driver-qemu, qemu-kvm, git
@@ -204,12 +247,20 @@
   ansible.builtin.shell:
     cmd: update-ca-trust
 
-- name: Ensure firewalld is disabled
-  ansible.builtin.systemd:
-    state: stopped 
-    masked: true
-    enabled: false
-    name: firewalld
+#- name: Ensure firewalld is disabled
+#  ansible.builtin.systemd:
+#    state: stopped
+#    masked: true
+#    enabled: false
+#    name: firewalld
+
+- name: Wait for registry port {{ lab_registry_host.split(":")[1] }} to become open on the host, do not start checking for 10 seconds
+  ansible.builtin.wait_for:
+    port: "{{ lab_registry_host.split(':')[1] }}"
+    host: "{{ lab_registry_host.split(':')[0] }}"
+    delay: 10
+    sleep: 10
+    timeout: 60
 
 - name: Ensure registry is running by login into it
   containers.podman.podman_login:


### PR DESCRIPTION
SUMMARY
Adds extra checks:
- When installing sushy-tools a restart is required if it is going to be executed twice.
- Disables firewalld since it is mandatory to be disabled. If I am right, firewalld, it is not enabled by default in RHPDS but anyway just in case it is enabled later on.
- Updating the commid id for an external repo we are using.
- Mounting an extra disk on /var/lib/libvirt since the installation by default does not allow selecting the proper disk size for the root filesystem. Since we are running multiple VMs the /var/lib/libvirt folder it gets exhausted easily. The task selects a disk > 500GB which is not in use.
- Adds a wait for the registry to be running before trying to log into it.

ISSUE TYPE
Bugfix Pull Request

COMPONENT NAME
ocp4_workload_5gran_deployments_lab

ADDITIONAL INFORMATION

cc/ @mvazquezc 