### PR TITLE
Set agnosticd_user_info data for ssh access in ocp4-cluster

### DIFF
--- a/ansible/configs/ocp4-cluster/post_infra.yml
+++ b/ansible/configs/ocp4-cluster/post_infra.yml
@@ -58,22 +58,23 @@
       when: item.name is match('bastion')
       set_fact:
         rhel_remote_host: "{{item.fqdns|d(item.publicIps)|d('')}}"
-      with_items: "{{vm_list}}"
+      loop: "{{ vm_list }}"
+
     - name: Set FQDN for each Windows VM
       set_fact:
         windows_remote_hosts: ""
+
     - name: Set FQDN for each Windows VM
       when: item.name is match ('vmwin*')
       set_fact:
         windows_remote_hosts: "{{item.fqdns|d(item.publicIps)|d('')}},{{windows_remote_hosts}}"
-      with_items: "{{vm_list}}"
+      loop: "{{ vm_list }}"
 
     - name: Print Host Information
-      agnosticd_user_info:
-        msg: "{{ item }}"
-      loop:
-      - "Remote User: {{ remote_user }}"
-      - "RHEL Bastion Host: {{ rhel_remote_host }}"
-      - "Windows Host(s): {{ windows_remote_hosts }}"
-      - "Windows Password: {{ windows_password }}"
       when: ocp4_cluster_show_access_user_info | bool
+      agnosticd_user_info:
+        msg: |
+          Remote User: {{ remote_user }}
+          RHEL Bastion Host: {{ rhel_remote_host }}
+          Windows Host(s): {{ windows_remote_hosts }}
+          Windows Password: {{ windows_password }}

--- a/ansible/configs/ocp4-cluster/post_software.yml
+++ b/ansible/configs/ocp4-cluster/post_software.yml
@@ -173,35 +173,15 @@
     - install_student_user | bool
     - ocp4_cluster_show_access_user_info | bool
     vars:
-      _bastion_inventory_name: "{{ groups['bastions'][0] }}"
-      _bastion_ssh_password: "{{ hostvars[bastion_hostname]['student_password'] }}"
-      _kubeadmin_password: "{{ hostvars[bastion_hostname]['kubeadmin_password']['content'] | b64decode }}"
-    block:
-    - name: Set Bastion Hostname (EC2)
-      when:
-      - cloud_provider == 'ec2'
-      set_fact:
-        _bastion_public_hostname: "{{ hostvars[_bastion_inventory_name].shortname }}.{{ guid }}{{ subdomain_base_suffix }}"
-    - name: Set Bastion Hostname (GCP)
-      when: cloud_provider == "azure" or cloud_provider == "gcp"
-      set_fact:
-        _bastion_public_hostname: "bastion.{{ guid }}.{{ ocp4_base_domain }}."
-    - name: Set Bastion Hostname (Other)
-      when:
-      - _bastion_public_hostname is not defined
-      set_fact:
-        _bastion_public_hostname: "{{ hostvars[_bastion_inventory_name].shortname }}.{{ guid }}.{{ ocp4_base_domain }}"
-    - name: Print access user info
-      agnosticd_user_info:
-        data:
-          bastion_public_hostname: "{{ _bastion_public_hostname }}"
-          bastion_ssh_password: "{{ _bastion_ssh_password }}"
-          bastion_ssh_user_name: "{{ student_name }}"
-        msg: |
-          You can access your bastion via SSH:
-          ssh {{ student_name }}@{{ _bastion_public_hostname }}
+      __ssh_host: "{{ lookup('agnosticd_user_info', 'bastion_public_hostname') }}"
+      __ssh_password: "{{ lookup('agnosticd_user_info', 'bastion_ssh_password') }}"
+      __ssh_user: "{{ lookup('agnosticd_user_info', 'bastion_ssh_user_name') }}"
+    agnosticd_user_info:
+      msg: |
+        You can access your bastion via SSH:
+        ssh {{ student_name }}@{{ __ssh_host }}
 
-          Make sure you use the username '{{ student_name }}' and the password '{{ _bastion_ssh_password }}' when prompted.
+        Make sure you use the username '{{ __ssh_user }}' and the password '{{ __ssh_password }}' when prompted.
 
 - name: Step 005.7 Clean up
   hosts: localhost

--- a/ansible/configs/ocp4-cluster/pre_software.yml
+++ b/ansible/configs/ocp4-cluster/pre_software.yml
@@ -74,6 +74,23 @@
         owner: "{{ student_name }}"
         remote_src: true
 
+  - name: Set bastion ssh data
+    when:
+    - install_student_user | bool
+    - student_name is defined
+    agnosticd_user_info:
+      data:
+        bastion_public_hostname: >-
+          {%- if cloud_provider == 'ec2' -%}
+          {{ shortname }}.{{ guid }}{{ subdomain_base_suffix }}
+          {%- elif cloud_provider == "azure" or cloud_provider == "gcp" -%}
+          bastion.{{ guid }}.{{ ocp4_base_domain }}
+          {%- else -%}
+          {{ shortname }}.{{ guid }}.{{ ocp4_base_domain }}
+          {%- endif -%}
+        bastion_ssh_password: "{{ student_password }}"
+        bastion_ssh_user_name: "{{ student_name }}"
+
 - name: Create a Python3 VirtualEnv for use in the k8s Ansible tasks
   hosts: bastions
   gather_facts: false


### PR DESCRIPTION
##### SUMMARY

Set `agnosticd_user_info` with `data` for bastion ssh access in ocp4-cluster config.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Config ocp4-cluster