### PR TITLE
Add to AgD user.info for ocp4-workload-workshop-admin-storage 

### DIFF
--- a/ansible/roles/ocp4-workload-workshop-admin-storage/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-workshop-admin-storage/defaults/main.yml
@@ -3,6 +3,7 @@ become_override: false
 ocp_username: kubeadmin
 silent: false
 WORKSHOP_FILE: workshop.yaml
+_ocp4-workload_workshop_admin_storage_report_kubeadmin: true
 
 _infra_node_replicas: 3
 _infra_node_instance_type: m5a.4xlarge

--- a/ansible/roles/ocp4-workload-workshop-admin-storage/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-workshop-admin-storage/defaults/main.yml
@@ -3,7 +3,7 @@ become_override: false
 ocp_username: kubeadmin
 silent: false
 WORKSHOP_FILE: workshop.yaml
-_ocp4-workload_workshop_admin_storage_report_kubeadmin: true
+_ocp4-workload_workshop_admin_storage_report_kubeadmin: false
 
 _infra_node_replicas: 3
 _infra_node_instance_type: m5a.4xlarge

--- a/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/post_workload.yml
+++ b/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/post_workload.yml
@@ -1,8 +1,7 @@
 ---
 - name: Step 005.6 Print Student Info
-  hosts: localhost
-  gather_facts: false
-  become: false
+  when:
+    - _ocp4-workload_workshop_admin_storage_report_kubeadmin | bool
   tasks:
     - name: Print access user info
       agnosticd_user_info:

--- a/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/post_workload.yml
+++ b/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/post_workload.yml
@@ -1,5 +1,14 @@
 ---
-# Implement your Post Workload deployment tasks here
+- name: Step 005.6 Print Student Info
+  hosts: localhost
+  gather_facts: false
+  become: false
+  tasks:
+    - name: Print access user info
+      agnosticd_user_info:
+        data:
+          ocp_console_username: "kubeadmin"
+          kubeadmin_password: "{{ kubeadmin_password }}"
 
 # Leave this as the last task in the playbook.
 - name: post_workload tasks complete


### PR DESCRIPTION
Adding kubeadmin to user.indo

-->
##### SUMMARY
Adding kubeadmin password to userdata, need to provide this in order to use them for the user-message-template when deploying. 


##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
ocp4-workload-workshop-admin-storage

##### ADDITIONAL INFORMATION


<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
