### PR TITLE
Update AWS CLI to v2 in ROSA Manual

### DIFF
--- a/ansible/configs/rosa-manual/software.yml
+++ b/ansible/configs/rosa-manual/software.yml
@@ -44,17 +44,17 @@
     - tags:
         - install_awscli
       block:
-        - name: Get awscli bundle
+        - name: Get awscli
           get_url:
-            url: https://s3.amazonaws.com/aws-cli/awscli-bundle-1.18.200.zip
-            dest: /tmp/awscli-bundle.zip
-        - name: Unzip awscli-bundle.zip
+            url: https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip
+            dest: /tmp/awscliv2.zip
+        - name: Unzip awscliv2.zip
           unarchive:
-            src: /tmp/awscli-bundle.zip
+            src: /tmp/awscliv2.zip
             dest: /tmp/
             remote_src: true
         - name: Install awscli
-          command: /tmp/awscli-bundle/install -i /usr/local/aws -b /bin/aws
+          command: /tmp/aws/install -i /usr/local/aws -b /bin/aws
           args:
             creates: /usr/local/aws
           become: true
@@ -63,8 +63,8 @@
             path: "{{ item }}"
             state: absent
           loop:
-            - /tmp/awscli-bundle
-            - /tmp/awscli-bundle.zip
+            - /tmp/aws
+            - /tmp/awscliv2.zip
 
     - tags:
         - create_aws_dir


### PR DESCRIPTION
##### SUMMARY

Update AWS CLI to v2 for ROSA Manual config.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
rosa_manual
