### PR TITLE
Removing warn: false to fix ansible.legacy.command error

### DIFF
--- a/ansible/roles/set-repositories/tasks/file-repos.yml
+++ b/ansible/roles/set-repositories/tasks/file-repos.yml
@@ -35,8 +35,6 @@
 
 - name: file | clean repositories
   command: "yum clean all"
-  args:
-    warn: false
   tags:
     - configure_repos
     - run_yum_repolist


### PR DESCRIPTION
Removing warn: false to fix following fatal error. 
TASK [set-repositories : file | clean repositories] ****************************fatal: [master1.9nn4m.internal]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (ansible.legacy.command) module: warn. Supported parameters include: _raw_params, _uses_shell, argv, chdir, creates, executable, removes, stdin, stdin_add_newline, strip_empty_ends."}

##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
