### PR TITLE
[ocp4-equinix-aio] Update ocp4_aio_base_virt version

### DIFF
--- a/ansible/configs/ocp4-equinix-aio/requirements.yml
+++ b/ansible/configs/ocp4-equinix-aio/requirements.yml
@@ -8,7 +8,7 @@ roles:
 - name: ocp4_aio_base_virt
   src: https://github.com/RHFieldProductManagement/ocp4_aio_infra_role_base_virt.git
   scm: git
-  version: v0.1.5
+  version: v0.1.6
 
 - name: ocp4_aio_prepare_bastion
   src: https://github.com/RHFieldProductManagement/ocp4_aio_infra_role_prepare_bastion.git


### PR DESCRIPTION
This version doesn't use community.libvirt
