### PR TITLE
adding tasks to move newest.egg file

### DIFF
--- a/ansible/configs/sap-hana/software.yml
+++ b/ansible/configs/sap-hana/software.yml
@@ -112,6 +112,17 @@
         - "{{ groups['s4hanas'] }}"
       ignore_errors: true  
 
+- name: Move newest.egg file to /tmp directory
+  hosts: hanas:s4hanas
+  become: true
+  gather_facts: true
+  tasks:
+    - name: Move newest.egg file to /tmp directory
+      command: mv /var/lib/insights/newest.egg  /tmp
+      
+    - name: Move newest.egg.asc file to /tmp directory
+      command: mv /var/lib/insights/newest.egg.asc  /tmp  
+ 
 - name: Deploy Ansible Tower
   hosts: towers
   gather_facts: False


### PR DESCRIPTION
as per the https://access.redhat.com/solutions/7007839 we need to move two files in /tmp directory in order to register the clients with red hat insight tool

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
