### PR TITLE
Update install_galaxy_roles.yml

### DIFF
--- a/ansible/install_galaxy_roles.yml
+++ b/ansible/install_galaxy_roles.yml
@@ -57,7 +57,7 @@
         {%- endif -%}"
       when: >-
         r_requirements_stat.stat.exists
-        and r_requirements_content | length > 0
+        and r_requirements_content|default([]) | length > 0
         and (r_requirements_content is sequence
              or (r_requirements_content is mapping
                  and 'roles' in r_requirements_content)


### PR DESCRIPTION
Tox tests failing:
TASK [Get installed collections (EE)] ******************************************
fatal: [localhost]: FAILED! => {"msg": "The conditional check '__from_ee | bool and r_requirements_content | length > 0 and r_requirements_content is mapping and \"collections\" in r_requirements_content' failed. The error was: error while evaluating conditional (__from_ee | bool and r_requirements_content | length > 0 and r_requirements_content is mapping and \"collections\" in r_requirements_content): 'r_requirements_content' is undefined\n\nThe error appears to be in '/home/runner/work/agnosticd/agnosticd/ansible/install_galaxy_roles.yml': line 90, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n    - name: Get installed collections (EE)\n      ^ here\n"}