### PR TITLE
Adds async to deploy cluster task

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/workload.yml
@@ -8,6 +8,8 @@
     chdir: /root/
   register: result
   failed_when: result.rc != 0 and ("Remove existing directory" not in result.stderr)
+  async: 3600
+  poll: 0
 
 - name: Ensure kubernetes manifests are downloaded
   ansible.builtin.get_url:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

adds async to a tasks that takes around 35m, there is another task that checks for completion.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4_workload_5gran_deployments_lab

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
