### PR TITLE
[infra-vmc-resources] fix typo

### DIFF
--- a/ansible/roles-infra/infra-vmc-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-vmc-resources/tasks/create_instance.yaml
@@ -81,7 +81,7 @@
   loop: "{{ range(1, _instance.count|default(1)|int+1) | list }}"
   loop_control:
     index_var: _index
-  until: r_vmc_instance is success and r_vmc_instance[_index].instance.ipv4 | default('') != ''
+  until: r_vmc_instance is success and r_vmc_instance.instance.ipv4 | default('') != ''
   retries: 5
   delay: 10
 


### PR DESCRIPTION
It doesnt require _index the registered variable