### PR TITLE
OHC: Fix VMware cluster UPI

### DIFF
--- a/ansible/configs/ocp4-upi-vmc/templates/install-config.yaml.j2
+++ b/ansible/configs/ocp4-upi-vmc/templates/install-config.yaml.j2
@@ -4,7 +4,7 @@ compute:
 - architecture: amd64
   hyperthreading: Enabled
   name: worker
-  replicas: 0
+  replicas: 2
 controlPlane:
   architecture: amd64
   hyperthreading: Enabled

--- a/ansible/configs/ocp4-upi-vmc/templates/power-on.sh.j2
+++ b/ansible/configs/ocp4-upi-vmc/templates/power-on.sh.j2
@@ -20,13 +20,12 @@ govc vm.power -on=true ${WORKER0_NAME}.${GUID}.${CLUSTER_DOMAIN}
 govc vm.power -on=true ${WORKER1_NAME}.${GUID}.${CLUSTER_DOMAIN}
 #govc vm.power -on=true ${WORKER2_NAME}.${GUID}.${CLUSTER_DOMAIN}
 
-# Omit for OHC Demo.  Demonstrator human will do this.
 
-# openshift-install wait-for bootstrap-complete  --dir ~/ocpinstall/install/ --log-level debug
-# export KUBECONFIG=~/ocpinstall/install/auth/kubeconfig
-# echo -e "\e[1;32m Wait 5 minutes and approve CSR \e[0m"
-# sleep 300
-# for i in `oc get csr --no-headers | grep -i pending |  awk '{ print $1 }'`; do oc adm certificate approve $i; done
-# echo -e "\e[1;32m .. and again .. Wait 3 minutes and approve CSR \e[0m"
-# sleep 180
-# for i in `oc get csr --no-headers | grep -i pending |  awk '{ print $1 }'`; do oc adm certificate approve $i; done
+openshift-install wait-for bootstrap-complete  --dir ~/ocpinstall/install/ --log-level debug
+export KUBECONFIG=~/ocpinstall/install/auth/kubeconfig
+echo -e "\e[1;32m Wait 5 minutes and approve CSR \e[0m"
+sleep 300
+for i in `oc get csr --no-headers | grep -i pending |  awk '{ print $1 }'`; do oc adm certificate approve $i; done
+echo -e "\e[1;32m .. and again .. Wait 3 minutes and approve CSR \e[0m"
+sleep 180
+for i in `oc get csr --no-headers | grep -i pending |  awk '{ print $1 }'`; do oc adm certificate approve $i; done


### PR DESCRIPTION
The VMware UPI was never completing successfully.  Demonstrators could not go off script and demonstrate adding a vmware cluster to RHACM.  Now they can.