### PR TITLE
fixing lint issues

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/tasks/install_devspaces.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/tasks/install_devspaces.yml
@@ -92,3 +92,47 @@
   loop: "{{ users }}"
   loop_control:
     loop_var: user
+
+- name: Get DevWorkspace pods in users' namespaces
+  kubernetes.core.k8s_info:
+    kind: Pod
+    namespace: '{{ user }}-devspaces'
+    label_selectors:
+      - controller.devfile.io/devworkspace_name=workshop-performance-monitoring-apps
+    field_selectors:
+      - status.phase=Running
+  register: running_workspaces
+  loop: "{{ users }}"
+  loop_control:
+    loop_var: user
+  retries: 30
+  delay: 10
+  until: (running_workspaces.resources | list | length) == 1
+
+- name: Number of Running workspaces
+  ansible.builtin.debug:
+    msg: "{{ running_workspaces.results | length }}"
+
+- name: Extract Pod metadata
+  ansible.builtin.set_fact:
+    workspaces: "{{ workspaces | default([]) + [{'podName': item.resources[0].metadata.name, 'namespace': item.resources[0].metadata.namespace}] }}"
+  with_items: "{{ running_workspaces.results }}"
+  no_log: true
+
+- name: Running Workspaces Metadata
+  ansible.builtin.debug:
+    msg: "{{ workspaces }}"
+
+- name: Attempt to warm up users' devspaces by running 'mvn package -DskipTests'
+  kubernetes.core.k8s_exec:
+    namespace: "{{ item.namespace }}"
+    pod: "{{ item.podName }}"
+    container: "tools"
+    command: /bin/bash -c 'mvn package -q -f "$PROJECT_SOURCE" -DskipTests'
+  register: command_status
+  with_items: "{{ workspaces }}"
+  ignore_errors: true
+
+# - name: Check last command status
+#   debug:
+#     msg: "{{ command_status.results }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/tasks/install_tekton.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/tasks/install_tekton.yml
@@ -30,6 +30,16 @@
   delay: 10
   until: r_tekton_pod.resources | list | length == 1
 
+- name: Check if Pipeline CRD exists
+  kubernetes.core.k8s_info:
+    kind: CustomResourceDefinition
+    api_version: apiextensions.k8s.io/v1
+    name: pipelines.tekton.dev
+  register: crd_result
+  retries: 20
+  delay: 10
+  until: crd_result.resources | length > 0
+
 - name: Patch TektonConfig to enable detailed metrics
   kubernetes.core.k8s:
     validate_certs: '{{ verify_tls }}'

--- a/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/templates/devspace_workspace.yml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/templates/devspace_workspace.yml.j2
@@ -154,6 +154,8 @@ spec:
         commandLine: |
           [[ -s "$HOME/.sdkman/bin/sdkman-init.sh" ]] && source "$HOME/.sdkman/bin/sdkman-init.sh"
           sdk default java 17.0.3-tem
+          #copy maven settings pointing to in-cluster nexus mirror
+          [[ -s "$PROJECT_SOURCE/settings.xml" ]] && cp -v $PROJECT_SOURCE/settings.xml $HOME/.m2/
     components:
     - attributes:
         che-code.eclipse.org/contribute-cpuLimit: true
@@ -266,7 +268,7 @@ spec:
       name: ubi-minimal
     - name: m2
       volume:
-        size: 1G
+        size: 3G
     events:
       postStart:
       - switch-to-java-17


### PR DESCRIPTION
##### SUMMARY
This change fixes an issue that was affecting the Tekton Operator install.
It also includes a set of tasks to augment the Openshift DevSpaces installation to warm-up the users' WorkSpaces.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_performance_monitoring

##### ADDITIONAL INFORMATION
N/A

<!-- ansible --version -->
```
ansible [core 2.14.3]
  python version = 3.11.2 (main, Feb 16 2023, 03:15:23) [Clang 14.0.0 (clang-1400.0.29.202)] (/usr/local/Cellar/ansible/7.3.0/libexec/bin/python3.11)
  jinja version = 3.1.2
  libyaml = True
```
<!-- pip freeze -->

The new output for the Devspaces install phase
```
TASK [roles_ocp_workloads/ocp4_workload_performance_monitoring : Get DevWorkspace pods in users' namespaces] **************************************************************************
FAILED - RETRYING: [localhost]: Get DevWorkspace pods in users' namespaces (30 retries left).
FAILED - RETRYING: [localhost]: Get DevWorkspace pods in users' namespaces (29 retries left).
ok: [localhost] => (item=user1)
ok: [localhost] => (item=user2)

TASK [roles_ocp_workloads/ocp4_workload_performance_monitoring : Number of Running workspaces] ****************************************************************************************
ok: [localhost] => {
    "msg": "2"
}

TASK [roles_ocp_workloads/ocp4_workload_performance_monitoring : Extract Pod metadata] ************************************************************************************************
ok: [localhost] => (item=None)
ok: [localhost] => (item=None)
ok: [localhost]

TASK [roles_ocp_workloads/ocp4_workload_performance_monitoring : Running Workspaces Metadata] *****************************************************************************************
ok: [localhost] => {
    "msg": [
        {
            "namespace": "user1-devspaces",
            "podName": "workspace57850d6a8ea04d5e-5799c9b499-c5cvt"
        },
        {
            "namespace": "user2-devspaces",
            "podName": "workspacec753c2d9b6c748af-c94c5fbd-pndsk"
        }
    ]
}

TASK [roles_ocp_workloads/ocp4_workload_performance_monitoring : Attempt to warm up users' devspaces by running 'mvn package -DskipTests'] ********************************************
changed: [localhost] => (item={'podName': 'workspace57850d6a8ea04d5e-5799c9b499-c5cvt', 'namespace': 'user1-devspaces'})
changed: [localhost] => (item={'podName': 'workspacec753c2d9b6c748af-c94c5fbd-pndsk', 'namespace': 'user2-devspaces'})
[DEPRECATION WARNING]: The 'return_code' return key is being renamed to 'rc'. Both keys are being returned for now to allow users to migrate their automation. This feature will be
removed from kubernetes.core in version 4.0.0. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

The new output for the Tekton install phase
```
TASK [roles_ocp_workloads/ocp4_workload_performance_monitoring : Check if Pipeline CRD exists] ****************************************************************************************
ok: [localhost]
```