### PR TITLE
ee: add v0.1.0 release and update changelog

### DIFF
--- a/tools/execution_environments/ee-multicloud-public/readme.adoc
+++ b/tools/execution_environments/ee-multicloud-public/readme.adoc
@@ -1,5 +1,20 @@
 == Changelog ==
 
+=== v0.1.0 ===
+
+* Add community.okd collection
+* size +5M
+* link:https://gist.github.com/fridim/c420ed8c415694a389bbc9e204b650b0[ee-report diff with v0.0.18]
+* link:https://gist.github.com/fridim/a12d0ac2387d030d07a2c6bf1e5c7b53[full ee-report]
+
+=== v0.0.18 ===
+
+* Fix requirements_collections path, see link:https://github.com/redhat-cop/agnosticd/pull/6746[#6746]
+* size +16M
+* link:https://gist.github.com/fridim/03ff4cff5183b323e6245fa95219122e[ee-report diff with v0.0.17]
+* link:https://gist.github.com/fridim/dfc2de437375ba437b1b41ffa57912a9[full ee-report]
+
+
 === v0.0.17 ===
 
 * Add `passlib` python module, needed for htpasswd


### PR DESCRIPTION
`ee-multicloud:v0.1.0-alpha` is out, this PR to be merged after the period of test of the pre-release is done.

