### PR TITLE
Add facts to AAP2 OCP installer workload

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/tasks/workload.yml
@@ -164,6 +164,12 @@
       aap_controller_admin_user: "{{ ocp4_workload_ansible_automation_platform_admin_username | default('admin') }}"
       aap_controller_admin_password: "{{ ocp4_workload_ansible_automation_platform_admin_password }}"
 
+- name: Set facts for Access information
+  ansible.builtin.set_fact:
+    aap_controller_web_url: "https://{{ automation_controller_hostname }}"
+    aap_controller_admin_user: "{{ ocp4_workload_ansible_automation_platform_admin_username | default('admin') }}"
+    aap_controller_admin_password: "{{ ocp4_workload_ansible_automation_platform_admin_password }}"
+
 # Leave this as the last task in the playbook.
 
 - name: workload tasks complete


### PR DESCRIPTION

##### SUMMARY

Add facts to the ocp aap2 installer role for availability elsewhere eg the loader role

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME

roles_ocp_workloads/ocp4_workload_ansible_automation_platform

##### ADDITIONAL INFORMATION
