### PR TITLE
Update argocd_info.yml - fix k8s facts to info

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_opentour_dach_2022/tasks/argocd_info.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_opentour_dach_2022/tasks/argocd_info.yml
@@ -1,6 +1,6 @@
 ---
 - name: Retrieve created route
-  k8s_facts:
+  k8s_info:
     api_version: "route.openshift.io/v1"
     kind: Route
     name: openshift-gitops-server
@@ -8,7 +8,7 @@
   register: r_route
 
 - name: Retrieve aap secret
-  k8s_facts:
+  k8s_info:
     api_version: "v1"
     kind: Secret
     name: openshift-gitops-cluster


### PR DESCRIPTION
Updating k8s_info in argocd_info.yml to fix the OpenShift GitOps server info error.

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
