### PR TITLE
Adds pyopenssl

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_telco_hypershift_lab/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_telco_hypershift_lab/tasks/pre_workload.yml
@@ -76,19 +76,13 @@
       - podman
       - httpd-tools
       - haproxy
+      - python3-pyOpenSSL
     state: present
 
 - name: Ensure ksushy requirements are installed
   ansible.builtin.pip:
     name: cherrypy
 
-# - name: Ensure epel-release is installed
-#   ansible.builtin.dnf:
-#     name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-
-# - name: Ensure python3-cherrypy is installed
-#   ansible.builtin.dnf:
-#     name: python3-cherrypy
 
 - name: Ensure kcli rpm is installed
   ansible.builtin.dnf:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

Fixes an issue where pyOpenSSL doesn't exist on the hypervisor and fails the provisioning.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4_workload_telco_hypershift_lab
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
