### PR TITLE
Update OSSM version in SMCP

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/servicemesh_controlplane.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_servicemesh_workshop/templates/servicemesh_controlplane.j2
@@ -4,7 +4,7 @@ metadata:
   name: workshop-install
   namespace: {{ namespace }}
 spec:
-  version: v2.2
+  version: v2.4
   proxy:
     networking:
       trafficControl:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Updating OSSM version to ensure proper operation on recent OCP versions
Fixes https://redhat.service-now.com/surl.do?n=TASK1585558

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4_workload_servicemesh_workshop

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
This was the event error that showed up related to multus and a deprecated OSSM version
```paste below
Event error: 
Failed to create pod sandbox: rpc error: code = Unknown desc = failed to create pod network sandbox k8s_boards-1-546vb_user1_dd8659ef-fb76-40f2-9433-e9f5a0117021_0(5f91722022d834c09103b117f50a29752c68181bbf09cba8a06c5f715a663c0c): error adding pod user1_boards-1-546vb to CNI network "multus-cni-network": plugin type="multus" name="multus-cni-network" failed (add): Multus: [user1/boards-1-546vb/dd8659ef-fb76-40f2-9433-e9f5a0117021]: error loading k8s delegates k8s args: TryLoadPodDelegates: error in getting k8s network for pod: GetNetworkDelegates: failed getting the delegate: GetCNIConfig: err in GetCNIConfigFromFile: No networks found in /etc/cni/multus/net.d
```
