### PR TITLE
New automation_platform_loader role to populate AAP resources

### DIFF
--- a/ansible/roles/automation_platform_loader/README.adoc
+++ b/ansible/roles/automation_platform_loader/README.adoc
@@ -1,0 +1,70 @@
+## automation_platform_loader
+
+
+This role is intended to be used to load resources onto an Ansible Automation Controller
+
+* Optionally generate an ssh keypair for use by the Automation Controller
+* Iterates through a list of resources to be loaded onto the Automation Controller
+
+NOTE: The role wraps the link:https://github.com/redhat-cop/controller_configuration/[infra.controller_configuration] collection, which is well documented
+
+
+### Variables
+
+The role is inherently simple, creating temporary `id_ed25519` and `id_ed25519.pub` files in `/tmp`. These are deleted after being captured into a fact `generated_ssh_keypair` which is then used by the `infra.controller_configuration` collection.
+[source,sh]
+----
+automation_platform_loader_generate_ssh_keypair: true
+
+automation_platform_loader_ssh_key_type: ed25519
+automation_platform_loader_ssh_key_path: "/tmp/id_{{ automation_platform_loader_ssh_key_type }}" 
+----
+
+In normal usage, you would not need to override these variable
+
+### Dependencies
+
+N/A
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
++
+[source,sh]
+----
+    - hosts: controller
+      vars:
+        controller_configuration_dispatcher_roles:
+          - role: organizations
+            var: controller_organizations
+            tags: organizations
+          - role: projects
+            var: controller_projects
+            tags: projects
+
+        controller_organizations:
+          - name: engineering
+            description: "Engineering Organization"
+          - name: sales
+            description: "Sales Organization"
+          
+         controller_projects:
+
+          - name: "GitLab playbook-rhaap"
+            scm_url: "https://gitlab.com/ansible-ssa/playbook-rhaap.git"
+            organization: Default
+            scm_type: git
+            scm_branch: "{{ project_version | default('main') }}"
+            scm_update_on_launch: true
+            scm_delete_on_update: true
+            state: "{{ controller_state | default('present') }}"
+
+      roles:
+         -  /automation_platform_loader
+----
+
+Author Information
+------------------
+
+Tony Kay 2023-04-26

--- a/ansible/roles/automation_platform_loader/README.adoc
+++ b/ansible/roles/automation_platform_loader/README.adoc
@@ -34,6 +34,11 @@ Including an example of how to use your role (for instance, with variables passe
 [source,sh]
 ----
     - hosts: controller
+      environment:
+        CONTROLLER_HOST: "{{ controller_host }}"
+        CONTROLLER_USERNAME: "{{ controller_username | default('admin') }}"
+        CONTROLLER_PASSWORD: "{{ controller_password }}"
+        CONTROLLER_VERIFY_SSL: "{{ controller_verify_ssl | default('true') }}"
       vars:
         controller_configuration_dispatcher_roles:
           - role: organizations

--- a/ansible/roles/automation_platform_loader/defaults/main.yml
+++ b/ansible/roles/automation_platform_loader/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+automation_platform_loader_generate_ssh_keypair: true
+
+automation_platform_loader_ssh_key_type: ed25519
+automation_platform_loader_ssh_key_path: "/tmp/id_{{ automation_platform_loader_ssh_key_type }}"

--- a/ansible/roles/automation_platform_loader/tasks/main.yml
+++ b/ansible/roles/automation_platform_loader/tasks/main.yml
@@ -1,0 +1,43 @@
+---
+- name: Configure AAP2 Controller and Hub with resources
+  ansible.builtin.debug:
+    msg: Configure AAP2 Controller and Hub with resources
+
+- name: Generate SSH keypair for use in AAP as machine credential
+  when: automation_platform_loader_generate_ssh_keypair | default(true) | bool
+  block:
+
+    - name: Generate SSH keypair (files)
+      ansible.builtin.command: >-
+        ssh-keygen
+        -t {{ automation_platform_loader_ssh_key_type }}
+        -f {{ automation_platform_loader_ssh_key_path }}
+        -q -N ""
+      args:
+        creates: "{{ automation_platform_loader_ssh_key_path }}"
+
+    - name: Set generated_ssh_keypair fact dictionary with both public and private key
+      ansible.builtin.set_fact:
+        generated_ssh_keypair:
+          private_key: "{{ lookup('file', automation_platform_loader_ssh_key_path) }}"
+          public_key: "{{ lookup('file', automation_platform_loader_ssh_key_path+'.pub') }}"
+
+    - name: Delete ssh key file artifacts
+      ansible.builtin.file:
+        path: "{{ __key_file }}"
+        state: absent
+      loop:
+        - "{{ automation_platform_loader_ssh_key_path }}"
+        - "{{ automation_platform_loader_ssh_key_path + '.pub' }}"
+      loop_control:
+        loop_var: __key_file
+
+- name: Create a new AAP2 Auth token using controller username/password
+  awx.awx.token:
+    description: Creating token to configure AAP2 resources
+    scope: write
+    state: present
+
+- name: Configure AAP2 Controller and Hub
+  ansible.builtin.import_role:
+    name: infra.controller_configuration.dispatch

--- a/ansible/roles/automation_platform_loader/tasks/main.yml
+++ b/ansible/roles/automation_platform_loader/tasks/main.yml
@@ -20,7 +20,7 @@
       ansible.builtin.set_fact:
         generated_ssh_keypair:
           private_key: "{{ lookup('file', automation_platform_loader_ssh_key_path) }}"
-          public_key: "{{ lookup('file', automation_platform_loader_ssh_key_path+'.pub') }}"
+          public_key: "{{ lookup('file', automation_platform_loader_ssh_key_path + '.pub') }}"
 
     - name: Delete ssh key file artifacts
       ansible.builtin.file:


### PR DESCRIPTION
##### SUMMARY

role to populate Ansible Automation Controllers and Hub with resources (projects, creds, job_templates etc)

- generates, optionally, an ssh key for a default machine credential (useful in infra/cloud deploys
- wraps `infra.controller_configuration.dispatch` to populate AAP2
-
##### ISSUE TYPE

- New role Pull Request

##### COMPONENT NAME
roles/automation_platform_loader
