### PR TITLE
try to make osp_migration use vaulted SSH key

### DIFF
--- a/ansible/configs/osp-migration/pre_infra.yml
+++ b/ansible/configs/osp-migration/pre_infra.yml
@@ -1,23 +1,50 @@
 ---
-- name: Step 000 Pre Infrastructure
+- name: Build inventory
   hosts: localhost
   connection: local
   become: false
+  gather_facts: false
   tags:
-  - step001
-  - pre_infrastructure
-  - osp_migration
+    - step002
   tasks:
-  - name: Create migration host group
-    add_host:
-      name: "{{ import_host }}"
-      ansible_become: true
-      ansible_ssh_private_key_file: "{{ migration_key_path | default(omit) }}"
-      ansible_user: "opentlc-mgr"
-      bastion: "{{ import_host }}"
-      group: "migration"
-      output_dir: "{{ output_dir }}"
-      remote_user: "opentlc-mgr"
+
+    - when: target_host is mapping
+      block:
+        - when:
+            - '"ansible_ssh_private_key_content" in target_host'
+            - '"ansible_ssh_private_key_file" in target_host'
+          fail:
+            msg: You cannot set both ansible_ssh_private_key_content and ansible_ssh_private_key_file
+
+        - when: '"ansible_ssh_private_key_content" in target_host'
+          block:
+            - name: Prepare ssh_key from provided content
+              copy:
+                content: "{{ target_host.ansible_ssh_private_key_content }}"
+                dest: "{{ output_dir }}/ssh_key.pem"
+                mode: 0600
+
+            - set_fact:
+                target_host_ansible_ssh_private_key_file: "{{ output_dir }}/ssh_key.pem"
+
+        - name: Add migration host to inventory
+          add_host:
+            name: >-
+              {{
+              target_host.name
+              | default(target_host.hostname)
+              | default(target_host.ansible_host)
+              }}
+            ansible_host: "{{ target_host.ansible_host | default(omit) }}"
+            group: migration
+            ansible_user: "{{ target_host.ansible_user | default(omit) }}"
+            ansible_port: "{{ target_host.ansible_port | default(omit) }}"
+            ansible_ssh_private_key_file: >-
+              {{ target_host.ansible_ssh_private_key_file
+              | default(target_host_ansible_ssh_private_key_file)
+              | default(omit) }}
+            ansible_ssh_extra_args: "{{ target_host.ansible_ssh_extra_args | default(omit) }}"
+            ansible_ssh_pipelining: true
 
 - name: Step 001 Migrating blueprints
   hosts: migration
@@ -25,30 +52,30 @@
   remote_user: opentlc-mgr
   gather_facts: true
   tags:
-  - step001
-  - pre_infrastructure
-  - osp_migration
+    - step001
+    - pre_infrastructure
+    - osp_migration
   tasks:
-  - name: Download images from project
-    become: true
-    environment:
-      OS_AUTH_URL: "{{ osp_auth_url }}"
-      OS_USERNAME: "{{ osp_auth_username }}"
-      OS_PASSWORD: "{{ osp_auth_password }}"
-      OS_PROJECT_NAME: "admin"
-      OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
-      OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"
-      OS_INTERFACE: "{{ osp_interface | default('internal') }}"
-      PATH: "/root/.local/bin:{{ ansible_env.PATH }}"
-      CEPH_CONF: "/etc/ceph/{{ ceph_cluster | default('red') }}.conf"
-    convert_blueprint:
-      ibm_endpoint: "{{ ibm_endpoint }}"
-      ibm_auth_endpoint: "{{ ibm_auth_endpoint }}"
-      ibm_api_key: "{{ ibm_api_key }}"
-      ibm_resource_id: "{{ ibm_resource_id }}"
-      bucket: "{{ ibm_bucket_name }}"
-      project: "{{ project }}"
-      output_dir: "{{ output_dir }}"
-      mode: "download"
-      glance_pool: "{{ ceph_cluster | default('red') }}-images"
-      overwrite: "{{ overwrite_image | default('false') }}"
+    - name: Download images from project
+      become: true
+      environment:
+        OS_AUTH_URL: "{{ osp_auth_url }}"
+        OS_USERNAME: "{{ osp_auth_username }}"
+        OS_PASSWORD: "{{ osp_auth_password }}"
+        OS_PROJECT_NAME: "admin"
+        OS_PROJECT_DOMAIN_ID: "{{ osp_auth_project_domain }}"
+        OS_USER_DOMAIN_NAME: "{{ osp_auth_user_domain }}"
+        OS_INTERFACE: "{{ osp_interface | default('internal') }}"
+        PATH: "/root/.local/bin:{{ ansible_env.PATH }}"
+        CEPH_CONF: "/etc/ceph/{{ ceph_cluster | default('red') }}.conf"
+      convert_blueprint:
+        ibm_endpoint: "{{ ibm_endpoint }}"
+        ibm_auth_endpoint: "{{ ibm_auth_endpoint }}"
+        ibm_api_key: "{{ ibm_api_key }}"
+        ibm_resource_id: "{{ ibm_resource_id }}"
+        bucket: "{{ ibm_bucket_name }}"
+        project: "{{ project }}"
+        output_dir: "{{ output_dir }}"
+        mode: "download"
+        glance_pool: "{{ ceph_cluster | default('red') }}-images"
+        overwrite: "{{ overwrite_image | default('false') }}"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
try to make osp_migration use vaulted SSH key
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
osp-migration

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
