### PR TITLE
Fixed typo in credentials name

### DIFF
--- a/ansible/configs/ansible-rhel-workshop/default_vars.yml
+++ b/ansible/configs/ansible-rhel-workshop/default_vars.yml
@@ -150,7 +150,7 @@ controller_configuration_dispatcher_roles:
 #     state: present
 
 controller_credentials:
-  - name: "Workshop Credential"
+  - name: "Workshop Credentials"
     organization: Default
     credential_type: "Machine"
     inputs:


### PR DESCRIPTION
##### SUMMARY
Fixed typo in automation controller credential variable

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
config: ansible-rhel-workshop