### PR TITLE
[SANDBOX VMC] Add the option to create DNS for OCP

### DIFF
--- a/ansible/configs/sandbox/default_vars_vmc.yaml
+++ b/ansible/configs/sandbox/default_vars_vmc.yaml
@@ -39,30 +39,22 @@ wait_for_dns: true
 # osp_cluster_dns_zone needs to come from secrets
 # subdomain_base_suffix: "{{ osp_cluster_dns_zone }}"
 
-# This will provision an API and Ingress FIP
-openshift_fip_provision: true
-
-# This requires DDNS or other DNS solution configured
-# If enabled, it will add DNS entries for the API and Ingress FIPs
-openshift_fip_dns: true
-
-# The external network in VMC where the floating IPs (FIPs) come from
-provider_network: external
-
 # Provision Public IPs for API and Ingress
 #additional_publicips: []
-#  - name: ocp_api
-#    dns: "api.cluster-{{ guid }}"
-#    nthhost: 201
-#  - name: ocp_ingress
-#    dns: "*.apps.cluster-{{ guid }}"
-#    nthhost: 202
+additional_publicip_ocp:
+  - name: ocp_api
+    dns: "api.cluster-{{ guid }}"
+    nthhost: 201
+  - name: ocp_ingress
+    dns: "*.apps.cluster-{{ guid }}"
+    nthhost: 202
 
-
-additional_publicips:
+additional_publicips_default:
   - name: wildcard
     dns: "*.{{ guid }}"
     nthhost: 10
+
+additional_publicips: "{% if ocp_dns|default(False) %}additional_publicip_ocp{% else %}additional_publicips_default{% endif %}"
 
 # Bastion Configuration
 bastion_instance_template: rhel86-tpl

--- a/ansible/configs/sandbox/default_vars_vmc.yaml
+++ b/ansible/configs/sandbox/default_vars_vmc.yaml
@@ -54,7 +54,7 @@ additional_publicips_default:
     dns: "*.{{ guid }}"
     nthhost: 10
 
-additional_publicips: "{% if ocp_dns|default(False) %}additional_publicip_ocp{% else %}additional_publicips_default{% endif %}"
+additional_publicips: "{% if ocp_dns|default(False) %}{{ additional_publicip_ocp }}{% else %}{{ additional_publicips_default }}{% endif %}"
 
 # Bastion Configuration
 bastion_instance_template: rhel86-tpl

--- a/ansible/configs/sandbox/post_software_vmc.yml
+++ b/ansible/configs/sandbox/post_software_vmc.yml
@@ -14,12 +14,26 @@
 
       Subnet CIDR: {{ hostvars.localhost.project_segment_cidr }} (Network {{ hostvars.localhost.project_segment_name }})
 
-      Wildcard DNS will point to your bastion: *.{{ guid }}.{{ cluster_dns_zone }}
-
-      VMRC access is not possible at this moment due a limitation with VMWare Cloud.
-
       IMPORTANT: All the VMs needs to be stored on the folder Workloads/{{ env_type }}-{{ guid }} to be visible for you
 
+- name: Print DNS information for bastion
+  when: sandbox_user_info_messages_enable | bool and not (ocp_dns | default(False))
+  agnosticd_user_info:
+    msg: |
+      Wildcard DNS will point to your bastion: *.{{ guid }}.{{ cluster_dns_zone }}
+
+- name: Print DNS information for OCP
+  when: sandbox_user_info_messages_enable | bool and (ocp_dns | default(False))
+  agnosticd_user_info:
+    msg: |
+      API DNS api.apps.{{ guid }}.{{ cluster_dns_zone }} to {{ hostvars.localhost.project_segment_cidr | nthhost(201) }}
+
+      Wildcard DNS *.apps.{{ guid }}.{{ cluster_dns_zone }} to {{ hostvars.localhost.project_segment_cidr | nthhost(202) }}
+      
+- name: Print WARNING
+  when: sandbox_user_info_messages_enable | bool
+  agnosticd_user_info:
+    msg: |
       ----------------------------WARNING--WARNING--WARNING----------------------------
 
         We monitor usage and we will be charging back to your cost center.

--- a/ansible/configs/sandbox/post_software_vmc.yml
+++ b/ansible/configs/sandbox/post_software_vmc.yml
@@ -29,7 +29,7 @@
       API DNS api.apps.{{ guid }}.{{ cluster_dns_zone }} to {{ hostvars.localhost.project_segment_cidr | nthhost(201) }}
 
       Wildcard DNS *.apps.{{ guid }}.{{ cluster_dns_zone }} to {{ hostvars.localhost.project_segment_cidr | nthhost(202) }}
-      
+
 - name: Print WARNING
   when: sandbox_user_info_messages_enable | bool
   agnosticd_user_info:


### PR DESCRIPTION
If the the option in the CI is enabled, api.apps.domain and *.apps.domain will be created