### PR TITLE
[ocp4-equinix-aio] Update version of ocp4_aio_deploy_ocp

### DIFF
--- a/ansible/configs/ocp4-equinix-aio/requirements.yml
+++ b/ansible/configs/ocp4-equinix-aio/requirements.yml
@@ -58,7 +58,7 @@ roles:
 - name: ocp4_aio_deploy_ocp
   src: https://github.com/RHFieldProductManagement/ocp4_aio_infra_role_deploy_ocp.git
   scm: git
-  version: v0.0.7
+  version: v0.0.8
 
 - name: ocp4_aio_workload_cnvlab
   src: https://github.com/RHFieldProductManagement/ocp4_aio_role_deploy_cnvlab.git


### PR DESCRIPTION
To don't use libvirt collection

