### PR TITLE
Fix downloaded helm, add completion, use FQ Modules

### DIFF
--- a/ansible/configs/rosa-manual/software.yml
+++ b/ansible/configs/rosa-manual/software.yml
@@ -5,13 +5,12 @@
   become: true
   tasks:
     - name: Generate user password if not defined
-      set_fact:
+      ansible.builtin.set_fact:
         rosa_user_password: >-
           {{ lookup('password', '/dev/null length={{ bastion_user_password_length }} chars=ascii_letters,digits') }}
 
     - name: Create user with password
-      become: true
-      user:
+      ansible.builtin.user:
         state: present
         name: "{{ bastion_user_name }}"
         password: "{{ rosa_user_password | password_hash( 'sha512' ) }}"
@@ -22,15 +21,13 @@
         shell: /bin/bash
 
     - name: Enable password authentication
-      become: true
-      lineinfile:
+      ansible.builtin.lineinfile:
         line: PasswordAuthentication yes
         regexp: '^ *PasswordAuthentication'
         path: /etc/ssh/sshd_config
 
     - name: Restart sshd
-      become: true
-      service:
+      ansible.builtin.service:
         name: sshd
         state: restarted
 
@@ -45,24 +42,24 @@
         - install_awscli
       block:
         - name: Get awscli
-          get_url:
+          ansible.builtin.get_url:
             url: https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip
             dest: /tmp/awscliv2.zip
 
         - name: Unzip awscliv2.zip
-          unarchive:
+          ansible.builtin.unarchive:
             src: /tmp/awscliv2.zip
             dest: /tmp/
             remote_src: true
 
         - name: Install awscli
-          command: /tmp/aws/install -i /usr/local/aws -b /usr/bin
+          become: true
+          ansible.builtin.command: /tmp/aws/install -i /usr/local/aws -b /usr/bin
           args:
             creates: /usr/local/aws
-          become: true
 
         - name: cleanup archive and tmp files
-          file:
+          ansible.builtin.file:
             path: "{{ item }}"
             state: absent
           loop:
@@ -73,19 +70,19 @@
         - install_oc
       block:
         - name: Set URL for OpenShift GA release
-          set_fact:
+          ansible.builtin.set_fact:
             ocp4_client_url: >-
               {{ '{0}/ocp/latest/openshift-client-linux.tar.gz'.format(
                 ocp4_installer_root_url | default("https://mirror.openshift.com/pub/openshift-v4/clients")
               ) }}
 
         - name: Ensure ocp4_client_url is set
-          assert:
+          ansible.builtin.assert:
             that: ocp4_client_url | default('') | length > 0
 
         - name: Install OpenShift CLI
           become: true
-          unarchive:
+          ansible.builtin.unarchive:
             src: "{{ ocp4_client_url }}"
             remote_src: true
             dest: /usr/bin
@@ -97,11 +94,15 @@
           until: r_client is success
           delay: 30
 
+        - name: Create OpenShift Bash completion file
+          become: true
+          ansible.builtin.shell: /usr/bin/oc completion bash >/etc/bash_completion.d/openshift
+
     - tags:
         - install_helm
       block:
         - name: Set URL for helm
-          set_fact:
+          ansible.builtin.set_fact:
             helm_url: >-
               {{ '{0}/helm/latest/helm-linux-amd64.tar.gz'.format(
                 ocp4_installer_root_url | default("https://mirror.openshift.com/pub/openshift-v4/clients")
@@ -109,7 +110,7 @@
 
         - name: Install helm command
           become: true
-          unarchive:
+          ansible.builtin.unarchive:
             src: "{{ helm_url }}"
             remote_src: true
             dest: /usr/bin
@@ -121,11 +122,25 @@
           until: r_client is success
           delay: 30
 
+        - name: Link downloaded helm command to helm
+          become: true
+          ansible.builtin.file:
+            src: /usr/bin/helm-linux-amd64
+            dest: /usr/bin/helm
+            owner: root
+            group: root
+            state: link
+
+        - name: Create Helm Bash completion file
+          become: true
+          ansible.builtin.shell: /usr/bin/helm completion bash >/etc/bash_completion.d/helm
+
+
     - tags:
         - create_aws_dir
       block:
         - name: Create .aws directory
-          file:
+          ansible.builtin.file:
             path: ~/.aws
             state: directory
 
@@ -133,7 +148,7 @@
         - create_aws_creds
       block:
         - name: Add aws credentials
-          blockinfile:
+          ansible.builtin.blockinfile:
             path: ~/.aws/credentials
             create: true
             mode: 0600
@@ -147,7 +162,7 @@
         - create_aws_config
       block:
         - name: Add aws config
-          blockinfile:
+          ansible.builtin.blockinfile:
             path: ~/.aws/config
             create: true
             mode: 0600
@@ -159,17 +174,17 @@
         - install_rosacli
       block:
         - name: Get ROSA CLI
-          get_url:
+          ansible.builtin.get_url:
             url: "{{ rosa_installer_url }}"
             dest: /tmp/rosa-linux.tar.gz
         - name: Unzip rosa-linux.tar.gz
-          unarchive:
+          ansible.builtin.unarchive:
             src: /tmp/rosa-linux.tar.gz
             dest: /usr/local/bin/
             remote_src: true
           become: true
         - name: cleanup archive file
-          file:
+          ansible.builtin.file:
             path: "{{ item }}"
             state: absent
           loop:
@@ -178,16 +193,16 @@
     - tags:
         - verify_rosa_installer
       block:
-        - set_fact:
+        - ansible.builtin.set_fact:
             rosa_token: "{{ gpte_rosa_token }}"
           when: rosa_token == ""
         - name: Log into ROSA
-          command: "/usr/local/bin/rosa login --token {{ rosa_token }}"
+          ansible.builtin.command: "/usr/local/bin/rosa login --token {{ rosa_token }}"
 
     - block:
         - name: Create .config/ocm directory in rosa user homedir
           become: true
-          file:
+          ansible.builtin.file:
             path: "~{{ bastion_user_name }}/.config/ocm"
             owner: "{{ bastion_user_name }}"
             state: directory
@@ -201,7 +216,7 @@
             remote_src: true
         - name: Create .aws directory in rosa user homedir
           become: true
-          file:
+          ansible.builtin.file:
             path: "~{{ bastion_user_name }}/.aws"
             owner: "{{ bastion_user_name }}"
             state: directory
@@ -223,12 +238,12 @@
     - block:
         - name: Set ROSA token warning boolean true
           when: rosa_token == gpte_rosa_token
-          set_fact:
+          ansible.builtin.set_fact:
             rosa_token_warning: true
 
         - name: Set ROSA token warning boolean false
           when: rosa_token != gpte_rosa_token
-          set_fact:
+          ansible.builtin.set_fact:
             rosa_token_warning: false
 
         - name: Save ansible vars to user_info data


### PR DESCRIPTION
##### SUMMARY

rosa-manual config was downloading helm as /usr/bin/helm-linux-amd64. Fixing by making a symlink to /usr/bin/helm.

Adding missing bash completion for oc and helm.

Adding fully qualified module names for software.yml

Remove unnecessary 'become: true' lines.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rosa-manual