### PR TITLE
Fix download location for hypershift cli

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/tasks/workload.yml
@@ -115,7 +115,7 @@
     get_url:
       url: "{{ ocp4_workload_rhacm_hypershift_cli_download_url }}"
       validate_certs: false
-      dest: /bin/hypershift
+      dest: /usr/bin/hypershift
       mode: 0775
       owner: root
       group: root


### PR DESCRIPTION
##### SUMMARY

Download Hypershift into /usr/bin/hypershift instead of /bin/hypershift.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_rhacm_hypershift