### PR TITLE
Upgrade ocp4 cluster pyOpenSSL to 23.1.0 LEcryprt dep issue

### DIFF
--- a/ansible/configs/ocp4-cluster/files/requirements_k8s.txt
+++ b/ansible/configs/ocp4-cluster/files/requirements_k8s.txt
@@ -31,7 +31,7 @@ pyasn1-modules==0.2.8
 pycparser==2.19
 PyJWT==1.7.1
 PyNaCl==1.3.0
-pyOpenSSL==22.0.0
+pyOpenSSL==23.1.1
 pyRFC3339==1.1
 python-dateutil==2.8.2
 python-string-utils==1.0.0


### PR DESCRIPTION

ocp4_cluster breaking on venv deps

https://levelup.gitconnected.com/fix-attributeerror-module-lib-has-no-attribute-openssl-521a35d83769

pin pyopenssl to 23.1.1

##### SUMMARY

Recent upgrade to more modern pip deps (#6388) introduced breaking changes to lets encrypt workload

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME

ocp4_cluster

##### ADDITIONAL INFORMATION
