### PR TITLE
Bump up bookbag image rebuild tries - source of failure

### DIFF
--- a/ansible/roles/bookbag/tasks/workload.yaml
+++ b/ansible/roles/bookbag/tasks/workload.yaml
@@ -65,7 +65,7 @@
     "Error: " in r_build_bookbag_image.stderr or
     "build error: " in r_build_bookbag_image.stdout
   until: r_build_bookbag_image is successful
-  retries: 10
+  retries: 30
   delay: 5
 
 - name: Read user-data.yaml


### PR DESCRIPTION

##### SUMMARY

bookbag can still fail on `Task Build bookbag image`

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
role bookbag

##### ADDITIONAL INFORMATION
