### PR TITLE
add LE/certbot to GCP deployments

### DIFF
--- a/ansible/roles/host-lets-encrypt-certs-certbot/files/requirements_certbot.txt
+++ b/ansible/roles/host-lets-encrypt-certs-certbot/files/requirements_certbot.txt
@@ -8,6 +8,7 @@ boto3==1.11.14
 botocore==1.14.14
 certbot==1.17.0
 certbot-dns-azure==1.3.0
+certbot-dns-google==1.17.0
 certbot-dns-rfc2136==1.17.0
 certbot-dns-route53==1.17.0
 certifi==2019.11.28

--- a/ansible/roles/host-lets-encrypt-certs-certbot/tasks/main.yml
+++ b/ansible/roles/host-lets-encrypt-certs-certbot/tasks/main.yml
@@ -30,6 +30,19 @@
       fail:
         msg: Azure Credentials are required when requesting certificates for a wildcard domain
 
+- name: Check on GCP credentials
+  when: _certbot_dns_provider is match('gcp')
+  block:
+    - name: Verify if GCP Credentials exist on the host
+      stat:
+        path: "/home/{{ _certbot_user }}/.gcp/osServiceAccount.json"
+      register: gcp_credentials_result
+
+    - name: Fail if GCP Credentials are not on the host
+      when: gcp_credentials_result.stat.exists == False
+      fail:
+        msg: GCP Credentials are required when requesting certificates for a wildcard domain
+
 - name: Check on DDNS credentials
   when: _certbot_dns_provider is match('rfc2136')
   block:

--- a/ansible/roles/host-lets-encrypt-certs-certbot/templates/run-certbot.j2
+++ b/ansible/roles/host-lets-encrypt-certs-certbot/templates/run-certbot.j2
@@ -12,6 +12,10 @@ certbot certonly -n --agree-tos --email {{ _certbot_le_email }} \
 {% elif _certbot_dns_provider is match('azure') %}
   --authenticator dns-azure \
   --dns-azure-config /home/{{ _certbot_user }}/.azure.ini \
+{% elif _certbot_dns_provider is match('gcp') %}
+  --dns-google \
+  --dns-google-credentials /home/{{ _certbot_user }}/.gcp/osServiceAccount.json \
+  --dns-google-propagation-seconds 15 \
 {% else %}
   {{ (_certbot_wildcard_certs|bool)|ternary('--dns-'+_certbot_dns_provider, '') }} \
 {% endif %}

--- a/ansible/roles_ocp_workloads/ocp4_workload_le_certificates/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_le_certificates/tasks/workload.yml
@@ -88,6 +88,28 @@
       - _certbot_cron_job_name: LETS_ENCRYPT_RENEW
       - use_python3: "{{ all_use_python3 | default(true) | bool }}"
 
+  - name: Get Certificates for GCP
+    when: cloud_provider == "gcp"
+    block:
+    - name: Create Let's Encrypt Certificates for GCP
+      include_role:
+        name: host-lets-encrypt-certs-certbot
+      vars:
+      - _certbot_domain: "{{ ocp4_workload_le_certificates_api_hostname }}"
+      - _certbot_wildcard_domain: "*.{{ r_ingress_controller.resources[0].status.domain }}"
+      - _certbot_dns_provider: "gcp"
+      - _certbot_remote_dir: "/home/{{ ansible_user }}"
+      - _certbot_remote_dir_owner: "{{ ansible_user }}"
+      - _certbot_install_dir: "/home/{{ ansible_user }}/certificates"
+      - _certbot_install_dir_owner: "{{ ansible_user }}"
+      - _certbot_cache_archive_file: "{{ output_dir|default('/tmp') }}/{{ guid }}-certs.tar.gz"
+      - _certbot_renew_automatically: true
+      - _certbot_use_cache: true
+      - _certbot_force_issue: false
+      - _certbot_production: true
+      - _certbot_cron_job_name: LETS_ENCRYPT_RENEW
+      - use_python3: "{{ all_use_python3 | default(true) | bool }}"
+
   - name: Get Certificates for OpenStack
     when: cloud_provider == "osp"
     block:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Add LE/certbot support to OCP on GCP

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
host-lets-encrypt-certs-certbot
ocp4_workload_le_certificates

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
