### PR TITLE
Change ocp4_workload_fraud_detection_usecase - Debug r_service_db_pod variable state

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_fraud_detection_usecase/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_fraud_detection_usecase/tasks/workload.yml
@@ -103,6 +103,10 @@
       - name=postgresql
   register: r_service_db_pod
 
+- name: Print postgres cache db data
+  ansible.builtin.debug:
+    msg: "Postgres cache db data: {{ r_service_db_pod }}"
+
 - name: Wait until postgres cache db is up
   kubernetes.core.k8s_exec:
     namespace: "{{ ocp4_workload.starburst.namespace }}"


### PR DESCRIPTION
The "Wait until postgres cache db is up" workload task is currently failing as r_service_db_pod.resources is empty. Local testing on an OCP 4.13 cluster does not reproduce this error. This PR adds a debug task to investigate the status of r_service_db_pod variable in the dev deployment.