### PR TITLE
Add showroom capability to ocp4-cluster

### DIFF
--- a/ansible/configs/ocp4-cluster/default_vars_ec2.yml
+++ b/ansible/configs/ocp4-cluster/default_vars_ec2.yml
@@ -167,6 +167,48 @@ instances:
   rootfs_size: "{{ bastion_rootfs_size }}"
   security_groups:
   - BastionSG
+  - WebSG
+  - ShowroomSG
+
+security_groups:
+
+- name: WebSG
+  rules:
+
+  - name: HTTPPorts
+    description: "HTTP Public"
+    from_port: 80
+    to_port: 80
+    protocol: tcp
+    cidr: "0.0.0.0/0"
+    rule_type: Ingress
+
+  - name: HTTPSPorts
+    description: "HTTP Public"
+    from_port: 443
+    to_port: 443
+    protocol: tcp
+    cidr: "0.0.0.0/0"
+    rule_type: Ingress
+
+- name: ShowroomSG
+  rules:
+
+  - name: ShowroomHTTPS
+    description: "Primary showroom endpoint - for reverse proxy"
+    from_port: 8443
+    to_port: 8443
+    protocol: tcp
+    cidr: "0.0.0.0/0"
+    rule_type: Ingress
+
+  - name: ShowroomExposed
+    description: "Showroom views or exposed services, up to 26 of them"
+    from_port: 8500
+    to_port: 8525
+    protocol: tcp
+    cidr: "0.0.0.0/0"
+    rule_type: Ingress
 
 # -------------------------------------------------------------------
 # AWS On-demand Capacity

--- a/ansible/configs/ocp4-cluster/post_software.yml
+++ b/ansible/configs/ocp4-cluster/post_software.yml
@@ -214,6 +214,18 @@
       path: "{{ output_dir }}/google-cloud-sdk"
       state: absent
 
+- name: Step 005.7 Deploy showroom if showroom_git_repo is defined
+  hosts: localhost
+  gather_facts: true
+  become: true
+  tasks:
+
+  - name: Deploy Showroom Web Interface
+    when:
+    - showroom_git_repo is defined
+    ansible.builtin.include_role:
+      name: showroom
+
 - name: Step 005.7 Tell CloudForms we are done
   hosts: localhost
   run_once: true


### PR DESCRIPTION
##### SUMMARY

Adds the capability to deploy showroom to the OCP4 bastion

- call the showroom role conditionally
- open showroom ports on ec2 bastions

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

configs/ocp4-cluster

(ansible/roles/showroom)


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
