### PR TITLE
Adding linux-based instructions for deploying with Ansible Execution

### DIFF
--- a/docs/Deploying_Using_Execution_Environments.adoc
+++ b/docs/Deploying_Using_Execution_Environments.adoc
@@ -1,6 +1,9 @@
 = AgnosticD Development Setup using Ansible Execution Environments
+:toc:
 
-== Prerequisties
+== Mac
+
+=== Prerequisties
 
 [NOTE]
 ====
@@ -88,13 +91,13 @@ cd ~/Development/agnosticd
 git clone git@github.com:redhat-cop/agnosticd.git
 ----
 
-== Create an Empty AWS Account
+=== Create an Empty AWS Account
 
 . Navigate to https://demo.rhpds.com
 . Select *Open Environments*
 . Provision the *AWS Blank Open Environment*
 
-== Creating Input for AgnosticD
+=== Creating Input for AgnosticD
 
 . Set up a file that holds your generic secrets (e.g. the OCP Pull Secret). Make sure the filename contains the word `secret` as to not accidentally commit it to the repo.
 +
@@ -136,7 +139,7 @@ email: << redacted >>@redhat.com
 agnosticd_aws_capacity_reservation_enable: false
 ----
 
-== Deploy a minimal OpenShift cluster
+=== Deploy a minimal OpenShift cluster
 
 . Set up the input variables file for your OpenShift Cluster
 +
@@ -223,7 +226,7 @@ ansible-navigator run ansible/main.yml -e @~/Development/ansible-workdir/ocp-clu
 ----
 
 
-== Deploy Workload on an existing Cluster
+=== Deploy Workload on an existing Cluster
 
 TBD
 
@@ -236,3 +239,268 @@ cd ~/Development/agnosticd
 
 ansible-navigator run ansible/main.yml -e @ansible/workdir/ocp-workload.yaml -e guid=jm46
 ----
