### PR TITLE
[VMC SANDBOX] Ensure the IP is gathered

### DIFF
--- a/ansible/roles-infra/infra-vmc-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-vmc-resources/tasks/create_instance.yaml
@@ -85,7 +85,7 @@
   loop: "{{ range(1, _instance.count|default(1)|int+1) | list }}"
   loop_control:
     index_var: _index
-  until: r_vmc_instance is success
+  until: "r_vmc_instance is success and 'ipv4' in r_vmc_instance[_index]['instance']"
   retries: 5
   delay: 10
 


### PR DESCRIPTION
In some situations the IP is not obtained properly and then the NAT creation fails