### PR TITLE
ocp4_workload_performance_monitoring: Fix DevSpaces 3.6 CR issue

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/templates/devspace_cluster.yml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/templates/devspace_cluster.yml.j2
@@ -5,6 +5,8 @@ metadata:
   namespace: openshift-devspaces
 spec:
   devEnvironments:
+    containerBuildConfiguration:
+      openShiftSecurityContextConstraint: container-build
     defaultEditor: che-incubator/che-code/insiders
     defaultNamespace:
       template: <username>-devspaces
@@ -12,6 +14,7 @@ spec:
     secondsOfRunBeforeIdling: -1
     maxNumberOfWorkspacesPerUser: 1
     maxNumberOfRunningWorkspacesPerUser: 1
+    startTimeoutSeconds: 300
     storage:
       pvcStrategy: per-workspace
   components:
@@ -33,7 +36,7 @@ spec:
     imagePuller:
       enable: true
       spec:
-        images: universal-developer-image-ubi8-latest={{ devspaces_tools_image }};devspaces-code-devfile-registry-image-gmxdkcq=registry.redhat.io/devspaces/code-rhel8@sha256:debc18de31a6b3b575e42cc485f6c2241ee4d3d6988fad4e4e9837edba24f89f;devspaces-code-plugin-registry-image-gmxdkcq=registry.redhat.io/devspaces/code-rhel8@sha256:debc18de31a6b3b575e42cc485f6c2241ee4d3d6988fad4e4e9837edba24f89f;devspaces-idea-devfile-registry-image-gmxdkcq=registry.redhat.io/devspaces/idea-rhel8@sha256:84df38ee2a2b751321512d2d8d37c30dc6d5e0135b8f16655a68e774a2b781ff;devspaces-idea-plugin-registry-image-gmxdkcq=registry.redhat.io/devspaces/idea-rhel8@sha256:84df38ee2a2b751321512d2d8d37c30dc6d5e0135b8f16655a68e774a2b781ff;devspaces-machineexec-plugin-registry-image-gmxdkcq=registry.redhat.io/devspaces/machineexec-rhel8@sha256:6d2ef8fd44829f32f13e4926d68b1e48c29807572b0f568c4c57cc2cff2590f1;devspaces-theia-devfile-registry-image-gmxdkcq=registry.redhat.io/devspaces/theia-rhel8@sha256:cdfd56dd97c896e92922e74f4c123a6dadc412510f8efdc15a641d8c475bebd3;devspaces-theia-endpoint-devfile-registry-image-gmxdkcq=registry.redhat.io/devspaces/theia-endpoint-rhel8@sha256:6845b8d4ac5e7df4a8ad8f3d75a8804363cc7bfa59eda251c9f714c4db945024;devspaces-theia-endpoint-plugin-registry-image-gmxdkcq=registry.redhat.io/devspaces/theia-endpoint-rhel8@sha256:6845b8d4ac5e7df4a8ad8f3d75a8804363cc7bfa59eda251c9f714c4db945024;devspaces-theia-plugin-registry-image-gmxdkcq=registry.redhat.io/devspaces/theia-rhel8@sha256:cdfd56dd97c896e92922e74f4c123a6dadc412510f8efdc15a641d8c475bebd3;devworkspace-project-clone-rhel8=registry.redhat.io/devworkspace/devworkspace-project-clone-rhel8@sha256:0f75bc36ff22f9c5aafeabafe32aff39ff40d738995dff932efd123f065e8d18;udi-rhel8=registry.redhat.io/devspaces/udi-rhel8@sha256:99ff1b5c541855e4cf368816c4bcdcdc86d32304023f72c4443213a4032ef05b
+        images: universal-developer-image-ubi8-latest={{ devspaces_tools_image }}
     metrics:
       enable: true
     pluginRegistry: {}

--- a/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/templates/devspace_workspace.yml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/templates/devspace_workspace.yml.j2
@@ -30,6 +30,7 @@ spec:
       controller.devfile.io/devworkspace-config:
         name: devworkspace-config
         namespace: openshift-devspaces
+      controller.devfile.io/scc: container-build
       controller.devfile.io/storage-type: per-workspace
       dw.metadata.annotations:
         che.eclipse.org/devfile-source: |
@@ -209,17 +210,17 @@ spec:
         endpoints:
         - exposure: public
           name: quarkus-app
-          protocol: http
+          protocol: https
           targetPort: 8701
           path: /quarkus
         - exposure: public
           name: micronaut-app
-          protocol: http
+          protocol: https
           targetPort: 8702
           path: /micronaut
         - exposure: public
           name: springboot-app
-          protocol: http
+          protocol: https
           targetPort: 8703
           path: /springboot
         - attributes:

--- a/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/templates/prometheus_pod_monitor.yml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/templates/prometheus_pod_monitor.yml.j2
@@ -48,4 +48,103 @@ spec:
   selector:
     matchLabels:      
       serving.knative.dev/service: springboot-app
-      serving.knative.dev/configuration: springboot-app                  
+      serving.knative.dev/configuration: springboot-app
+---
+apiVersion: monitoring.coreos.com/v1 
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: prometheus-app-monitor
+  name: quarkus-app-sm
+spec:
+  endpoints:
+  - port: queue-proxy-metrics
+    scheme: http
+  - port: app-metrics
+    scheme: http
+  namespaceSelector: {}
+  selector:
+    matchLabels:
+       name: quarkus-app-sm
+---
+apiVersion: monitoring.coreos.com/v1 
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: prometheus-app-monitor
+  name: micronaut-app-sm
+spec:
+  endpoints:
+  - port: queue-proxy-metrics
+    scheme: http
+  - port: app-metrics
+    scheme: http
+  namespaceSelector: {}
+  selector:
+    matchLabels:
+       name: micronaut-app-sm
+---
+apiVersion: monitoring.coreos.com/v1 
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: prometheus-app-monitor
+  name: springboot-app-sm
+spec:
+  endpoints:
+  - port: queue-proxy-metrics
+    scheme: http
+  - port: app-metrics
+    scheme: http
+  namespaceSelector: {}
+  selector:
+    matchLabels:
+       name: springboot-app-sm
+---
+apiVersion: v1 
+kind: Service
+metadata:
+  name: quarkus-app-sm
+  labels:
+    name: quarkus-app-sm
+spec:
+  ports:
+  - name: queue-proxy-metrics
+    port: 9091
+    protocol: TCP
+    targetPort: 9091
+  selector:
+    serving.knative.dev/service: quarkus-app
+  type: ClusterIP
+---
+apiVersion: v1 
+kind: Service
+metadata:
+  name: micronaut-app-sm
+  labels:
+    name: micronaut-app-sm
+spec:
+  ports:
+  - name: queue-proxy-metrics
+    port: 9091
+    protocol: TCP
+    targetPort: 9091
+  selector:
+    serving.knative.dev/service: micronaut-app
+  type: ClusterIP
+---
+apiVersion: v1 
+kind: Service
+metadata:
+  name: springboot-app-sm
+  labels:
+    name: springboot-app-sm
+spec:
+  ports:
+  - name: queue-proxy-metrics
+    port: 9091
+    protocol: TCP
+    targetPort: 9091
+  selector:
+    serving.knative.dev/service: springboot-app
+  type: ClusterIP


### PR DESCRIPTION

##### SUMMARY
 * This PR adjusts DevSpaces CRs to v3.6 (just released this morning breaking our automation)
 * It also adds ServiceMonitors for knative-serving services

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_performance_monitoring

##### ADDITIONAL INFORMATION
N/A