### PR TITLE
shell command using tabs instead of spaces causing failure. Now fixed.

### DIFF
--- a/ansible/roles/ocp4-workload-camel3-workshop/tasks/provision_streams.yaml
+++ b/ansible/roles/ocp4-workload-camel3-workshop/tasks/provision_streams.yaml
@@ -31,8 +31,8 @@
 - name: Get Streams CSV name
   shell: 
     cmd: >
-       oc get csv -n {{ operators_project }} -o custom-columns=NAME:.metadata.name --no-headers
-      | grep amqstreams
+      oc get csv -n {{ operators_project }} -o custom-columns=NAME:.metadata.name --no-headers
+      | grep amqstreams
   register: sub_streams_name
 
 - name: Print sub_streams_name


### PR DESCRIPTION
fixed shell command.