### PR TITLE
Azure owner change for subs

### DIFF
--- a/ansible/roles/open-env-azure-add-user-to-subscription/defaults/main.yml
+++ b/ansible/roles/open-env-azure-add-user-to-subscription/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
+#azure_owner_role_name: "Owner"
 azure_owner_role_name: "Custom-Owner (Block Billing and Subscription deletion)"

--- a/ansible/roles/open-env-azure-add-user-to-subscription/defaults/main.yml
+++ b/ansible/roles/open-env-azure-add-user-to-subscription/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+azure_owner_role_name: "Custom-Owner (Block Billing and Subscription deletion)"

--- a/ansible/roles/open-env-azure-add-user-to-subscription/tasks/main.yml
+++ b/ansible/roles/open-env-azure-add-user-to-subscription/tasks/main.yml
@@ -53,11 +53,11 @@
       command: >
         az tag create --resource-id {{ subscription_fqid }} --tags GUID={{ guid }} EMAIL={{ requester_email }}
 
-    - name: Get Owner Role Definition
+    - name: Get Role Definition to use for subscription access
       azure.azcollection.azure_rm_roledefinition_info:
         auth_source: env
         scope: "{{ subscription_fqid }}"
-        role_name: Owner
+        role_name: "{{ azure_owner_role_name }}"
       register: role_definition
 
     - name: Set user as Owner for the subscription


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Use custom owner role for subscriptions so that users cannot delete the subscription.

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
roles/open-env-azure-add-user-to-subscription

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
