### PR TITLE
configs/convert-to-rhel migrate to standard bookbag role

### DIFF
--- a/ansible/configs/convert-to-rhel/post_software.yml
+++ b/ansible/configs/convert-to-rhel/post_software.yml
@@ -74,6 +74,13 @@
               ssh_command: "ssh {{ ansible_service_account_user_name }}@{{ groups['bastions'][0] | regex_replace('\\..*$') }}.{{ guid }}{{ agnosticd_domain_name }}"
               ssh_password: "{{ student_password }}"
 
+        - name: Deploy Bookbag
+          when: bookbag_git_repo is defined
+          include_role:
+            name: bookbag
+          vars:
+            ACTION: create
+
 - name: PostSoftware flight-check
   hosts: localhost
   connection: local

--- a/ansible/configs/convert-to-rhel/post_software.yml
+++ b/ansible/configs/convert-to-rhel/post_software.yml
@@ -74,11 +74,6 @@
               ssh_command: "ssh {{ ansible_service_account_user_name }}@{{ groups['bastions'][0] | regex_replace('\\..*$') }}.{{ guid }}{{ agnosticd_domain_name }}"
               ssh_password: "{{ student_password }}"
 
-    - name: Deploy Bookbag
-      ansible.builtin.include_role:
-        name: ocp4_workload_bookbag
-
-
 - name: PostSoftware flight-check
   hosts: localhost
   connection: local


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Removing bookbag role call from post software and switching to using bookbag role defined through AgV. 

Fixes deployment issues when migrating to EE deployment. 



##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
/configs/convert-to-rhel

