### PR TITLE
Update gitea api versions for workloads retrieving a Gitea instance.

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_acc_new_app_dev/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_acc_new_app_dev/tasks/pre_workload.yml
@@ -26,7 +26,7 @@
 
 - name: Retrieve Gitea instance
   kubernetes.core.k8s_info:
-    api_version: gpte.opentlc.com/v1
+    api_version: pfe.rhpds.com/v1
     kind: Gitea
     name: "{{ ocp4_workload_acc_new_app_dev_gitea_instance }}"
     namespace: "{{ ocp4_workload_acc_new_app_dev_gitea_project }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_aiml_edge_workshop/tasks/setup-gitops.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_aiml_edge_workshop/tasks/setup-gitops.yml
@@ -1,7 +1,7 @@
 ---
 - name: Retrieve Gitea instance
   kubernetes.core.k8s_info:
-    api_version: gpte.opentlc.com/v1
+    api_version: pfe.rhpds.com/v1
     kind: Gitea
     name: "{{ ocp4_workload_big_demo_gitea_instance }}"
     namespace: "{{ ocp4_workload_big_demo_gitea_project }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/tasks/setup-gitops.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ama_demo/tasks/setup-gitops.yml
@@ -44,7 +44,7 @@
 
 - name: Retrieve Gitea instance
   kubernetes.core.k8s_info:
-    api_version: gpte.opentlc.com/v1
+    api_version: pfe.rhpds.com/v1
     kind: Gitea
     name: "{{ ocp4_workload_ama_demo_gitea_instance }}"
     namespace: "{{ ocp4_workload_ama_demo_gitea_project }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_ama_demo_shared/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ama_demo_shared/tasks/workload.yml
@@ -74,7 +74,7 @@
 
 - name: Get Gitea instance
   kubernetes.core.k8s_info:
-    api_version: gpte.opentlc.com/v1
+    api_version: pfe.rhpds.com/v1
     kind: Gitea
     name: "{{ ocp4_workload_ama_demo_shared_gitea_instance }}"
     namespace: "{{ ocp4_workload_ama_demo_shared_gitea_project }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_amq_streams_dev_exp/tasks/remove_workload_gitea.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_amq_streams_dev_exp/tasks/remove_workload_gitea.yml
@@ -2,7 +2,7 @@
 
 - name: find all gitea resources
   k8s_info:
-    api_version: gpte.opentlc.com/v1alpha1
+    api_version: pfe.rhpds.com/v1
     kind: gitea
     namespace: "{{ ocp4_workload_amq_streams_dev_exp_project_gitea }}"
   register: r_gitea

--- a/ansible/roles_ocp_workloads/ocp4_workload_amq_streams_dev_exp/tasks/workload_gitea.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_amq_streams_dev_exp/tasks/workload_gitea.yml
@@ -25,7 +25,7 @@
 
 - name: wait until gitea-server has running condition
   k8s_info:
-    api_version: gpte.opentlc.com/v1alpha1
+    api_version: pfe.rhpds.com/v1
     kind: Gitea
     name: gitea-server
     namespace: "{{ ocp4_workload_amq_streams_dev_exp_project_gitea }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_amq_streams_dev_exp/templates/gitea-server.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_amq_streams_dev_exp/templates/gitea-server.j2
@@ -1,4 +1,4 @@
-apiVersion: gpte.opentlc.com/v1alpha1
+apiVersion: pfe.rhpds.com/v1
 kind: Gitea
 metadata:
   name: gitea-server

--- a/ansible/roles_ocp_workloads/ocp4_workload_big_demo/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_big_demo/tasks/workload.yml
@@ -44,7 +44,7 @@
 
 - name: Retrieve Gitea instance
   kubernetes.core.k8s_info:
-    api_version: gpte.opentlc.com/v1
+    api_version: pfe.rhpds.com/v1
     kind: Gitea
     name: "{{ ocp4_workload_big_demo_gitea_instance }}"
     namespace: "{{ ocp4_workload_big_demo_gitea_project }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_blackhat_secured_container_pipelines/tasks/setup_infrastructure_prerequisites.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_blackhat_secured_container_pipelines/tasks/setup_infrastructure_prerequisites.yml
@@ -6,7 +6,7 @@
 
 - name: Retrieve Gitea instance
   kubernetes.core.k8s_info:
-    api_version: gpte.opentlc.com/v1
+    api_version: pfe.rhpds.com/v1
     kind: Gitea
     name: gitea
     namespace: gitea

