### PR TITLE
OCP4 install plans: Fix confusing error message

### DIFF
--- a/ansible/roles/install_operator/tasks/install.yml
+++ b/ansible/roles/install_operator/tasks/install.yml
@@ -84,7 +84,7 @@
   retries: 30
   delay: 10
   until:
-  - r_install_plans.resources | length > 0
+  - r_install_plans.resources | default([]) | length > 0
   - r_install_plans.resources | to_json | from_json | json_query(_query)
 
 - name: "{{ install_operator_name }} - Set InstallPlan name"

--- a/ansible/roles/install_operator/tasks/remove.yml
+++ b/ansible/roles/install_operator/tasks/remove.yml
@@ -35,7 +35,7 @@
   register: r_install_plans
 
 - name: "{{ install_operator_name }} - Set InstallPlan name"
-  when: r_install_plans.resources | length > 0
+  when: r_install_plans.resources | default([]) | length > 0
   set_fact:
     install_operator_install_plan_name: "{{ r_install_plans.resources | to_json | from_json | json_query(query) }}"
   vars:

--- a/ansible/roles/ocp-workload-aiedge-computing-blueprint/tasks/approve_installplan.yml
+++ b/ansible/roles/ocp-workload-aiedge-computing-blueprint/tasks/approve_installplan.yml
@@ -11,7 +11,7 @@
   retries: 60
   delay: 5
   until:
-    - r_install_plans.resources | length > 0
+    - r_install_plans.resources | default([]) | length > 0
     - r_install_plans.resources | to_json | from_json | json_query(_query)
 
 - name: Set InstallPlan name

--- a/ansible/roles/ocp4-workload-dil-serverless/tasks/approves_installplan.yaml
+++ b/ansible/roles/ocp4-workload-dil-serverless/tasks/approves_installplan.yaml
@@ -10,7 +10,7 @@
   retries: 30
   delay: 5
   until:
-  - r_install_plans.resources | length > 0
+  - r_install_plans.resources | default([]) | length > 0
   - r_install_plans.resources | to_json | from_json | json_query(_query)
 
 - name: Set InstallPlan Name

--- a/ansible/roles/ocp4-workload-pipelines/tasks/remove_workload.yml
+++ b/ansible/roles/ocp4-workload-pipelines/tasks/remove_workload.yml
@@ -86,7 +86,7 @@
   register: r_install_plans
 
 - name: Set InstallPlan Name
-  when: r_install_plans.resources | length > 0
+  when: r_install_plans.resources | default([]) | length > 0
   set_fact:
     ocp4_workload_pipelines_install_plan_name: "{{ r_install_plans.resources | to_json | from_json | json_query(query) }}"
   vars:

--- a/ansible/roles/ocp4-workload-serverless/tasks/remove_workload.yml
+++ b/ansible/roles/ocp4-workload-serverless/tasks/remove_workload.yml
@@ -78,7 +78,7 @@
   register: r_install_plans
 
 - name: Set InstallPlan Name
-  when: r_install_plans.resources | length > 0
+  when: r_install_plans.resources | default([]) | length > 0
   set_fact:
     ocp4_workload_serverless_install_plan_name: "{{ r_install_plan.resources | to_json | from_json | json_query(query) }}"
   vars:

--- a/ansible/roles_ocp_workloads/ocp4_workload_argocd_operator/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_argocd_operator/tasks/remove_workload.yml
@@ -40,7 +40,7 @@
   register: r_install_plans
 
 - name: Set InstallPlan Name
-  when: r_install_plans.resources | length > 0
+  when: r_install_plans.resources | default([]) | length > 0
   set_fact:
     ocp4_workload_argocd_operator_install_plan_name: >-
       {{ r_install_plans.resources | to_json | from_json | json_query(query) }}

--- a/ansible/roles_ocp_workloads/ocp4_workload_argocd_operator/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_argocd_operator/tasks/workload.yml
@@ -34,7 +34,7 @@
   retries: 30
   delay: 5
   until:
-  - r_install_plans.resources | length > 0
+  - r_install_plans.resources | default([]) | length > 0
   - r_install_plans.resources | to_json | from_json | json_query(_query)
 
 - name: Set InstallPlan Name

--- a/ansible/roles_ocp_workloads/ocp4_workload_image_puller_operator/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_image_puller_operator/tasks/workload.yml
@@ -36,7 +36,7 @@
   retries: 30
   delay: 5
   until:
-  - r_install_plans.resources | length > 0
+  - r_install_plans.resources | default([]) | length > 0
   - r_install_plans.resources | to_json | from_json | json_query(_query)
 
 - name: Set InstallPlan Name

