### PR TITLE
Remove common packages from ocp4-cluster, add jq to common on RHEL8

### DIFF
--- a/ansible/configs/ocp4-cluster/default_vars.yml
+++ b/ansible/configs/ocp4-cluster/default_vars.yml
@@ -100,8 +100,8 @@ worker_instance_count: 2
 # Install OpenShift 4 - and which version
 install_ocp4: true
 
-# Use 4.9 for latest available release in the `stable-4.9` directory.
-# Use 4.9.9 for exactly the specified release
+# Use 4.12 for latest available release in the `stable-4.12` directory.
+# Use 4.12.2 for exactly the specified release
 ocp4_installer_version: "4.12"
 
 # Run logic to enable cluster shutdown before 24h initial certificate rotation

--- a/ansible/configs/ocp4-cluster/default_vars.yml
+++ b/ansible/configs/ocp4-cluster/default_vars.yml
@@ -74,20 +74,12 @@ repo_method: satellite
 # Packages to install on all of the hosts deployed as part of the agnosticd config
 # This invokes the "common" role
 install_common: true
-common_packages_el9:
-  - python3
-  - unzip
-  - bash-completion
-  - tmux
-  - bind-utils
-  - wget
-  - nano
-  - git
-  - vim-enhanced
-  - httpd-tools
-  - ansible-core
-  - ansible-navigator
-  - python3-pip
+
+# To install extra packages (beyond what's in the common list of packages)
+# e.g. RHEL 8 
+# common_extra_packages:
+# - java-17-openjdk
+# - maven
 
 # As part of the "common" role, this cause it to do a yum update on the host
 update_packages: true
@@ -110,7 +102,7 @@ install_ocp4: true
 
 # Use 4.9 for latest available release in the `stable-4.9` directory.
 # Use 4.9.9 for exactly the specified release
-ocp4_installer_version: "4.9"
+ocp4_installer_version: "4.12"
 
 # Run logic to enable cluster shutdown before 24h initial certificate rotation
 # Only works for OCP 4.1 and 4.2. OCP 4.4.8 and later no longer require this.

--- a/ansible/configs/ocp4-cluster/default_vars.yml
+++ b/ansible/configs/ocp4-cluster/default_vars.yml
@@ -76,7 +76,7 @@ repo_method: satellite
 install_common: true
 
 # To install extra packages (beyond what's in the common list of packages)
-# e.g. RHEL 8 
+# e.g. RHEL 8
 # common_extra_packages:
 # - java-17-openjdk
 # - maven

--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -33,6 +33,7 @@ common_packages_el8:
 - skopeo
 - buildah
 - tree
+- jq
 
 # Common Packages to install for RHEL 9
 common_packages_el9:


### PR DESCRIPTION
##### SUMMARY

Removed the common el9 package variable from ocp4-cluster. Common packages should not be changed. 

Added hint to ocp4-cluster to use extra packages variable to add packages to the config.

Added `jq` to the default list of packages for RHEL8.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-cluster
common (role)