### PR TITLE
Enhance ocp_bearer_token logic for aap loader role

### DIFF
--- a/ansible/roles/automation_platform_loader/tasks/ocp_bearer_token.yml
+++ b/ansible/roles/automation_platform_loader/tasks/ocp_bearer_token.yml
@@ -1,9 +1,16 @@
 ---
 
+- name: Get kubeadmin password
+  ansible.builtin.slurp:
+    path: /home/{{ ansible_user }}/{{ cluster_name }}/auth/kubeadmin-password
+  vars:
+    cluster_name: "{{ cluster_name | default('cluster-' + guid) }}"
+  register: r_kubeadmin_password
+
 - name: Login to OpenShift
   ansible.builtin.command: >
     oc login --username {{ openshift_admin_user }}
-    --password {{ openshift_kubeadmin_password }}
+    --password {{ r_kubeadmin_password }}
     {{ openshift_api_url }}
 
 - name: Get OCP bearer token


### PR DESCRIPTION

##### SUMMARY

- Bug fix, kubeadmin password was not available to role, user_data and not a fact)
- This retrieves it to allow token generation via oc login

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME

roles/automation_platform_loader 

##### ADDITIONAL INFORMATION

