### PR TITLE
Revert "Update ocp4_workload_quay_operator_channel stable-3.9"

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/defaults/main.yml
@@ -11,7 +11,7 @@ silent: false
 ocp4_workload_quay_operator_install_operator: true
 
 # Operator channel to subscribe to
-ocp4_workload_quay_operator_channel: "stable-3.9"
+ocp4_workload_quay_operator_channel: "stable-3.6"
 
 # Operator namespace
 ocp4_workload_quay_operator_namespace: openshift-operators


### PR DESCRIPTION
Reverts redhat-cop/agnosticd#7088
Reverting that as we should put default Quay to higher version.