### PR TITLE
Do not fail on cloudformation errors when in sandbox

### DIFF
--- a/ansible/roles-infra/infra-ec2-template-destroy/defaults/main.yaml
+++ b/ansible/roles-infra/infra-ec2-template-destroy/defaults/main.yaml
@@ -1,2 +1,2 @@
 ---
-_sandbox_zone: "{{ sandbox_zone | default('') }}"
+cloudformation_destroy_ignore_failure: "{{ sandbox_zone | default('') != '' }}"

--- a/ansible/roles-infra/infra-ec2-template-destroy/defaults/main.yaml
+++ b/ansible/roles-infra/infra-ec2-template-destroy/defaults/main.yaml
@@ -1,0 +1,2 @@
+---
+_sandbox_zone: "{{ sandbox_zone | default('') }}"

--- a/ansible/roles-infra/infra-ec2-template-destroy/tasks/main.yml
+++ b/ansible/roles-infra/infra-ec2-template-destroy/tasks/main.yml
@@ -28,6 +28,7 @@
   when:
     - not cloudformation_result is succeeded
     - cloud_provider == 'ec2'
+    - (sandbox_zone is not defined) or (sandbox_zone|length == 0)
   tags:
     - destroying
     - destroy_cf_deployment

--- a/ansible/roles-infra/infra-ec2-template-destroy/tasks/main.yml
+++ b/ansible/roles-infra/infra-ec2-template-destroy/tasks/main.yml
@@ -28,7 +28,7 @@
   when:
     - not cloudformation_result is succeeded
     - cloud_provider == 'ec2'
-    - _sandbox_zone == ''
+    - not cloudfomation_destroy_ignore_failure
   tags:
     - destroying
     - destroy_cf_deployment

--- a/ansible/roles-infra/infra-ec2-template-destroy/tasks/main.yml
+++ b/ansible/roles-infra/infra-ec2-template-destroy/tasks/main.yml
@@ -28,7 +28,7 @@
   when:
     - not cloudformation_result is succeeded
     - cloud_provider == 'ec2'
-    - (sandbox_zone is not defined) or (sandbox_zone|length == 0)
+    - sandbox_zone | default('') != ''
   tags:
     - destroying
     - destroy_cf_deployment

--- a/ansible/roles-infra/infra-ec2-template-destroy/tasks/main.yml
+++ b/ansible/roles-infra/infra-ec2-template-destroy/tasks/main.yml
@@ -28,7 +28,7 @@
   when:
     - not cloudformation_result is succeeded
     - cloud_provider == 'ec2'
-    - sandbox_zone | default('') != ''
+    - _sandbox_zone == ''
   tags:
     - destroying
     - destroy_cf_deployment


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Do not fail on cloudformation errors when in sandbox.  The account will be nuked anyway and this failure just hangs up deletion.
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
roles-infra/infra-ec2-template-destroy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
