### PR TITLE
Disable retries on bookbag get project

### DIFF
--- a/ansible/roles/bookbag/tasks/workload.yaml
+++ b/ansible/roles/bookbag/tasks/workload.yaml
@@ -6,9 +6,7 @@
     kind: Project
     name: "{{ bookbag_namespace }}"
   register: r_get_bookbag_namespace
-  until: r_get_bookbag_namespace is successful
-  retries: 10
-  delay: 5
+  failed_when: false
 
 - name: Create bookbag namespace
   when: r_get_bookbag_namespace.resources | default([]) | length == 0


### PR DESCRIPTION
##### SUMMARY

When not running as cluster admin the check if a project exists will fail with a 403 error and the design of the `k8s_info` module does not allow differentiation based on the error code.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

bookbag role