### PR TITLE
toughen up check for environments that might not have a bastion

### DIFF
--- a/ansible/roles-infra/infra-common-ssh-config-generate/tasks/main.yml
+++ b/ansible/roles-infra/infra-common-ssh-config-generate/tasks/main.yml
@@ -69,7 +69,7 @@
       {% endif %}
         User {{ remote_user }}
         IdentityFile {{ ssh_provision_key_path | default(ssh_key) | default(infra_ssh_key) | default(ansible_ssh_private_key_file) | default(default_key_name) }}
-      {% if hostvars[item].bastion != '' %}
+      {% if bastion in hostvars[item] and hostvars[item].bastion != '' %}
         ProxyCommand ssh -F {{ ansible_ssh_config }} {{ hostvars[item].bastion }} -W %h:%p
       {% else %}
         ProxyCommand ssh -F {{ ansible_ssh_config }} {{ bastion_hostname }} -W %h:%p


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
toughen up check for environments that might not have a bastion
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
roles-infra/infra-common-ssh-config-generate

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
