### PR TITLE
user info was missing number of provisioned users

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_authentication/tasks/setup_htpasswd.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_authentication/tasks/setup_htpasswd.yml
@@ -140,6 +140,7 @@
     agnosticd_user_info:
       data:
         openshift_cluster_user_base: "{{ ocp4_workload_authentication_htpasswd_user_base }}"
+        openshift_cluster_num_users: "{{ ocp4_workload_authentication_htpasswd_user_count }}"
         openshift_cluster_admin_username: "{{ ocp4_workload_authentication_admin_user }}"
         openshift_cluster_admin_password: "{{ _ocp4_workload_authentication_admin_password }}"
         openshift_cluster_console_url: "{{ _ocp4_workload_authentication_console_route }}"


### PR DESCRIPTION
##### SUMMARY

AgnosticD user info was missing the number of provisioned users. Added to the output.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_authentication