### PR TITLE
Fix check for oVirt VM IPs - and check for running database

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/tasks/rhev-setup-oracle-vm.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/tasks/rhev-setup-oracle-vm.yml
@@ -16,6 +16,10 @@
       nic_name: eth0
     cloud_init_persist: true
 
+- name: Sleep 5 seconds to prepare for next query
+  ansible.builtin.pause:
+    seconds: 5
+
 - name: Get Oracle VM NIC
   ovirt.ovirt.ovirt_nic_info:
     auth:
@@ -65,3 +69,15 @@
   local_action:
     module: shell
     args: ssh-keyscan -H "{{ _ocp4_workload_ama_demo_oracle_ip }}" >> $HOME/.ssh/known_hosts
+
+- name: Wait for Oracle database to be running
+  ansible.builtin.wait_for:
+    host: "{{ _ocp4_workload_ama_demo_oracle_ip }}"
+    port: 1521
+    state: started
+    timeout: 300
+  register: r_wait_for_database
+
+- name: Print result of wait step
+  ansible.builtin.debug:
+    msg: "{{ r_wait_for_database }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/tasks/rhev-setup-oracle-vm.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/tasks/rhev-setup-oracle-vm.yml
@@ -16,10 +16,6 @@
       nic_name: eth0
     cloud_init_persist: true
 
-- name: Sleep 5 seconds to prepare for next query
-  ansible.builtin.pause:
-    seconds: 5
-
 - name: Get Oracle VM NIC
   ovirt.ovirt.ovirt_nic_info:
     auth:
@@ -31,7 +27,7 @@
   retries: 50
   delay: 10
   failed_when: >-
-    r_nic_oracle | json_query("ovirt_nics[0].reported_devices[0].ips[?version=='v4'].address") | length < 1
+    r_nic_oracle | json_query("ovirt_nics[0].reported_devices[0].ips[?version=='v4'].address") | default([], true) | length < 1
   until: r_nic_oracle is successful
 
 - name: Save Oracle VM IP Address

--- a/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/tasks/rhev-setup-tomcat-vm.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/tasks/rhev-setup-tomcat-vm.yml
@@ -16,6 +16,10 @@
       nic_name: eth0
     cloud_init_persist: true
 
+- name: Sleep 5 seconds to prepare for next query
+  ansible.builtin.pause:
+    seconds: 5
+
 - name: Get Tomcat VM NIC
   ovirt.ovirt.ovirt_nic_info:
     auth:

--- a/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/tasks/rhev-setup-tomcat-vm.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/tasks/rhev-setup-tomcat-vm.yml
@@ -16,10 +16,6 @@
       nic_name: eth0
     cloud_init_persist: true
 
-- name: Sleep 5 seconds to prepare for next query
-  ansible.builtin.pause:
-    seconds: 5
-
 - name: Get Tomcat VM NIC
   ovirt.ovirt.ovirt_nic_info:
     auth:
@@ -31,7 +27,7 @@
   retries: 50
   delay: 10
   failed_when: >-
-    r_nic_tomcat | json_query("ovirt_nics[0].reported_devices[0].ips[?version=='v4'].address") | length < 1
+    r_nic_tomcat | json_query("ovirt_nics[0].reported_devices[0].ips[?version=='v4'].address") | default([], true) | length < 1
   until: r_nic_tomcat is successful
 
 - name: Save Tomcat VM IP Address

--- a/ansible/roles_ocp_workloads/ocp4_workload_ama_demo_shared/tasks/rhv-setup-oracle-vm.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ama_demo_shared/tasks/rhv-setup-oracle-vm.yml
@@ -27,12 +27,8 @@
   retries: 50
   delay: 10
   failed_when: >-
-    r_nic_oracle | json_query("ovirt_nics[0].reported_devices[0].ips[?version=='v4'].address") | length < 1
+    r_nic_oracle | json_query("ovirt_nics[0].reported_devices[0].ips[?version=='v4'].address") | default([], true) | length < 1
   until: r_nic_oracle is successful
-
-- name: Sleep 5 seconds to prepare for next query
-  ansible.builtin.pause:
-    seconds: 5
 
 - name: Save Oracle VM IP Address
   ansible.builtin.set_fact:

--- a/ansible/roles_ocp_workloads/ocp4_workload_ama_demo_shared/tasks/rhv-setup-oracle-vm.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ama_demo_shared/tasks/rhv-setup-oracle-vm.yml
@@ -30,6 +30,10 @@
     r_nic_oracle | json_query("ovirt_nics[0].reported_devices[0].ips[?version=='v4'].address") | length < 1
   until: r_nic_oracle is successful
 
+- name: Sleep 5 seconds to prepare for next query
+  ansible.builtin.pause:
+    seconds: 5
+
 - name: Save Oracle VM IP Address
   ansible.builtin.set_fact:
     _ocp4_workload_ama_demo_shared_oracle_ip: >-
@@ -65,3 +69,15 @@
   local_action:
     module: shell
     args: ssh-keyscan -H "{{ _ocp4_workload_ama_demo_shared_oracle_ip }}" >> $HOME/.ssh/known_hosts
+
+- name: Wait for Oracle database to be running
+  ansible.builtin.wait_for:
+    host: "{{ _ocp4_workload_ama_demo_shared_oracle_ip }}"
+    port: 1521
+    state: started
+    timeout: 300
+  register: r_wait_for_database
+
+- name: Print result of wait step
+  ansible.builtin.debug:
+    msg: "{{ r_wait_for_database }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_ama_demo_shared/tasks/rhv-setup-tomcat-vm.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ama_demo_shared/tasks/rhv-setup-tomcat-vm.yml
@@ -16,6 +16,10 @@
       nic_name: eth0
     cloud_init_persist: true
 
