### PR TITLE
Fix role ocp4-workload-ccnrd-stable

### DIFF
--- a/ansible/roles/ocp4-workload-ccnrd-stable/files/devspaces_cr.yaml
+++ b/ansible/roles/ocp4-workload-ccnrd-stable/files/devspaces_cr.yaml
@@ -4,6 +4,8 @@ kind: CheCluster
 metadata:
   name: devspaces
   namespace: openshift-operators
+  annotations:
+    che.eclipse.org/checluster-defaults-cleanup: '{"spec.components.pluginRegistry.openVSXURL":"true"}'
 spec:
   components:
     cheServer:


### PR DESCRIPTION
##### SUMMARY

This PR adds a workaround to configure Dev Spaces to use the online VisualStudio Code extension registry open-vsx.org (thousands of extensions) instead of the embedded one (~50 extensions). 

More details about the problem are available in the upstream issue https://github.com/eclipse/che/issues/22322.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

OpenShift Dev Spaces CR file for ocp4-workload-ccnrd-stable 

##### ADDITIONAL INFORMATION

Before this change some extensions like `redhat.windup-vscode-extension` could not be installed.