### PR TITLE
move to venv

### DIFF
--- a/ansible/configs/osp-migration/pre_infra.yml
+++ b/ansible/configs/osp-migration/pre_infra.yml
@@ -44,7 +44,8 @@
               | default(target_host_ansible_ssh_private_key_file)
               | default(omit) }}
             ansible_ssh_extra_args: "{{ target_host.ansible_ssh_extra_args | default(omit) }}"
-            ansible_ssh_pipelining: false
+            ansible_ssh_pipelining: true
+            ansible_python_interpreter: /root/virtualenvs/python3.8-migration/bin/python
 
 - name: Step 001 Migrating blueprints
   hosts: migration


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
move osp-migration to env on migration server
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
osp-migration

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
