### PR TITLE
New ocp4_workload_ansible_automation_platform

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/defaults/main.yml
@@ -11,7 +11,8 @@ ocp4_workload_ansible_automation_platform_app_name: "aap"
 ocp4_workload_ansible_automation_platform_display: "ansible-automation-platform"
 ocp4_workload_ansible_automation_platform_description: "Ansible Automation Platorm"
 
-ocp4_workload_ansible_automation_platform_admin_password: "{{ common_password | default(aap_controller_admin_password) }}"
+ocp4_workload_ansible_automation_platform_admin_password: >- 
+  {{ common_password | default(aap_controller_admin_password) }}
 
 ocp4_workload_ansible_automation_platform_manifest:
   inject: false

--- a/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/defaults/main.yml
@@ -6,13 +6,15 @@ ocp4_workload_ansible_automation_platform_tmp_dir: /tmp/{{ guid }}
 ocp4_workload_ansible_automation_platform_tmp_kubeconfig: >-
   {{ ocp4_workload_ansible_automation_platform_tmp_dir }}/.kube/config
 
-ocp4_workload_ansible_automation_platform_project: "automation-controller"
-ocp4_workload_ansible_automation_platform_display: "automation-controller"
-ocp4_workload_ansible_automation_platform_app_name: "automation-controller"
-ocp4_workload_ansible_automation_platform_admin_secret: "automation-controller-admin-password"
-ocp4_workload_ansible_automation_platform_admin_password: "{{ common_password }}"
-ocp4_workload_ansible_automation_platform_upload_manifest: true
+ocp4_workload_ansible_automation_platform_project: "aap"
+ocp4_workload_ansible_automation_platform_app_name: "aap"
+ocp4_workload_ansible_automation_platform_display: "ansible-automation-platform"
+ocp4_workload_ansible_automation_platform_description: "Ansible Automation Platorm"
 
-# ocp4_workload_ansible_automation_platform_ocp_username: user-redhat.com
-# ocp4_workload_ansible_automation_platform_hostname:  # LEAVE EMPTY AS IT'S CALCULATED IN THE ROLE
-# ocp4_workload_ansible_automation_platform_manifest_url: https://www.example.com/automationcontroller_manifest.zip
+ocp4_workload_ansible_automation_platform_admin_password: "{{ common_password | default(aap_controller_admin_password) }}"
+
+ocp4_workload_ansible_automation_platform_manifest:
+  inject: false
+  url: https://example.com/manifest
+  username: jonsnow
+  password: got2023

--- a/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/defaults/main.yml
@@ -11,7 +11,7 @@ ocp4_workload_ansible_automation_platform_app_name: "aap"
 ocp4_workload_ansible_automation_platform_display: "ansible-automation-platform"
 ocp4_workload_ansible_automation_platform_description: "Ansible Automation Platorm"
 
-ocp4_workload_ansible_automation_platform_admin_password: >- 
+ocp4_workload_ansible_automation_platform_admin_password: >-
   {{ common_password | default(aap_controller_admin_password) }}
 
 ocp4_workload_ansible_automation_platform_manifest:

--- a/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/readme.adoc
@@ -4,69 +4,81 @@
 
 Deploys Ansible Automation Platform onto an OpenShift cluster, into a new project or an existing project.
 
-* Automation Controller
-* or Automation Controller and Private Automation Hub (PAH)
+* Automation Controller and Private Automation Hub (PAH)
+* Injects Manifest if provided *and* requested (see below)
 
-NOTE: There is no option, as yet, to solely install Private Automation Hub (PAH) without Controller
+Created by: Tony Kay, tok@redhat.com
+Date: 2022-04-18
 
