### PR TITLE
guimou-mad-dev-rhods-adjust

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_mad_roadshow/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mad_roadshow/tasks/workload.yml
@@ -315,6 +315,12 @@
     install_operator_catalogsource_image: "{{ ocp4_workload_mad_roadshow_rhods_catalogsource_image }}"
     install_operator_catalogsource_image_tag: "{{ ocp4_workload_mad_roadshow_rhods_catalogsource_image_tag }}"
 
+- name: Adjust RHODS configuration
+  when: ocp4_workload_mad_roadshow_rhods_setup | bool
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('template', 'rhods/odh-dashboard-config.yaml.j2' ) | from_yaml }}"
+
 # --------------------------------------------------------
 # Deploy Module Guides and User Distribution for Dev Track
 # --------------------------------------------------------

--- a/ansible/roles_ocp_workloads/ocp4_workload_mad_roadshow/templates/rhods/odh-dashboard-config.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mad_roadshow/templates/rhods/odh-dashboard-config.yaml.j2
@@ -1,0 +1,51 @@
+apiVersion: opendatahub.io/v1alpha
+kind: OdhDashboardConfig
+metadata:
+  name: odh-dashboard-config
+  namespace: redhat-ods-applications
+spec:
+  dashboardConfig:
+    disableBYONImageStream: false
+    disableClusterManager: false
+    disableISVBadges: false
+    disableInfo: false
+    disableSupport: false
+    disableTracking: false
+    disableUserManagement: false
+    enablement: true
+  groupsConfig:
+    adminGroups: 'cluster-admins,dedicated-admins,rhods-admins'
+    allowedGroups: 'system:authenticated'
+  notebookController:
+    enabled: true
+    gpuSetting: '4'
+    notebookNamespace: rhods-notebooks
+    notebookTolerationSettings:
+      enabled: true
+      key: notebooksonly
+    pvcSize: 1Gi
+  notebookSizes:
+    - name: Small
+      resources:
+        limits:
+          cpu: '2'
+          memory: 4Gi
+        requests:
+          cpu: '1'
+          memory: 2Gi
+    - name: Medium
+      resources:
+        limits:
+          cpu: '6'
+          memory: 6Gi
+        requests:
+          cpu: '3'
+          memory: 4Gi
+    - name: Large
+      resources:
+        limits:
+          cpu: '8'
+          memory: 8Gi
+        requests:
+          cpu: '4'
+          memory: 6Gi


### PR DESCRIPTION
##### SUMMARY

Adjustment of RHODS configuration for the MAD Dev module 6. Default notebook size is now smaller to consume less resources on the cluster.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_mad_roadshow

##### ADDITIONAL INFORMATION
Not a real bugfix, simply a configuration adjustment to consume less resources.
