### PR TITLE
Fixed typo in sap-smart config

### DIFF
--- a/ansible/configs/sap-smart/default_vars.yml
+++ b/ansible/configs/sap-smart/default_vars.yml
@@ -405,7 +405,7 @@ ansible_tower:
           sap_hana_hsr_hana_primary_hostname: "hana-{{ guid }}1"
           sap_hana_hsr_role: primary
           sap_hana_hsr_alias: DC1
-          sap_hana_hsr_full_primary_hostname: "hana-{{ guid }}1""
+          sap_hana_hsr_full_primary_hostname: "hana-{{ guid }}1"
           sap_hana_hsr_full_secondary_hostname: "hana-{{ guid }}2"
       - name: "hana-{{ guid }}2"
         description: "SAP HANA Host"
@@ -454,7 +454,7 @@ ansible_tower:
           sap_hana_hsr_hana_primary_hostname: "hana-{{ guid }}1"
           sap_hana_hsr_role: secondary
           sap_hana_hsr_alias: DC2
-          sap_hana_hsr_full_primary_hostname: "hana-{{ guid }}1""
+          sap_hana_hsr_full_primary_hostname: "hana-{{ guid }}1"
           sap_hana_hsr_full_secondary_hostname: "hana-{{ guid }}2"
       - name: "s4hana-{{ guid }}"
         description: "SAP S/4HANA Host"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
Deleted extra @ in default_vars.yaml

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
