### PR TITLE
Fix macro indentation issue showroom compose template showroom

### DIFF
--- a/ansible/roles/showroom/templates/main_compose_template.j2
+++ b/ansible/roles/showroom/templates/main_compose_template.j2
@@ -18,9 +18,9 @@ services:
       - "{{ showroom_home_dir }}/content/gh-pages:/usr/share/nginx/html:Z"
 
 {% for service in showroom_tab_services %}
-  {% macro fake_indent_op() %}
-    {% include 'service_' + service + '/service_' + service + '.j2' ignore missing %}
-  {% endmacro %}
+{% macro fake_indent_op() %}
+{% include 'service_' + service + '/service_' + service + '.j2' ignore missing %}
+{% endmacro %}
   {{ fake_indent_op() | indent(2) }}
 
 {% endfor %}


### PR DESCRIPTION

##### SUMMARY

Fussy jinja macro broke some indenting in a compose file

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

roles/showroom
##### ADDITIONAL INFORMATION
