### PR TITLE
Improve aap_deploy to be less dependent on Internet/Red Hat CDN

### DIFF
--- a/ansible/roles/aap_deploy/templates/automationcontroller_inventory.j2
+++ b/ansible/roles/aap_deploy/templates/automationcontroller_inventory.j2
@@ -33,6 +33,7 @@ admin_password='{{ deploy_automationcontroller_admin_password }}'
 automationhub_admin_password='{{ deploy_automationcontroller_admin_password }}'
 ansible_become=true
 ansible_become_method=sudo
+{% if groups['pah'] is defined %}ee_from_hub_only=true{% endif %}
 
 {% if groups['automationcontroller_database'] is defined %}
 pg_host={{ groups['automationcontroller_database'][0] }}

--- a/ansible/roles/aap_deploy/templates/automationcontroller_inventory.j2
+++ b/ansible/roles/aap_deploy/templates/automationcontroller_inventory.j2
@@ -33,7 +33,9 @@ admin_password='{{ deploy_automationcontroller_admin_password }}'
 automationhub_admin_password='{{ deploy_automationcontroller_admin_password }}'
 ansible_become=true
 ansible_become_method=sudo
-{% if groups['pah'] is defined %}ee_from_hub_only=true{% endif %}
+{% if groups['pah'] is defined %}
+ee_from_hub_only=true
+{% endif %}
 
 {% if groups['automationcontroller_database'] is defined %}
 pg_host={{ groups['automationcontroller_database'][0] }}
@@ -66,5 +68,5 @@ registry_url='registry.redhat.io'
 registry_username='{{ registry_username }}'
 registry_password='{{ registry_password }}'
 
-# seems to fail
-# enable_insights_collection={{ aap_deploy_insights }}
+# disable Insights by setting to false
+enable_insights_collection={{ aap_deploy_insights }}


### PR DESCRIPTION
##### SUMMARY

1. If there is a PAH, controller should pull the EE images from it instead from redhat.io.
1. Enable the disabling of Insights in aap_deploy

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

aap_deploy (role)

##### ADDITIONAL INFORMATION

Works now with AAP 2.3
