### PR TITLE
ee: increase expiration of image for PR to 7 days

### DIFF
--- a/.github/workflows/build-ee-pr.yml
+++ b/.github/workflows/build-ee-pr.yml
@@ -19,7 +19,7 @@ jobs:
     with:
       tag: pr-${{ github.event.number }}
       labels: |-
-        quay.expires-after=1d
+        quay.expires-after=7d
         org.opencontainers.image.source=${{ github.event.repository.html_url }}
         org.opencontainers.image.revision=${{ github.sha }}
 


### PR DESCRIPTION
When creating a PR to update the EE image, there is a workflow to automatically build a temporary image based on the branch of the PR.

The expiration is currently set to 1 day. That is a bit low. Increase this to 7 days.

