### PR TITLE
Fix bookbag build retry

### DIFF
--- a/ansible/roles/bookbag/tasks/workload.yaml
+++ b/ansible/roles/bookbag/tasks/workload.yaml
@@ -37,6 +37,7 @@
 - name: Process bookbag build template
   command: >-
     oc process --local -f {{ (r_bookbag_tmp.path ~ '/build-template.yaml') | quote }} -o json
+    --param GIT_REPO={{ bookbag_git_repo | quote }}
   register: r_process_build_template
 
 - name: Apply resources from build template
@@ -59,6 +60,8 @@
     --namespace={{ bookbag_namespace | quote }}
     --from-dir={{ r_bookbag_tmp.path | quote }}
   register: r_build_bookbag_image
+  failed_when: >-
+    r_build_bookbag_image is failed or "Error: " in r_build_bookbag_image.stderr
   until: r_build_bookbag_image is successful
   retries: 10
   delay: 5


### PR DESCRIPTION
##### SUMMARY

Fix bookbag build retries:

- Watch for errors in stderr of `oc start-build`
- Set GIT_REPO in BuildConfig

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

bookbag role