### PR TITLE
Adding common_packages_el9 to the ocp4-cluster config for RHEL9 bastion builds

### DIFF
--- a/ansible/configs/ocp4-cluster/default_vars.yml
+++ b/ansible/configs/ocp4-cluster/default_vars.yml
@@ -68,9 +68,26 @@ repo_method: satellite
 # own_repo_path: points to a repo mirror. Must defined in secrets
 # own_repo_path: <FROM_SECRETS>
 
+# -------------------------------------------------
+# Role: common
+# -------------------------------------------------
 # Packages to install on all of the hosts deployed as part of the agnosticd config
 # This invokes the "common" role
 install_common: true
+common_packages_el9:
+  - python3
+  - unzip
+  - bash-completion
+  - tmux
+  - bind-utils
+  - wget
+  - nano
+  - git
+  - vim-enhanced
+  - httpd-tools
+  - ansible-core
+  - ansible-navigator
+  - python3-pip
 
 # As part of the "common" role, this cause it to do a yum update on the host
 update_packages: true


### PR DESCRIPTION
##### SUMMARY

Adding common_packages_el9 to ocp4-cluster config

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-cluster (where a RHEL9 bastion is used)

##### ADDITIONAL INFORMATION
Due to recent changes in the default playbooks, this is now required when using a RHEL9 bastion.  Since this is undefined in the ocp4-config, it causes the deploy to fail when it should not.

```
TASK [common : install common packages for RHEL 9] *****************************
fatal: [ocp4-cluster.domain.local]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'common_packages_el9' is undefined. 'common_packages_el9' is undefined\n\nThe error appears to be in '/home/jappleii/development/agnosticd/ansible/roles/common/tasks/packages_el9.yml': line 4, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n######################### Install Basic Packages\n- name: install common packages for RHEL 9\n  ^ here\n"}
```

I add the files from other configs where it is defined.  If this is common, though, we might want to define a higher-level, smaller set of dependencies into a single default configurations so that this isn't undefined for any lab.