### PR TITLE
Showroom role, add WeTTY logic replacing butterfly tty in showroom/bookbag 2 UI

### DIFF
--- a/ansible/roles/showroom/templates/container-compose.yml.j2
+++ b/ansible/roles/showroom/templates/container-compose.yml.j2
@@ -21,9 +21,9 @@ services:
     container_name: terminal-01
     hostname: terminal-01
     command:
-      - "--ssh-host={{ targethost }}"
-      - "--ssh-user={{ ssh_username }}"
-      - "--ssh-pass={{ ssh_password }}"
+      - "--ssh-user={{ f_user_data.ssh_username }}"
+      - "--ssh-pass={{ f_user_data.ssh_password }}"
+      - "--ssh-host={{ f_user_data.targethost }}"
       - --allow-iframe=true
     ports:
       - "8001:3000"
@@ -33,9 +33,9 @@ services:
     container_name: terminal-02
     hostname: terminal-02
     command:
-      - "--ssh-host={{ targethost }}"
-      - "--ssh-user={{ ssh_username }}"
-      - "--ssh-pass={{ ssh_password }}"
+      - "--ssh-user={{ f_user_data.ssh_username }}"
+      - "--ssh-pass={{ f_user_data.ssh_password }}"
+      - "--ssh-host={{ f_user_data.targethost }}"
       - --allow-iframe=true
     ports:
       - "8002:3000"

--- a/ansible/roles/showroom/templates/index.html.j2
+++ b/ansible/roles/showroom/templates/index.html.j2
@@ -12,16 +12,10 @@
 			</div>
 			<div class="split right">
 				<div class="tab">
-					<button class="tablinks" onclick="openTerminal(event, 'codeserver_tab')" id="defaultOpen" tabindex="0">VS Code</button>
+					<button class="tablinks" onclick="openTerminal(event, 'terminal_tab')" id="defaultOpen" tabindex="0">Terminal</button>
+					<button class="tablinks" onclick="openTerminal(event, 'codeserver_tab')">VS Code</button>
 					<button class="tablinks" onclick="openTerminal(event, 'docs_tab')">Ansible Docs</button>
-					<button class="tablinks" onclick="openTerminal(event, 'terminal_tab')">Terminal</button>
 				</div>
-					<div id="codeserver_tab" class="tabcontent">
-                        <iframe id="codeserver" src="http://{{ showroom_host }}:8003" height="100%" width="100%" style="border:none;"></iframe>
-					</div>
-					<div id="docs_tab" class="tabcontent">
-						<iframe id="docs" src="https://docs.ansible.com/" width="100%" style="border:none;"></iframe>
-					</div>
 					<div id="terminal_tab" class="tabcontent">
 						<div class="split top">
 						    <iframe id="terminal_01"  src="http://{{ showroom_host }}:8001/wetty" width="100%" style="border:none;"></iframe>
@@ -29,6 +23,12 @@
 						<div class="split bottom">
 							<iframe id="terminal_02"  src="http://{{ showroom_host }}:8002/wetty" width="100%" style="border:none;"></iframe>
 						</div>
+					</div>
+					<div id="codeserver_tab" class="tabcontent">
+                        <iframe id="codeserver" src="http://{{ showroom_host }}:8003" height="100%" width="100%" style="border:none;"></iframe>
+					</div>
+					<div id="docs_tab" class="tabcontent">
+						<iframe id="docs" src="https://docs.ansible.com/" width="100%" style="border:none;"></iframe>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
##### SUMMARY

Enhancement to the web based ttys in showroom role

- moved from butterfly based to WeTTY
- Automated ssh in tty's i.e. they automatically pre-ssh into the VM (e.g. bastion etc)
- Tweaked tab order with ttys default (then VSCode, external site)

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

role/showroom

##### ADDITIONAL INFORMATION
