### PR TITLE
rosa: remove deprecated SSH variables and role (For EE / Controller)

### DIFF
--- a/ansible/configs/rosa/default_vars.yml
+++ b/ansible/configs/rosa/default_vars.yml
@@ -28,11 +28,6 @@ cloud_tags:
   course_name: "{{ course_name | default( 'unknown' ) }}"
   platform: "{{ platform | default( 'unknown' ) }}"
 
-set_env_authorized_key: true
-env_authorized_key: "{{guid}}key"
-key_name: "rosa_key"
-ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem
-
 bastion_user_name: rosa
 bastion_user_enable_sudo: false
 bastion_user_use_password: false

--- a/ansible/configs/rosa/destroy_env.yml
+++ b/ansible/configs/rosa/destroy_env.yml
@@ -9,12 +9,6 @@
     AWS_SECRET_ACCESS_KEY: "{{aws_secret_access_key}}"
     AWS_DEFAULT_REGION: "{{aws_region_final|d(aws_region)}}"
   tasks:
-  - name: Create infra key
-    include_role:
-      name: infra-ec2-ssh-key
-    when:
-    - install_infra_ssh_key | default(false) | bool
-
   - name: Get fact for cloudformation stack
     cloudformation_facts:
       stack_name: "{{ project_tag }}"

--- a/ansible/configs/rosa/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/rosa/files/cloud_providers/ec2_cloud_template.j2
@@ -204,7 +204,7 @@ Resources:
         - {{ instance.image | default(aws_default_image) }}
 {%     endif %}
       InstanceType: "{{instance['flavor'][cloud_provider]}}"
-      KeyName: "{{instance.key_name | default(key_name)}}"
+      KeyName: "{{instance.key_name | default(ssh_provision_key_name) | default(key_name)}}"
 {%     if instance['UserData'] is defined %}
       {{instance['UserData']}}
 {%     endif %}

--- a/ansible/configs/rosa/pre_software.yml
+++ b/ansible/configs/rosa/pre_software.yml
@@ -1,23 +1,4 @@
 ---
-- name: Step 003 - Pre Software
-  hosts: localhost
-  connection: local
-  gather_facts: false
-  become: false
-  tags:
-  - step003
-  - generate_env_keys
-  tasks:
-  - name: Generate SSH keys
-    when: set_env_authorized_key | bool
-    openssh_keypair:
-      state: present
-      path: "{{ output_dir }}/{{ env_authorized_key }}"
-      comment: "{{ key_name }}"
-      size: 4096
-      type: rsa
-      mode: 0400
-
 # Cloudformation or Heat template or equivalent should tag all hosts with Project:{{ env_type }}-{{ guid }}
 - name: Configure all hosts with Repositories, Common Files and Set environment key
   hosts: all
@@ -29,8 +10,6 @@
   roles:
   - role: common
     when: install_common | default( true ) | bool
-  - role: set_env_authorized_key
-    when: set_env_authorized_key | bool
   tasks:
   - name: Add GUID to /etc/skel/.bashrc
     lineinfile:


### PR DESCRIPTION

##### SUMMARY
Fix the rosa config to use the correct SSH keys and not the old deprecated variables.


This change fixes the following  error that occurs on Controller when using EE:

```
TASK [infra-ec2-wait_for_linux_hosts : wait for linux host to be available (retry)] ***12:30:41
640
fatal: [bastion.rhz6l.internal]: FAILED! => {"changed": false, "elapsed": 260, "msg": "timed out waiting for ping module test: Failed to connect to the host via ssh: no such identity: /home/runner/.ssh/opentlc_admin_backdoor.pem: No such file or directory\r\nec2-user@ec2-3-23-174-219.us-east-2.compute.amazonaws.com: Permission denied (publickey,gssapi-keyex,gssapi-with-mic)."}
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
