### PR TITLE
Add common user password to shared cluster deploy role

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/tasks/workload.yml
@@ -116,6 +116,12 @@
       openshift_cluster_num_users: "{{ ocp4_workload_deploy_hosted_cluster_user_count }}"
       openshift_cluster_user_base: "{{ ocp4_workload_deploy_hosted_cluster_user_base }}"
 
+- name: Save common user password if not randomized
+  when: not ocp4_workload_deploy_hosted_cluster_user_password_randomized | bool
+  agnosticd_user_info:
+    data:
+      openshift_cluster_user_password: "{{ _ocp4_workload_deploy_hosted_cluster_user_password }}"
+
 - name: Save user information for each user
   when: ocp4_workload_deploy_hosted_cluster_authentication | default('none') == 'htpasswd'
   agnosticd_user_info:


### PR DESCRIPTION
##### SUMMARY

One more to add the common user password to the shared cluster deploy workload.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_deploy_shared_cluster