### PR TITLE
ee-multicloud: release v0.1.1 version

### DIFF
--- a/.github/workflows/build-ee-pr.yml
+++ b/.github/workflows/build-ee-pr.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
     paths:
       - tools/execution_environments/ee-multicloud-public/**
+    paths-ignore:
+      - tools/execution_environments/ee-multicloud-public/*.adoc
 
 jobs:
   build-and-push:

--- a/tools/execution_environments/ee-multicloud-public/readme.adoc
+++ b/tools/execution_environments/ee-multicloud-public/readme.adoc
@@ -2,12 +2,13 @@
 
 === v0.1.1 ===
 
+* size +50M
 * Add OpenStack missing clients link:https://github.com/redhat-cop/agnosticd/pull/6916[#6916]
 * Pin the version of `openstacksdk` python module, see this link:https://storyboard.openstack.org/#!/story/2010908[upstream issue] and link:https://github.com/redhat-cop/agnosticd/pull/6963[#6963]
 * Use latest prod version of Ansible Builder's entrypoint link:https://github.com/redhat-cop/agnosticd/pull/6981[#6981]
 ** Patch it to be able to dynamically install collections: link:https://github.com/redhat-cop/agnosticd/pull/7111[#7111]
-* link:https://gist.github.com/fridim/0caa55f43734a1bb0362592103debd26[ee-report diff with v0.1.0]
-* link:https://gist.github.com/fridim/690832d4cbaa8bd91872d7ec147f5737[full ee-report]
+* link:https://gist.github.com/fridim/226f62f3a028d734e25c8480722c2ce6[ee-report diff with v0.1.0]
+* link:https://gist.github.com/fridim/1b2726bb22c7944ee180aa866966e1e4[full ee-report]
 
 === v0.1.0 ===
 

--- a/tools/execution_environments/ee-multicloud-public/readme.adoc
+++ b/tools/execution_environments/ee-multicloud-public/readme.adoc
@@ -1,5 +1,13 @@
 == Changelog ==
 
+=== v0.1.1 ===
+
+* Add OpenStack missing clients link:https://github.com/redhat-cop/agnosticd/pull/6916[#6916]
+* Pin the version of `openstacksdk` python module, see this link:https://storyboard.openstack.org/#!/story/2010908[upstream issue] and link:https://github.com/redhat-cop/agnosticd/pull/6963[#6963]
+* Use latest prod version of Ansible Builder's entrypoint link:https://github.com/redhat-cop/agnosticd/pull/6981[#6981]
+* link:https://gist.github.com/fridim/0caa55f43734a1bb0362592103debd26[ee-report diff with v0.1.0]
+* link:https://gist.github.com/fridim/690832d4cbaa8bd91872d7ec147f5737[full ee-report]
+
 === v0.1.0 ===
 
 * Add community.okd collection

--- a/tools/execution_environments/ee-multicloud-public/readme.adoc
+++ b/tools/execution_environments/ee-multicloud-public/readme.adoc
@@ -2,7 +2,7 @@
 
 === v0.1.1 ===
 
-* size +50M
+* size -5M
 * Add OpenStack missing clients link:https://github.com/redhat-cop/agnosticd/pull/6916[#6916]
 * Pin the version of `openstacksdk` python module, see this link:https://storyboard.openstack.org/#!/story/2010908[upstream issue] and link:https://github.com/redhat-cop/agnosticd/pull/6963[#6963]
 * Use latest prod version of Ansible Builder's entrypoint link:https://github.com/redhat-cop/agnosticd/pull/6981[#6981]

--- a/tools/execution_environments/ee-multicloud-public/readme.adoc
+++ b/tools/execution_environments/ee-multicloud-public/readme.adoc
@@ -5,6 +5,7 @@
 * Add OpenStack missing clients link:https://github.com/redhat-cop/agnosticd/pull/6916[#6916]
 * Pin the version of `openstacksdk` python module, see this link:https://storyboard.openstack.org/#!/story/2010908[upstream issue] and link:https://github.com/redhat-cop/agnosticd/pull/6963[#6963]
 * Use latest prod version of Ansible Builder's entrypoint link:https://github.com/redhat-cop/agnosticd/pull/6981[#6981]
+** Patch it to be able to dynamically install collections: link:https://github.com/redhat-cop/agnosticd/pull/7111[#7111]
 * link:https://gist.github.com/fridim/0caa55f43734a1bb0362592103debd26[ee-report diff with v0.1.0]
 * link:https://gist.github.com/fridim/690832d4cbaa8bd91872d7ec147f5737[full ee-report]
 


### PR DESCRIPTION
Release new version of ee-multicloud v0.1.1.


This PR should be merged after the testing phase of is done.

* alpha release: `quay.io/agnosticd/ee-multicloud:v0.1.1-alpha`
* 2nd alpha release: `quay.io/agnosticd/ee-multicloud:v0.1.1-alpha.2`

##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME

ee-multicloud Execution Environment
