### PR TITLE
Add retries to oc rollout in bookbag role

### DIFF
--- a/ansible/roles/bookbag/tasks/wait-for-bookbag-deployment.yml
+++ b/ansible/roles/bookbag/tasks/wait-for-bookbag-deployment.yml
@@ -34,6 +34,8 @@
     command: >-
       oc {% if _bookbag_kubeconfig is defined %}--kubeconfig={{ _bookbag_kubeconfig }}{% endif %}
       -n {{ bookbag_namespace }} rollout latest dc/{{ _bookbag_instance_name }}
+    retries: 5
+    delay: 15
 
   - name: Set bookbag deploy retry count
     set_fact:


### PR DESCRIPTION
##### SUMMARY

Need retries on `oc rollout` in bookbag deployment retry because the previous deployment attempt may not be marked as complete after it has failed.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

bookbag role