### PR TITLE
Refactor the AAP2 controller admin var to make more consistent with othe…

### DIFF
--- a/ansible/roles/deploy_automationcontroller/tasks/main.yml
+++ b/ansible/roles/deploy_automationcontroller/tasks/main.yml
@@ -98,10 +98,10 @@
 
     - name: Inject automation controller license via manifest
       ansible.builtin.uri:
-        url: "https://{{groups['automationcontroller'][0] }}/api/v2/config/"
+        url: "https://{{ groups['automationcontroller'][0] }}/api/v2/config/"
         method: POST
-        user: "{{ deploy_automationcontroller_admin_user | default('admin') }}"
-        password: "{{ deploy_automationcontroller_admin_password }}"
+        user: "{{ controller_admin_user | default(deploy_automationcontroller_admin_user) | default('admin') }}"
+        password: "{{ controller_admin_password | default(deploy_automationcontroller_admin_password) }}"
         body: >
           {
             "eula_accepted": true,


### PR DESCRIPTION
Over the years there have become many vars used for Tower and Controller Admin

This makes the role more consistent and will enable more refactoring and simplification over time

##### SUMMARY

Adds an **additional** but preferred by precedence `controller_admin_user` and `controller_admin_password` to AAP installer role

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

roles/deploy_automationcontroller

##### ADDITIONAL INFORMATION

