### PR TITLE
Make provisions default for set-repositories

### DIFF
--- a/ansible/roles/set-repositories/defaults/main.yaml
+++ b/ansible/roles/set-repositories/defaults/main.yaml
@@ -14,3 +14,5 @@ set_repositories_satellite_force_register: false
 
 # By default use content view mode
 use_content_view: true
+
+ACTION: provision


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Make provisions default for set-repositories
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
set-repositories

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
