### PR TITLE
Add flag to suppress agnosticd_user_info messages to rosa_manual

### DIFF
--- a/ansible/configs/rosa-manual/default_vars.yml
+++ b/ansible/configs/rosa-manual/default_vars.yml
@@ -54,6 +54,11 @@ gpte_rosa_token: ""
 rosa_token: ""
 
 # ------------------------------------------------------
+# agnosticd_user_info Messages
+# ------------------------------------------------------
+print_agnosticd_user_info: true
+
+# ------------------------------------------------------
 # Bookbag
 # ------------------------------------------------------
 # Deploy a bookbag with instructions to a shared cluster

--- a/ansible/configs/rosa-manual/software.yml
+++ b/ansible/configs/rosa-manual/software.yml
@@ -212,8 +212,8 @@
 
         - name: Print ROSA token warning
           when:
-          - rosa_token_warning | bool
-          - print_agnosticd_user_info | bool
+            - rosa_token_warning | bool
+            - print_agnosticd_user_info | bool
           agnosticd_user_info:
             msg: |
 

--- a/ansible/configs/rosa-manual/software.yml
+++ b/ansible/configs/rosa-manual/software.yml
@@ -187,6 +187,7 @@
               rosa_token_warning: "{{ rosa_token_warning }}"
 
         - name: Print ROSA admin credentials as user.info
+          when: print_agnosticd_user_info | bool
           agnosticd_user_info:
             msg: |
 
@@ -210,7 +211,9 @@
               * Please see the ROSA CLI documentation on necessary steps after `rosa login`.
 
         - name: Print ROSA token warning
-          when: rosa_token_warning
+          when:
+          - rosa_token_warning | bool
+          - print_agnosticd_user_info | bool
           agnosticd_user_info:
             msg: |
 


### PR DESCRIPTION
##### SUMMARY

Add a variable to rosa_manual config to suppress agnosticd_user_info messages. This is to beautify the workshop output when claiming an environment until workshop has the adoc template capability.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
rosa_manual