### PR TITLE
[infra-vmc-resources] Update create_public_ip_and_nat.yaml to add retries

### DIFF
--- a/ansible/roles-infra/infra-vmc-resources/tasks/create_public_ip_and_nat.yaml
+++ b/ansible/roles-infra/infra-vmc-resources/tasks/create_public_ip_and_nat.yaml
@@ -45,6 +45,10 @@
     name: "{{ item.instance.hw_name }}"
     state: present
     attributes: "{{ [{'name':'public_ip', 'value': _vm_public_ip}]  }}"
+  register: r_vmware_guest_custom_attributes
+  until: r_vmware_guest_custom_attributes is success
+  retries: 5
+  delay: 10      
 
 - name: Set a new variable appending the IP to the lab public ips 
   set_fact: 


### PR DESCRIPTION
TASK [infra-vmc-resources : Add public IP to VM guest attributes] **************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: }
fatal: [localhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/var/lib/awx/.ansible/tmp/ansible-tmp-1681871891.8768113-1513-232574941244844/AnsiballZ_vmware_guest_custom_attributes.py\", line 102, in <module>\n    _ansiballz_main()\n  File \"/var/lib/awx/.ansible/tmp/ansible-tmp-1681871891.8768113-1513-232574941244844/AnsiballZ_vmware_guest_custom_attributes.py\", line 94, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/var/lib/awx/.ansible/tmp/ansible-tmp-1681871891.8768113-1513-232574941244844/AnsiballZ_vmware_guest_custom_attributes.py\", line 40, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.community.vmware.plugins.modules.vmware_guest_custom_attributes', init_globals=None, run_name='__main__', alter_sys=True)\n  File \"/usr/lib64/python3.6/runpy.py\", line 205, in run_modu…