### PR TITLE
Fix ocp4_workload_dbaas_operator CSV install check

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_dbaas_operator/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_dbaas_operator/tasks/workload.yml
@@ -16,17 +16,13 @@
 - name: "Wait until CSV is installed"
   kubernetes.core.k8s_info:
     api_version: operators.coreos.com/v1alpha1
-    kind: ClusterServiceVersion
-    name: dbaas-operator.v0.4.0
+    kind: Subscription
+    name: dbaas-operator
     namespace: openshift-dbaas-operator
-  register: r_csv
+  register: r_sub
   retries: 40
   delay: 30
-  until:
-    - r_csv.resources[0].status.phase is defined
-    - r_csv.resources[0].status.phase | length > 0
-    - r_csv.resources[0].status.phase == "Succeeded"
-
+  until: r_sub.resources[0].status.installedCSV | default('') != ''
 
 # Leave this as the last task in the playbook.
 # --------------------------------------------


### PR DESCRIPTION
##### SUMMARY

Fix ocp4_workload_dbaas_operator CSV install check to not depend on a specific version.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role ocp4_workload_dbaas_operator