### PR TITLE
ocp4-workload-dil-servless- user-terminal - authentication change 

### DIFF
--- a/ansible/roles/ocp4-workload-dil-serverless/tasks/user_terminal.yaml
+++ b/ansible/roles/ocp4-workload-dil-serverless/tasks/user_terminal.yaml
@@ -4,7 +4,7 @@
     host: "{{ api_url }}"
     verify_ssl: false
     username: '{{ __user }}'
-    password: '{{ ocp4_workload_authentication_htpasswd_user_password | default(ocp4_workload_dil_serverless_workshop_openshift_user_password, true) }}'
+    password: '{{ ocp4_workload_authentication_htpasswd_user_password | default(ocp4_workload_authentication, true) }}'
   register: k8s_auth_results
   
 - name: Create DevWorkspace for {{ __user }}


### PR DESCRIPTION
Update user_terminal.yaml

use 
ocp4_workload_authentication 

instead of dil authentication

https://github.com/rhpds/agnosticv/blob/master/azure_gpte/SUMMIT_2021_AZURE_MULTICLOUD_WKSP/dev.yaml 


TASK [ocp4-workload-dil-serverless : Log in OCP as user1] **********************
fatal: [bastion-7f2d2]: FAILED! => {"changed": false, "msg": "Authorization failed.", "req_method": "GET", "req_reason": "Unauthorized", "req_status_code": 401, "req_url": "https://oauth-********.apps.ocp4-7f2d2-ipi.azure.opentlc.com/oauth/authorize?response_type=code&client_id=********-challenging-client&state=1&code_challenge_method=S256"}
