### PR TITLE
use 'lab_ui_url' to set bookbag url

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_cloud_architecture_workshop_summit2023/tasks/bookbag.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cloud_architecture_workshop_summit2023/tasks/bookbag.yml
@@ -19,7 +19,7 @@
   agnosticd_user_info:
     user: "{{ ocp4_workload_cloud_architecture_workshop_user_prefix }}{{ n }}"
     data:
-      instructions_url: >-
+      lab_ui_url: >-
         https://bookbag-bookbag-{{ ocp4_workload_cloud_architecture_workshop_user_prefix }}{{ n }}.{{ r_openshift_subdomain }}
   loop: "{{ range(1, 1 + ocp4_workload_cloud_architecture_workshop_user_count | int) | list }}"
   loop_control:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_cloud_architecture_workshop_summit2023

##### ADDITIONAL INFORMATION
Use 'lab_ui_url' as variable for the url to bookbag.
