### PR TITLE
Patch 7

### DIFF
--- a/ansible/roles/ocp4-workload-dil-streaming/tasks/provision_broker.yaml
+++ b/ansible/roles/ocp4-workload-dil-streaming/tasks/provision_broker.yaml
@@ -8,7 +8,7 @@
 
 - name: Evaluate Operator Group
   k8s:
-    api_version: operators.coreos.com/v1alpha2
+    api_version: operators.coreos.com/v1
     kind: OperatorGroup
     name: workshop-operators
     namespace: '{{ operators_project }}'

--- a/ansible/roles/ocp4-workload-dil-streaming/tasks/provision_camelk.yaml
+++ b/ansible/roles/ocp4-workload-dil-streaming/tasks/provision_camelk.yaml
@@ -8,7 +8,7 @@
 
 - name: Evaluate Operator Group
   k8s:
-    api_version: operators.coreos.com/v1alpha2
+    api_version: operators.coreos.com/v1
     kind: OperatorGroup
     name: workshop-operators
     namespace: '{{ operators_project }}'

--- a/ansible/roles/ocp4-workload-dil-streaming/tasks/provision_devspaces.yaml
+++ b/ansible/roles/ocp4-workload-dil-streaming/tasks/provision_devspaces.yaml
@@ -9,7 +9,7 @@
 
 - name: Evaluate Operator Group
   k8s:
-    api_version: operators.coreos.com/v1alpha2
+    api_version: operators.coreos.com/v1
     kind: OperatorGroup
     name: workshop-operators
     namespace: '{{ operators_project }}'

--- a/ansible/roles/ocp4-workload-dil-streaming/tasks/provision_streams.yaml
+++ b/ansible/roles/ocp4-workload-dil-streaming/tasks/provision_streams.yaml
@@ -8,7 +8,7 @@
 
 - name: Evaluate Operator Group
   k8s:
-    api_version: operators.coreos.com/v1alpha2
+    api_version: operators.coreos.com/v1
     kind: OperatorGroup
     name: workshop-operators
     namespace: '{{ operators_project }}'


### PR DESCRIPTION
##### SUMMARY

test and prod instances failed at task provisioning Camel K.

These changes are updating the apiversion of coreos to v1, instead of v1alpha2

