### PR TITLE
launch ocp4_workload_gitops_bootstrap from config

### DIFF
--- a/ansible/configs/prp-binder/README.adoc
+++ b/ansible/configs/prp-binder/README.adoc
@@ -1,0 +1,72 @@
+== Overview
+
+*prp-binder* _config_ is an empty test config that does nothing other
+call in sequnece the default playbooks.
+image::topology.png[width=100%]
+
+== Supported Cloud Providers
+
+An empty test cloud prover has been created
+
+* `test`
+
+== Review the Env_Type variable file
+
+For further information on customizing images consult the link:../../../docs/Creating_a_config.adoc[Creating a Config Guide]
+
+== Review the `sample_vars.yml` variable file
+
+----
+
+---
+guid:               test-config-00
+env_type:           prp-binder
+cloud_provider:     test
+...
+
+----
+
+== Deploying the `prp-binder`
+
+You can deploy this config by running the following command from the `ansible`
+directory.
+
+
+`ansible-playbook main.yml -e @configs/prp-binder/sample_vars.yml`
+
+== Force failing the `prp-binder`
+
+You can force this config to fail at any stage including the cloud provider stage
+by setting or passing the appropriate boolean value:
+
+[source,yaml]
+----
+fail_pre_infra
+fail_test_cloud_provider
+fail_post_infra
+fail_pre_software
+fail_software
+fail_post_software
+----
+
+`ansible-playbook main.yml -e @configs/prp-binder/sample_vars.yml -e '{ "fail_software" : true }'`
+
+== Controlling provision duration
+
+You can control how long it takes this config to complete by enabling a pause during the.
+
+[source,yaml]
+----
+prp_binder_pause_post_software
+prp_binder_pause_post_software_seconds
+----
+
+`ansible-playbook main.yml -e @configs/prp-binder/sample_vars.yml -e '{"prp_binder_pause_post_software" : true, "prp_binder_pause_post_software_seconds": 600}'`
+
+=== To Delete an environment
+
+This step is unnecessary as nothing is actiually created. However the following
+will simulate a deletion.
+
+
+`ansible-playbook destroy.yml -e @configs/prp-binder/sample_vars.yml`

--- a/ansible/configs/prp-binder/default_vars.yml
+++ b/ansible/configs/prp-binder/default_vars.yml
@@ -1,0 +1,10 @@
+---
+# To use bookbag, bookbag_deploy must be true and a value must be provided for
+# bookbag_git_repo
+bookbag_deploy: false
+#bookbag_git_repo: https://github.com/redhat-gpte-labs/bookbag-template.git
+
+# Control whether to simulate multi-user environment by reporting per-user info messages and data
+prp_binder_multi_user: false
+prp_binder_user_count: "{{ user_count | default(num_users) | default(10) }}"
+...

--- a/ansible/configs/prp-binder/default_vars_ec2.yml
+++ b/ansible/configs/prp-binder/default_vars_ec2.yml
@@ -1,0 +1,3 @@
+---
+# mandatory to run ansible/destroy.yml playbook
+aws_region: us-east-1

--- a/ansible/configs/prp-binder/destroy_env.yml
+++ b/ansible/configs/prp-binder/destroy_env.yml
@@ -1,0 +1,40 @@
+---
+- name: Destroy playbook
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  become: false
+  tasks:
+
+  - name: Entering the prp-binder destroy.yml
+    debug:
+      msg:
+      - Entering the prp-binder destroy.yml
+
+  - name: Remove Bookbag
+    when:
+    - bookbag_git_repo is defined
+    include_role:
+      name: bookbag
+    vars:
+      ACTION: destroy
+
+  - when: pause_destroy | default(false) | bool
+    pause:
+      seconds: 30
+
+  - when: cloud_provider == 'osp'
+    name: Include AWS dry-run read-only role
+    include_role:
+      name: infra-osp-dry-run
+
+  - when: cloud_provider == 'ec2'
+    name: Include AWS dry-run read-only role
+    include_role:
+      name: infra-aws-dry-run
+
+  - name: Exiting the prp-binder destroy.yml
+    debug:
+      msg:
+      - Exiting the prp-binder destroy.yml
+...

