### PR TITLE
chore: add instructions to lab output for using gitops lab

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_gitops_cluster_mgmt_workshop/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitops_cluster_mgmt_workshop/tasks/post_workload.yml
@@ -1,5 +1,17 @@
 ---
-# Ensure ACM is working
+
+- name: output workshop info
+  agnosticd_user_info:
+    msg: "{{ item }}"
+  loop:
+    - ""
+    - "GitOps Demo/Workshop Provisioned"
+    - ""
+    - "The instructions can be found at: https://redhat-scholars.github.io/summit-2023-gitops-lab-guide/summit-2023-gitops-workshop-guide/main/"
+    - ""
+    - "If you enabled the workshop user interface when provisioning the lab, you can visit https://demo.redhat.com/ and go to the Services page to"
+    - "obtain the URL and password that can be used by lab attendees to access their lab environment."
+  when: not silent | bool
 
 # Leave this as the last task in the playbook.
 - name: post_workload tasks complete


### PR DESCRIPTION

##### SUMMARY

Add the lab instructions URL to the output from `post_workload`.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

`roles_ocp_workloads/ocp4_workload_gitops_cluster_mgmt_workshop` - AKA the "Using GitOps to control and customise" lab.
