### PR TITLE
[WIP] remove "api://" from create-for-rbac

### DIFF
--- a/ansible/roles/open-env-azure-create-open-env/tasks/main.yml
+++ b/ansible/roles/open-env-azure-create-open-env/tasks/main.yml
@@ -50,7 +50,7 @@
 - name: Create the Application and SP
   ansible.builtin.command: >-
     az ad sp create-for-rbac
-    --name "api://openenv-{{ guid }}"
+    --name "openenv-{{ guid }}"
     --role Owner
     --scopes "{{ azrg.resourcegroups[0].id }}"
   register: azappcreate
@@ -125,7 +125,7 @@
 - name: Create the Service Principal for ARO
   ansible.builtin.command: >-
     az ad sp create-for-rbac
-    --name "api://openenv-aro-{{ guid }}"
+    --name "openenv-aro-{{ guid }}"
     --role Contributor
     --scopes "{{ azrg.resourcegroups[0].id }}"
   register: azaroappcreate


### PR DESCRIPTION

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
having **"api://"** in _create-for-rbac_ will fail on the new az command required for controller based deployments using the EE

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Merge after tags are updated

