### PR TITLE
Allow users to also manage Tomcat VM

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/tasks/rhev-setup-user.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/tasks/rhev-setup-user.yml
@@ -41,3 +41,15 @@
     object_name: "{{ ocp4_workload_ama_demo_oracle_vm_name }}"
     role: "{{ item }}"
   loop: "{{ ocp4_workload_ama_demo_rhev_user_vm_roles }}"
+
+- name: Add vm roles to new user for Tomcat VM
+  when: ocp4_workload_ama_demo_tomcat_vm_setup | bool
+  ovirt.ovirt.ovirt_permission:
+    auth:
+      insecure: true
+    user_name: "{{ ocp4_workload_ama_demo_rhev_user_name }}"
+    authz_name: "{{ ocp4_workload_ama_demo_rhev_user_domain }}"
+    object_type: vm
+    object_name: "{{ ocp4_workload_ama_demo_tomcat_vm_name }}"
+    role: "{{ item }}"
+  loop: "{{ ocp4_workload_ama_demo_rhev_user_vm_roles }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_ama_demo_shared/tasks/rhv-setup-user.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ama_demo_shared/tasks/rhv-setup-user.yml
@@ -41,3 +41,15 @@
     object_name: "{{ ocp4_workload_ama_demo_shared_oracle_vm_name }}"
     role: "{{ item }}"
   loop: "{{ ocp4_workload_ama_demo_shared_rhv_user_vm_roles }}"
+
+- name: Add vm roles to new user for Tomcat VM
+  when: ocp4_workload_ama_demo_shared_tomcat_vm_setup | bool
+  ovirt.ovirt.ovirt_permission:
+    auth:
+      insecure: true
+    user_name: "{{ ocp4_workload_ama_demo_shared_rhv_user_name }}"
+    authz_name: "{{ ocp4_workload_ama_demo_shared_rhv_user_domain }}"
+    object_type: vm
+    object_name: "{{ ocp4_workload_ama_demo_shared_tomcat_vm_name }}"
+    role: "{{ item }}"
+  loop: "{{ ocp4_workload_ama_demo_shared_rhv_user_vm_roles }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_mad_roadshow/tasks/rhv-setup-user.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mad_roadshow/tasks/rhv-setup-user.yml
@@ -41,3 +41,15 @@
     object_name: "{{ ocp4_workload_mad_roadshow_oracle_vm_name }}"
     role: "{{ item }}"
   loop: "{{ ocp4_workload_mad_roadshow_rhv_user_vm_roles }}"
+
+- name: Add vm roles to new user for Tomcat VM
+  when: ocp4_workload_mad_roadshow_tomcat_vm_setup | bool
+  ovirt.ovirt.ovirt_permission:
+    auth:
+      insecure: true
+    user_name: "{{ ocp4_workload_mad_roadshow_rhv_user_name }}"
+    authz_name: "{{ ocp4_workload_mad_roadshow_rhv_user_domain }}"
+    object_type: vm
+    object_name: "{{ ocp4_workload_mad_roadshow_tomcat_vm_name }}"
+    role: "{{ item }}"
+  loop: "{{ ocp4_workload_mad_roadshow_rhv_user_vm_roles }}"


### PR DESCRIPTION
##### SUMMARY

To troubleshoot Tomcat VMs sometimes it's necessary to shutdown/start the VMs. This PR adds permissions to the created user to manipulate the Tomcat VM in addition to the Oracle VM.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_ama_demo
ocp4_workload_ama_demo_shared
ocp4_workload_ama_mad_roadshow