--- a/ansible/roles_ocp_workloads/ocp4_workload_jenkins_operator/tasks/deploy_jenkins.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_jenkins_operator/tasks/deploy_jenkins.yml
@@ -32,7 +32,7 @@
   retries: 30
   delay: 5
   until:
-  - r_install_plans.resources | length > 0
+  - r_install_plans.resources | default([]) | length > 0
   - r_install_plans.resources | to_json | from_json | json_query(_query)
 
 - name: Set InstallPlan Name

--- a/ansible/roles_ocp_workloads/ocp4_workload_jenkins_operator/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_jenkins_operator/tasks/remove_workload.yml
@@ -42,7 +42,7 @@
   register: r_install_plans
 
 - name: Set InstallPlan Name
-  when: r_install_plans.resources | length > 0
+  when: r_install_plans.resources | default([]) | length > 0
   set_fact:
     ocp4_workload_pipelines_rhtr_jenkins_install_plan_name: "{{ r_install_plans.resources | to_json | from_json | json_query(query) }}"
   vars:

--- a/ansible/roles_ocp_workloads/ocp4_workload_logging/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_logging/tasks/workload.yml
@@ -80,7 +80,7 @@
     retries: 30
     delay: 5
     until:
-    - r_install_plans.resources | length > 0
+    - r_install_plans.resources | default([]) | length > 0
     - r_install_plans.resources | to_json | from_json | json_query(_query)
 
   - name: Set InstallPlan name
@@ -198,7 +198,7 @@
   retries: 30
   delay: 5
   until:
-  - r_install_plans.resources | length > 0
+  - r_install_plans.resources | default([]) | length > 0
   - r_install_plans.resources | to_json | from_json | json_query(_query)
 
 - name: Set InstallPlan name

--- a/ansible/roles_ocp_workloads/ocp4_workload_migration_training/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_migration_training/tasks/remove_workload.yml
@@ -44,7 +44,7 @@
     register: r_install_plans
 
   - name: Set InstallPlan Name
-    when: r_install_plans.resources | length > 0
+    when: r_install_plans.resources | default([]) | length > 0
     set_fact:
       __ocp4_workload_migration_training_install_plan_name: "{{ r_install_plans.resources | to_json | from_json | json_query(__query) }}"
     vars:

--- a/ansible/roles_ocp_workloads/ocp4_workload_migration_training/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_migration_training/tasks/workload.yml
@@ -47,7 +47,7 @@
     retries: 30
     delay: 5
     until:
-    - r_install_plans.resources | length > 0
+    - r_install_plans.resources | default([]) | length > 0
     - r_install_plans.resources | to_json | from_json | json_query(__query)
 
   - name: Set InstallPlan Name

--- a/ansible/roles_ocp_workloads/ocp4_workload_ml_workflows_user/tasks/open_data_hub.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ml_workflows_user/tasks/open_data_hub.yml
@@ -50,7 +50,7 @@
   retries: 30
   delay: 5
   until:
-  - r_install_plans.resources | length > 0
+  - r_install_plans.resources | default([]) | length > 0
   - r_install_plans.resources | to_json | from_json | json_query(_query)
 
 - name: Set InstallPlan Name

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_container_storage/tasks/install_operator.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_container_storage/tasks/install_operator.yml
@@ -79,7 +79,7 @@
   retries: 30
   delay: 10
   until:
-    - r_install_plans.resources | length > 0
+    - r_install_plans.resources | default([]) | length > 0
 
 - name: "{{ install_operator_name }} - Set InstallPlan name"
   set_fact:

--- a/ansible/roles_ocp_workloads/ocp4_workload_plus/tasks/workload_argocd.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_plus/tasks/workload_argocd.yml
@@ -22,7 +22,7 @@
   retries: 30
   delay: 5
   until:
-  - r_install_plans.resources | length > 0
+  - r_install_plans.resources | default([]) | length > 0
   - r_install_plans.resources | to_json | from_json | json_query(_query)
 
 - name: Set InstallPlan Name

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhtr_xraylab/tasks/amq-streams-operator.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhtr_xraylab/tasks/amq-streams-operator.yaml
@@ -26,7 +26,7 @@
   retries: 30
   delay: 5
   until:
-  - r_install_plans.resources | length > 0
+  - r_install_plans.resources | default([]) | length > 0
   - r_install_plans.resources | to_json | from_json | json_query(_query)
 
 - name: Set InstallPlan Name

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhtr_xraylab/tasks/odh-operator.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhtr_xraylab/tasks/odh-operator.yaml
@@ -26,7 +26,7 @@
   retries: 30
   delay: 5
   until:
-  - r_install_plans.resources | length > 0
+  - r_install_plans.resources | default([]) | length > 0
   - r_install_plans.resources | to_json | from_json | json_query(_query)
 
 - name: Set InstallPlan Name

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhtr_xraylab/tasks/storage.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhtr_xraylab/tasks/storage.yaml
@@ -62,7 +62,7 @@
   retries: 30
   delay: 5
   until:
-  - r_install_plans.resources | length > 0
+  - r_install_plans.resources | default([]) | length > 0
   - r_install_plans.resources | to_json | from_json | json_query(_query)
 
 - name: Set InstallPlan Name

--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless_ml_workshop/tasks/install_amqstreams_operator.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless_ml_workshop/tasks/install_amqstreams_operator.yaml
@@ -23,7 +23,7 @@
   retries: 30
   delay: 5
   until:
-  - r_install_plans.resources | length > 0
+  - r_install_plans.resources | default([]) | length > 0
   - r_install_plans.resources | to_json | from_json | json_query(_query)
 
 - name: Set InstallPlan Name

--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless_ml_workshop/tasks/install_crw_operator.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless_ml_workshop/tasks/install_crw_operator.yaml
@@ -30,7 +30,7 @@
   retries: 30
   delay: 5
   until:
-  - r_install_plans.resources | length > 0
+  - r_install_plans.resources | default([]) | length > 0
   - r_install_plans.resources | to_json | from_json | json_query(_query)
 
 - name: Set InstallPlan Name

--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless_ml_workshop/tasks/install_ocs_operator.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless_ml_workshop/tasks/install_ocs_operator.yaml
@@ -30,7 +30,7 @@
   retries: 30
   delay: 5
   until:
-  - r_install_plans.resources | length > 0
+  - r_install_plans.resources | default([]) | length > 0
   - r_install_plans.resources | to_json | from_json | json_query(_query)
 
 - name: Set InstallPlan Name

--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless_ml_workshop/tasks/install_serverless_operator.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless_ml_workshop/tasks/install_serverless_operator.yaml
@@ -23,7 +23,7 @@
   retries: 30
   delay: 5
   until:
-  - r_install_plans.resources | length > 0
+  - r_install_plans.resources | default([]) | length > 0
   - r_install_plans.resources | to_json | from_json | json_query(_query)
 
 - name: Set InstallPlan Name

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh/tasks/install_jaeger_operator.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh/tasks/install_jaeger_operator.yml
@@ -16,7 +16,7 @@
   retries: 30
   delay: 5
   until:
-  - r_install_plans.resources | length > 0
+  - r_install_plans.resources | default([]) | length > 0
   - r_install_plans.resources | to_json | from_json | json_query(_query)
 
 - name: Set InstallPlan Name

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh/tasks/install_kiali_operator.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh/tasks/install_kiali_operator.yml
@@ -16,7 +16,7 @@
   retries: 30
   delay: 5
   until:
-  - r_install_plans.resources | length > 0
+  - r_install_plans.resources | default([]) | length > 0
   - r_install_plans.resources | to_json | from_json | json_query(_query)
 
 - name: Set InstallPlan Name

--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh/tasks/install_servicemesh_operator.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh/tasks/install_servicemesh_operator.yml
@@ -16,7 +16,7 @@
   retries: 30
   delay: 5
   until:
-  - r_install_plans.resources | length > 0
+  - r_install_plans.resources | default([]) | length > 0
   - r_install_plans.resources | to_json | from_json | json_query(_query)
 
 - name: Set InstallPlan Name

--- a/ansible/roles_ocp_workloads/ocp4_workload_snyk/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_snyk/tasks/workload.yml
@@ -38,7 +38,7 @@
   retries: 30
   delay: 5
   until:
-    - r_install_plans.resources | length > 0
+    - r_install_plans.resources | default([]) | length > 0
     - r_install_plans.resources | to_json | from_json | json_query(_query)
 
 - name: Get Installed CSV


### PR DESCRIPTION
This is a retried task, so the error is non-fatal, but it is still confusing.

Add a default([])

```
FAILED - RETRYING: [bastion.bdhcw.internal]: openshift-pipelines-operator - Wait until InstallPlan is created (9 retries left).
fatal: [bastion.bdhcw.internal]: FAILED! => {"msg": "The conditional check 'r_install_plans.resources | length > 0' failed. The error was: error while evaluating conditional (r_install_plans.resources | length > 0): 'dict object' has no attribute 'resources'. 'dict object' has no attribute 'resources'"}
```

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