+== Role Returns
+
+This role returns, via agnosticd_user_info (info and data) the following:
+
+[source,yaml]
+----
+aap_controller_web_url: "https://{{ automation_controller_hostname }}"
+aap_controller_admin_user: "{{ ocp4_workload_ansible_automation_platform_admin_username | default('admin') }}"
+aap_controller_admin_password: "{{ ocp4_workload_ansible_automation_platform_admin_password }}"
+----
+
+=== Resources and PriorArt
+
+. link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/deploying_the_red_hat_ansible_automation_platform_operator_on_openshift_container_platform/index[Deploying the Red Hat Ansible Automation Platform operator on OpenShift Container Platform]
+.. Especially Chapter 5 - link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/deploying_the_red_hat_ansible_automation_platform_operator_on_openshift_container_platform/ansible-automation-platform-operator#installing-the-operator[Installing the Operator]
+.. Note the `oc apply` documented in Chapter 5 will fail, as the Subscription needs time to be created. The `oc apply` command should be run again after a few moments.
+. link:https://github.com/redhat-cop/agnosticd/tree/development/ansible/roles_ocp_workloads/ocp4_workload_lpe_automation_controller[Agnosticd LPE role]
+. link:https://gitlab.com/ansible-ssa/role-aap-operator[Ansible SSA AAP Operator role]
+.. Very comprehensive
 
 == Review the defaults variable file
 
 * This file link:./defaults/main.yml[./defaults/main.yml] contains all the variables you need to define to control the deployment of your workload.
-/* * The variable *ocp_username* is mandatory to assign the workload to the correct OpenShift user. */
 * A variable *silent=True* can be passed to suppress debug messages.
 * You can modify any of these default values by adding `-e "variable_name=variable_value"` to the command line
 
+
+=== Providing and Injecting a Manifest
+
+By default *no* Manifest is injected. To inject a manifest, you need to provide the following variables:
+
+[source,yaml]
+----
+ocp4_workload_ansible_automation_platform_manifest:
+  inject: true
+  url: https://example.com/manifest <1>
+  username: <USER> <2>
+  password: <PASSWORD> <3>
+----
+
+. Valid Automation Controller Manifest file
+. username - username for an external authentication eg external CDN via htpasswd etc
+. password - password for an external authentication eg external CDN via htpasswd etc
+
+
 === Deploy a Workload with the `ocp-workload` playbook [Mostly for testing]
 
-----
-TARGET_HOST="bastion.na39.openshift.opentlc.com"
-OCP_USERNAME="mitsharm-redhat.com"
-WORKLOAD="ocp4_workload_lpe_automation_controller"
-GUID=1001
+. Authenticate to the cluster e.g. `oc login ...`
+. Run a playbook calling the `ocp4_workload_ansible_automation_platform` role
 
-# a TARGET_HOST is specified in the command line, without using an inventory file
-ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
-    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
-    -e"ansible_user=ec2-user" \
-    -e"ocp_workload=${WORKLOAD}" \
-    -e"silent=False" \
-    -e"guid=${GUID}" \
-    -e"ACTION=create"
+.Sample Playbook
+[source,yaml]
+----
+---
+
+- name: Test ocp4_workload_ansible_automation_platform role
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  become: false
+  vars:
+    ACTION: create
+    ocp4_workload_ansible_automation_platform_admin_password: <DESIRED_PASSWORD>
+
+  roles:
+
+    - ocp4_workload_ansible_automation_platform
 ----
 
 === To Delete an environment
 
-----
-TARGET_HOST="bastion.na39.openshift.opentlc.com"
-/* OCP_USERNAME="psrivast-redhat.com" */
-WORKLOAD="ocp4_workload_lpe_automation_controller"
-GUID=1002
-
-# a TARGET_HOST is specified in the command line, without using an inventory file
-ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
-    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
-    -e"ansible_user=ec2-user" \
-    -e"ocp_workload=${WORKLOAD}" \
-    -e"guid=${GUID}" \
-    -e"ACTION=remove"
-----
-
-
-== Other related information:
-
-=== Deploy Workload on OpenShift Cluster from an existing playbook:
-
-[source,yaml]
-----
-- name: Deploy a workload role on a master host
-  hosts: all
-  become: true
-  gather_facts: False
-  tags:
-    - step007
-  roles:
-    - { role: "{{ ocp_workload }}", when: 'ocp_workload is defined' }
-----
-
-NOTE: You might want to change `hosts: all` to fit your requirements
+Simply call the above playbook with `ACTION: remove`

--- a/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/tasks/remove_workload.yml
@@ -21,7 +21,7 @@
     - name: Create OpenShift objects for workload
       kubernetes.core.k8s:
         state: absent
-        definition: "{{ lookup('template', 'namespace.j2' ) }}"
+        definition: "{{ lookup('template', 'namespace.j2') }}"
 
 - name: Remove temp kube config
   ansible.builtin.file:

--- a/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/tasks/workload.yml
@@ -147,10 +147,10 @@
         path: /tmp/aap-manifest.zip
         state: absent
 
-- name: Display Version and credentials 
+- name: Display Version and credentials
   when: not silent | bool
   ansible.builtin.debug:
