### PR TITLE
Update 5G RAN Lab to latest OCP release 4.13

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/defaults/main.yml
@@ -3,12 +3,13 @@ become_override: true
 ocp_username: opentlc-mgr
 silent: false
 
-lab_version: "lab-4.12"
+lab_version: "lab-4.13"
+repo_user: "RHsyseng"
 kcli_baremetal_plan_revision: 0cdab26571acf61feeaabf216c1d3066f780cb87
 # yamllint disable rule:line-length
-kcli_rpm: "https://github.com/RHsyseng/5g-ran-deployments-on-ocp-lab/raw/{{ lab_version }}/lab-materials/kcli-rpm/kcli-99.0.0.git.202305180753.3473537-0.el8.x86_64.rpm"
+kcli_rpm: "https://github.com/{{ repo_user }}/5g-ran-deployments-on-ocp-lab/raw/{{ lab_version }}/lab-materials/kcli-rpm/kcli-99.0.0.git.202305180753.3473537-0.el8.x86_64.rpm"
 # yamllint enable rule:line-length
-ocp4_major_release: "4.12"
+ocp4_major_release: "4.13"
 lab_network_cidr: "192.168.125.0/24"
 lab_network_domain: "5g-deployment.lab"
 lab_registry_host: "infra.5g-deployment.lab:8443"
@@ -21,10 +22,9 @@ lab_sno_vm_cpus: 12
 lab_sno_vm_memory: 24000
 lab_sno_vm_disk: 200
 extra_disk_libvirt_images: true
-rhcos_live_image_url: 'https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.12/4.12.3/rhcos-4.12.3-x86_64-live-rootfs.x86_64.img'
-rhcos_rootfs_image_url: 'https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.12/4.12.3/rhcos-4.12.3-x86_64-live.x86_64.iso'
+rhcos_live_image_url: 'https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.13/4.13.0/rhcos-4.13.0-x86_64-live-rootfs.x86_64.img'
+rhcos_rootfs_image_url: 'https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.13/4.13.0/rhcos-4.13.0-x86_64-live.x86_64.iso'
 lab_url: "https://labs.sysdeseng.com/5g-ran-deployments-on-ocp-lab/{{ ocp4_major_release }}/index.html"
-
 # yamllint disable rule:line-length
 etc_hosts_records: "infra.5g-deployment.lab api.hub.5g-deployment.lab multicloud-console.apps.hub.5g-deployment.lab console-openshift-console.apps.hub.5g-deployment.lab oauth-openshift.apps.hub.5g-deployment.lab openshift-gitops-server-openshift-gitops.apps.hub.5g-deployment.lab api.sno1.5g-deployment.lab api.sno2.5g-deployment.lab"
 # yamllint enable rule:line-length

--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/pre_workload.yml
@@ -132,13 +132,13 @@
     mode: "{{ item.mode }}"
   # yamllint disable rule:line-length
   with_items:
-    - {url: "https://raw.githubusercontent.com/RHsyseng/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/dnsmasq/dnsmasq.conf", destination: "/opt/dnsmasq/dnsmasq.conf", mode: "0644"}
-    - {url: "https://raw.githubusercontent.com/RHsyseng/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/dnsmasq/upstream-resolv.conf", destination: "/opt/dnsmasq/upstream-resolv.conf", mode: "0644"}
-    - {url: "https://raw.githubusercontent.com/RHsyseng/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/dnsmasq/hub.ipv4", destination: "/opt/dnsmasq/include.d/hub.ipv4", mode: "0644"}
-    - {url: "https://raw.githubusercontent.com/RHsyseng/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/dnsmasq/sno1.ipv4", destination: "/opt/dnsmasq/include.d/sno1.ipv4", mode: "0644"}
-    - {url: "https://raw.githubusercontent.com/RHsyseng/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/dnsmasq/sno2.ipv4", destination: "/opt/dnsmasq/include.d/sno2.ipv4", mode: "0644"}
-    - {url: "https://raw.githubusercontent.com/RHsyseng/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/dnsmasq/infrastructure-host.ipv4", destination: "/opt/dnsmasq/include.d/infrastructure-host.ipv4", mode: "0644"}
-    - {url: "https://raw.githubusercontent.com/RHsyseng/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/dnsmasq/dnsmasq-virt.service", destination: "/etc/systemd/system/dnsmasq-virt.service", mode: "0644"}
+    - {url: "https://raw.githubusercontent.com/{{ repo_user }}/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/dnsmasq/dnsmasq.conf", destination: "/opt/dnsmasq/dnsmasq.conf", mode: "0644"}
+    - {url: "https://raw.githubusercontent.com/{{ repo_user }}/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/dnsmasq/upstream-resolv.conf", destination: "/opt/dnsmasq/upstream-resolv.conf", mode: "0644"}
+    - {url: "https://raw.githubusercontent.com/{{ repo_user }}/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/dnsmasq/hub.ipv4", destination: "/opt/dnsmasq/include.d/hub.ipv4", mode: "0644"}
+    - {url: "https://raw.githubusercontent.com/{{ repo_user }}/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/dnsmasq/sno1.ipv4", destination: "/opt/dnsmasq/include.d/sno1.ipv4", mode: "0644"}
+    - {url: "https://raw.githubusercontent.com/{{ repo_user }}/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/dnsmasq/sno2.ipv4", destination: "/opt/dnsmasq/include.d/sno2.ipv4", mode: "0644"}
+    - {url: "https://raw.githubusercontent.com/{{ repo_user }}/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/dnsmasq/infrastructure-host.ipv4", destination: "/opt/dnsmasq/include.d/infrastructure-host.ipv4", mode: "0644"}
+    - {url: "https://raw.githubusercontent.com/{{ repo_user }}/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/dnsmasq/dnsmasq-virt.service", destination: "/etc/systemd/system/dnsmasq-virt.service", mode: "0644"}
   # yamllint enable rule:line-length
 
 - name: Ensure DNS Upstream server is configured
