### PR TITLE
fix aro service principal name

### DIFF
--- a/ansible/roles/open-env-azure-create-open-env/tasks/main.yml
+++ b/ansible/roles/open-env-azure-create-open-env/tasks/main.yml
@@ -125,7 +125,7 @@
 - name: Create the Service Principal for ARO
   ansible.builtin.command: >-
     az ad sp create-for-rbac
-    --name "openenv-aro-{{ guid }}"
+    --name "api://openenv-aro-{{ guid }}"
     --role Contributor
     --scopes "{{ azrg.resourcegroups[0].id }}"
   register: azaroappcreate


### PR DESCRIPTION
add missing "api://" to aro service principal