### PR TITLE
fix typo in rhods destroy

### DIFF
--- a/ansible/roles-infra/infra-osp-resources-destroy/tasks/keypairs.yml
+++ b/ansible/roles-infra/infra-osp-resources-destroy/tasks/keypairs.yml
@@ -9,7 +9,7 @@
   environment: "{{ __infra_osp_resources_destroy_environment }}"
   block:
   - name: Get user info
-    openstack.cloud.user_info:
+    openstack.cloud.identity_user_info:
       name: "{{ _keypair_owner }}"
       domain: default
     register: r_osp_user_info


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
fix typo in rhods destroy
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
roles-infra/infra-osp-resources-destroy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
