### PR TITLE
Fix install_operator namespace creation

### DIFF
--- a/ansible/roles/install_operator/tasks/install.yml
+++ b/ansible/roles/install_operator/tasks/install.yml
@@ -6,7 +6,7 @@
     fail_msg: install_operator_name must be set.
 
 - name: "{{ install_operator_name }} - Set up for Namespace other than 'openshift-operators'"
-  when: install_operator_namespace is not match("openshift-operators")
+  when: install_operator_namespace != "openshift-operators"
   block:
   - name: "{{ install_operator_name }} - Ensure Namespace exists"
     kubernetes.core.k8s:


### PR DESCRIPTION
When installing ElasticSearch operator, the namespace was not created because the condition matched, when it shouldn't.

```
- name: install elasticsearch operator
  ansible.builtin.include_role:
    name: install_operator
  vars:
    install_operator_name: elasticsearch-operator
    install_operator_namespace: openshift-operators-redhat
    ...
```