### PR TITLE
Adds retries to kubernetes tasks

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/workload.yml
@@ -44,6 +44,10 @@
     kubeconfig: /root/hub-kubeconfig
     state: present
     src: /tmp/lvmcluster.yaml
+  register: result
+  until: result.failed != true
+  retries: 5
+  delay: 60
 
 - name: Ensure ArgoCD instance is patched for ZTP support
   kubernetes.core.k8s:
@@ -55,12 +59,20 @@
     state: patched
     src: /tmp/argocd-openshift-gitops-patch.json
     merge_type: merge
+  register: result
+  until: result.failed != true
+  retries: 5
+  delay: 60
 
 - name: Apply ArgoCD ClusterRoleBinding manifest to the cluster
   kubernetes.core.k8s:
     kubeconfig: /root/hub-kubeconfig
     state: present
     src: /tmp/argocd-clusterrolebinding.yaml
+  register: result
+  until: result.failed != true
+  retries: 5
+  delay: 60
 
 - name: Wait until ArgoCD Pods are ready
   kubernetes.core.k8s_info:
@@ -81,6 +93,11 @@
     kubeconfig: /root/hub-kubeconfig
     state: present
     src: /tmp/hub-operators-argoapps.yaml
+  register: result
+  until: result.failed != true
+  retries: 5
+  delay: 60
+
 
 - name: Wait until LVMCluster is ready
   kubernetes.core.k8s_info:
@@ -108,6 +125,11 @@
       metadata:
         annotations:
           storageclass.kubernetes.io/is-default-class: "true"
+  register: result
+  until: result.failed != true
+  retries: 5
+  delay: 60
+
 
 - name: Wait until ArgoCD APP for HUB Cluster Operators deployment is ready
   kubernetes.core.k8s_info:
@@ -189,6 +211,11 @@
     kubeconfig: /root/hub-kubeconfig
     state: present
     src: /tmp/sno1-argoapp.yaml
+  register: result
+  until: result.failed != true
+  retries: 5
+  delay: 60
+
 
 - name: Wait until ArgoCD APP for SNO1 Cluster deployment is ready
   kubernetes.core.k8s_info:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

Sometimes some K8s tasks fail because some component is not ready, this PR adds retries to such tasks.
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4_workload_5gran_deployments_lab


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
