### PR TITLE
OHC Binder - set K8s auth to 2.4.0

### DIFF
--- a/ansible/configs/hybrid-cloud-binder/requirements.yml
+++ b/ansible/configs/hybrid-cloud-binder/requirements.yml
@@ -5,7 +5,7 @@
 #  version: v0.17
 collections:
 - name: kubernetes.core
-  version: 2.3.1
+  version: 2.4.0
 - name: amazon.aws
   version: 2.2.0
 - name: community.general


### PR DESCRIPTION
- name: kubernetes.core
  version: 2.4.0

Bug fix PR

