### PR TITLE
Fix agnosticd_restore_output_dir to not consider 403 an error

### DIFF
--- a/ansible/roles/agnosticd_restore_output_dir/tasks/fetch-from-s3-s3_object.yml
+++ b/ansible/roles/agnosticd_restore_output_dir/tasks/fetch-from-s3-s3_object.yml
@@ -16,6 +16,7 @@
   register: r_get_output_dir_archive
   failed_when: >-
     r_get_output_dir_archive is failed
+    and r_get_output_dir_archive.error.code | default(0) | int != 403
     and 'does not exist' not in r_get_output_dir_archive.msg
     and 'Could not find the key' not in r_get_output_dir_archive.msg
 ...


### PR DESCRIPTION
##### SUMMARY

Newer versions of amazon.aws.s3_object module do not return a message indicating why the response code was forbidden. Need to handle 403 as a non-error.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role agnosticd_restore_output_dir