### PR TITLE
ee: Move mkdir to containerfile

### DIFF
--- a/tools/execution_environments/ee-multicloud-public/Containerfile
+++ b/tools/execution_environments/ee-multicloud-public/Containerfile
@@ -75,7 +75,8 @@ RUN for dir in \
       /runner/env \
       /runner/inventory \
       /runner/project \
-      /runner/artifacts ; \
+      /runner/artifacts \
+      /runner/requirements_collections/ansible_collections ; \
     do mkdir -m 0775 -p $dir ; chmod -R g+rwx $dir ; chgrp -R root $dir ; done && \
     for file in \
       /home/runner/.ansible/galaxy_token \

--- a/tools/execution_environments/ee-multicloud-public/Containerfile
+++ b/tools/execution_environments/ee-multicloud-public/Containerfile
@@ -67,16 +67,15 @@ RUN rm -rf /tmp/* /root/.cache /root/*
 # In OpenShift, container will run as a random uid number and gid 0. Make sure things
 # are writeable by the root group.
 RUN for dir in \
-      /home/runner \
       /home/runner/.ansible \
       /home/runner/.ansible/tmp \
-      /runner \
       /home/runner \
       /runner/env \
       /runner/inventory \
       /runner/project \
       /runner/artifacts \
-      /runner/requirements_collections/ansible_collections ; \
+      /runner/requirements_collections/ansible_collections \
+      /runner ; \
     do mkdir -m 0775 -p $dir ; chmod -R g+rwx $dir ; chgrp -R root $dir ; done && \
     for file in \
       /home/runner/.ansible/galaxy_token \

--- a/tools/execution_environments/ee-multicloud-public/ee-report.sh
+++ b/tools/execution_environments/ee-multicloud-public/ee-report.sh
@@ -24,3 +24,6 @@ dnf list installed
 
 echo -e "\n# Alternatives\n"
 alternatives --list
+
+echo -e "\n# /runner directory \n"
+find /runner -ls

--- a/tools/execution_environments/ee-multicloud-public/ee-report.sh
+++ b/tools/execution_environments/ee-multicloud-public/ee-report.sh
@@ -26,5 +26,4 @@ echo -e "\n# Alternatives\n"
 alternatives --list
 
 echo -e "\n# /runner directory \n"
-# do not print first column inode as it changes
-find /runner -ls | perl -pe 's/^[\s\t]+\d+//'
+find /runner -printf "%M %u %g %k %p\n"

--- a/tools/execution_environments/ee-multicloud-public/ee-report.sh
+++ b/tools/execution_environments/ee-multicloud-public/ee-report.sh
@@ -26,4 +26,5 @@ echo -e "\n# Alternatives\n"
 alternatives --list
 
 echo -e "\n# /runner directory \n"
-find /runner -ls
+# do not print first column inode as it changes
+find /runner -ls | perl -pe 's/^[\s\t]+\d+//'

--- a/tools/execution_environments/ee-multicloud-public/entrypoint.sh
+++ b/tools/execution_environments/ee-multicloud-public/entrypoint.sh
@@ -78,5 +78,5 @@ SCRIPT=/usr/local/bin/dumb-init
 if [ -f "/usr/bin/dumb-init" ]; then
     SCRIPT=/usr/bin/dumb-init
 fi
-mkdir -p /runner/requirements_collections/ansible_collections/
+
 exec $SCRIPT -- "${@}"


### PR DESCRIPTION
Instead of entrypoint, move the mkdir to containerfile as it shouldn't require to be dynamic

Also add `find /runner -ls` to ee-report

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

