### PR TITLE
Fix Issue redhat-cop/agnosticd#6473

### DIFF
--- a/ansible/roles/install_operator/tasks/install.yml
+++ b/ansible/roles/install_operator/tasks/install.yml
@@ -80,7 +80,7 @@
   register: r_install_plans
   vars:
     _query: >-
-      [?starts_with(spec.clusterServiceVersionNames[0], '{{ install_operator_csv_nameprefix }}') && status.phase ]
+      [?contains(spec.clusterServiceVersionNames[] | join(',', @), '{{ install_operator_csv_nameprefix }}') && status.phase ]
   retries: 50
   delay: 10
   until:
@@ -92,7 +92,11 @@
     install_operator_install_plan_name: "{{ r_install_plans.resources | to_json | from_json | json_query(query) }}"
   vars:
     query: >-
-      [?starts_with(spec.clusterServiceVersionNames[0], '{{ install_operator_csv_nameprefix }}' )].metadata.name|[0]
+      [?contains(spec.clusterServiceVersionNames[] | join(',', @), '{{ install_operator_csv_nameprefix }}')].metadata.name|[0]
+
+- name: "{{ install_operator_name }} - Print InstallPlan"
+  debug:
+    msg: "InstallPlan: {{ install_operator_install_plan_name }}"
 
 - name: "{{ install_operator_name }} - Get InstallPlan"
   kubernetes.core.k8s_info:


### PR DESCRIPTION
##### SUMMARY

More robust operator installation, fixes #6473 OpenShift operator install only queries first item in list of clusterServiceVersionNames 
 
##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role install_operator

##### ADDITIONAL INFORMATION

Role still works as expected, no breaking 'api' changes. 
