### PR TITLE
Add namespace to cert-utils OperatorGroup

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_utils_operator/templates/cert-utils-operarator.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_utils_operator/templates/cert-utils-operarator.j2
@@ -15,5 +15,6 @@ apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: cert-utils-operator
+  namespace: openshift-operators
 spec:
   targetNamespaces: []


### PR DESCRIPTION

##### SUMMARY

Forgot namespace in cert-utils OperatorGroup!

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

roles_ocp_workloads/ocp4_workload_cert_utils_operator

##### ADDITIONAL INFORMATION
