### PR TITLE
Refactor ocp4_workload_web_terminal to use install_operator

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_web_terminal/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_web_terminal/defaults/main.yml
@@ -1,5 +1,35 @@
+---
 become_override: false
 ocp_username: opentlc-mgr
 silent: false
-tmp_dir: /tmp/{{ guid }}
-tmp_kubeconfig: "{{ tmp_dir }}/.kube/config"
+
+# Channel to use for the Web Terminal subscription
+ocp4_workload_web_terminal_channel: fast
+
+
+# Set automatic InstallPlan approval. If set to false it is also suggested
+# to set the starting_csv to pin a specific version
+# This variable has no effect when using a catalog snapshot (always true)
+ocp4_workload_web_terminal_automatic_install_plan_approval: true
+
+# Set a starting ClusterServiceVersion.
+# Recommended to leave empty to get latest in the channel when not using
+# a catalog snapshot.
+# Highly recommended to be set when using a catalog snapshot but can be
+# empty to get the latest available in the channel at the time when
+# the catalog snapshot got created.
+ocp4_workload_web_terminal_starting_csv: "web-terminal.v1.8.0"
+
+# Use a catalog snapshot
+ocp4_workload_web_terminal_use_catalog_snapshot: false
+
+# Catalog Source Name when using a catalog snapshot. This should be unique
+# in the cluster to avoid clashes
+ocp4_workload_web_terminal_catalogsource_name: redhat-operators-snapshot-web-terminal
+
+# Catalog snapshot image
+ocp4_workload_web_terminal_catalog_snapshot_image: quay.io/gpte-devops-automation/olm_snapshot_redhat_catalog
+
+# Catalog snapshot image tag
+ocp4_workload_web_terminal_catalog_snapshot_image_tag: v4.13_2023_07_31
+

--- a/ansible/roles_ocp_workloads/ocp4_workload_web_terminal/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_web_terminal/tasks/remove_workload.yml
@@ -1,9 +1,18 @@
-- name: Remove web terminal operator
-  k8s:
-    state: absent
-    definition: "{{ lookup('template',  item ) | from_yaml }}"
-  loop:
-  - web-terminal-subscription.yaml.j2
+---
+- name: Install  Web Terminal operator
+  include_role:
+    name: install_operator
+  vars:
+    install_operator_action: remove
+    install_operator_name: web-terminal
+    install_operator_namespace: openshift-operators
+    install_operator_channel: "{{ ocp4_workload_web_terminal_channel }}"
+    install_operator_catalog: redhat-operators
+    install_operator_catalogsource_setup: "{{ ocp4_workload_web_terminal_use_catalog_snapshot | default(false) }}"
+    install_operator_catalogsource_name: "{{ ocp4_workload_web_terminal_catalogsource_name | default('') }}"
+    install_operator_catalogsource_namespace: openshift-operators
+    install_operator_catalogsource_image: "{{ ocp4_workload_web_terminal_catalog_snapshot_image | default('') }}"
+    install_operator_catalogsource_image_tag: "{{ ocp4_workload_web_terminal_catalog_snapshot_image_tag | default('') }}"
 
 # Leave this as the last task in the playbook.
 - name: remove_workload tasks complete

--- a/ansible/roles_ocp_workloads/ocp4_workload_web_terminal/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_web_terminal/tasks/workload.yml
@@ -1,7 +1,17 @@
 ---
-- name: Set up web terminal
-  kubernetes.core.k8s:
-    state: present
-    definition: "{{ lookup('template',  item ) | from_yaml }}"
-  loop:
-  - web-terminal-subscription.yaml.j2
+- name: Install Web Terminal operator
+  ansible.builtin.include_role:
+    name: install_operator
+  vars:
+    install_operator_action: install
+    install_operator_name: web-terminal
+    install_operator_namespace: openshift-operators
+    install_operator_channel: "{{ ocp4_workload_web_terminal_channel }}"
+    install_operator_catalog: redhat-operators
+    install_operator_automatic_install_plan_approval: "{{ ocp4_workload_web_terminal_automatic_install_plan_approval | default(true) }}"
+    install_operator_starting_csv: "{{ ocp4_workload_web_terminal_starting_csv }}"
+    install_operator_catalogsource_setup: "{{ ocp4_workload_web_terminal_use_catalog_snapshot | default(false) }}"
+    install_operator_catalogsource_name: "{{ ocp4_workload_web_terminal_catalogsource_name | default('') }}"
+    install_operator_catalogsource_namespace: openshift-operators
+    install_operator_catalogsource_image: "{{ ocp4_workload_web_terminal_catalog_snapshot_image | default('') }}"
+    install_operator_catalogsource_image_tag: "{{ ocp4_workload_web_terminal_catalog_snapshot_image_tag | default('') }}"


### PR DESCRIPTION

##### SUMMARY

Refactor role ocp4_workload_web_terminal to use install_operator role and support `ocp4_workload_web_terminal_catalog_snapshot_image`


##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ocp4_workload_web_terminal

##### ADDITIONAL INFORMATION

Example env.yaml 
```
# -------------------------------------------------------------------
# Workload: ocp4_workload_web_terminal
# -------------------------------------------------------------------
ocp4_workload_web_terminal_use_catalog_snapshot: true
ocp4_workload_web_terminal_starting_csv: "web-terminal.v1.8.0"
ocp4_workload_web_terminal_catalog_snapshot_image: quay.io/gpte-devops-automation/olm_snapshot_redhat_catalog
ocp4_workload_web_terminal_catalog_snapshot_image_tag: v4.13_2023_07_31
```


