### PR TITLE
Minor cleaup of showroon, ensure pip, FQCN fix

### DIFF
--- a/ansible/roles/showroom/defaults/main.yml
+++ b/ansible/roles/showroom/defaults/main.yml
@@ -38,6 +38,7 @@ showroom_dnf_packages:
   - git
   - systemd-container
   - podman
+  - python-devel
   - unzip
 
 showroom_pip_packages:

--- a/ansible/roles/showroom/tasks/50-showroom-service.yml
+++ b/ansible/roles/showroom/tasks/50-showroom-service.yml
@@ -74,7 +74,7 @@
       shell: "loginctl enable-linger $USER; systemctl --user enable podman.socket --now"
       become: true
       become_user: "{{ showroom_user }}"
-      become_method: machinectl
+      become_method: community.general.machinectl
       vars:
         ansible_become_pass: "{{ common_password }}"
       environment:


### PR DESCRIPTION

##### SUMMARY

- Showroom needs `python-devel` so ensure it is installed
- machinectl should have been a FQCN. FIXED

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

roles/showroom

##### ADDITIONAL INFORMATION
