### PR TITLE
Removes kubeadmin user since it is not needed

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/workload.yml
@@ -36,6 +36,14 @@
     dest: /root/hub-kubeconfig
     remote_src: true
 
+- name: Remove kubeadmin user
+  kubernetes.core.k8s:
+    state: absent
+    api_version: v1
+    kind: Secret
+    namespace: kube-system
+    name: kubeadmin
+
 - name: Ensure ArgoCD instance is patched for ZTP support
   kubernetes.core.k8s:
     kubeconfig: /root/hub-kubeconfig


### PR DESCRIPTION
##### SUMMARY

Removes the kubeadmin user from OCP. There is no need to use kubeadmin since we already created a admin user which is provided to the student.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
A new task is added to remove the kubeadmin secrets once the cluster is deployed.