### PR TITLE
Update default collections for ocp4-cluster

### DIFF
--- a/ansible/configs/ocp4-cluster/requirements.yml
+++ b/ansible/configs/ocp4-cluster/requirements.yml
@@ -6,17 +6,19 @@ roles:
   version: v0.17
 
 collections:
-- name: amazon.aws
-  version: 2.2.0
-- name: ansible.posix
-  version: 1.3.0
 - name: community.general
-  version: 4.6.1
+  version: 6.5.0
+- name: community.crypto
+  version: 2.11.1
+- name: ansible.posix
+  version: 1.5.1
+- name: kubernetes.core
+  version: 2.4.0
+- name: amazon.aws
+  version: 2.3.0
 - name: community.vmware
   version: 2.7.0
 - name: google.cloud
   version: 1.0.2
-- name: kubernetes.core
-  version: 2.3.0
 - name: openstack.cloud
   version: 1.7.2


### PR DESCRIPTION
##### SUMMARY

The config ocp4-cluster had some rather old collections in its requirements file.
Updated to the current available ones.
Also added community.crypto because of changes to the authentication workload (which now uses the htpasswd module - which requires crypto).

These have been tested for quite a while in other existing configs (MAD Roadshow etc.) via overrides.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4-cluster