### PR TITLE
adding delay to the task

### DIFF
--- a/ansible/roles/install_operator/tasks/install.yml
+++ b/ansible/roles/install_operator/tasks/install.yml
@@ -81,7 +81,7 @@
   vars:
     _query: >-
       [?starts_with(spec.clusterServiceVersionNames[0], '{{ install_operator_csv_nameprefix }}') && status.phase ]
-  retries: 30
+  retries: 50
   delay: 10
   until:
   - r_install_plans.resources | default([]) | length > 0


### PR DESCRIPTION
TASK [install_operator : openshift-pipelines-operator - Wait until InstallPlan is created]
FAILED - RETRYING: [bastion.qlhsr.internal]: openshift-pipelines-operator - Wait until InstallPlan is created (2 retries left).
FAILED - RETRYING: [bastion.qlhsr.internal]: openshift-pipelines-operator - Wait until InstallPlan is created (1 retries left).
fatal: [bastion.qlhsr.internal]: FAILED! => {"api_found": true, "attempts": 30, "changed": false, "resources":

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
