### PR TITLE
Update workload.yml - improve Install Plan retires

### DIFF
--- a/ansible/roles/ocp4-workload-pipelines/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-pipelines/tasks/workload.yml
@@ -51,8 +51,8 @@
       kind: InstallPlan
       namespace: openshift-operators
     register: r_install_plan
-    retries: 30
-    delay: 5
+    retries: 50
+    delay: 10
     until:
     - r_install_plan|selectattr('clusterServiceVersionNames', 'contains', 'openshift-pipelines-operator')
 


### PR DESCRIPTION
Allow more attempts with a delay  of 10 between each retry. Also adding 50 retires from 30

