### PR TITLE
Explicitly prefix EEs for PRs 'temporary-pr-...'

### DIFF
--- a/.github/workflows/build-ee-pr.yml
+++ b/.github/workflows/build-ee-pr.yml
@@ -17,7 +17,7 @@ jobs:
       registry_username: ${{ secrets.QUAY_EE_MULTICLOUD_USER }}
       registry_password: ${{ secrets.QUAY_EE_MULTICLOUD_TOKEN }}
     with:
-      tag: pr-${{ github.event.number }}
+      tag: temporary-pr-${{ github.event.number }}
       labels: |-
         quay.expires-after=7d
         org.opencontainers.image.source=${{ github.event.repository.html_url }}
@@ -43,5 +43,5 @@ jobs:
         run: |
           ./compare.sh \
             quay.io/agnosticd/ee-multicloud:latest \
-            quay.io/agnosticd/ee-multicloud:pr-${PR} \
+            quay.io/agnosticd/ee-multicloud:temporary-pr-${PR} \
             | gh pr comment ${PR} --body-file -

--- a/tools/execution_environments/ee-multicloud-public/release_cycle.adoc
+++ b/tools/execution_environments/ee-multicloud-public/release_cycle.adoc
@@ -14,7 +14,7 @@ The release cycle for execution environments is designed to go through several s
 === 2. Automated PR Builds
 
 . *Environment Build*: An ephemeral execution environment is automatically built when a PR is created.
-  - Naming convention: `pr-XXXX` where `XXXX` is the PR number.
+  - Naming convention: `temporary-pr-XXXX` where `XXXX` is the PR number.
 . *Expiration*: These execution environments are ephemeral and will expire after 7 days.
 . *Purpose*: These execution environments are solely for testing and should not be used in any production-like environment.
 

--- a/tools/execution_environments/readme.adoc
+++ b/tools/execution_environments/readme.adoc
@@ -156,7 +156,7 @@ To build a new version of ee-multicloud, you can simply open a PR to update its 
 - requirements.yml (ansible collections)
 - ...
 
-A GitHub workflow will automatically create the image and push it to Quay using a tag `pr-1234` with 1234 being the id of the Pull Request.
+A GitHub workflow will automatically create the image and push it to Quay using a tag `temporary-pr-1234` with 1234 being the id of the Pull Request.
 
 
 Alternatively, you can build from your local machine:


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Pull Requests to update the ee-multicloud execution environment automatically triggers  A GitHub Action that builds a temporary image in the form `pr-1234`.

This change adds the `temporary-` as a prefix to be clear those images are for testing and are moving targets and not use for other purposes. Mostly because:

* they expire after 7 days
* PRs can be updated so does the image tag

before: `pr-1234`, after: `temporary-pr-1234`

see https://github.com/redhat-cop/agnosticd/blob/development/tools/execution_environments/ee-multicloud-public/release_cycle.adoc

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request


##### COMPONENT NAME
* Github action `build-ee-pr.yml`

