### PR TITLE
Update workload.yml add when bool for self-provisioner task

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_aiml_edge_workshop/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_aiml_edge_workshop/tasks/workload.yml
@@ -20,6 +20,7 @@
         name: user{{ item }}
     state: present
   loop: "{{ range(1, num_users | int + 1, 1) | list }}"
+  when: false | bool
 
 - name: Git checkout
   ansible.builtin.git:


### PR DESCRIPTION
rhjcd-patch-Update workload.yml add when bool for self-provisioner task

##### SUMMARY

<when boolean needed for self-provisioner task as it is not necessary as default in a deploy>

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
