### PR TITLE
Simplify showroom podman socket code - drop machinectl

### DIFF
--- a/ansible/roles/showroom/tasks/20-showroom-user-setup.yml
+++ b/ansible/roles/showroom/tasks/20-showroom-user-setup.yml
@@ -47,23 +47,28 @@
         group: "{{ showroom_user_group }}"
         mode: u=rw,g-rwx,o-rwx
 
-    - name: Add ansible_user to group wheel for machinectl privileges
-      ansible.builtin.user:
-        name: "{{ ansible_user }}"
-        password: "{{ generated_password | default(common_password) | password_hash('sha512') }}"
-        groups: wheel
-        append: true
+    - name: "Setup {{ showroom_user }} ssh directory"
+      ansible.builtin.file:
+        path: "{{ showroom_user_home_dir }}/.ssh"
+        state: directory
+        owner: "{{ showroom_user | default('showroom') }}"
+        group: "{{ showroom_user_group | default('showroom') }}"
+        mode: u=rw,go=
+
+    - name: "Borrow {{ ansible_user }} authorized keys for {{ showroom_user }}"
+      ansible.builtin.copy:
+        src: "~{{ ansible_user }}/.ssh/authorized_keys"
+        dest: "~{{ showroom_user }}/.ssh/authorized_keys"
+        owner: "{{ showroom_user }}"
+        mode: u=rw,go=
+        remote_src: true
 
     - name: "Start --user {{ showroom_user }} podman.socket for traefik"
       ansible.builtin.shell: "loginctl enable-linger $USER; systemctl --user enable podman.socket --now"
-      become: true
-      become_user: "{{ showroom_user }}"
-      become_method: community.general.machinectl
       vars:
-        ansible_become_pass: "{{ generated_password | default(common_password) }}"
-      environment:
-        XDG_RUNTIME_DIR: "/run/user/{{ showroom_user_uid }}"
-        DBUS_SESSION_BUS_ADDRESS: "unix:path=/run/user/{{ showroom_user_uid }}/bus"
+        ansible_user: "{{ showroom_user }}"
+        remote_user: "{{ showroom_user }}"
+      become: false
 
     - name: "Create a Podman network {{ showroom_podman_network }}"
       containers.podman.podman_network:


### PR DESCRIPTION

##### SUMMARY

Eliminate complex and fragile `become_method: machinectl`

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

roles/showroom

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