@@ -172,9 +172,11 @@
 
 - name: Ensure dispatcher script exists
   ansible.builtin.get_url:
-    url: "https://raw.githubusercontent.com/RHsyseng/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/hypervisor/forcedns"
+  # yamllint disable rule:line-length
+    url: "https://raw.githubusercontent.com/{{ repo_user }}/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/hypervisor/forcedns"
     dest: "/etc/NetworkManager/dispatcher.d/forcedns"
     mode: "0755"
+  # yamllint enable rule:line-length
 
 - name: Ensure NetworkManager is restarted
   ansible.builtin.systemd:
@@ -188,7 +190,7 @@
 - name: Ensure disconnected webcache config files exist
   ansible.builtin.get_url:
     # yamllint disable rule:line-length
-    url: "https://raw.githubusercontent.com/RHsyseng/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/webcache/podman-webcache.service"
+    url: "https://raw.githubusercontent.com/{{ repo_user }}/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/webcache/podman-webcache.service"
     # yamllint enable rule:line-length
     dest: "/etc/systemd/system/podman-webcache.service"
     mode: "0644"
@@ -251,10 +253,10 @@
     mode: "{{ item.mode }}"
   # yamllint disable rule:line-length
   with_items:
-    - {url: "https://raw.githubusercontent.com/RHsyseng/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/registry/registry-key.pem", destination: "/opt/registry/certs/registry-key.pem", mode: "0644"}
-    - {url: "https://raw.githubusercontent.com/RHsyseng/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/registry/registry-cert.pem", destination: "/opt/registry/certs/registry-cert.pem", mode: "0644"}
-    - {url: "https://raw.githubusercontent.com/RHsyseng/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/registry/config.yml", destination: "/opt/registry/conf/config.yml", mode: "0644"}
-    - {url: "https://raw.githubusercontent.com/RHsyseng/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/registry/podman-registry.service", destination: "/etc/systemd/system/podman-registry.service", mode: "0644"}
+    - {url: "https://raw.githubusercontent.com/{{ repo_user }}/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/registry/registry-key.pem", destination: "/opt/registry/certs/registry-key.pem", mode: "0644"}
+    - {url: "https://raw.githubusercontent.com/{{ repo_user }}/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/registry/registry-cert.pem", destination: "/opt/registry/certs/registry-cert.pem", mode: "0644"}
+    - {url: "https://raw.githubusercontent.com/{{ repo_user }}/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/registry/config.yml", destination: "/opt/registry/conf/config.yml", mode: "0644"}
+    - {url: "https://raw.githubusercontent.com/{{ repo_user }}/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/registry/podman-registry.service", destination: "/etc/systemd/system/podman-registry.service", mode: "0644"}
   # yamllint enable rule:line-length
 
 - name: Ensure disconnected registry user credentials exist
@@ -316,7 +318,7 @@
 - name: Ensure git server config file exists
   ansible.builtin.get_url:
     # yamllint disable rule:line-length
-    url: "https://raw.githubusercontent.com/RHsyseng/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/gitea/podman-gitea.service"
+    url: "https://raw.githubusercontent.com/{{ repo_user }}/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/gitea/podman-gitea.service"
     # yamllint enable rule:line-length
     dest: "/etc/systemd/system/podman-gitea.service"
     mode: "0644"
