### PR TITLE
add ami block per msavage

### DIFF
--- a/ansible/configs/aap2-ansible-workshops/vars/automate_smart_mgmt_vars.yml
+++ b/ansible/configs/aap2-ansible-workshops/vars/automate_smart_mgmt_vars.yml
@@ -63,6 +63,10 @@ ec2_xtra:
     disk_throughput: 125
     architecture: x86_64
     python_interpreter: '/usr/bin/python'
+  pre_build_controller_ami:
+  us-east-2: ami-04946da7990fb2a1c
+  ap-southeast-1: ami-09d9971507052e964
+  eu-central-1: ami-0f4d3580a7c4d1e37
 
 ## Should be sourced from BASH script
 #admin_password: 'dynamic from BASH'                 # password used for student account on control node

--- a/ansible/configs/aap2-ansible-workshops/vars/automate_smart_mgmt_vars.yml
+++ b/ansible/configs/aap2-ansible-workshops/vars/automate_smart_mgmt_vars.yml
@@ -64,9 +64,9 @@ ec2_xtra:
     architecture: x86_64
     python_interpreter: '/usr/bin/python'
   pre_build_controller_ami:
-  us-east-2: ami-04946da7990fb2a1c
-  ap-southeast-1: ami-09d9971507052e964
-  eu-central-1: ami-0f4d3580a7c4d1e37
+    us-east-2: ami-04946da7990fb2a1c
+    ap-southeast-1: ami-09d9971507052e964
+    eu-central-1: ami-0f4d3580a7c4d1e37
 
 ## Should be sourced from BASH script
 #admin_password: 'dynamic from BASH'                 # password used for student account on control node


### PR DESCRIPTION
rhjcd-patch-add ami block per @heatmiser 

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

add a new block section to the automate smart management var file for accessing the required ami's

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
aap2-ansible-workshop ami block for automate_smart_mgmt_vars.yml