### PR TITLE
Retry bookbag build on build error

### DIFF
--- a/ansible/roles/bookbag/tasks/workload.yaml
+++ b/ansible/roles/bookbag/tasks/workload.yaml
@@ -61,7 +61,9 @@
     --from-dir={{ r_bookbag_tmp.path | quote }}
   register: r_build_bookbag_image
   failed_when: >-
-    r_build_bookbag_image is failed or "Error: " in r_build_bookbag_image.stderr
+    r_build_bookbag_image is failed or
+    "Error: " in r_build_bookbag_image.stderr or
+    "build error: " in r_build_bookbag_image.stdout
   until: r_build_bookbag_image is successful
   retries: 10
   delay: 5


### PR DESCRIPTION
##### SUMMARY

Retry build if `build error:` is in build stdout.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

bookbag role