### PR TITLE
Add missing become to hcp download

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/tasks/workload.yml
@@ -112,6 +112,7 @@
   when: ocp4_workload_rhacm_hypershift_s3_workaround | bool
   block:
   - name: Download Hypershift CLI
+    become: true
     get_url:
       url: "{{ ocp4_workload_rhacm_hypershift_cli_download_url }}"
       validate_certs: false


### PR DESCRIPTION
##### SUMMARY

Need to be root to install binaries into /bin. Fixing.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_rhacm_hypershift