--- a/ansible/roles_ocp_workloads/ocp4_workload_coolstore_apac_summit/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_coolstore_apac_summit/tasks/workload.yml
@@ -15,7 +15,7 @@
 
 - name: Retrieve Gitea instance
   kubernetes.core.k8s_info:
-    api_version: gpte.opentlc.com/v1
+    api_version: pfe.rhpds.com/v1
     kind: Gitea
     name: "{{ ocp4_workload_coolstore_apac_summit_instance }}"
     namespace: "{{ ocp4_workload_coolstore_apac_summit_project }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_coolstore_backoffice_demo_ohc/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_coolstore_backoffice_demo_ohc/tasks/workload.yml
@@ -44,7 +44,7 @@
 
 - name: Retrieve Gitea instance
   kubernetes.core.k8s_info:
-    api_version: gpte.opentlc.com/v1
+    api_version: pfe.rhpds.com/v1
     kind: Gitea
     name: "{{ ocp4_workload_coolstore_backoffice_demo_ohc_gitea_instance }}"
     namespace: "{{ ocp4_workload_coolstore_backoffice_demo_ohc_gitea_project }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_devsecops_validated_pattern/tasks/setup_infrastructure_prerequisites.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_devsecops_validated_pattern/tasks/setup_infrastructure_prerequisites.yml
@@ -6,7 +6,7 @@
 
 - name: Retrieve Gitea instance
   kubernetes.core.k8s_info:
-    api_version: gpte.opentlc.com/v1
+    api_version: pfe.rhpds.com/v1
     kind: Gitea
     name: gitea
     namespace: gitea

--- a/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/readme.adoc
@@ -29,18 +29,18 @@
 
 == Gitea Custom Resource
 
-The operator uses a custom resource *Gitea.gpte.opentlc.com/v1alpha1* to set up the Gitea instance. Variables are in defaults/main.yaml and can be overwritten by setting them globally.
+The operator uses a custom resource *Gitea.pfe.rhpds.com/v1* to set up the Gitea instance. Variables are in defaults/main.yaml and can be overwritten by setting them globally.
 
 [source,yaml]
 ----
-apiVersion: gpte.opentlc.com/v1alpha1
+apiVersion: pfe.rhpds.com/v1
 kind: Gitea
 metadata:
   name: sourcerepo
   namespace: gitea-operator
 spec:
-  giteaImage: quay.io/gpte-devops-automation/gitea
-  giteaImageTag: 0.14.2
+  giteaImage: quay.io/rhpds/gitea
+  giteaImageTag: 1.20.0
   giteaVolumeSize: 10Gi
   postgresqlVolumeSize: 10Gi
   giteaSsl: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_gitops_amqstreams/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitops_amqstreams/tasks/workload.yml
@@ -8,7 +8,7 @@
   block:
     - name: Retrieve Gitea instance
       kubernetes.core.k8s_info:
-        api_version: gpte.opentlc.com/v1
+        api_version: pfe.rhpds.com/v1
         kind: Gitea
         name: gitea
         namespace: gitea

--- a/ansible/roles_ocp_workloads/ocp4_workload_gitops_hashicorp_vault/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitops_hashicorp_vault/tasks/workload.yml
@@ -8,7 +8,7 @@
   block:
     - name: Retrieve Gitea instance
       kubernetes.core.k8s_info:
-        api_version: gpte.opentlc.com/v1
+        api_version: pfe.rhpds.com/v1
         kind: Gitea
         name: gitea
         namespace: gitea

--- a/ansible/roles_ocp_workloads/ocp4_workload_gitops_openshift_data_foundation/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitops_openshift_data_foundation/tasks/workload.yml
@@ -8,7 +8,7 @@
   block:
     - name: Retrieve Gitea instance
       kubernetes.core.k8s_info:
-        api_version: gpte.opentlc.com/v1
+        api_version: pfe.rhpds.com/v1
         kind: Gitea
         name: gitea
         namespace: gitea

--- a/ansible/roles_ocp_workloads/ocp4_workload_gitops_openshift_gitops/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitops_openshift_gitops/tasks/workload.yml
@@ -8,7 +8,7 @@
   block:
     - name: Retrieve Gitea instance
       kubernetes.core.k8s_info:
-        api_version: gpte.opentlc.com/v1
+        api_version: pfe.rhpds.com/v1
         kind: Gitea
         name: gitea
         namespace: gitea

--- a/ansible/roles_ocp_workloads/ocp4_workload_gitops_quay_registry/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitops_quay_registry/tasks/workload.yml
@@ -8,7 +8,7 @@
   block:
     - name: Retrieve Gitea instance
       kubernetes.core.k8s_info:
