### PR TITLE
Add kustomize-envvar plugin to openshift-gitops

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_gitops_bootstrap/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitops_bootstrap/tasks/workload.yml
@@ -36,7 +36,7 @@
     name: bootstrap
     namespace: openshift-gitops
   register: argocd_bootstrap
-  retries: 60
+  retries: 90
   delay: 10
   until:
   - argocd_bootstrap is defined

--- a/ansible/roles_ocp_workloads/ocp4_workload_gitops_bootstrap/templates/application.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitops_bootstrap/templates/application.yaml.j2
@@ -10,9 +10,13 @@ spec:
     repoURL: {{ ocp4_workload_gitops_bootstrap_repo_url }}
     targetRevision: {{ ocp4_workload_gitops_bootstrap_repo_revision }}
     path: {{ ocp4_workload_gitops_bootstrap_repo_path }}
+    plugin:
+      name: kustomize-envvar
+{% if ocp4_workload_gitops_bootstrap_helm_values | length > 0 %}
     helm:
       values: |
         {{ ocp4_workload_gitops_bootstrap_helm_values | combine(_ocp4_workload_gitops_bootstrap_deployer_values) }}
+{% endif %}
   destination:
     server: https://kubernetes.default.svc
   syncPolicy:

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/defaults/main.yml
@@ -90,8 +90,7 @@ ocp4_workload_openshift_gitops_server_limits_memory: 256Mi
 # Use with ocp4_workload_openshift_gitops_update_resources: true
 ocp4_workload_openshift_gitops_rbac_update: false
 ocp4_workload_openshift_gitops_rbac_policy: |
-  g, system:cluster-admins, role:admin
-  g, cluster-admins, role:admin
+  g, admin, role:admin
 
 # Resource exclusion customizations for the system ArgoCD.
 # Default is empty

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/main.yml
@@ -1,30 +1,27 @@
 ---
-
-# Do not modify this file
-
 - name: Running Pre Workload Tasks
-  include_tasks:
+  ansible.builtin.include_tasks:
     file: ./pre_workload.yml
     apply:
       become: "{{ become_override | bool }}"
   when: ACTION == "create" or ACTION == "provision"
 
 - name: Running Workload Tasks
-  include_tasks:
+  ansible.builtin.include_tasks:
     file: ./workload.yml
     apply:
       become: "{{ become_override | bool }}"
   when: ACTION == "create" or ACTION == "provision"
 
 - name: Running Post Workload Tasks
-  include_tasks:
+  ansible.builtin.include_tasks:
     file: ./post_workload.yml
     apply:
       become: "{{ become_override | bool }}"
   when: ACTION == "create" or ACTION == "provision"
 
 - name: Running Workload removal Tasks
-  include_tasks:
+  ansible.builtin.include_tasks:
     file: ./remove_workload.yml
     apply:
       become: "{{ become_override | bool }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/post_workload.yml
@@ -7,9 +7,9 @@
     agnosticd_user_info:
       msg: "{{ item }}"
     loop:
-    - "OpenShift GitOps ArgoCD URL: https://openshift-gitops-server-openshift-gitops.{{ _ocp4_workload_openshift_gitops_domain }}"
+    - "OpenShift GitOps ArgoCD: https://openshift-gitops-server-openshift-gitops.{{ _ocp4_workload_openshift_gitops_domain }}"
   - name: save project information
     agnosticd_user_info:
       data:
-        openshift_gitops_server: "openshift-gitops-server-openshift-gitops.{{ _ocp4_workload_openshift_gitops_domain }}"
+        openshift_gitops_server: "https://openshift-gitops-server-openshift-gitops.{{ _ocp4_workload_openshift_gitops_domain }}"
 # yamllint enable rule:line-length

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/post_workload.yml
@@ -1,9 +1,15 @@
 ---
-# Implement your Post Workload deployment tasks here
-
-
-# Leave this as the last task in the playbook.
-- name: post_workload tasks complete
-  debug:
-    msg: "Post-Workload Tasks completed successfully."
-  when: not silent|bool
+# yamllint disable rule:line-length
+- name: project information
+  when: openshift_console_url is defined
+  block:
+  - name: output project information
+    agnosticd_user_info:
+      msg: "{{ item }}"
+    loop:
+    - "OpenShift GitOps ArgoCD URL: https://openshift-gitops-server-openshift-gitops.{{ _ocp4_workload_openshift_gitops_domain }}"
+  - name: save project information
+    agnosticd_user_info:
+      data:
+        openshift_gitops_server: "openshift-gitops-server-openshift-gitops.{{ _ocp4_workload_openshift_gitops_domain }}"
+# yamllint enable rule:line-length

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/pre_workload.yml
@@ -1,8 +1,11 @@
 ---
-# Implement your Pre Workload deployment tasks here
+- name: get IngressController
+  kubernetes.core.k8s_info:
+    kind: IngressController
+    name: default
+    namespace: openshift-ingress-operator
+  register: r_ingress_controller
 
-# Leave this as the last task in the playbook.
-- name: pre_workload tasks complete
-  debug:
-    msg: "Pre-Workload tasks completed successfully."
-  when: not silent|bool
+- name: set _ocp4_workload_openshift_gitops_domain
+  ansible.builtin.set_fact:
+    _ocp4_workload_openshift_gitops_domain: "{{ r_ingress_controller.resources[0].status.domain }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/remove_workload.yml
@@ -1,6 +1,4 @@
 ---
