### PR TITLE
[ee-multicloud-public] Fix openstacksdk python library

### DIFF
--- a/tools/execution_environments/ee-multicloud-public/requirements.txt
+++ b/tools/execution_environments/ee-multicloud-public/requirements.txt
@@ -8,7 +8,7 @@ dumb-init
 jsonpatch
 kubernetes>=12.0.0
 ncclient
-openstacksdk>=1.0.0
+openstacksdk==1.3.1
 packet-python>=1.43.1
 passlib
 paramiko

--- a/tools/execution_environments/ee-multicloud-public/requirements.txt
+++ b/tools/execution_environments/ee-multicloud-public/requirements.txt
@@ -8,6 +8,7 @@ dumb-init
 jsonpatch
 kubernetes>=12.0.0
 ncclient
+# Fix openstacksdk version till this issue is solved: https://storyboard.openstack.org/#!/story/2010908
 openstacksdk==1.3.1
 packet-python>=1.43.1
 passlib


### PR DESCRIPTION
Newer version doesn't allow to filter by metadata keys which doesn't exist (i.e. *guid*)

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
