### PR TITLE
Fixes to showroom re simplified machinectl become excalation

### DIFF
--- a/ansible/roles/showroom/tasks/50-showroom-service.yml
+++ b/ansible/roles/showroom/tasks/50-showroom-service.yml
@@ -63,10 +63,12 @@
         group: "{{ showroom_user_group }}"
         mode: u=rw,g-rwx,o-rwx
 
-    - name: Set a root password for machinectl
+    - name: Add ansible_user to group wheel for machinectl privileges
       ansible.builtin.user:
-        name: root
+        name: "{{ ansible_user }}"
+        groups: wheel
         password: "{{ common_password | password_hash('sha512') }}"
+        append: true
 
     - name: "Start --user {{ showroom_user }} podman.socket for traefik"
       shell: "loginctl enable-linger $USER; systemctl --user enable podman.socket --now"


### PR DESCRIPTION

##### SUMMARY

become machienctl was hacky (needed so showroom could see dbus for podman.socket)
- removed the task giving a root password
- enhanced ansible_user to have membership of `wheel` && a password

Works on ec2  ec2-user. 

May want to revisit


##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

roles/showroom

##### ADDITIONAL INFORMATION
