### PR TITLE
Update ATE main.yml - fix automation controller task

### DIFF
--- a/ansible/roles/deploy_automationcontroller/tasks/main.yml
+++ b/ansible/roles/deploy_automationcontroller/tasks/main.yml
@@ -105,10 +105,9 @@
         body: >
           {
             "eula_accepted": true,
-            "manifest":
-            "{{
-              r_automationcontroller_manifest_local.content |
-              default(r_automationcontroller_manifest_remote.content)
+            "manifest": "{{
+              r_automationcontroller_manifest_local['content'] |
+              default(r_automationcontroller_manifest_remote['content'])
             }}"
           }
         body_format: json


### PR DESCRIPTION
Change to correctly use dictionary key access (['content']) instead of attempting to access the content attribute directly