--- a/ansible/configs/prp-binder/infra.yml
+++ b/ansible/configs/prp-binder/infra.yml
@@ -1,0 +1,41 @@
+---
+- name: Step 001 infra
+  hosts: localhost
+  connection: local
+  become: false
+  gather_facts: false
+  tags:
+    - step001
+    - infrastructure
+  tasks:
+
+    - name: Entering the prp-binder infra.yml
+      debug:
+        msg:
+          - Entering the prp-binder infra.yml
+
+    - when: fail_infra | default(false) | bool
+      name: Fail the prp-binder infra.yml if requested
+      fail:
+        msg: infra.yml failed as requested
+
+    - when: cloud_provider == 'osp'
+      name: Include AWS dry-run read-only role
+      include_role:
+        name: infra-osp-dry-run
+
+    - when: cloud_provider == 'ec2'
+      name: Include AWS dry-run read-only role
+      include_role:
+        name: infra-aws-dry-run
+
+    - when: cloud_provider == 'equinix_metal'
+      name: Include Equinix Metal dry-run read-only role
+      include_role:
+        name: infra-equinix-metal-dry-run
+
+    - name: Exiting the prp-binder infra.yml
+      debug:
+        msg:
+          - Exiting the prp-binder infra.yml
+...

--- a/ansible/configs/prp-binder/lifecycle.yml
+++ b/ansible/configs/prp-binder/lifecycle.yml
@@ -1,0 +1,20 @@
+- name: Step lifecycle
+  hosts: localhost
+  connection: local
+  become: false
+  gather_facts: false
+  tasks:
+    - when: cloud_provider == 'osp'
+      name: Include AWS dry-run read-only role
+      include_role:
+        name: infra-osp-dry-run
+
+    - when: cloud_provider == 'ec2'
+      name: Include AWS dry-run read-only role
+      include_role:
+        name: infra-aws-dry-run
+
+    - when: cloud_provider == 'equinix_metal'
+      name: Include Equinix Metal dry-run read-only role
+      include_role:
+        name: infra-equinix-metal-dry-run

--- a/ansible/configs/prp-binder/post_infra.yml
+++ b/ansible/configs/prp-binder/post_infra.yml
@@ -1,0 +1,26 @@
+---
+- name: Step 002 Post Infrastructure
+  hosts: localhost
+  connection: local
+  become: false
+  gather_facts: false
+  tags:
+    - step002
+    - post_infrastructure
+  tasks:
+
+    - name: Entering the prp-binder post_infra.yml
+      debug:
+        msg:
+          - Entering the prp-binder post_infra.yml
+
+    - when: fail_post_infra | default(false) | bool
+      name: Fail the prp-binder post_infra.yml if requested
+      fail:
+        msg: post_infra.yml failed as requested
+
+    - name: Exiting the prp-binder post_infra.yml
+      debug:
+        msg:
+          - Exiting the prp-binder post_infra.yml
+...

