### PR TITLE
Update devworkspacetemplate.yaml

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_gitops_cluster_mgmt_workshop/files/devworkspacetemplate.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitops_cluster_mgmt_workshop/files/devworkspacetemplate.yaml
@@ -3,6 +3,7 @@ kind: DevWorkspaceTemplate
 metadata:
   annotations:
     controller.devfile.io/allow-import-from: '*'
+    web-terminal.redhat.com/unmanaged-state: 'true'
   labels:
     console.openshift.io/terminal: "true"
   name: web-terminal-tooling


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

This change sets the Web Terminal CR to unmanaged to prevent the default image from overriding the custom image on lab restart.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
DevWorkspaceTemplate

##### ADDITIONAL INFORMATION
When a demo.redhat.com lab stops and starts again, the Web Terminal operator attached to this workshop will lose the custom image it is spun up with and revert to the Operator default. This change intends to stop this default behavior.
