### PR TITLE
Parametrize aap subscription channel

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/defaults/main.yml
@@ -12,6 +12,7 @@ ocp4_workload_ansible_automation_platform_display: "ansible-automation-platform"
 ocp4_workload_ansible_automation_platform_description: "Ansible Automation Platorm"
 # OCP bearer token lifecycle for use as an AAP cred - default to 2 weeks
 ocp4_workload_ansible_automation_platform_ocp_token_lifecycle: 1209600
+ocp4_workload_ansible_automation_platform_subscription_channel: "stable-2.3"
 
 ocp4_workload_ansible_automation_platform_admin_password: >-
   {{ common_password | default(aap_controller_admin_password) }}

--- a/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/templates/subscription.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/templates/subscription.j2
@@ -5,7 +5,7 @@ metadata:
   name: ansible-automation-platform-operator
   namespace: {{ ocp4_workload_ansible_automation_platform_project }}
 spec:
-  channel: 'stable-2.3'
+  channel: {{ ocp4_workload_ansible_automation_platform_subscription_channel }}
   installPlanApproval: Automatic
   name: ansible-automation-platform-operator
   source: redhat-operators


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
AAP has been updated to stable-2.4 and the channel needs updating, this change should not affect any other labs, as channel is now made a parameter with default set to stable-2.3

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New config Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4_workload_ansible_automation_platform

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
