### PR TITLE
Fix: Intermittent deploy failures of WebTerminal

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_service_interconnect/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_service_interconnect/tasks/workload.yml
@@ -4,6 +4,13 @@
   debug:
     msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
 
+# Workaround for intermittent problems when installing the Terminal Operator too quickly after DevWorkspaces
+# checking the DevWorkspaces install would be better, but... *quickfix
+- name: Pause for 5 minutes to allow the cluster to settle down
+  ansible.builtin.pause:
+    minutes: 5
+
+
 - name: Deploy application on AWS OCP Cluster
   block:
     - name: install resources


### PR DESCRIPTION
##### SUMMARY
Workaround - we have seen intermittent problems with a cluster becoming degraded, or failing on WebTerminal Operator deployment. 9 out of 10 work.
Simply giving it some time to settle down before the workload (incl. WebTerminal) gets deployed. Just in case.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

`ansible/roles_ocp_workloads/ocp4_workload_service_interconnect/tasks/workload.yml`


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

![image](https://github.com/redhat-cop/agnosticd/assets/33287465/1865ca2e-1680-4cb4-8f99-f7b151dfbaf2)
...as a following error the WebTerminal Operator fails with 
```error validating existing CRs against new CRD's schema for "devworkspacetemplates.workspace.devfile.io": error listing resources in GroupVersionResource schema.GroupVersionResource{Group:"workspace.devfile.io", Version:"v1alpha1", Resource:"devworkspacetemplates"}: Internal error occurred: error resolving resource ```
because the DevWorkspaces Operator (AgV, not workload) isn't finished.

Simply giving it some time to settle down before the workload (incl. WebTerminal) gets deployed.




<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
Test today on Dev - successful deployment

![image](https://github.com/redhat-cop/agnosticd/assets/33287465/94bf95b0-784b-48e0-89a8-eb2e72548c8f)


