### PR TITLE
Update crw-devfile.yaml.j2

### DIFF
--- a/ansible/roles/ocp4-workload-camel3-workshop/templates/crw-devfile.yaml.j2
+++ b/ansible/roles/ocp4-workload-camel3-workshop/templates/crw-devfile.yaml.j2
@@ -22,7 +22,7 @@ components:
   -
     type: dockerimage
     alias: tools
-    image: quay.io/redhatintegration/rhi-tools:latest
+    image: quay.io/redhatintegration/rhi-tools:devspaces
     env:
       - name: MAVEN_CONFIG
         value: ""


### PR DESCRIPTION
replaced the rhi-tools image's `latest` tag by the `devspaces` tag to enforce specific Camel tool versions needed for the workshop.

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
