### PR TITLE
Fix azure destroy

### DIFF
--- a/ansible/cloud_providers/azure_destroy_env.yml
+++ b/ansible/cloud_providers/azure_destroy_env.yml
@@ -12,13 +12,14 @@
       include_role:
         name: infra-azure-delete-service-principal
 
-- name: Cleanup Azure Sandbox
+- name: Cleanup Azure Subscription Based Sandbox
   hosts: localhost
   connection: local
   gather_facts: false
   become: false
   environment:
     AZURE_CONFIG_DIR: "{{ output_dir }}/.azure-{{ project_tag }}"
+  when: env_type == 'open-environment-azure-subscription'
   tasks:
     - name: Run the azure delete open env role
       include_role:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Fix azure destroy to only run subscription based destroy functions when running the subscription based env type.
The destroy functions for subscription based destroy are not compatible with resource group based env types.

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
./cloud_providers/azure_destroy_env.yml

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
