### PR TITLE
Fix var typo subdomain_base_suffix ent-demo-ate-base

### DIFF
--- a/ansible/configs/ent-demo-ate-base/post_software.yml
+++ b/ansible/configs/ent-demo-ate-base/post_software.yml
@@ -28,7 +28,7 @@
         msg: "{{ __user_info }}"
       loop:
         - "To Access Ansible Controller via browser:"
-        - "Ansible Controller URL: https://{{ groups['automationcontroller'][0] | regex_replace('\\..*$') }}.{{ guid }}{{ subdomain_prefix }}"
+        - "Ansible Controller URL: https://{{ groups['automationcontroller'][0] | regex_replace('\\..*$') }}.{{ guid }}{{ subdomain_base_suffix }}"
         - "Ansible Controller Username: {{ deploy_automationcontroller_admin_user }}"
         - "Ansible Controller Admin Password: {{ deploy_automationcontroller_admin_password }}"
         - ""
@@ -44,8 +44,8 @@
     - name: Set installed ansible automation controller user_info data
       agnosticd_user_info:
         data:
-          controller_host: "https://{{ groups['automationcontroller'][0] | regex_replace('\\..*$') }}.{{ guid }}{{ subdomain_prefix }}"
-          hub_host: "https://{{ groups['automationhub'][0] | regex_replace('\\..*$') }}.{{ guid }}{{ subdomain_prefix }}"
+          controller_host: "https://{{ groups['automationcontroller'][0] | regex_replace('\\..*$') }}.{{ guid }}{{ subdomain_base_suffix }}"
+          hub_host: "https://{{ groups['automationhub'][0] | regex_replace('\\..*$') }}.{{ guid }}{{ subdomain_base_suffix }}"
           controller_username: "{{ deploy_automationcontroller_admin_user }}"
           controller_password: "{{ deploy_automationcontroller_admin_password }}"
           ssh_public_key: "{{ lookup('file', ssh_provision_pubkey_path) }}"
@@ -59,7 +59,7 @@
             msg: "{{ __user_info }}"
           loop:
             - "To Access Control node via SSH:"
-            - "ssh {{ ansible_service_account_user_name }}@{{ groups['bastions'][0] | regex_replace('\\..*$') }}.{{ guid }}{{ subdomain_prefix }}"
+            - "ssh {{ ansible_service_account_user_name }}@{{ groups['bastions'][0] | regex_replace('\\..*$') }}.{{ guid }}{{ subdomain_base_suffix }}"
             - "Enter ssh password when prompted: {{ student_password }}"
             - ""
           loop_control:
@@ -68,7 +68,7 @@
         - name: Set agnosticd_user_info ssh data
           agnosticd_user_info:
             data:
-              ssh_command: "ssh {{ ansible_service_account_user_name }}@{{ groups['bastions'][0] | regex_replace('\\..*$') }}.{{ guid }}{{ subdomain_prefix }}"
+              ssh_command: "ssh {{ ansible_service_account_user_name }}@{{ groups['bastions'][0] | regex_replace('\\..*$') }}.{{ guid }}{{ subdomain_base_suffix }}"
               ssh_password: "{{ student_password }}"
 
     - name: Deploy Bookbag


### PR DESCRIPTION

##### SUMMARY

Simply an incorrect var in config ent-demo-ate-base - changed to `subdomain_base_suffix`

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
config ent-demo-ate-base

##### ADDITIONAL INFORMATION
