### PR TITLE
Add 'int' filter to htpassword user count to prevent failures when us…

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_authentication/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_authentication/defaults/main.yml
@@ -15,7 +15,7 @@ ocp4_workload_authentication_idm_type: htpasswd
 # -----------------------------------------------
 # Base of the users for htpasswd
 ocp4_workload_authentication_htpasswd_user_base: user
-ocp4_workload_authentication_htpasswd_user_count: "{{ user_count | default(num_users) | default(10) }}"
+ocp4_workload_authentication_htpasswd_user_count: "{{ user_count | default(num_users) | default(10) | int }}"
 
 # If true then generate a unique password of specified lenght for every user
 # Also if true then a provided user password will be ignored.

--- a/ansible/roles_ocp_workloads/ocp4_workload_authentication/tasks/setup_htpasswd.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_authentication/tasks/setup_htpasswd.yml
@@ -19,7 +19,7 @@
       {{ _ocp4_workload_authentication_htpasswd_user_passwords + [ lookup('password',
         '/dev/null chars=ascii_letters,digits '
         ~ 'length=' ~ ocp4_workload_authentication_htpasswd_user_password_length ) ] }}
-  loop: "{{ range(0, ocp4_workload_authentication_htpasswd_user_count, 1) | list }}"
+  loop: "{{ range(0, ocp4_workload_authentication_htpasswd_user_count | int, 1) | list }}"
 
 - name: Set up common user password array
   when: not ocp4_workload_authentication_htpasswd_user_password_randomized | bool
@@ -42,7 +42,7 @@
     ansible.builtin.set_fact:
       _ocp4_workload_authentication_htpasswd_user_passwords: >-
         {{ _ocp4_workload_authentication_htpasswd_user_passwords + [ _ocp4_workload_authentication_htpasswd_user_password ] }}
-    loop: "{{ range(0, ocp4_workload_authentication_htpasswd_user_count, 1) | list }}"
+    loop: "{{ range(0, ocp4_workload_authentication_htpasswd_user_count | int, 1) | list }}"
 
 - name: Create temporary htpasswd file
   ansible.builtin.tempfile:
@@ -61,7 +61,7 @@
     path: "{{ r_htpasswd.path }}"
     name: "{{ ocp4_workload_authentication_htpasswd_user_base }}{{ item + 1 }}"
     password: "{{ _ocp4_workload_authentication_htpasswd_user_passwords[ item ] }}"
-  loop: "{{ range(0, ocp4_workload_authentication_htpasswd_user_count, 1) | list }}"
+  loop: "{{ range(0, ocp4_workload_authentication_htpasswd_user_count | int, 1) | list }}"
 
 - name: Read contents of htpasswd file
   ansible.builtin.slurp:


### PR DESCRIPTION
…er count is quoted

##### SUMMARY

Updated authentication workload would fail if the user count for htpasswd authentication was in quotes. Add '| int' filter where appropriate to defend that.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_authentication