### PR TITLE
Extend OCP bearer token lifecycle

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/defaults/main.yml
@@ -10,6 +10,8 @@ ocp4_workload_ansible_automation_platform_project: "aap"
 ocp4_workload_ansible_automation_platform_app_name: "aap"
 ocp4_workload_ansible_automation_platform_display: "ansible-automation-platform"
 ocp4_workload_ansible_automation_platform_description: "Ansible Automation Platorm"
+# OCP bearer token lifecycle for use as an AAP cred - default to 2 weeks
+ocp4_workload_ansible_automation_platform_ocp_token_lifecycle: 1209600
 
 ocp4_workload_ansible_automation_platform_admin_password: >-
   {{ common_password | default(aap_controller_admin_password) }}

--- a/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/tasks/workload.yml
@@ -5,6 +5,14 @@
     KUBECONFIG: "{{ ocp4_workload_ansible_automation_platform_tmp_kubeconfig }}"
   block:
 
+    - name: Extend OCP Bearer Token life for AAP cred use
+      kubernetes.core.k8s:
+        state: present
+        definition: "{{ lookup('template', 'ocp_bearer_token_lifecycle.j2') }}"
+      register: r_extend_token_lifecycle
+      until: r_extend_token_lifecycle is succeeded
+      retries: 5
+
     - name: Create Project {{ ocp4_workload_ansible_automation_platform_project }}
       kubernetes.core.k8s:
         state: present


### PR DESCRIPTION

##### SUMMARY

OCP AAP2 installer roll now extends default ocp bearer token to 2 weeks for use as a cred in AAP

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

roles_ocp_workloads/ocp4_workload_ansible_automation_platform


##### ADDITIONAL INFORMATION