@@ -347,7 +349,7 @@
     password: student
     method: POST
     # yamllint disable rule:line-length
-    body: '{"service":"2","clone_addr":"https://github.com/RHsyseng/5g-ran-deployments-on-ocp-lab.git","uid":1,"repo_name":"5g-ran-deployments-on-ocp-lab"}'
+    body: '{"service":"2","clone_addr":"https://github.com/{{ repo_user }}/5g-ran-deployments-on-ocp-lab.git","uid":1,"repo_name":"5g-ran-deployments-on-ocp-lab"}'
     # yamllint enable rule:line-length
     body_format: json
     status_code: 201
@@ -388,9 +390,11 @@
 
 - name: Ensure plan file exists
   ansible.builtin.get_url:
-    url: "https://raw.githubusercontent.com/RHsyseng/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/hub-cluster/hub.yml"
+    # yamllint disable rule:line-length
+    url: "https://raw.githubusercontent.com/{{ repo_user }}/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/hub-cluster/hub.yml"
     dest: "/root/kcli-openshift4-baremetal/hub.yml"
     mode: "0644"
+    # yamllint enable rule:line-length
 
 - name: Setup admin password
   set_fact:

--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/workload.yml
@@ -16,11 +16,11 @@
     mode: "{{ item.mode }}"
   # yamllint disable rule:line-length
   with_items:
-    - {url: "https://raw.githubusercontent.com/RHsyseng/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/hub-cluster/lvmcluster.yaml", destination: "/tmp/lvmcluster.yaml", mode: "0644"}
-    - {url: "https://raw.githubusercontent.com/RHsyseng/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/hub-cluster/argocd-patch.json", destination: "/tmp/argocd-openshift-gitops-patch.json", mode: "0644"}
-    - {url: "https://raw.githubusercontent.com/RHsyseng/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/hub-cluster/hub-operators-argoapps.yaml", destination: "/tmp/hub-operators-argoapps.yaml", mode: "0644"}
-    - {url: "https://raw.githubusercontent.com/RHsyseng/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/hub-cluster/sno1-argoapp.yaml", destination: "/tmp/sno1-argoapp.yaml", mode: "0644"}
-    - {url: "https://raw.githubusercontent.com/RHsyseng/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/hub-cluster/argocd-clusterrolebinding.yaml", destination: "/tmp/argocd-clusterrolebinding.yaml", mode: "0644"}
+    - {url: "https://raw.githubusercontent.com/{{ repo_user }}/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/hub-cluster/lvmcluster.yaml", destination: "/tmp/lvmcluster.yaml", mode: "0644"}
+    - {url: "https://raw.githubusercontent.com/{{ repo_user }}/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/hub-cluster/argocd-patch.json", destination: "/tmp/argocd-openshift-gitops-patch.json", mode: "0644"}
+    - {url: "https://raw.githubusercontent.com/{{ repo_user }}/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/hub-cluster/hub-operators-argoapps.yaml", destination: "/tmp/hub-operators-argoapps.yaml", mode: "0644"}
+    - {url: "https://raw.githubusercontent.com/{{ repo_user }}/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/hub-cluster/sno1-argoapp.yaml", destination: "/tmp/sno1-argoapp.yaml", mode: "0644"}
+    - {url: "https://raw.githubusercontent.com/{{ repo_user }}/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/hub-cluster/argocd-clusterrolebinding.yaml", destination: "/tmp/argocd-clusterrolebinding.yaml", mode: "0644"}
   # yamllint enable rule:line-length
 
 - name: Wait for hub cluster to be deployed via kcli
@@ -244,9 +244,11 @@
 
 - name: Ensure HAProxy config is downloaded
   ansible.builtin.get_url:
-    url: "https://raw.githubusercontent.com/RHsyseng/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/haproxy/haproxy.cfg"
+    # yamllint disable rule:line-length
+    url: "https://raw.githubusercontent.com/{{ repo_user }}/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/haproxy/haproxy.cfg"
     dest: "/etc/haproxy/haproxy.cfg"
     mode: "0644"
+    # yamllint enable rule:line-length
 
 - name: Ensure HAProxy service is enabled and running
   ansible.builtin.systemd:


### PR DESCRIPTION
#### SUMMARY

Small changes to adapt to the new version of the lab targeting OCP 4.13. Basically:

- Update to OCP 4.13 release
- Add the change to specify a different Git repo and branch. Notice that this is set in the defaults. That will help us to test the playbook against our forked repo.

##### ISSUE TYPE
- New config Pull Request

##### COMPONENT NAME
ocp4_workload_5gran_deployments_lab

cc/ @mvazquezc 
