### PR TITLE
Add loginctl command to vscode-server role to avoid podman moaning

### DIFF
--- a/ansible/roles/vscode-server/tasks/vscode-server.yml
+++ b/ansible/roles/vscode-server/tasks/vscode-server.yml
@@ -73,4 +73,10 @@
     state: started
     daemon_reload: true
     name: "code-server@{{ vscode_user_name }}"
+
+# because the vscode terminal isn't a login shell, it can be that podman
+# moans about no systemd user session being available
+- name: vscode | make sure user lingers to avoid issues with podman
+  command:
+    cmd: "loginctl enable-linger {{ vscode_user_name }}"
 ...


### PR DESCRIPTION


<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

Because the VScode terminal isn't a login session, it can be that podman complains about no systemd user session being available. loginctl enable-linger solves the issue

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
vscode_server

##### ADDITIONAL INFORMATION
tested with advanced automation controller