### PR TITLE
Change ocp4_workload_fraud_detection_usecase - add retry loop when getting postgres db data

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_fraud_detection_usecase/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_fraud_detection_usecase/tasks/workload.yml
@@ -102,6 +102,10 @@
     label_selectors:
       - name=postgresql
   register: r_service_db_pod
+  until: r_service_db_pod["resources"] is defined and (r_service_db_pod["resources"] | length>0)
+
+  retries: 10
+  delay: 6
 
 - name: Print postgres cache db data
   ansible.builtin.debug:

--- a/ansible/roles_ocp_workloads/ocp4_workload_fraud_detection_usecase/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_fraud_detection_usecase/tasks/workload.yml
@@ -102,8 +102,7 @@
     label_selectors:
       - name=postgresql
   register: r_service_db_pod
-  until: r_service_db_pod["resources"] is defined and (r_service_db_pod["resources"] | length>0)
-
+  until: r_service_db_pod["resources"] is defined and (r_service_db_pod["resources"] | length > 0)
   retries: 10
   delay: 6
 
@@ -161,6 +160,9 @@
     label_selectors:
       - app=postgres
   register: r_catalog_db_pod
+  until: r_catalog_db_pod["resources"] is defined and (r_catalog_db_pod["resources"] | length > 0)
+  retries: 10
+  delay: 6
 
 - name: Wait until postgresql catalog db is running
   kubernetes.core.k8s_exec:

--- a/ansible/roles_ocp_workloads/ocp4_workload_fraud_detection_usecase/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_fraud_detection_usecase/tasks/workload.yml
@@ -106,10 +106,6 @@
   retries: 10
   delay: 6
 
-- name: Print postgres cache db data
-  ansible.builtin.debug:
-    msg: "Postgres cache db data: {{ r_service_db_pod }}"
-
 - name: Wait until postgres cache db is up
   kubernetes.core.k8s_exec:
     namespace: "{{ ocp4_workload.starburst.namespace }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_fraud_detection_usecase/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_fraud_detection_usecase/tasks/workload.yml
@@ -103,6 +103,10 @@
       - name=postgresql
   register: r_service_db_pod
 
+- name: Print postgres cache db data
+  ansible.builtin.debug:
+    msg: "Postgres cache db data: {{ r_service_db_pod }}"
+
 - name: Wait until postgres cache db is up
   kubernetes.core.k8s_exec:
     namespace: "{{ ocp4_workload.starburst.namespace }}"


### PR DESCRIPTION
This PR fixes the issue of the playbook continuing before the postgres pods are ready and leaving the postgres pod data variable undefined. It adds a retry loop to ensure the pod is running before proceeding.