### PR TITLE
Add ocp bearer token and refactor aap2 loader role

### DIFF
--- a/ansible/roles/automation_platform_loader/tasks/main.yml
+++ b/ansible/roles/automation_platform_loader/tasks/main.yml
@@ -3,47 +3,21 @@
   ansible.builtin.debug:
     msg: Configure AAP2 Controller and Hub with resources
 
-- name: Generate SSH keypair for use in AAP as machine credential
+- name: Generate OCP bearer token for use in AAP as OCP credential
+  when: automation_platform_loader_generate_ocp_token | default(false) | bool
+  ansible.builtin.include_tasks: ./ocp_bearer_token.yml
+
+- name: Generate SSH keypair for use in AAP as ssh machine credential
   when: automation_platform_loader_generate_ssh_keypair | default(true) | bool
-  block:
-
-    - name: Generate SSH keypair (files)
-      ansible.builtin.command: >-
-        ssh-keygen
-        -t {{ automation_platform_loader_ssh_key_type }}
-        -f {{ automation_platform_loader_ssh_key_path }}
-        -q -N ""
-      args:
-        creates: "{{ automation_platform_loader_ssh_key_path }}"
-
-    - name: Retrieve private ssh key
-      ansible.builtin.slurp:
-        src: "{{ automation_platform_loader_ssh_key_path }}"
-      register: __r_private_key
-
-    - name: Retrieve public ssh key
-      ansible.builtin.slurp:
-        src: "{{ automation_platform_loader_ssh_key_path + '.pub' }}"
-      register: __r_public_key
-
-    - name: Set generated_ssh_keypair fact dictionary with both public and private key
-      ansible.builtin.set_fact:
-        generated_ssh_keypair:
-          private_key: "{{ __r_private_key['content'] | b64decode }}"
-          public_key: "{{ __r_public_key['content'] | b64decode }}"
-
-    - name: Delete ssh key file artifacts
-      ansible.builtin.file:
-        path: "{{ __key_file }}"
-        state: absent
-      loop:
-        - "{{ automation_platform_loader_ssh_key_path }}"
-        - "{{ automation_platform_loader_ssh_key_path + '.pub' }}"
-      loop_control:
-        loop_var: __key_file
+  ansible.builtin.include_tasks: ./machine_credential.yml
 
 - name: Create AAP2 resources
   when: automation_platform_loader_run | default(true) | bool
+  environment:
+    CONTROLLER_HOST: "{{ aap_auth.controller_host | default(aap_controller_web_url) }}"
+    CONTROLLER_USERNAME: "{{ aap_auth.controller_username | default(aap_controller_admin_user) | default('admin') }}"
+    CONTROLLER_PASSWORD: "{{ aap_auth.controller_password | default(aap_controller_admin_password) }}"
+    CONTROLLER_VERIFY_SSL: "{{ aap_auth.controller_verify_ssl | default('true') }}"
   block:
 
     - name: Create a new AAP2 Auth token using controller username/password
@@ -55,9 +29,3 @@
     - name: Configure AAP2 Controller and Hub
       ansible.builtin.import_role:
         name: infra.controller_configuration.dispatch
-
-  environment:
-    CONTROLLER_HOST: "{{ aap_auth.controller_host | default(aap_controller_web_url) }}"
-    CONTROLLER_USERNAME: "{{ aap_auth.controller_username | default(aap_controller_admin_user) | default('admin') }}"
-    CONTROLLER_PASSWORD: "{{ aap_auth.controller_password | default(aap_controller_admin_password)}}"
-    CONTROLLER_VERIFY_SSL: "{{ aap_auth.controller_verify_ssl | default('true') }}"


### PR DESCRIPTION
##### SUMMARY

- Added, off by default (in case not running on OCP, OCP bearer token generation for OCP AAP2 creds
- Refactored main.yml as it was getting long

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### COMPONENT NAME

roles/automation_platform_loader