### PR TITLE
Rebalance sizing of advanced controller and standardize on t3a

### DIFF
--- a/ansible/configs/ansible-automation-platform/env_vars.yml
+++ b/ansible/configs/ansible-automation-platform/env_vars.yml
@@ -72,38 +72,39 @@ subdomain_base_suffix: ".example.opentlc.com"
 subdomain_base: "{{subdomain_base_short}}{{subdomain_base_suffix}}"
 
 ## Environment Sizing
-bastion_instance_type: "t2.medium"
+bastion_instance_type: "t3a.medium"
 bastion_instance_image: "RHEL91GOLD-latest"
 
 # Set tower_instance_count to "1" for single-instance Tower (no cluster), "3" for Tower cluster (Set pgdb to "1" then!)
 tower_instance_name: autoctl  # default is tower
 tower_instance_count: 3
-tower_instance_type: "t2.large"
+tower_instance_type: "t3a.large"
 tower_instance_image: "RHEL91GOLD-latest"
 
 # Set to "0" if no cluster, "1" for Tower cluster
 pgdb_instance_name: pgdb  # default is pgdb
 pgdb_instance_count: 1
+# uses tower_instance type and image
 
 node_instance_count: 3
-node_instance_type: "t2.large"
+node_instance_type: "t3a.medium"
 node_instance_image: "RHEL91GOLD-latest"
 
 worker_instance_count: 0
-worker_instance_type: "t2.large"
+worker_instance_type: "t3a.medium"
 worker_instance_image: "RHEL91GOLD-latest"
 
 support_instance_count: 0
-support_instance_type: "t2.large"
+support_instance_type: "t3a.medium"
 support_instance_image: "RHEL91GOLD-latest"
 
 # Set to 1 to deploy Private Automation Hub
 pah_instance_count: 0
-pah_instance_type: "t2.large"
+pah_instance_type: "t3a.large"
 pah_instance_image: "RHEL91GOLD-latest"
 
 exec_instance_count: 0  # increase also tower_expected_instances accordingly!
-exec_instance_type: "t2.medium"
+exec_instance_type: "t3a.medium"
 exec_instance_image: "RHEL91GOLD-latest"
 
 subnets:


### PR DESCRIPTION
##### SUMMARY

t3a is slightly cheaper than t2, and some of the helper VMs were rather too big, compensated by the controller/DB being now bigger (to overcome potential performance issues).

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ansible-automation-platform (config)

##### ADDITIONAL INFORMATION

Related to #10250 on AgnosticV
