### PR TITLE
ee: Update UBI base image to latest 8 version

### DIFF
--- a/tools/execution_environments/ee-multicloud-public/Containerfile
+++ b/tools/execution_environments/ee-multicloud-public/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:8.7
+FROM registry.access.redhat.com/ubi8/ubi
 
 USER root
 WORKDIR /root


### PR DESCRIPTION
Update the base image of the Execution Environment to latest UBI 8.

This fixes all the security vulnerabilities reported by Quay.