### PR TITLE
Fix retries on oc rollout in bookbag role

### DIFF
--- a/ansible/roles/bookbag/tasks/wait-for-bookbag-deployment.yml
+++ b/ansible/roles/bookbag/tasks/wait-for-bookbag-deployment.yml
@@ -34,6 +34,8 @@
     command: >-
       oc {% if _bookbag_kubeconfig is defined %}--kubeconfig={{ _bookbag_kubeconfig }}{% endif %}
       -n {{ bookbag_namespace }} rollout latest dc/{{ _bookbag_instance_name }}
+    register: r_oc_rollout
+    until: r_oc_rollout is successful
     retries: 5
     delay: 15
 


### PR DESCRIPTION
##### SUMMARY

Fix retries in bookbag deployment retries. Was missing `register` and `until`

##### ISSUE TYPE

- Bugfix Pull Request