### PR TITLE
Add rwx_supported to mta6

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_mta6/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta6/defaults/main.yml
@@ -59,6 +59,7 @@ ocp4_workload_mta6_seed_pull_policy: IfNotPresent
 # Tackle V2 specific settings
 # --------------------------------
 ocp4_workload_mta6_feature_auth_required: false
+ocp4_workload_mta6_rwx_supported: true
 ocp4_workload_mta6_rwx_storage_class: ocs-storagecluster-cephfs
 ocp4_workload_mta6_rwo_storage_class: ocs-storagecluster-ceph-rbd
 ocp4_workload_mta6_maven_data_volume_size: 10Gi

--- a/ansible/roles_ocp_workloads/ocp4_workload_mta6/templates/tackle.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta6/templates/tackle.yaml.j2
@@ -7,11 +7,18 @@ metadata:
   labels:
     app.kubernetes.io/name: tackle
 spec:
-  feature_auth_required: {{ ocp4_workload_mta6_feature_auth_required | default(false) }}
-  keycloak_database_data_volume_size: {{ ocp4_workload_mta6_keycloak_database_data_volume_size  | default('1Gi') }}
-  maven_data_volume_size: {{ ocp4_workload_mta6_maven_data_volume_size  | default('10Gi') }}
-  hub_bucket_volume_size: {{ ocp4_workload_mta6_hub_bucket_volume_size  | default('10Gi') }}
-  hub_database_volume_size: {{ ocp4_workload_mta6_hub_database_volume_size  | default('5Gi') }}
-  pathfinder_database_data_volume_size: {{ ocp4_workload_mta6_pathfinder_database_data_volume_size  | default('1Gi') }}
+  feature_auth_required: {{ ocp4_workload_mta6_feature_auth_required }}
+  keycloak_database_data_volume_size: {{ ocp4_workload_mta6_keycloak_database_data_volume_size }}
+  maven_data_volume_size: {{ ocp4_workload_mta6_maven_data_volume_size }}
+  hub_bucket_volume_size: {{ ocp4_workload_mta6_hub_bucket_volume_size }}
+  hub_database_volume_size: {{ ocp4_workload_mta6_hub_database_volume_size }}
+  pathfinder_database_data_volume_size: {{ ocp4_workload_mta6_pathfinder_database_data_volume_size }}
+{% if ocp4_workload_mta6_rwo_storage_class | length > 0 %}
   rwo_storage_class: {{ ocp4_workload_mta6_rwo_storage_class }}
+{% endif %}
+{% if ocp4_workload_mta6_rwx_storage_class | length > 0 %}
   rwx_storage_class: {{ ocp4_workload_mta6_rwx_storage_class }}
+{% endif %}
+{% if ocp4_workload_mta6_rwx_supported | default("") | length > 0 %}
+  rwx_supported: {{ ocp4_workload_mta6_rwx_supported  }}
+{% endif %}

--- a/ansible/roles_ocp_workloads/ocp4_workload_mta6/templates/tackle.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta6/templates/tackle.yaml.j2
@@ -20,5 +20,5 @@ spec:
   rwx_storage_class: {{ ocp4_workload_mta6_rwx_storage_class }}
 {% endif %}
 {% if not ocp4_workload_mta6_rwx_supported %}
-  rwx_supported: {{ ocp4_workload_mta6_rwx_supported  }}
+  rwx_supported: false
 {% endif %}

--- a/ansible/roles_ocp_workloads/ocp4_workload_mta6/templates/tackle.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta6/templates/tackle.yaml.j2
@@ -19,6 +19,6 @@ spec:
 {% if ocp4_workload_mta6_rwx_storage_class | length > 0 %}
   rwx_storage_class: {{ ocp4_workload_mta6_rwx_storage_class }}
 {% endif %}
-{% if ocp4_workload_mta6_rwx_supported | default("") | length > 0 %}
+{% if not ocp4_workload_mta6_rwx_supported %}
   rwx_supported: {{ ocp4_workload_mta6_rwx_supported  }}
 {% endif %}


### PR DESCRIPTION
This is just for the single user operator install, without argo application(set).

https://access.redhat.com/documentation/en-us/migration_toolkit_for_applications/6.0/html/release_notes/mta-6-0-1