-# Implement your Workload removal tasks here
-
 - name: Install OpenShift GitOps operator
   include_role:
     name: install_operator
@@ -10,7 +8,7 @@
     install_operator_namespace: openshift-operators
     install_operator_channel: preview
     install_operator_catalog: redhat-operators
-    install_operator_catalogsource_setup: "{{ ocp4_workload_openshift_gitops_use_catalog_snapshot | default(false)}}"
+    install_operator_catalogsource_setup: "{{ ocp4_workload_openshift_gitops_use_catalog_snapshot | default(false) }}"
     install_operator_catalogsource_name: "{{ ocp4_workload_openshift_gitops_catalogsource_name | default('') }}"
     install_operator_catalogsource_namespace: openshift-operators
     install_operator_catalogsource_image: "{{ ocp4_workload_openshift_gitops_catalog_snapshot_image | default('') }}"
@@ -20,7 +18,7 @@
   when: ocp4_workload_openshift_gitops_setup_cluster_admin | bool
   kubernetes.core.k8s:
     state: absent
-    definition: "{{ lookup('file', 'clusterrolebinding.yaml' ) | from_yaml }}"
+    definition: "{{ lookup('file', 'clusterrolebinding.yaml') | from_yaml }}"
 
 - name: Remove openshift-gitops namespace
   kubernetes.core.k8s:
@@ -28,9 +26,3 @@
     api_version: v1
     kind: namespace
     name: openshift-gitops
-
-# Leave this as the last task in the playbook.
-- name: remove_workload tasks complete
-  debug:
-    msg: "Remove Workload tasks completed successfully."
-  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/workload.yml
@@ -1,12 +1,6 @@
 ---
-# Implement your Workload deployment tasks here
-
-- name: Setting up workload for user
-  debug:
-    msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
-
 - name: Install OpenShift GitOps operator
-  include_role:
+  ansible.builtin.include_role:
     name: install_operator
   vars:
     install_operator_action: install
@@ -16,7 +10,7 @@
     install_operator_catalog: redhat-operators
     install_operator_automatic_install_plan_approval: "{{ ocp4_workload_openshift_gitops_automatic_install_plan_approval | default(true) }}"
     install_operator_starting_csv: "{{ ocp4_workload_openshift_gitops_starting_csv }}"
-    install_operator_catalogsource_setup: "{{ ocp4_workload_openshift_gitops_use_catalog_snapshot | default(false)}}"
+    install_operator_catalogsource_setup: "{{ ocp4_workload_openshift_gitops_use_catalog_snapshot | default(false) }}"
     install_operator_catalogsource_name: "{{ ocp4_workload_openshift_gitops_catalogsource_name | default('') }}"
     install_operator_catalogsource_namespace: openshift-operators
     install_operator_catalogsource_image: "{{ ocp4_workload_openshift_gitops_catalog_snapshot_image | default('') }}"
@@ -26,7 +20,7 @@
   when: ocp4_workload_openshift_gitops_setup_cluster_admin | bool
   kubernetes.core.k8s:
     state: present
-    definition: "{{ lookup('file', 'clusterrolebinding.yaml' ) | from_yaml }}"
+    definition: "{{ lookup('file', 'clusterrolebinding.yaml') | from_yaml }}"
 
 - name: Update resources for openshift-gitops ArgoCD instance
   when: ocp4_workload_openshift_gitops_update_resources | bool
@@ -46,10 +40,4 @@
   - name: Update resources for the openshift-gitops ArgoCD instance
     kubernetes.core.k8s:
       state: patched
-      definition: "{{ lookup('template', 'openshift-gitops.yaml.j2' ) | from_yaml }}"
-
-# Leave this as the last task in the playbook.
-- name: workload tasks complete
-  debug:
-    msg: "Workload Tasks completed successfully."
-  when: not silent|bool
+      definition: "{{ lookup('template', 'openshift-gitops.yaml.j2') | from_yaml }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/templates/openshift-gitops.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/templates/openshift-gitops.yaml.j2
@@ -5,6 +5,12 @@ metadata:
   name: openshift-gitops
   namespace: openshift-gitops
 spec:
+  configManagementPlugins: |-
+    - name: kustomize-envvar
+      generate:
+        command: ["sh", "-c"]
+        args: ["kustomize build --enable-helm . | perl -pe 's{\\$(\\{)?(\\w+)(?(1)\\})}{$ENV{$2} // $&}ge'"]
+  kustomizeBuildOptions: "--enable-helm --enable-alpha-plugins"
 {% if ocp4_workload_openshift_gitops_rbac_update | default(false) | bool %}
   rbac:
     policy: |
@@ -53,6 +59,9 @@ spec:
         memory: "{{ ocp4_workload_openshift_gitops_redis_requests_memory }}"
 {% endif %}
   repo:
+    env:
+      - name: SUB_DOMAIN
+        value: {{ _ocp4_workload_openshift_gitops_domain }}
 {% if ocp4_workload_openshift_gitops_repo_update | default(false) | bool %}
     resources:
       limits:


### PR DESCRIPTION
This will allow the usage of environment vars in kustomize manifests, so it is possible for gitops deployments to have access to information such as the cluster subdomain.