--- a/ansible/configs/prp-binder/post_software.yml
+++ b/ansible/configs/prp-binder/post_software.yml
@@ -1,0 +1,37 @@
+---
+- name: Step 005 Post Software
+  hosts: localhost
+  connection: local
+  become: false
+  gather_facts: false
+  tags:
+  - step005
+  - post_software
+  environment:
+    K8S_AUTH_VERIFY_SSL: false
+    K8S_AUTH_HOST: "{{ prp_ocp_argo.openshift_api_server_url }}"
+    K8S_AUTH_USERNAME: "{{ prp_ocp_argo.openshift_cluster_admin_username }}"
+    K8S_AUTH_PASSWORD: "{{ prp_ocp_argo.openshift_cluster_admin_password }}"
+  tasks:
+
+  - name: Entering the prp-binder post_software.yml
+    debug:
+      msg:
+      - Entering the prp-binder post_software.yml
+
+  # must call this as a role to allow the collections to be updated.
+  # roles lazy evaluate, allowing time (and context?) for the requirements.yml
+  # to be processed
+  - name: Log in to OpenShift and run the gitops_bootstrapper
+    ansible.builtin.include_role:
+      name: ocp_auth_bootstrapper
+
+  - name: Print string expected by Cloudforms
+    debug:
+      msg: "Post-Software checks completed successfully"
+
+  - name: Exiting the prp-binder post_software.yml
+    debug:
+      msg:
+      - Exiting the prp-binder post_software.yml
+...

--- a/ansible/configs/prp-binder/pre_infra.yml
+++ b/ansible/configs/prp-binder/pre_infra.yml
@@ -1,0 +1,28 @@
+---
+- name: Step 000 Pre Infrastructure
+  hosts: localhost
+  connection: local
+  become: false
+  gather_facts: false
+
+  tags:
+    - step001
+    - pre_infrastructure
+
+  tasks:
+
+    - name: Entering the prp-binder pre_infra.yml
+      debug:
+        msg:
+          - Entering the prp-binder pre_infra.yml
+
+    - when: fail_pre_infra | default(false) | bool
+      name: Fail the prp-binder pre_infra.yml if requested
+      fail:
+        msg: pre_infra.yml failed as requested
+
+    - name: Exiting the prp-binder pre_infra.yml
+      debug:
+        msg:
+          - Exiting the prp-binder pre_infra.yml
+...

--- a/ansible/configs/prp-binder/pre_software.yml
+++ b/ansible/configs/prp-binder/pre_software.yml
@@ -1,0 +1,28 @@
+---
+- name: Step 003 Pre Software
+  hosts: localhost
+  connection: local
+  become: false
+  gather_facts: false
+  tags:
+    - step003
+    - pre_software
+  tasks:
+
+    - name: Entering the prp-binder pre_software.yml
+      debug:
+        msg:
+          - Entering the prp-binder pre_software.yml
+
+    - when: fail_pre_software | default(false) | bool
+      name: Fail the prp-binder pre_software.yml if requested
+      fail:
+        msg: pre_software.yml failed as requested
+
+    - name: Exiting the prp-binder pre_software.yml
+      debug:
+        msg:
+          - Exiting the prp-binder pre_software.yml
+    - debug:
+        msg: Pre-Software checks completed successfully
+...

--- a/ansible/configs/prp-binder/requirements.yml
+++ b/ansible/configs/prp-binder/requirements.yml
@@ -1,0 +1,6 @@
+---
+collections:
+  - name: community.okd
+    version: 2.3.0
+  - name: kubernetes.core
+    version: 2.4.0

--- a/ansible/configs/prp-binder/roles/ocp_auth_bootstrapper/tasks/main.yml
+++ b/ansible/configs/prp-binder/roles/ocp_auth_bootstrapper/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: Log in obtain access token
+  #community.okd.openshift_auth:
+  community.okd.openshift_auth:
+    validate_certs: false
+    username: "{{ prp_ocp_argo.openshift_cluster_admin_username }}"
+    password: "{{ prp_ocp_argo.openshift_cluster_admin_password }}"
+    host: "{{ prp_ocp_argo.openshift_api_server_url }}"
+  register: _auth_results
+
+- name: |
+    Call role ocp4_workload_gitops_bootstrap with environment
+  ansible.builtin.include_role:
+    name: ocp4_workload_gitops_bootstrap
+    apply:
+      environment:
+        K8S_AUTH_VERIFY_SSL: false
+        K8S_AUTH_HOST: "{{ prp_ocp_argo.openshift_api_server_url }}"
+        K8S_AUTH_USERNAME: "{{ prp_ocp_argo.openshift_cluster_admin_username }}"
+        K8S_AUTH_API_KEY: "{{ _auth_results.openshift_auth.api_key }}"

