### PR TITLE
Add localhost support for ocp-workloads

### DIFF
--- a/ansible/configs/ocp-workloads/default_vars.yml
+++ b/ansible/configs/ocp-workloads/default_vars.yml
@@ -27,5 +27,8 @@ infra_workloads: []
 
 # List of student workload roles to apply for each user
 student_workloads: []
+
+target_host: localhost
+
 user_count: 0
 user_count_start: 1

--- a/ansible/configs/ocp-workloads/post_infra.yml
+++ b/ansible/configs/ocp-workloads/post_infra.yml
@@ -52,5 +52,8 @@
           add_host:
             name: "{{ target_host }}"
             group: ocp_bastions
+            ansible_connection: "{{ 'local' if target_host == 'localhost' else omit }}"
+            ansible_python_interpreter: "{{ ansible_playbook_python if target_host == 'localhost' else omit }}"
+
 
 - import_playbook: ../../include_vars.yml

--- a/ansible/configs/ocp-workloads/readme.adoc
+++ b/ansible/configs/ocp-workloads/readme.adoc
@@ -62,6 +62,16 @@ This variable correspond to the bastion host used to run `oc` commands or `k8s` 
 
 You can specify the target host in 2 different ways.
 
+=== As localhost
+
+[source,yaml]
+----
+target_host: localhost
+----
+
+This will execute the workload from localhost.
+It requires that whatever host the playbook is run from is authenticated to the OpenShift cluster.
+
 === As an hostname
 
 If you want to just specify:

--- a/ansible/configs/ocp-workloads/sample_vars/authentication-and-bookbag.yaml
+++ b/ansible/configs/ocp-workloads/sample_vars/authentication-and-bookbag.yaml
@@ -1,0 +1,13 @@
+---
+cloud_provider: none
+env_type: ocp-workloads
+guid: test
+
+infra_workloads:
+- ocp4_workload_authentication
+- bookbag
+
+user_count: 3
+
+bookbag_git_repo: https://github.com/redhat-gpte-labs/bookbag-template
+bookbag_namespace: bookbag


### PR DESCRIPTION
##### SUMMARY

Add ability to use `target_host: localhost` with ocp-workloads config.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Config ocp-workloads