### PR TITLE
Revert breaking machinectl changes for showroom

### DIFF
--- a/ansible/roles/showroom/tasks/20-showroom-user-setup.yml
+++ b/ansible/roles/showroom/tasks/20-showroom-user-setup.yml
@@ -47,28 +47,23 @@
         group: "{{ showroom_user_group }}"
         mode: u=rw,g-rwx,o-rwx
 
-    - name: "Setup {{ showroom_user }} ssh directory"
-      ansible.builtin.file:
-        path: "{{ showroom_user_home_dir }}/.ssh"
-        state: directory
-        owner: "{{ showroom_user | default('showroom') }}"
-        group: "{{ showroom_user_group | default('showroom') }}"
-        mode: u=rw,go=
-
-    - name: "Borrow {{ ansible_user }} authorized keys for {{ showroom_user }}"
-      ansible.builtin.copy:
-        src: "~{{ ansible_user }}/.ssh/authorized_keys"
-        dest: "~{{ showroom_user }}/.ssh/authorized_keys"
-        owner: "{{ showroom_user }}"
-        mode: u=rw,go=
-        remote_src: true
+    - name: Add ansible_user to group wheel for machinectl privileges
+      ansible.builtin.user:
+        name: "{{ ansible_user }}"
+        password: "{{ generated_password | default(common_password) | password_hash('sha512') }}"
+        groups: wheel
+        append: true
 
     - name: "Start --user {{ showroom_user }} podman.socket for traefik"
       ansible.builtin.shell: "loginctl enable-linger $USER; systemctl --user enable podman.socket --now"
+      become: true
+      become_user: "{{ showroom_user }}"
+      become_method: community.general.machinectl
       vars:
-        ansible_user: "{{ showroom_user }}"
-        remote_user: "{{ showroom_user }}"
-      become: false
+        ansible_become_pass: "{{ generated_password | default(common_password) }}"
+      environment:
+        XDG_RUNTIME_DIR: "/run/user/{{ showroom_user_uid }}"
+        DBUS_SESSION_BUS_ADDRESS: "unix:path=/run/user/{{ showroom_user_uid }}/bus"
 
     - name: "Create a Podman network {{ showroom_podman_network }}"
       containers.podman.podman_network:


### PR DESCRIPTION

##### SUMMARY

Recent changes to resolve an ocp4-cluster issue with showroom broke that role

- revert changes to how showroom creates the podman.socket for treafik

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

roles/showroom

##### ADDITIONAL INFORMATION
