### PR TITLE
fix cert-manager policy, remove debug stuff

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/tasks/workload.yml
@@ -84,7 +84,7 @@
     _ocp4_workload_deploy_hosted_cluster_console_url: >-
       https://console-openshift-console.apps.{{ ocp4_workload_deploy_hosted_cluster_name }}.{{ ocp4_workload_deploy_hosted_cluster_base_domain }}
 
-- name: Ensure that the namespaces exists
+- name: Ensure that the policy namespaces exist on the hub
   kubernetes.core.k8s:
     state: present
     api_version: v1
@@ -94,22 +94,6 @@
   - "{{ ocp4_workload_deploy_hosted_cluster_channels_namespace }}"
   - "{{ ocp4_workload_deploy_hosted_cluster_applications_namespace }}"
   - "{{ ocp4_workload_deploy_hosted_cluster_policies_namespace }}"
-
-- name: Debug vars
-  ansible.builtin.debug:
-    msg: "{{ item }}"
-  loop:
-  - "ID: {{ ocp4_workload_deploy_hosted_cluster_certmanager_aws_access_key_id | default('Unset') }}"
-  - "Secret: {{ ocp4_workload_deploy_hosted_cluster_certmanager_aws_secret_access_key | default('Unset') }}"
-  - "Zone: {{ ocp4_workload_deploy_hosted_cluster_certmanager_aws_hostedzone_id | default('Unset') }}"
-
-- name: Debug cert-manager policy
-  when: ocp4_workload_deploy_hosted_cluster_certmanager_enabled | bool
-  ansible.builtin.template:
-    dest: "~{{ ansible_user }}/policy-cert-manager.yaml"
-    src: certmanager/policy.yaml.j2
-    owner: "{{ ansible_user }}"
-    mode: 0660
 
 - name: Create cert-manager policy
   when: ocp4_workload_deploy_hosted_cluster_certmanager_enabled | bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/templates/certmanager/policy.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/templates/certmanager/policy.yaml.j2
@@ -4,6 +4,7 @@ kind: Policy
 metadata:
   name: certmanager-{{ guid }}
   namespace: {{ ocp4_workload_deploy_hosted_cluster_policies_namespace }}
+spec:
   remediationAction: enforce
   disabled: false
   policy-templates:


### PR DESCRIPTION
##### SUMMARY

cert-manager policy was missing the `spec:` line. Added.
Also removed debug information.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_deploy_hosted_cluster