### PR TITLE
Change workload ocp4_workload_rhacs to EPBF collection 

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacs/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacs/tasks/workload.yml
@@ -154,7 +154,7 @@
           contactImageScanners: ScanIfMissing
         perNode:
           collector:
-            collection: KernelModule
+            collection: EBPF
             imageFlavor: Regular
           taintToleration: TolerateTaints
 


### PR DESCRIPTION
##### SUMMARY
Starting RHACS 4.1, you can't use the KernelModule anymore, you must use EBPF
It's removed as per the release notes https://docs.openshift.com/acs/4.1/release_notes/41-release-notes.html#kernel-module-collection-method_release-notes-41

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
ansible/roles_ocp_workloads/ocp4_workload_hands_on_rhacs