-    msg: 
+    msg:
       - "{{ r_result.json.version }}"
       - "Automation Controller URL: https://{{ automation_controller_hostname }}"
       - "Automation Controller Admin Login: admin"
@@ -160,9 +160,9 @@
   agnosticd_user_info:
     msg: "{{ item }}"
   loop:
-      - "Automation Controller URL: https://{{ automation_controller_hostname }}"
-      - "Automation Controller Admin Login: admin"
-      - "Automation Controller Admin Password: {{ ocp4_workload_ansible_automation_platform_admin_password }}"
+    - "Automation Controller URL: https://{{ automation_controller_hostname }}"
+    - "Automation Controller Admin Login: admin"
+    - "Automation Controller Admin Password: {{ ocp4_workload_ansible_automation_platform_admin_password }}"
 
 - name: Print Access information
   agnosticd_user_info:

--- a/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/tasks/workload.yml
@@ -1,5 +1,4 @@
 ---
-# Implement your Workload deployment tasks here
 
 - name: Setup environment vars
   environment:
@@ -9,7 +8,7 @@
     - name: Create Project {{ ocp4_workload_ansible_automation_platform_project }}
       kubernetes.core.k8s:
         state: present
-        definition: "{{ lookup('template', 'namespace.j2' ) }}"
+        definition: "{{ lookup('template', 'namespace.j2') }}"
       register: r_createproject
       until: r_createproject is succeeded
       retries: 5
@@ -17,11 +16,13 @@
     - name: Create Operator group, secret and Install operator
       kubernetes.core.k8s:
         state: present
-        definition: "{{ lookup('template', item ) }}"
+        definition: "{{ lookup('template', __definition) }}"
       loop:
         - operatorgroup.j2
-        - admin_secret.j2
         - subscription.j2
+        - admin_secret.j2
+      loop_control:
+        loop_var: __definition
 
     - name: Wait until subscription is created
       kubernetes.core.k8s_info:
@@ -38,37 +39,58 @@
         - r_aap_operator.resources | length > 0
         - r_aap_operator.resources | to_json | from_json | json_query(_query)
 
-    - name: Get Installed CSV
-      kubernetes.core.k8s_info:
-        api_version: operators.coreos.com/v1alpha1
-        kind: Subscription
-        name: ansible-automation-platform-operator
-        namespace: "{{ ocp4_workload_ansible_automation_platform_project }}"
-      register: r_subscription
-      retries: 30
-      delay: 10
-      until:
-        - r_subscription.resources[0].status.currentCSV is defined
-        - r_subscription.resources[0].status.currentCSV | length > 0
+- name: Wait until all AAP2 Operators are running
+  block:
 
-    - name: Wait until CSV is Installed
+    - name: Wait until the Automation Controller Manager operator is running
       kubernetes.core.k8s_info:
-        api_version: operators.coreos.com/v1alpha1
-        kind: ClusterServiceVersion
-        name: "{{ r_subscription.resources[0].status.currentCSV }}"
+        api_version: v1
+        kind: Deployment
+        name: automation-controller-operator-controller-manager
         namespace: "{{ ocp4_workload_ansible_automation_platform_project }}"
-      register: r_csv
-      retries: 30
-      delay: 10
+      register: r_aap_controller_manager_operator
       until:
-        - r_csv.resources[0].status.phase is defined
-        - r_csv.resources[0].status.phase | length > 0
-        - r_csv.resources[0].status.phase == "Succeeded"
+        - r_aap_controller_manager_operator.resources[0].status.readyReplicas is defined
+        - "r_aap_controller_manager_operator.resources[0].status.replicas == \
+            r_aap_controller_manager_operator.resources[0].status.readyReplicas"
+      retries: 15
+      delay: 10
+
+    - name: Wait until the Automation Hub Manager operator is running
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Deployment
+        name: automation-hub-operator-controller-manager
+        namespace: "{{ ocp4_workload_ansible_automation_platform_project }}"
+      register: r_aap_hub_manager_operator
+      until:
+        - r_aap_hub_manager_operator.resources[0].status.readyReplicas is defined
+        - "r_aap_hub_manager_operator.resources[0].status.replicas == \
+            r_aap_hub_manager_operator.resources[0].status.readyReplicas"
+      retries: 15
+      delay: 10
+
+    - name: Wait until the Automation Resource Manager operator is running
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Deployment
+        name: resource-operator-controller-manager
+        namespace: "{{ ocp4_workload_ansible_automation_platform_project }}"
+      register: r_aap_resource_manager_operator
+      until:
+        - r_aap_resource_manager_operator.resources[0].status.readyReplicas is defined
+        - "r_aap_resource_manager_operator.resources[0].status.replicas == \
+            r_aap_resource_manager_operator.resources[0].status.readyReplicas"
+      retries: 15
+      delay: 10
+
+- name: Deploy Ansible Automation Platform 2 (AAP2)
+  block:
 
     - name: Create Automation Controller
       kubernetes.core.k8s:
         state: present
