### PR TITLE
Move manifest injection to module ocp4_workload_ansible...

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/tasks/workload.yml
@@ -127,20 +127,13 @@
         username: "{{ ocp4_workload_ansible_automation_platform_manifest.username | default(omit) }}"
         password: "{{ ocp4_workload_ansible_automation_platform_manifest.password | default(omit) }}"
 
-    - name: Load Automation Controller manifest into variable
-      ansible.builtin.slurp:
-        src: /tmp/aap-manifest.zip
-      register: r_aap_manifest_file
-
-    - name: Post Automation Controller manifest file
-      ansible.builtin.uri:
-        url: "https://{{ automation_controller_hostname }}/api/v2/config/"
-        method: POST
-        user: admin
-        password: "{{ ocp4_workload_ansible_automation_platform_admin_password }}"
-        body: '{ "eula_accepted": true, "manifest": "{{ r_aap_manifest_file.content }}" }'
-        body_format: json
-        force_basic_auth: true
+    - name: Inject AAP2 Controller manifest
+      awx.awx.license:
+        manifest: /tmp/aap-manifest.zip
+        controller_host: "{{ automation_controller_hostname }}"
+        controller_username: admin
+        controller_password: "{{ ocp4_workload_ansible_automation_platform_admin_password }}"
+        validate_certs: true
 
     - name: Remove AAP manifest
       ansible.builtin.file:


### PR DESCRIPTION

##### SUMMARY

- tidy up code by moving `uri` task to `awx.awx.license`

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

roles_ocp_workloads/ocp4_workload_ansible_automation_platform

##### ADDITIONAL INFORMATION

requires collection awx.awx
