### PR TITLE
Fixes centos8 streams url

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/defaults/main.yml
@@ -3,7 +3,7 @@ become_override: true
 ocp_username: opentlc-mgr
 silent: false
 
-kcli_baremetal_plan_revision: 18bb25c9315c48fcafe37fda096ef9052472e863
+kcli_baremetal_plan_revision: dd31614599222deb5682437bb5ea04594bbb06ee
 ocp4_major_release: "4.12"
 lab_version: "lab-4.12"
 lab_network_cidr: "192.168.125.0/24"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

The role ocp4_workload_5gran_deployments_lab is failing cause centos stream images being used by our automation have been removed from the centos mirror. 

This PR points to a new commit for our automation plan that has these links fixed.
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4_workload_5gran_deployments_lab

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