-        definition: "{{ lookup('template', 'automationcontroller.j2' ) }}"
+        definition: "{{ lookup('template', 'automationcontroller.j2') }}"
 
     - name: Retrieve created route
       kubernetes.core.k8s_info:
@@ -87,39 +109,67 @@
 
     - name: Wait for automation_controller to be running
       ansible.builtin.uri:
-        url: http://{{ ocp4_workload_ansible_automation_platform_hostname }}/api/v2/ping/
+        url: http://{{ automation_controller_hostname }}/api/v2/ping/
         status_code: 200
       register: r_result
       until: r_result.json.version is defined
       retries: 60
       delay: 45
 
-    # TODO: Can this pause be replaced with something "better"?
+- name: Inject AAP2 Manifest if provided
+  when: ocp4_workload_ansible_automation_platform_manifest.inject | default(false) | bool
+  block:
 
-    - name: Pause for 5 minutes for AC to be ready
-      ansible.builtin.pause:
-        minutes: 5
+    - name: Fetch Automation Controller manifest file
+      ansible.builtin.get_url:
+        url: "{{ ocp4_workload_ansible_automation_platform_manifest.url }}"
+        dest: /tmp/aap-manifest.zip
+        username: "{{ ocp4_workload_ansible_automation_platform_manifest.username | default(omit) }}"
+        password: "{{ ocp4_workload_ansible_automation_platform_manifest.password | default(omit) }}"
 
-    - name: Display version
-      when: not silent | bool
-      ansible.builtin.debug:
-        msg: "{{ r_result.json.version }}"
+    - name: Load Automation Controller manifest into variable
+      ansible.builtin.slurp:
+        src: /tmp/aap-manifest.zip
+      register: r_aap_manifest_file
 
-    - name: Print Access information
-      agnosticd_user_info:
-        msg: "{{ item }}"
-      loop:
-        - "Automation Controller Web URL: https://{{ automation_controller_hostname }}"
-        - "Login Name:  admin"
-        - "Login Password: {{ ocp4_workload_ansible_automation_platform_admin_password }}"
+    - name: Post Automation Controller manifest file
+      ansible.builtin.uri:
+        url: "https://{{ automation_controller_hostname }}/api/v2/config/"
+        method: POST
+        user: admin
+        password: "{{ ocp4_workload_ansible_automation_platform_admin_password }}"
+        body: '{ "eula_accepted": true, "manifest": "{{ r_aap_manifest_file.content }}" }'
+        body_format: json
+        force_basic_auth: true
 
-    - name: Print Access information
-      agnosticd_user_info:
-        data:
-          ac_web_url: >-
-            https://{{ ocp4_workload_ansible_automation_platform_hostname | default(automation_controller_hostname) }}
-          ac_user: "{{ ocp4_workload_ansible_automation_platform_admin_username | default('admin') }}"
-          ac_password: "{{ ocp4_workload_ansible_automation_platform_admin_password }}"
+    - name: Remove AAP manifest
+      ansible.builtin.file:
+        path: /tmp/aap-manifest.zip
+        state: absent
+
+- name: Display Version and credentials 
+  when: not silent | bool
+  ansible.builtin.debug:
+    msg: 
+      - "{{ r_result.json.version }}"
+      - "Automation Controller URL: https://{{ automation_controller_hostname }}"
+      - "Automation Controller Admin Login: admin"
+      - "Automation Controller Admin Password: {{ ocp4_workload_ansible_automation_platform_admin_password }}"
+
+- name: Print Access information
+  agnosticd_user_info:
+    msg: "{{ item }}"
+  loop:
+      - "Automation Controller URL: https://{{ automation_controller_hostname }}"
+      - "Automation Controller Admin Login: admin"
+      - "Automation Controller Admin Password: {{ ocp4_workload_ansible_automation_platform_admin_password }}"
+
+- name: Print Access information
+  agnosticd_user_info:
+    data:
+      aap_controller_web_url: "https://{{ automation_controller_hostname }}"
+      aap_controller_admin_user: "{{ ocp4_workload_ansible_automation_platform_admin_username | default('admin') }}"
+      aap_controller_admin_password: "{{ ocp4_workload_ansible_automation_platform_admin_password }}"
 
 # Leave this as the last task in the playbook.
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/templates/admin_secret.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/templates/admin_secret.j2
@@ -1,9 +1,10 @@
 ---
