### PR TITLE
fix missing ssh key on destroy

### DIFF
--- a/ansible/configs/rosa/destroy_env.yml
+++ b/ansible/configs/rosa/destroy_env.yml
@@ -12,6 +12,13 @@
     - name: Run infra-ec2-create-inventory role
       include_role:
         name: infra-ec2-create-inventory
+
+    - name: Create local ssh provision facts (key already exists)
+      include_role:
+        name: create_ssh_provision_key
+      when:
+        - ssh_provision_key_name is undefined
+
     - name: SSH config setup
       when:
         - groups["bastions"] is defined


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
fix missing ssh key on destroy
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
rosa

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