-        api_version: gpte.opentlc.com/v1
+        api_version: pfe.rhpds.com/v1
         kind: Gitea
         name: gitea
         namespace: gitea

--- a/ansible/roles_ocp_workloads/ocp4_workload_gitops_rhacs_secured_cluster/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitops_rhacs_secured_cluster/tasks/workload.yml
@@ -8,7 +8,7 @@
   block:
     - name: Retrieve Gitea instance
       kubernetes.core.k8s_info:
-        api_version: gpte.opentlc.com/v1
+        api_version: pfe.rhpds.com/v1
         kind: Gitea
         name: gitea
         namespace: gitea

--- a/ansible/roles_ocp_workloads/ocp4_workload_gitops_sonarqube/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitops_sonarqube/tasks/workload.yml
@@ -8,7 +8,7 @@
   block:
     - name: Retrieve Gitea instance
       kubernetes.core.k8s_info:
-        api_version: gpte.opentlc.com/v1
+        api_version: pfe.rhpds.com/v1
         kind: Gitea
         name: gitea
         namespace: gitea

--- a/ansible/roles_ocp_workloads/ocp4_workload_mad_roadshow/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mad_roadshow/tasks/workload.yml
@@ -74,7 +74,7 @@
 
 - name: Get Gitea instance
   kubernetes.core.k8s_info:
-    api_version: gpte.opentlc.com/v1
+    api_version: pfe.rhpds.com/v1
     kind: Gitea
     name: "{{ ocp4_workload_mad_roadshow_gitea_instance }}"
     namespace: "{{ ocp4_workload_mad_roadshow_gitea_project }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_managed_cluster_workload/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_managed_cluster_workload/tasks/workload.yml
@@ -74,7 +74,7 @@
 
     - name: Wait for Gitea route to be available
       kubernetes.core.k8s_info:
-        api_version: gpte.opentlc.com/v1
+        api_version: pfe.rhpds.com/v1
         kind: Gitea
         name: "{{ ocp4_workload_gitea_operator_name }}"
         namespace: "{{ ocp4_workload_gitea_operator_project }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_object_detection_ai_ml_ohc/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_object_detection_ai_ml_ohc/tasks/workload.yml
@@ -16,7 +16,7 @@
 
 - name: Retrieve Gitea instance
   kubernetes.core.k8s_info:
-    api_version: gpte.opentlc.com/v1
+    api_version: pfe.rhpds.com/v1
     kind: Gitea
     name: "{{ ocp4_workload_object_detection_ai_ml_ohc_gitea_instance }}"
     namespace: "{{ ocp4_workload_object_detection_ai_ml_ohc_gitea_project }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_object_detection_ai_ml_setup/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_object_detection_ai_ml_setup/tasks/workload.yml
@@ -59,7 +59,7 @@
 
 - name: Retrieve Gitea instance
   kubernetes.core.k8s_info:
-    api_version: gpte.opentlc.com/v1
+    api_version: pfe.rhpds.com/v1
     kind: Gitea
     name: "{{ ocp4_workload_big_demo_gitea_instance }}"
     namespace: "{{ ocp4_workload_big_demo_gitea_project }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_retail_aiml_workshop/tasks/setup-gitops.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_retail_aiml_workshop/tasks/setup-gitops.yml
@@ -1,7 +1,7 @@
 ---
 - name: Retrieve Gitea instance
   kubernetes.core.k8s_info:
-    api_version: gpte.opentlc.com/v1
+    api_version: pfe.rhpds.com/v1
     kind: Gitea
     name: "{{ ocp4_workload_big_demo_gitea_instance }}"
     namespace: "{{ ocp4_workload_big_demo_gitea_project }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_retail_store_workshop/tasks/setup-gitops.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_retail_store_workshop/tasks/setup-gitops.yml
@@ -1,7 +1,7 @@
 ---
 - name: Retrieve Gitea instance
   kubernetes.core.k8s_info:
-    api_version: gpte.opentlc.com/v1
+    api_version: pfe.rhpds.com/v1
     kind: Gitea
     name: "{{ ocp4_workload_big_demo_gitea_instance }}"
     namespace: "{{ ocp4_workload_big_demo_gitea_project }}"


### PR DESCRIPTION
##### SUMMARY

apiVersion of the Gitea CR changed for V2.
Updating all workloads that used the old version to retrieve a running Gitea instance. This should prevent breakage when tagging code with newer tags - or deploying in DEV.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
many