### PR TITLE
Add image builder configuration to Wxpand your workload to the cloud CI

### DIFF
--- a/ansible/configs/expanding-workload-rhel/image_builder_repos.yml
+++ b/ansible/configs/expanding-workload-rhel/image_builder_repos.yml
@@ -1,0 +1,70 @@
+---
+- name: Setup Image Builder for Satellite
+  hosts: bastions
+  become: True
+  gather_facts: False
+  vars:
+    baseos_baseurl: "https://labsat-ha.opentlc.com/pulp/repos/Red_Hat_GPTE_Labs/Library/rhel-9_0/content/dist/rhel9/9.0/x86_64/baseos/os"
+    appstream_baseurl: "https://labsat-ha.opentlc.com/pulp/repos/Red_Hat_GPTE_Labs/Library/rhel-9_0/content/dist/rhel9/9.0/x86_64/appstream/os"
+    enabled_services:
+      - cockpit
+      - osbuild-composer
+    imagebuilder_packages:
+      - osbuild-composer
+      - composer-cli
+      - cockpit-composer
+      - bash-completion
+  tasks:
+    - name: Install Packages for Image-builder
+      ansible.builtin.dnf:
+        state: present
+        name: "{{ imagebuilder_packages }}"
+   
+    - name: Create osbuild-composer/repositories directories
+      ansible.builtin.file:
+        path: /etc/osbuild-composer/repositories
+        state: directory
+        mode: '0755'
+
+    - name: Copy osbuild-composer repo file from /usr/share/
+      ansible.builtin.copy:
+        remote_src: True
+        src: /usr/share/osbuild-composer/repositories/rhel-90.json
+        dest: /etc/osbuild-composer/repositories/rhel-90.json
+        owner: root
+        group: root
+        mode: '0644'
+    
+    - name: Modify hard coded baseos content path
+      ansible.builtin.replace:
+        path: /etc/osbuild-composer/repositories/rhel-90.json
+        regexp: 'https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os'
+        replace: "{{ baseos_baseurl }}"
+
+    - name: Modify hard coded appstream content path
+      ansible.builtin.replace:
+        path: /etc/osbuild-composer/repositories/rhel-90.json
+        regexp: 'https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os'
+        replace: "{{ appstream_baseurl }}"
+
+    - name: Remove redhat-uep.pem file
+      ansible.builtin.file:
+        path: /etc/rhsm/ca/redhat-uep.pem
+        state: absent
+    
+    - name: Create link to katello-ca-cert
+      ansible.builtin.file:
+        src: /etc/rhsm/ca/katello-server-ca.pem
+        dest: /etc/rhsm/ca/redhat-uep.pem
+        owner: root
+        group: root
+        state: link
+    
+    - name: Enable Related Services
+      ansible.builtin.service:
+        name: "{{ service }}"
+        state: restarted
+        enabled: True
+      loop: "{{ enabled_services }}"
+      loop_control:
+        loop_var: service

--- a/ansible/configs/expanding-workload-rhel/pre_software.yml
+++ b/ansible/configs/expanding-workload-rhel/pre_software.yml
@@ -80,18 +80,7 @@
       ansible.builtin.include_role:
         name: user-create-ansible-service-account
 
-#- name: Enable podman based service on utility group
-#  hosts: utility
-#  become: true
-#  vars:
-#    container_service_deploy_name: classroom
-#
-#    tasks:
-#      - name: Setup Podman based Linux Systemd Service
-#        import_role:
-#          name: container_service_deploy
-#        vars:
-#          container_service_deploy_url: "{{ container_service_resource_url }}"
+- import_playbook: "image_builder_repos.yml"
 
 - name: PreSoftware flight-check
   hosts: localhost


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
This PR will satisfy the requirements of building an on premise cockpit driven image-builder integrated with a satellite.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
expanding-workload-rhel

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
