### PR TITLE
Excluding the package ansible-7.2.0-1.el8.noarch

### DIFF
--- a/ansible/configs/sap-hana/software.yml
+++ b/ansible/configs/sap-hana/software.yml
@@ -170,8 +170,8 @@
           - ansible
         state: present
         exclude:
-          - ansible-6.3.0-1.el8.noarch
           - ansible-6.3.0-2.el8.1.noarch
+          - ansible-7.2.0-1.el8.noarch
           
     - name: Install Ansible Tower
       include_role:


### PR DESCRIPTION
TASK [Ensure additional packages are installed] ******************************** fatal: [tower-bdwfw]: FAILED! => {"changed": false, "failures": [], "msg": "Depsolve Error occured: \n Problem: cannot install the best candidate for the job\n  - nothing provides /usr/bin/python3.11 needed by ansible-7.2.0-1.el8.noarch\n  - nothing provides python(abi) = 3.11 needed by ansible-7.2.0-1.el8.noarch\n  - nothing provides python3.11dist(ansible-core) >= 2.14.2 needed by ansible-7.2.0-1.el8.noarch", "rc": 1, "results": []}

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
