### PR TITLE
Fix bookbag namespace creation issue

### DIFF
--- a/ansible/roles/bookbag/tasks/workload.yaml
+++ b/ansible/roles/bookbag/tasks/workload.yaml
@@ -18,6 +18,10 @@
       metadata:
         name: "{{ bookbag_namespace }}"
   register: r_create_bookbag_namespace
+  # Work around https://github.com/ansible-collections/kubernetes.core/issues/623
+  failed_when: >-
+    r_create_bookbag_namespace is failed and
+    'AlreadyExists' not in r_create_bookbag_namespace.msg | default('')
   until: r_create_bookbag_namespace is successful
   retries: 10
   delay: 5


### PR DESCRIPTION
##### SUMMARY

This issue is caused by https://github.com/ansible-collections/kubernetes.core/issues/623

Workaround is to not fail on this task when it is reported that projectrequest already exists.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

bookbag role