### PR TITLE
Role generate_ssh_keypair to generate an ssh keypair

### DIFF
--- a/ansible/roles/generate_ssh_keypair/README.adoc
+++ b/ansible/roles/generate_ssh_keypair/README.adoc
@@ -1,0 +1,55 @@
+## generate_ssh_keypair
+
+A simple role to generate an ssh keypair for use outside the actual AgnosticD deployment process. IE is to be consumed post-install by platforms like Ansible Automation Controller that may need ssh keys for its own use as credentials. For example, to inject whilst deploying VMs to a cloud.
+
+### Returns via `agnosticd_user_info` data
+
+[source,sh]
+----
+generated_ssh_public_key
+generated_ssh_private_key
+----
+
+NOTE: This role does not output `agnosticd_user_info` to stdout, only via `data` and would not typically be expected to be consumed by the end user. It is intended to be consumed by other roles or configs/chained-configs, such as the config `binder-aap2-default` for injection into Automation Controllers, but of course, can be used anywhere an ssh keypair is required.
+
+### Requirements
+
+collection community.crypto
+
+[source,sh]
+----
+ansible-galaxy collection install community.crypto
+----
+
+### Role Variables
+
+The role is inherently simple, creating temporary `id_rsa` and `id_rsa.pub` files in `generate_ssh_keypair_tmp_dir`. These are deleted after being stored as AgnosticD variables.
+
+[source,sh]
+----
+generate_ssh_keypair_tmp_dir # defaulted to /tmp, but can be overridden
+----
+
+In normal usage, you would not need to override this variable
+
+### Dependencies
+
+N/A
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
++
+[source,sh]
+----
+    - hosts: servers
+      roles:
+         - generate_ssh_keypair
+----
+
+Author Information
+------------------
+
+Tony Kay 2023-04-25

--- a/ansible/roles/generate_ssh_keypair/defaults/main.yml
+++ b/ansible/roles/generate_ssh_keypair/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+generate_ssh_keypair_tmp_dir: /tmp

--- a/ansible/roles/generate_ssh_keypair/tasks/main.yml
+++ b/ansible/roles/generate_ssh_keypair/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+
+- name: Generate SSH keypair for use outside deployment
+  community.crypto.openssh_keypair:
+    path: "{{ generate_ssh_keypair_tmp_dir }}/id_rsa"
+    force: true
+  register: r_openssh_keypair
+
+- name: Set facts for both public and private key
+  ansible.builtin.set_fact:
+    generate_ssh_keypair_public_key: "{{ r_openssh_keypair.public_key }}"
+    generate_ssh_keypair_private_key: "{{ lookup('file', generate_ssh_keypair_tmp_dir + '/id_rsa') }}"
+
+- name: Cleanup and delete ssh key file artifacts
+  ansible.builtin.file:
+    path: "{{ __key_file }}"
+    state: absent
+  loop:
+    - "{{ generate_ssh_keypair_tmp_dir }}/id_rsa"
+    - "{{ generate_ssh_keypair_tmp_dir }}/id_rsa.pub"
+  loop_control:
+    loop_var: __key_file
+
+- name: Output ssh keypair as user data
+  agnosticd_user_info:
+    data:
+      generated_ssh_public_key: "{{ generate_ssh_keypair_public_key }}"
+      generated_ssh_private_key: "{{ generate_ssh_keypair_private_key }}"


### PR DESCRIPTION
For configs etc that need their own ssh keys for demos etc like AAP2 controllers making VMs