### PR TITLE
Update to OCP Auth - dil serverless

### DIFF
--- a/ansible/configs/ocp4-cluster/requirements.yml
+++ b/ansible/configs/ocp4-cluster/requirements.yml
@@ -22,3 +22,5 @@ collections:
   version: 1.0.2
 - name: openstack.cloud
   version: 2.1.0
+- name: community.okd
+  version: 2.3.0

--- a/ansible/roles/ocp4-workload-dil-serverless/tasks/user_terminal.yaml
+++ b/ansible/roles/ocp4-workload-dil-serverless/tasks/user_terminal.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Log in OCP as {{ __user }}
-  k8s_auth:
+  community.okd.openshift_auth:
     host: "{{ api_url }}"
     verify_ssl: false
     username: '{{ __user }}'


### PR DESCRIPTION
add  community.okd instead of k8's auth

  version: 2.3.0 