### PR TITLE
Add namespace to cert_utils subscription

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_utils_operator/templates/cert-utils-operarator.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_utils_operator/templates/cert-utils-operarator.j2
@@ -3,6 +3,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: cert-utils-operator
+  namespace: openshift-operators
 spec:
   channel: alpha
   installPlanApproval: Automatic


### PR DESCRIPTION
##### SUMMARY

ocp4_workload_cert_utils_operator failed because yaml lacked namespace - added

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME

ocp4_workload_cert_utils_operator

##### ADDITIONAL INFORMATION
