### PR TITLE
Add default AWS region to AWS Credentials for ROSA

### DIFF
--- a/ansible/configs/rosa-manual/software.yml
+++ b/ansible/configs/rosa-manual/software.yml
@@ -141,6 +141,7 @@
               [default]
               aws_access_key_id={{ hostvars.localhost.rosa_access_key_id }}
               aws_secret_access_key={{ hostvars.localhost.rosa_secret_access_key }}
+              region={{ aws_region  }}
 
     - tags:
         - create_aws_config


### PR DESCRIPTION
##### SUMMARY

rosa_manual config had the aws region in ~/.aws/config. But for the AWS CLI to pick up that as the default that does not seem to be enough. Also adding the region to ~/.aws/credentials.

@rut31337 FYI

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rosa-manual