### PR TITLE
Add follow to tasks to get ovirt NICs

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/tasks/rhev-setup-oracle-vm.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/tasks/rhev-setup-oracle-vm.yml
@@ -22,7 +22,7 @@
       insecure: true
     vm: "{{ ocp4_workload_ama_demo_oracle_vm_name }}"
     follow:
-    - reported_devices  
+    - reported_devices
   register: r_nic_oracle
   retries: 50
   delay: 10

--- a/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/tasks/rhev-setup-oracle-vm.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/tasks/rhev-setup-oracle-vm.yml
@@ -21,6 +21,8 @@
     auth:
       insecure: true
     vm: "{{ ocp4_workload_ama_demo_oracle_vm_name }}"
+    follow:
+    - reported_devices  
   register: r_nic_oracle
   retries: 50
   delay: 10

--- a/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/tasks/rhev-setup-tomcat-vm.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/tasks/rhev-setup-tomcat-vm.yml
@@ -22,7 +22,7 @@
       insecure: true
     vm: "{{ ocp4_workload_ama_demo_tomcat_vm_name }}"
     follow:
-    - reported_devices  
+    - reported_devices
   register: r_nic_tomcat
   retries: 50
   delay: 10

--- a/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/tasks/rhev-setup-tomcat-vm.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/tasks/rhev-setup-tomcat-vm.yml
@@ -21,6 +21,8 @@
     auth:
       insecure: true
     vm: "{{ ocp4_workload_ama_demo_tomcat_vm_name }}"
+    follow:
+    - reported_devices  
   register: r_nic_tomcat
   retries: 50
   delay: 10

--- a/ansible/roles_ocp_workloads/ocp4_workload_ama_demo_shared/tasks/rhv-setup-oracle-vm.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ama_demo_shared/tasks/rhv-setup-oracle-vm.yml
@@ -21,6 +21,8 @@
     auth:
       insecure: true
     vm: "{{ ocp4_workload_ama_demo_shared_oracle_vm_name }}"
+    follow:
+    - reported_devices  
   register: r_nic_oracle
   retries: 50
   delay: 10

--- a/ansible/roles_ocp_workloads/ocp4_workload_ama_demo_shared/tasks/rhv-setup-oracle-vm.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ama_demo_shared/tasks/rhv-setup-oracle-vm.yml
@@ -22,7 +22,7 @@
       insecure: true
     vm: "{{ ocp4_workload_ama_demo_shared_oracle_vm_name }}"
     follow:
-    - reported_devices  
+    - reported_devices
   register: r_nic_oracle
   retries: 50
   delay: 10

--- a/ansible/roles_ocp_workloads/ocp4_workload_ama_demo_shared/tasks/rhv-setup-tomcat-vm.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ama_demo_shared/tasks/rhv-setup-tomcat-vm.yml
@@ -22,7 +22,7 @@
       insecure: true
     vm: "{{ ocp4_workload_ama_demo_shared_tomcat_vm_name }}"
     follow:
-    - reported_devices  
+    - reported_devices
   register: r_nic_tomcat
   retries: 50
   delay: 10

--- a/ansible/roles_ocp_workloads/ocp4_workload_ama_demo_shared/tasks/rhv-setup-tomcat-vm.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ama_demo_shared/tasks/rhv-setup-tomcat-vm.yml
@@ -21,6 +21,8 @@
     auth:
       insecure: true
     vm: "{{ ocp4_workload_ama_demo_shared_tomcat_vm_name }}"
+    follow:
+    - reported_devices  
   register: r_nic_tomcat
   retries: 50
   delay: 10

--- a/ansible/roles_ocp_workloads/ocp4_workload_mad_roadshow/tasks/rhv-setup-oracle-vm.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mad_roadshow/tasks/rhv-setup-oracle-vm.yml
@@ -21,6 +21,8 @@
     auth:
       insecure: true
     vm: "{{ ocp4_workload_mad_roadshow_oracle_vm_name }}"
+    follow:
+    - reported_devices  
   register: r_nic_oracle
   retries: 50
   delay: 10

--- a/ansible/roles_ocp_workloads/ocp4_workload_mad_roadshow/tasks/rhv-setup-oracle-vm.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mad_roadshow/tasks/rhv-setup-oracle-vm.yml
@@ -22,7 +22,7 @@
       insecure: true
     vm: "{{ ocp4_workload_mad_roadshow_oracle_vm_name }}"
     follow:
-    - reported_devices  
+    - reported_devices
   register: r_nic_oracle
   retries: 50
   delay: 10

--- a/ansible/roles_ocp_workloads/ocp4_workload_mad_roadshow/tasks/rhv-setup-tomcat-vm.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mad_roadshow/tasks/rhv-setup-tomcat-vm.yml
@@ -21,6 +21,8 @@
     auth:
       insecure: true
     vm: "{{ ocp4_workload_mad_roadshow_tomcat_vm_name }}"
+    follow:
+    - reported_devices  
   register: r_nic_tomcat
   retries: 50
   delay: 10

--- a/ansible/roles_ocp_workloads/ocp4_workload_mad_roadshow/tasks/rhv-setup-tomcat-vm.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mad_roadshow/tasks/rhv-setup-tomcat-vm.yml
@@ -22,7 +22,7 @@
       insecure: true
     vm: "{{ ocp4_workload_mad_roadshow_tomcat_vm_name }}"
     follow:
-    - reported_devices  
+    - reported_devices
   register: r_nic_tomcat
   retries: 50
   delay: 10


### PR DESCRIPTION
##### SUMMARY

On the new oVirt platform it is necessary to specify `follow` to get details about the NICs. Added to all workloads that use oVirt.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_mad_roadshow
ocp4_workload_ama_demo
ocp4_workload_ama_demo_shared