### PR TITLE
check if binary exists in venv before setting python interpreter to use it

### DIFF
--- a/ansible/configs/ocp4-cluster/destroy_env_ec2.yml
+++ b/ansible/configs/ocp4-cluster/destroy_env_ec2.yml
@@ -95,24 +95,32 @@
   run_once: true
   become: false
   tasks:
-  - name: Set Ansible Python interpreter to k8s virtualenv
-    set_fact:
-      ansible_python_interpreter: /opt/virtualenvs/k8s/bin/python
+  - name: Check if k8s interpreter venv is installed
+    ansile.builtin.stat:
+      path: /opt/virtualenvs/k8s/bin/python
+    register: interpreter_bin
 
-  - name: Remove ocp workloads on bastion
-    when:
-    - remove_workloads_bastion | default("") | length > 0
+  - name: Remove workloads
+    when: interpreter_bin.stat.exists
     block:
-    - name: Invoke roles to remove ocp workloads
-      include_role:
-        name: "{{ workload_loop_var }}"
-      vars:
-        ocp_username: "system:admin"
-        ACTION: "remove"
-        silent: false
-      loop: "{{ remove_workloads_bastion }}"
-      loop_control:
-        loop_var: workload_loop_var
+    - name: Set Ansible Python interpreter to k8s virtualenv
+      set_fact:
+        ansible_python_interpreter: /opt/virtualenvs/k8s/bin/python
+
+    - name: Remove ocp workloads on bastion
+      when:
+      - remove_workloads_bastion | default("") | length > 0
+      block:
+      - name: Invoke roles to remove ocp workloads
+        include_role:
+          name: "{{ workload_loop_var }}"
+        vars:
+          ocp_username: "system:admin"
+          ACTION: "remove"
+          silent: false
+        loop: "{{ remove_workloads_bastion }}"
+        loop_control:
+          loop_var: workload_loop_var
 
 - name: Have the OpenShift installer cleanup what it did
   hosts: bastions


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
check if binary exists in venv before setting python interpreter to use it
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4-cluster

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