+
+== Linux
+
+[NOTE]
+====
+All commands should be run as your own user account - do not take the name of root in vain!
+====
+
+=== Prerequisites
+
+- Install Podman (we need rootless podman)
+- Python 3.9+ installed with ansible-navigator prerequisites
+
+==== Configure rootless Podman
+
+https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md[Primary docs are here]
+
+If you haven't configured your subuids and subgids before, this will setup the basics for your user.  Follow the rest of the documents in the tutorial for configuring podman:
+
+
+. Configure subuids and subgids for podman
+[source,bash]
++
+----
+sudo bash -c "echo $(whoami):100000:65536 > /etc/subuid"
+sudo bash -c "echo $(whoami):100000:65536 > /etc/subgid"
+----
+
+. Once complete, pull the multicloud-ee execution environment
++
+[source,bash]
+----
+podman pull quay.io/agnosticd/ee-multicloud:latest
+----
+
+[NOTE]
+====
+This may take some time as the image is currently 3.02GB in size, but it has all of our cloud depenencies and libraries installed and will make your first steps much easier.
+====
+
+==== Create your virtual environment
+
+Create a python 3.9+ virtualenv somewhere standard - `~/venvs/` or `~/virtualenvs/`
+
+[source,bash]
+----
+mkdir ~/venvs/
+cd ~/venvs/
+python3 -mvenv ansible-navigator
+. ~/venvs/ansible-navigator/bin/activate
+(ansible-navigator) [user@localhost venvs]$ _
+----
+
+https://github.com/redhat-cop/agnosticd/blob/development/tools/execution_environments/requirements-ee.txt[See here for the Ansible Navigator prerequisites for agnosticd]
+
+[source,bash]
+----
+(ansible-navigator) [user@localhost venvs]$ pip3 install ansible-builder ansible-runner ansible-navigator
+...
+Requirement already satisfied: lockfile>=0.10 in ./venvs/ansible-navigator/lib64/python3.11/site-packages (from python-daemon->ansible-runner) (0.12.2)
+Requirement already satisfied: types-setuptools>=57.0.0 in ./venvs/ansible-navigator/lib64/python3.11/site-packages (from requirements-parser->ansible-builder) (67.7.0.1)
+Requirement already satisfied: pycparser in ./venvs/ansible-navigator/lib64/python3.11/site-packages (from cffi>=1->onigurumacffi<2,>=1.1.0->ansible-navigator) (2.21)  
+
+(ansible-navigator) [user@localhost venvs]$ _
+----
+
+=== Configure the Ansible Execution Environment
+
+We'll create the execution environments volume-folders next:
+
+[NOTE]
+====
+<username> should be substituted with your own username
+====
+
+. Create the Ansible Navigator configuration file `~/.ansible-navigator.yaml`:
++
+[source,yaml]
+----
+ansible-navigator:
+  execution-environment:
+    container-engine: podman 
+    image: quay.io/agnosticd/ee-multicloud:latest
+    volume-mounts:
+    - src: /home/<username>/development/tmp/
+      dest: /tmp
+    - src: /home/<username>/development/secrets/
+      dest: /secrets
+    - src: /home/<username>/development/vars/
+      dest: /vars
+  mode: stdout
+----
+
+. Set up the volume mounts and your agnosticd Directory
++
+[source,bash]
+----
+# Set up AgnosticD
+mkdir -p ~/development/{tmp,secrets,vars}
+
+cd ~/development/
+git clone git@github.com:redhat-cop/agnosticd.git
+cd agnosticd
+----
+
+
+=== Create an Empty AWS Account
+
+. Navigate to https://demo.rhpds.com
+. Select *Open Environments*
+. Provision the *AWS Blank Open Environment*
+
+=== Creating Input for AgnosticD
+
+. Set up a file that holds your generic secrets (e.g. the OCP Pull Secret). Make sure the filename contains the word `secret` so as to remind you *not under any circumstances* to accidentally commit it to the repo.
++
+.~/development/secrets/secrets.yaml
+[source,yaml]
+----
+# Either use satellite
+set_repositories_satellite_url: labsat-ha.opentlc.com
+set_repositories_satellite_ha: true
+set_repositories_satellite_org: Red_Hat_GPTE_Labs
+set_repositories_satellite_activationkey: << redacted >>
+
+# Or use your Employee subscription:
+rhel_subscription_user: user@example.com
+rhel_subscription_pass: << redacted >>
+
+# OpenShift Pull Secret (get from https://console.redhat.com using your employee login)
+ocp4_token: '{"auths":{"cloud.openshift.com":{"auth":"username","email":"user@example.com"},"quay.io":{"auth":"username","email":"user@example.com"},"registry.connect.redhat.com":{"auth":"username","email":"user@example.com"},"registry.redhat.io":{"auth":"username","email":"user@example.com"}}}'
+
+ocp4_pull_secret: "{{ ocp4_token }}"
+
+# Make sure your SSH public key is available on Github
+ssh_authorized_keys:
+- key: https://github.com/username/repository/usernames_cryptographicallysecure_ed25519.pub
+----
+
+. Set up a second file that contains your AWS Open Environment Credentials (from the e-mail you received when you created the open environment):
++
+.~/development/secrets/sandbox-secrets.yaml
+[source,yaml]
+----
+aws_access_key_id: << redacted >>
+aws_secret_access_key: << redacted >>
+
+subdomain_base_suffix: .sandboxXXXX.opentlc.com
+
+email: user@example.com
+
+agnosticd_aws_capacity_reservation_enable: false
+----
+
+=== Deploy a minimal OpenShift cluster
+
+. Set up the input variables file for your OpenShift Cluster
++
+.~/development/vars/ocp-cluster.yaml
+[source,yaml]
+----
+---
+# -------------------------------------------------------------------
+# User specific
+# -------------------------------------------------------------------
+subdomain_base_suffix: .{{ sandbox }}.opentlc.com
+output_dir: /ansible-output/{{ guid }}
+cloud_tags:
+  - owner: user@example.com
+  - Purpose: development
+  - env_type: "{{ env_type }}"
+  - guid: "{{ guid }}"
+  - platform: labs
+
+# -------------------------------------------------------------------
+# Top level vars
+# -------------------------------------------------------------------
+cloud_provider: ec2
+env_type: ocp4-cluster
+software_to_deploy: openshift4
+
+# -------------------------------------------------------------------
+# Repos to use for the bastion
+# -------------------------------------------------------------------
+repo_method: satellite
+# repo_method: rhn # for employee subscription
+
+# -------------------------------------------------------------------
+# VM configuration
+# -------------------------------------------------------------------
+master_instance_type: m5a.2xlarge
+master_instance_count: 1
+worker_instance_type: m5a.2xlarge
+worker_instance_count: 2
+bastion_instance_type: t3a.medium
+bastion_instance_image: RHEL84GOLD-latest
+
+# -------------------------------------------------------------------
+# OpenShift installer
+# -------------------------------------------------------------------
+ocp4_installer_version: "4.12"
+
+# -------------------------------------------------------------------
+# Student user on bastion
+# -------------------------------------------------------------------
+install_student_user: false
+# student_name: lab-user
+# student_sudo: true
+# if not set generate random password
+# student_password: 1_r3411Y-H4t3_h4Rdc0D3d-p4$$w0rDs_0
+
+# -------------------------------------------------------------------
+# Workloads
+# -------------------------------------------------------------------
+# --- Infra Workloads (YAML List)
+infra_workloads:
+- ocp4_workload_authentication
+- ocp4_workload_le_certificates
+
+# -------------------------------------------------------------------
+# Workload: ocp4_workload_authentication
+# -------------------------------------------------------------------
+ocp4_workload_authentication_idm_type: htpasswd
+ocp4_workload_authentication_admin_user: admin
+ocp4_workload_authentication_htpasswd_admin_password: 1_r3511Y-H4t3_hArdc0d3_-p4$$w0rDs_1
+ocp4_workload_authentication_htpasswd_user_base: user
+#ocp4_workload_authentication_htpasswd_user_password: 1_r3A11Y-H4t3_cl34Rt3X7-p4$$w0rDs_2 (autogenerated when not specified)
+ocp4_workload_authentication_htpasswd_user_count: 1
+ocp4_workload_authentication_remove_kubeadmin: true
+----
+
+. Run Ansible Navigator to deploy your cluster:
++
+[NOTE]
+====
+Outside of the playbook immediately after `run`, all `-e` options must be specified relative to their mountpoint _inside_ the execution environment's container.  See `~/.ansible-navigator.yaml` for what you previously set
+====
+[source,sh]
+----
+cd ~/Development/agnosticd
+
+ansible-navigator run ansible/main.yml \
+-e @/vars/ocp-cluster.yaml \
+-e @/secrets/secrets.yaml \
+-e @/secrets/sandbox-secrets.yaml \
+-e guid=XXXXXX # replace with your specific GUID - e.g. 7hbpt
+----
+
+
+=== Deploy Workload on an existing Cluster
+
+TBD
+
+
+Run Navigator to deploy a workload to a cluster:
+
+[source,sh]
+----
+cd ~/Development/agnosticd
+
+ansible-navigator run ansible/main.yml \
+-e @/vars/ocp-cluster.yaml \
+-e guid=7hbpt
+----
+

