### PR TITLE
Add logic to download hypershift CLI for RHACM 2.8

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/tasks/workload.yml
@@ -202,11 +202,11 @@
       label_selectors:
       - "operators.coreos.com/advanced-cluster-management.open-cluster-management ="
     register: r_rhacm_csv
-  
+
   # Strip first 5 directories if RHACM is 2.7 or earlier
   # Archive contains `remote-source/app/bin/linux/amd64/hypershift`
   - name: Install Hypershift CLI on bastion (RHACM 2.7 or earlier)
-    when: r_rhacm_csv.resources[0].spec.version is version_compare('2.8.0', '<') 
+    when: r_rhacm_csv.resources[0].spec.version is version_compare('2.8.0', '<')
     become: true
     ansible.builtin.unarchive:
       src: /tmp/hypershift.tar.gz
@@ -223,7 +223,7 @@
   # Regular extract if RHACM is 2.8 or newser
   # Archive contains `./hypershift`
   - name: Install Hypershift CLI on bastion (RHACM 2.8 or newer)
-    when: r_rhacm_csv.resources[0].spec.version is version_compare('2.8.0', '>=') 
+    when: r_rhacm_csv.resources[0].spec.version is version_compare('2.8.0', '>=')
     become: true
     ansible.builtin.unarchive:
       src: /tmp/hypershift.tar.gz

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/tasks/workload.yml
@@ -194,9 +194,19 @@
     retries: 10
     delay: 10
 
+  - name: Get currently installed RHACM version
+    kubernetes.core.k8s_info:
+      api_version: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      namespace: open-cluster-management
+      label_selectors:
+      - "operators.coreos.com/advanced-cluster-management.open-cluster-management ="
+    register: r_rhacm_csv
+  
+  # Strip first 5 directories if RHACM is 2.7 or earlier
   # Archive contains `remote-source/app/bin/linux/amd64/hypershift`
-  # Strip first 5 directories
-  - name: Install Hypershift CLI on bastion
+  - name: Install Hypershift CLI on bastion (RHACM 2.7 or earlier)
+    when: r_rhacm_csv.resources[0].spec.version is version_compare('2.8.0', '<') 
     become: true
     ansible.builtin.unarchive:
       src: /tmp/hypershift.tar.gz
@@ -207,6 +217,21 @@
       group: root
       extra_opts:
         --strip-components=5
+    args:
+      creates: /usr/bin/hypershift
+
+  # Regular extract if RHACM is 2.8 or newser
+  # Archive contains `./hypershift`
+  - name: Install Hypershift CLI on bastion (RHACM 2.8 or newer)
+    when: r_rhacm_csv.resources[0].spec.version is version_compare('2.8.0', '>=') 
+    become: true
+    ansible.builtin.unarchive:
+      src: /tmp/hypershift.tar.gz
+      remote_src: true
+      dest: /usr/bin
+      mode: 0775
+      owner: root
+      group: root
     args:
       creates: /usr/bin/hypershift
 


### PR DESCRIPTION
##### SUMMARY

RHACM 2.8 fixed the hypershift CLI package (it's no longer 5 directories deep). This PR adds a check to unzip it properly for 2.8 and newer as well as for 2.7 and earlier.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_rhacm_hypershift