### PR TITLE
Fix default oc cli version for rosa

### DIFF
--- a/ansible/configs/rosa-consolidated/install_rosa.yml
+++ b/ansible/configs/rosa-consolidated/install_rosa.yml
@@ -11,7 +11,7 @@
 - name: Set default facts for ROSA version
   ansible.builtin.set_fact:
     rosa_version_to_install: ""
-    rosa_ocp_cli_version: "{{ r_rosa_versions.stdout | from_json | json_query(query) }}"
+    rosa_ocp_cli_version: "{{ (r_rosa_versions.stdout | from_json | json_query(query)) [0].raw_id }}"
   vars:
     query: "[?default==`true`]"
 
@@ -33,8 +33,8 @@
   ansible.builtin.debug:
     msg: "{{ item }}"
   loop:
-  - "ROSA Version to be installed: '{{ rosa_version_to_install }}'."
-  - "OCP CLI to be installed:      '{{ rosa_ocp_cli_version}}'."
+  - "ROSA Version to be installed: {{ rosa_version_to_install }}"
+  - "OCP CLI to be installed: {{ rosa_ocp_cli_version}}"
 
 - name: Create ROSA account roles
   ansible.builtin.command: >-


### PR DESCRIPTION
##### SUMMARY

Bugfix: for default ROSA version had wrong logic to calculate the matching oc cli version.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rosa-consolidated