### PR TITLE
Set openshift_console_url in ocp4_workload_authentication

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_authentication/tasks/setup_htpasswd.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_authentication/tasks/setup_htpasswd.yml
@@ -184,6 +184,7 @@
         user: "{{ ocp4_workload_authentication_htpasswd_user_base }}{{ n +1 }}"
         password: "{{ _ocp4_workload_authentication_htpasswd_user_passwords[ n ] }}"
         console_url: "{{ _ocp4_workload_authentication_console_route }}"
+        openshift_console_url: "{{ _ocp4_workload_authentication_console_route }}"
         openshift_cluster_ingress_domain: "{{ _ocp4_workload_authentication_cluster_ingress_domain }}"
         login_command: >-
           oc login --insecure-skip-tls-verify=false


### PR DESCRIPTION
##### SUMMARY

- The name "console_url" conflicts with a builtin variable for bookbag/openshift-homeroom.
- The name "openshift_console_url" is more descriptive.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Role ocp4_workload_authentication