### PR TITLE
Fixes an issue with 5gran workload and tunes ssh

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/defaults/main.yml
@@ -3,8 +3,6 @@ become_override: true
 ocp_username: opentlc-mgr
 silent: false
 
-ansible_ssh_common_args: "-o ConnectionAttempts=20"
-
 kcli_baremetal_plan_revision: 0cdab26571acf61feeaabf216c1d3066f780cb87
 ocp4_major_release: "4.12"
 lab_version: "lab-4.12"

--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/main.yml
@@ -2,6 +2,10 @@
 
 # Do not modify this file
 
+- name: Tune ssh connection parameter
+  include_vars:
+    ansible_ssh_common_args: "-o ConnectionAttempts=20"
+
 - name: Running Pre Workload Tasks
   include_tasks:
     file: ./pre_workload.yml

--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/workload.yml
@@ -178,7 +178,9 @@
 # SNO1 deployment starts
 - name: Ensure SNO ssh key is downloaded
   ansible.builtin.get_url:
-    url: "http://infra.5g-deployment.lab:3000/student/5g-ran-deployments-on-ocp-lab/raw/branch/main/lab-materials/lab-env-data/hypervisor/ssh-key"
+    # yamllint disable rule:line-length
+    url: "http://infra.5g-deployment.lab:3000/student/5g-ran-deployments-on-ocp-lab/raw/branch/{{ lab_version }}/lab-materials/lab-env-data/hypervisor/ssh-key"
+    # yamllint enable rule:line-length
     dest: "/root/.ssh/snokey"
     mode: "0400"
 


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc
-->
##### SUMMARY

When running our lab automation, we get random issues related to ssh connections:

~~~console
TASK [ocp4_workload_5gran_deployments_lab : Ensure trusted certs are updated] ***
fatal: [hypervisor]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh: Shared connection to hypervisor.example.com closed.", "unreachable": true}
~~~

This change adds ssh connection retries.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4_workload_5gran_deployments_lab
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
