### PR TITLE
ee-multicloud: Use latest for collections and rm receptor

### DIFF
--- a/tools/execution_environments/ee-multicloud-public/Containerfile
+++ b/tools/execution_environments/ee-multicloud-public/Containerfile
@@ -41,8 +41,8 @@ COPY ansible.cfg /root/.ansible.cfg
 COPY requirements.yml /tmp/requirements.yml
 RUN ansible-galaxy role install \
     -r /tmp/requirements.yml \
-    --roles-path "/usr/share/ansible/roles"
-RUN ansible-galaxy collection install -vv \
+    --roles-path "/usr/share/ansible/roles" \
+    && ansible-galaxy collection install -vv \
     -r /tmp/requirements.yml \
     --collections-path "/usr/share/ansible/collections" \
     && pip install --no-cache-dir -r /usr/share/ansible/collections/ansible_collections/azure/azcollection/requirements-azure.txt \
@@ -63,9 +63,6 @@ RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc \
     && dnf clean all
 
 RUN rm -rf /tmp/* /root/.cache /root/*
-
-COPY --from=quay.io/ansible/receptor:v1.3.0 /usr/bin/receptor /usr/bin/receptor
-RUN mkdir -p /var/run/receptor
 
 # In OpenShift, container will run as a random uid number and gid 0. Make sure things
 # are writeable by the root group.

--- a/tools/execution_environments/ee-multicloud-public/requirements.yml
+++ b/tools/execution_environments/ee-multicloud-public/requirements.yml
@@ -4,52 +4,39 @@ collections:
 # boto3 >= 1.18.0
 # botocore >= 1.21.0
 - name: amazon.aws
-  version: 5.2.0
 
 - name: ansible.netcommon
-  version: 4.1.0
 - name: ansible.posix
-  version: 1.5.1
 - name: ansible.utils
-  version: 2.9.0
 
 - name: awx.awx
 
 # requirements-azure.txt from the collection
 - name: azure.azcollection
-  version: 1.14.0
 
 # boto3 >= 1.18.0
 # botocore >= 1.21.0
 - name: community.aws
-  version: 5.2.0
 
 - name: community.general
-  version: 6.3.0
 
 # requirements.txt from the collection
 - name: community.vmware
-  version: 3.3.0
 
 # packet-python>=1.43.1
 - name: equinix.metal
-  version: 1.4.1
 
 # requirements.txt from the collection
 - name: google.cloud
-  version: 1.1.2
 
 # Needs awx.awx collection
 - name: infra.controller_configuration
-  version: 2.2.5
 
 # kubernetes>=12.0.0
 # requests-oauthlib
 # jsonpatch
 # From requirements.txt
 - name: kubernetes.core
-  version: 2.4.0
 
 # openstacksdk>=1.0.0
 - name: openstack.cloud
-  version: 2.0.0


### PR DESCRIPTION
Since we have a detailed changelog now, use latest versions of Galaxy Collections. The versions of the collecions for each version of the Execution Environment will be properly documented.

Remove receptor as it should not be needed.
See this comment: https://github.com/ansible/awx-ee/pull/33#pullrequestreview-582446299 Removing the x86_64 binary will:
- facilitate the creation of an image for ARM.
- reduce size

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- EE update