### PR TITLE
Fix starburst-secret to handle automatic data conversion

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_starburst/templates/starburst-secret.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_starburst/templates/starburst-secret.j2
@@ -3,7 +3,9 @@ kind: Secret
 metadata:
   name: {{ ocp4_workload_starburst_secret }}
   namespace: {{ ocp4_workload_starburst_namespace }}
-stringData:
-  starburstdata.license: |-
-    {{ starburst_license | replace("'", '"')  }}
+data:
+  starburstdata.license: >-
+    {{ (
+      starburst_license | to_json if starburst_license is mapping else starburst_license
+    ) | b64encode }}
 type: Opaque


### PR DESCRIPTION
##### SUMMARY

Depending on how the value for `starburst_license` is included Ansible may spontaneously convert the string to a dictionary/mapping because it is JSON structured data within the string. To handle this case we must test the data type before determining if the `to_json` filter will be required.

Also, it is best to used a secret's `data` field with `b64encode` rather that `stringData` as encoding removes any potential issues with newlines in the generated YAML.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role ocp4_workload_starburst