### PR TITLE
Fix showroom var typo (-url_url)

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/workload.yml
@@ -43,7 +43,7 @@
   agnosticd_user_info:
     msg: "Lab instructions: {{ _showroom_url }}"
     data:
-      showroom_url: "{{ _showroom_url_url }}"
+      showroom_url: "{{ _showroom_url }}"
   vars:
     _route: "{{ r_showroom_route.resources[0] }}"
     _showroom_url: >-


### PR DESCRIPTION

##### SUMMARY

Fix a typo in var name (double _url_url)

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ocp4_workload_showroom

##### ADDITIONAL INFORMATION
<