### PR TITLE
In ARO role, emit the preconfigure_aad var to user_data for bookbag customization

### DIFF
--- a/ansible/roles/open-env-azure-install-aro/tasks/main.yml
+++ b/ansible/roles/open-env-azure-install-aro/tasks/main.yml
@@ -182,3 +182,8 @@
       retries: 6
       delay: 60
       until: r_update_oauth is success
+
+    - name: Put preconfigure_aad status in user_data
+      agnosticd_user_info:
+        data:
+          preconfigure_aad: "{{ preconfigure_aad }}"


### PR DESCRIPTION
Workshop adoc authors want to detect this to switch on/off AAD instructions.