### PR TITLE
ocp4_workload_performance_monitoring: wait for DevSpaces container-build scc

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/tasks/install_devspaces.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/tasks/install_devspaces.yml
@@ -84,6 +84,17 @@
   delay: 10
   until: api_response.status == 200
 
+- name: Wait DevSpaces container-build scc
+  kubernetes.core.k8s_info:
+    validate_certs: '{{ verify_tls }}'
+    api_version: security.openshift.io/v1
+    kind: SecurityContextConstraints
+    name: container-build
+  register: r_devspace_scc
+  retries: 120
+  delay: 10
+  until: (r_devspace_scc.api_found is true and r_devspace_scc.resources | list | length == 1)
+
 - name: Check Workspaces for Users
   kubernetes.core.k8s:
     validate_certs: '{{ verify_tls }}'


### PR DESCRIPTION
##### SUMMARY
This PR fix another issue related to the DevSpaces upgrade (v3.6), which now requires a new `scc`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_performance_monitoring

##### ADDITIONAL INFORMATION
N/A
