### PR TITLE
Uses a specific version for the automation tool

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/defaults/main.yml
@@ -3,9 +3,12 @@ become_override: true
 ocp_username: opentlc-mgr
 silent: false
 
-kcli_baremetal_plan_revision: 0cdab26571acf61feeaabf216c1d3066f780cb87
-ocp4_major_release: "4.12"
 lab_version: "lab-4.12"
+kcli_baremetal_plan_revision: 0cdab26571acf61feeaabf216c1d3066f780cb87
+# yamllint disable rule:line-length
+kcli_rpm: "https://github.com/RHsyseng/5g-ran-deployments-on-ocp-lab/raw/{{ lab_version }}/lab-materials/kcli-rpm/kcli-99.0.0.git.202305180753.3473537-0.el8.x86_64.rpm"
+# yamllint enable rule:line-length
+ocp4_major_release: "4.12"
 lab_network_cidr: "192.168.125.0/24"
 lab_network_domain: "5g-deployment.lab"
 lab_registry_host: "infra.5g-deployment.lab:8443"

--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/pre_workload.yml
@@ -56,12 +56,12 @@
   ansible.builtin.shell:
     cmd: restorecon /var/lib/libvirt
 
-- name: Ensure kcli copr repo is enabled
-  community.general.copr:
-    state: enabled
-    host: copr.fedorainfracloud.org
-    chroot: epel-8-x86_64
-    name: karmab/kcli
+#- name: Ensure kcli copr repo is enabled
+#  community.general.copr:
+#    state: enabled
+#    host: copr.fedorainfracloud.org
+#    chroot: epel-8-x86_64
+#    name: karmab/kcli
 
 # group all dnf installs in the same task to save time
 - name: Ensure lab dependencies are installed
@@ -71,13 +71,16 @@
       - libvirt-daemon-driver-qemu
       - qemu-kvm
       - git
-      - kcli
       - dnsmasq
       - policycoreutils-python-utils
       - podman
       - httpd-tools
       - haproxy
     state: present
+
+- name: Ensure kcli rpm is installed
+  ansible.builtin.dnf:
+    name: "{{ kcli_rpm }}"
 
 - name: Ensure libvirtd service is enabled and running
   ansible.builtin.systemd:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Makes the role use a specific version of the tooling that deploys the cluster to avoid issues when this tool gets updated without being tested in our environment.
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4_workload_5gran_deployments_lab
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
