### PR TITLE
Update retries as sometimes it is taking much more time than expected

### DIFF
--- a/ansible/roles/ocp4-workload-dil-streaming/tasks/provision_devspaces.yaml
+++ b/ansible/roles/ocp4-workload-dil-streaming/tasks/provision_devspaces.yaml
@@ -58,8 +58,8 @@
     status_code: '200'
   register: result
   until: result.status == 200
-  retries: 100
-  delay: 40
+  retries: 120
+  delay: 50
 
 - name: Add users and create workspaces
   include_tasks: user_workspace.yaml


### PR DESCRIPTION
##### SUMMARY
Updating reties for TASK [ocp4-workload-dil-streaming : Evaluate OpenShift Dev Spaces Cluster] as until logic is already in place.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Role: ocp4-workload-dil-streaming, TASK [ocp4-workload-dil-streaming : Evaluate OpenShift Dev Spaces Cluster]