--- a/docs/Deploying_Using_Execution_Environments.adoc
+++ b/docs/Deploying_Using_Execution_Environments.adoc
@@ -83,10 +83,9 @@ ansible-navigator:
 [source,sh]
 ----
 # Set up AgnosticD
-mkdir -p ~/Development/agnosticd
 mkdir -p ~/Development/agnosticd-workdir
 
-cd ~/Development/agnosticd
+cd ~/Development/
 
 git clone git@github.com:redhat-cop/agnosticd.git
 ----
@@ -478,7 +477,7 @@ Outside of the playbook immediately after `run`, all `-e` options must be specif
 ====
 [source,sh]
 ----
-cd ~/Development/agnosticd
+cd ~/development/agnosticd
 
 ansible-navigator run ansible/main.yml \
 -e @/vars/ocp-cluster.yaml \
@@ -497,7 +496,7 @@ Run Navigator to deploy a workload to a cluster:
 
 [source,sh]
 ----
-cd ~/Development/agnosticd
+cd ~/development/agnosticd
 
 ansible-navigator run ansible/main.yml \
 -e @/vars/ocp-cluster.yaml \


### PR DESCRIPTION
Environments on Fedora Linux 37

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Updating deploying execution environments document with instructions for Linux
A couple of fixes to the instructions for MAC commands that are using incorrect directory paths
Reformatted with ToC as the file is larger now, and changed heading levels to match with the new "Mac" and "Linux" headers

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Deploying_Using_Execution_Environments.adoc

##### ADDITIONAL INFORMATION
Instructions for Mac did not work for Linux (Fedora 37), so I have tested these and pulled them from my history and attempted to format as closely to the Mac setup as possible for parallelism.

I have swapped podman rootless for docker in the Linux config, as well, as this is what I tested.