--- a/ansible/configs/prp-binder/sample_vars.yml
+++ b/ansible/configs/prp-binder/sample_vars.yml
@@ -1,0 +1,9 @@
+---
+guid: test-config-00
+env_type: prp-binder
+cloud_provider: test
+
+prp_binder_passthrough_user_data: |
+  hello: world
+  foo: bar
+...

--- a/ansible/configs/prp-binder/software.yml
+++ b/ansible/configs/prp-binder/software.yml
@@ -1,0 +1,32 @@
+---
+- name: Step 004 Software
+  hosts: localhost
+  connection: local
+  become: false
+  gather_facts: false
+  tags:
+    - step004
+    - deploy_software
+  tasks:
+
+    - name: Entering the prp-binder software.yml
+      debug:
+        msg:
+          - Entering the prp-binder software.yml
+
+    - when: fail_software | default(false) | bool
+      name: Fail the prp-binder software.yml if requested
+      fail:
+        msg: software.yml failed as requested
+
+    - name: Exiting the prp-binder software.yml
+      debug:
+        msg:
+          - Exiting the prp-binder software.yml
+
+    - name: Test agnosticd_user_info with GUID message and data
+      agnosticd_user_info:
+        msg: GUID is {{ guid }}
+        data:
+          GUID: "{{ guid }}"
+...

--- a/ansible/configs/prp-binder/status.yml
+++ b/ansible/configs/prp-binder/status.yml
@@ -1,0 +1,19 @@
+---
+- hosts: localhost
+  connection: local
+  gather_facts: false
+  tasks:
+  - name: Report status data in user info
+    agnosticd_user_info:
+      data:
+        instances:
+        - name: fake-server
+          state: running
+          type: fake-type
+
+  - name: Report status messages in user info
+    agnosticd_user_info:
+      msg: |-
+        {{ "%-60s %-10s %s" | format("Instance", "State", "Type") }}
+        ----------------------------------------------------------------
+        {{ "%-60s %-10s %s" | format("fake-server", "running", "fake-type") }}

--- a/ansible/configs/prp-binder/update.yml
+++ b/ansible/configs/prp-binder/update.yml
@@ -1,0 +1,34 @@
+---
+- name: Update prp-binder
+  hosts: localhost
+  connection: local
+  become: false
+  gather_facts: false
+  tasks:
+    - name: Entering the prp-binder update.yml
+      debug:
+        msg:
+          - Entering the prp-binder update.yml
+
+    - name: Check presence of random_string in user info from initial provision
+      debug:
+        msg: "random_string: {{ lookup('agnosticd_user_data', 'random_string') }}"
+
+    - when: fail_update | default(false) | bool
+      name: Fail the prp-binder update.yml if requested
+      fail:
+        msg: update.yml failed as requested
+
+    - name: Test update agnosticd_user_info with current timestamp
+      agnosticd_user_info:
+        msg: Updated at {{ __timestamp }}
+        data:
+          test_update_timestamp: "{{ __timestamp }}"
+      vars:
+        __timestamp: "{{ now(utc=true, fmt='%FT%TZ') }}"
+
+    - name: Exiting the prp-binder update.yml
+      debug:
+        msg:
+          - Exiting the prp-binder update.yml
+...


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

this is a new config for the new demo "The Power of the Red Hat Platform"

It takes the provision data from the base component, which includes OCP log in info.
It logs into the server and passes processing to the ocp4_workload_gitops_bootstrap role

NOTE: It's needed a dedicated role in the config at this time because requirements.yml in the config is not processed for use by the config.  it can only be used in a role.
  
Might end up abstracting that role.  Perhaps there's already something.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New config Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

config/prp-binder

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