+- name: Sleep 5 seconds to prepare for next query
+  ansible.builtin.pause:
+    seconds: 5
+
 - name: Get Tomcat VM NIC
   ovirt.ovirt.ovirt_nic_info:
     auth:

--- a/ansible/roles_ocp_workloads/ocp4_workload_ama_demo_shared/tasks/rhv-setup-tomcat-vm.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ama_demo_shared/tasks/rhv-setup-tomcat-vm.yml
@@ -16,10 +16,6 @@
       nic_name: eth0
     cloud_init_persist: true
 
-- name: Sleep 5 seconds to prepare for next query
-  ansible.builtin.pause:
-    seconds: 5
-
 - name: Get Tomcat VM NIC
   ovirt.ovirt.ovirt_nic_info:
     auth:
@@ -31,7 +27,7 @@
   retries: 50
   delay: 10
   failed_when: >-
-    r_nic_tomcat | json_query("ovirt_nics[0].reported_devices[0].ips[?version=='v4'].address") | length < 1
+    r_nic_tomcat | json_query("ovirt_nics[0].reported_devices[0].ips[?version=='v4'].address") | default([], true) | length < 1
   until:
   - r_nic_tomcat is successful
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_mad_roadshow/tasks/rhv-setup-oracle-vm.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mad_roadshow/tasks/rhv-setup-oracle-vm.yml
@@ -16,6 +16,10 @@
       nic_name: eth0
     cloud_init_persist: true
 
+- name: Sleep 5 seconds to prepare for next query
+  ansible.builtin.pause:
+    seconds: 5
+
 - name: Get Oracle VM NIC
   ovirt.ovirt.ovirt_nic_info:
     auth:
@@ -65,3 +69,15 @@
   local_action:
     module: shell
     args: ssh-keyscan -H "{{ _ocp4_workload_mad_roadshow_oracle_ip }}" >> $HOME/.ssh/known_hosts
+
+- name: Wait for Oracle database to be running
+  ansible.builtin.wait_for:
+    host: "{{ _ocp4_workload_mad_roadshow_oracle_ip }}"
+    port: 1521
+    state: started
+    timeout: 300
+  register: r_wait_for_database
+
+- name: Print result of wait step
+  ansible.builtin.debug:
+    msg: "{{ r_wait_for_database }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_mad_roadshow/tasks/rhv-setup-oracle-vm.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mad_roadshow/tasks/rhv-setup-oracle-vm.yml
@@ -16,10 +16,6 @@
       nic_name: eth0
     cloud_init_persist: true
 
-- name: Sleep 5 seconds to prepare for next query
-  ansible.builtin.pause:
-    seconds: 5
-
 - name: Get Oracle VM NIC
   ovirt.ovirt.ovirt_nic_info:
     auth:
@@ -31,7 +27,7 @@
   retries: 50
   delay: 30
   failed_when: >-
-    r_nic_oracle | json_query("ovirt_nics[0].reported_devices[0].ips[?version=='v4'].address") | length < 1
+    r_nic_oracle | json_query("ovirt_nics[0].reported_devices[0].ips[?version=='v4'].address") | default([], true) | length < 1
   until: r_nic_oracle is successful
 
 - name: Save Oracle VM IP Address

--- a/ansible/roles_ocp_workloads/ocp4_workload_mad_roadshow/tasks/rhv-setup-tomcat-vm.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mad_roadshow/tasks/rhv-setup-tomcat-vm.yml
@@ -16,6 +16,10 @@
       nic_name: eth0
     cloud_init_persist: true
 
+- name: Sleep 5 seconds to prepare for next query
+  ansible.builtin.pause:
+    seconds: 5
+
 - name: Get Tomcat VM NIC
   ovirt.ovirt.ovirt_nic_info:
     auth:

--- a/ansible/roles_ocp_workloads/ocp4_workload_mad_roadshow/tasks/rhv-setup-tomcat-vm.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mad_roadshow/tasks/rhv-setup-tomcat-vm.yml
@@ -16,10 +16,6 @@
       nic_name: eth0
     cloud_init_persist: true
 
-- name: Sleep 5 seconds to prepare for next query
-  ansible.builtin.pause:
-    seconds: 5
-
 - name: Get Tomcat VM NIC
   ovirt.ovirt.ovirt_nic_info:
     auth:
@@ -31,7 +27,7 @@
   retries: 50
   delay: 10
   failed_when: >-
-    r_nic_tomcat | json_query("ovirt_nics[0].reported_devices[0].ips[?version=='v4'].address") | length < 1
+    r_nic_tomcat | json_query("ovirt_nics[0].reported_devices[0].ips[?version=='v4'].address") | default([], true) | length < 1
   until: r_nic_tomcat is successful
 
 - name: Save Tomcat VM IP Address


### PR DESCRIPTION
##### SUMMARY

Query for NIC would fail occasionally when executed too quickly. Fixed check by defaulting to an empty array if nothing was returned.

Also added task to check for the Oracle Database to be up and running before continuing. This prevents Tomcat VMs from being created that can't connect to the database.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_ama_demo
ocp4_workload_ama_demo_shared
ocp4_workload_mad_roadshow
