### PR TITLE
Update osp_infrastructure_deployment.yml

### DIFF
--- a/ansible/cloud_providers/osp_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/osp_infrastructure_deployment.yml
@@ -55,11 +55,11 @@
           metadata:
             guid: "{{ guid }}"
             env_type: "{{ env_type }}"
-      register: r_osp_facts
+      register: r_osp_server_facts
 
     - name: debug osp_facts
       debug:
-        var: r_osp_facts
+        var: r_osp_server_facts
         verbosity: 2
 
     - name: Run infra-osp-dns Role


### PR DESCRIPTION
replace r_osp_facts  to r_osp_server_facts

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

I will be changing the r_ocp_fact to r_osp_server_facts in 
https://github.com/redhat-cop/agnosticd/blob/development/ansible/cloud_providers/osp_infrastructure_deployment.yml

as we made this change before in file ansible/roles-infra/infra-osp-create-inventory/tasks/main.yml
https://github.com/redhat-cop/agnosticd/pull/6824

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
osp_infrastructure_deployment

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Inventory creation failed due to undefined error

TASK [infra-osp-create-inventory : Add hosts to inventory] *********************
fatal: [localhost]: FAILED! => {"msg": "'r_osp_server_facts' is undefined"}

CI openstack.elt-odf*

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