-apiVersion: v1
+api_version: v1
 kind: Secret
 metadata:
-  name: {{ ocp4_workload_ansible_automation_platform_admin_secret }}
+  name: "{{ ocp4_workload_ansible_automation_platform_app_name }}-admin-password"
   namespace: {{ ocp4_workload_ansible_automation_platform_project }}
-type: Opaque
+label_selectors:
+  - "app.kubernetes.io/name={{ ocp4_workload_ansible_automation_platform_project }}"
 data:
-    password: {{ ocp4_workload_ansible_automation_platform_admin_password | string | b64encode }}
+    password: {{ ocp4_workload_ansible_automation_platform_admin_password | b64encode }}

--- a/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/templates/automationcontroller.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/templates/automationcontroller.j2
@@ -5,24 +5,4 @@ metadata:
   name: {{ ocp4_workload_ansible_automation_platform_app_name }}
   namespace: {{ ocp4_workload_ansible_automation_platform_project }}
 spec:
-  create_preload_data: true
-  route_tls_termination_mechanism: Edge
-  garbage_collect_secrets: false
-  loadbalancer_port: 80
-  image_pull_policy: IfNotPresent
-  projects_storage_size: 8Gi
-  task_privileged: false
-  projects_storage_access_mode: ReadWriteMany
-  projects_persistence: false
   replicas: 1
-  admin_user: admin
-  loadbalancer_protocol: http
-  nodeport_port: 30080
-  admin_password_secret: {{ ocp4_workload_ansible_automation_platform_admin_secret }}
-  init_container_image: registry.access.redhat.com/ubi8/ubi
-  init_container_image_version: latest
-  init_container_extra_commands: |
-    until getent hosts {{ ocp4_workload_ansible_automation_platform_app_name }}-postgres-13
-    do echo waiting for {{ ocp4_workload_ansible_automation_platform_app_name }}-postgres-13 
-    sleep 2
-    done

--- a/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/templates/namespace.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/templates/namespace.j2
@@ -2,10 +2,9 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  annotations:
-    openshift.io/description: ""
-    openshift.io/display-name: {{ ocp4_workload_ansible_automation_platform_display }}
   name: {{ ocp4_workload_ansible_automation_platform_project }}
-spec:
-  finalizers:
-  - kubernetes
+  annotations:
+    openshift.io/description: "{{ ocp4_workload_ansible_automation_platform_description }}"
+    openshift.io/display-name: {{ ocp4_workload_ansible_automation_platform_display }}
+  labels:
+    openshift.io/cluster-monitoring: "true"

--- a/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/templates/operatorgroup.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/templates/operatorgroup.j2
@@ -2,8 +2,8 @@
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: {{ ocp4_workload_ansible_automation_platform_project }}
+  name: ansible-automation-platform-operator
   namespace: {{ ocp4_workload_ansible_automation_platform_project }}
 spec:
   targetNamespaces:
-  - {{ ocp4_workload_ansible_automation_platform_project }}
+    - {{ ocp4_workload_ansible_automation_platform_project }}

--- a/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/templates/subscription.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/templates/subscription.j2
@@ -5,7 +5,7 @@ metadata:
   name: ansible-automation-platform-operator
   namespace: {{ ocp4_workload_ansible_automation_platform_project }}
 spec:
-  channel: stable-2.2
+  channel: 'stable-2.3'
   installPlanApproval: Automatic
   name: ansible-automation-platform-operator
   source: redhat-operators


### PR DESCRIPTION
##### SUMMARY

- Installs Ansible Automation Platform (Controller and Hub) on OpenShift (currently 2.3 on OCP 4.12)
- Optionally injects manifest
- Does **not**, by design, load any resources into Controller and Hub

##### ISSUE TYPE

- New role Pull Request

##### COMPONENT NAME

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
