### PR TITLE
Update snapshot-catalogsource.yaml.j2

### DIFF
--- a/ansible/roles/ocp4-workload-dil-streaming/templates/snapshot-catalogsource.yaml.j2
+++ b/ansible/roles/ocp4-workload-dil-streaming/templates/snapshot-catalogsource.yaml.j2
@@ -6,7 +6,7 @@
     namespace: {{ snapshot_operator_project }}
   spec:
     sourceType: grpc
-    image: quay.io/gpte-devops-automation/olm_snapshot_redhat_catalog:v4.10_2023_01_16
+    image: quay.io/gpte-devops-automation/olm_snapshot_redhat_catalog:v4.12_2023_06_26
     displayName: "Red Hat Operators Snapshot (2023-Q1)"
     publisher: "GPTE"
 ---


### PR DESCRIPTION
Change to new snapshot
   # image: quay.io/gpte-devops-automation/olm_snapshot_redhat_catalog:v4.10_2023_01_16
    image: quay.io/gpte-devops-automation/olm_snapshot_redhat_catalog:v4.12_2023_06_26
Bug Fix - DIL Streamning as old image/snapshot  doesn't exist 

https://github.com/redhat-cop/agnosticd/blob/f419c9971b25f04796bcfa530cdcec2071844e81/ansible/roles/ocp4-workload-camel3-workshop/templates/snapshot-catalogsource.yaml.j2#L33C4-L33C87 