### PR TITLE
Added and verified showroom rendering

### DIFF
--- a/ansible/roles/showroom/tasks/30-showroom-clone-and-inject.yml
+++ b/ansible/roles/showroom/tasks/30-showroom-clone-and-inject.yml
@@ -1,41 +1,44 @@
 ---
-- name: Clone showroom primary repo - asciidoc source
-  ansible.builtin.git:
-    repo: "{{ showroom_git_repo }}"
-    dest: /opt/showroom/content
-    version: master
-  become_user: "{{ showroom_user }}"
-  tags:
-    - showroom-git
-#
-# TODO: Add the "view" injection code
-#   - a default index.html
-#   - (future) ability to add multiple views
-
-- name: Inject the index.html
-  ansible.builtin.debug:
-    msg: "Inject index.html"
-
-- name: Setup and inject userdata
+- name: Clone and Inject Showroom Tasks
   block:
 
-    - name: Load AgnosticD User Data
-      ansible.builtin.set_fact:
-        f_user_data: >-
-          {{ lookup('file', hostvars.localhost.output_dir ~ '/user-data.yaml', errors='ignore') | from_yaml }}
+    - name: Clone showroom primary repo - asciidoc source
+      ansible.builtin.git:
+        repo: "{{ showroom_git_repo }}"
+        dest: /opt/showroom/content
+        force: true
+        version: master
+      become_user: "{{ showroom_user }}"
 
-    - name: Fallback for AgnosticD User Data
-      when: f_user_data | default({}) | length == 0
-      ansible.builtin.set_fact:
-        f_user_data: []
+    # TODO: Add the "view" injection code
+    #   - a default index.html
+    #   - (future) ability to add multiple views
 
-    - name: Create KV file
-      ansible.builtin.template:
-        src: include_vars.adoc.j2
-        dest: "{{ showroom_home_dir }}/content/documentation/modules/ROOT/pages/include_vars.adoc"
-        owner: "{{ showroom_user }}"
-        group: "{{ showroom_group }}"
-        mode: '0644'
+    - name: Inject the index.html
+      ansible.builtin.debug:
+        msg: "Inject index.html"
 
+    - name: Setup and inject userdata
+      block:
+
+        - name: Load AgnosticD User Data
+          ansible.builtin.set_fact:
+            f_user_data: >-
+              {{ lookup('file', hostvars.localhost.output_dir ~ '/user-data.yaml', errors='ignore') | from_yaml }}
+
+        - name: Fallback for AgnosticD User Data
+          when: f_user_data | default({}) | length == 0
+          ansible.builtin.set_fact:
+            f_user_data: []
+
+        - name: Create KV file
+          ansible.builtin.template:
+            src: include_vars.adoc.j2
+            dest: "{{ showroom_home_dir }}/content/documentation/modules/ROOT/pages/include_vars.adoc"
+            owner: "{{ showroom_user }}"
+            group: "{{ showroom_group }}"
+            mode: '0644'
+          tags:
+            - showroom-var-injection
   tags:
-    - showroom-var-injection
+    - showroom-clone-and-inject

--- a/ansible/roles/showroom/tasks/40-showroom-render.yml
+++ b/ansible/roles/showroom/tasks/40-showroom-render.yml
@@ -1,8 +1,18 @@
 ---
-#
-# TODO: Placeholder, render with podman antora container
-#
 
-- name: Render to html
+- name: Render asciidoc via antora container
+  containers.podman.podman_container:
+    name: container
+    image: docker.io/antora/antora
+    command: site.yml
+    volumes:
+      - "{{ showroom_home_dir }}/content:/antora:Z"
+  become_user: "{{ showroom_user }}"
+  register: r_podman_run_antora
+  tags:
+    - showroom-render
+
+- name: Debug Render asciidoc via antora container
   ansible.builtin.debug:
-    msg: "Render to html"
+    var: "{{ r_podman_run_antora }}"
+    verbosity: 2

--- a/ansible/roles/showroom/tasks/main.yml
+++ b/ansible/roles/showroom/tasks/main.yml
@@ -15,10 +15,14 @@
 - name: Clone primary showroom repo and inject externals (vars, html templates)
   ansible.builtin.include_tasks:
     file: 30-showroom-clone-and-inject.yml
+  tags:
+    - showroom-clone-and-inject
 
 - name: Render showroom to html if required
   ansible.builtin.include_tasks:
     file: 40-showroom-render.yml
+  tags:
+    - showroom-render
 
 - name: Create, enable, start showroom systemd service
   ansible.builtin.include_tasks:


### PR DESCRIPTION

##### SUMMARY

Added rendering, via podman and antora, to showroom role

Any AgnosticD userdata var, for example `foo` can be automagically referenced via `{foo}` in adoc

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

roles/showroom

##### ADDITIONAL INFORMATION

