### PR TITLE
Work around ansible bug on length of vaulted string

### DIFF
--- a/ansible/roles/host-ocp4-provisioner/tasks/ec2_prereqs.yml
+++ b/ansible/roles/host-ocp4-provisioner/tasks/ec2_prereqs.yml
@@ -50,8 +50,8 @@
 - name: Add aws credentials for shared account
   when:
     - hostvars.localhost.student_access_key_id | default("") | length == 0
-    - aws_access_key_id | default("") | length > 0
-    - aws_secret_access_key | default("") | length > 0
+    - aws_access_key_id | default("") != ""
+    - aws_secret_access_key | default("") != ""
   become: false
   blockinfile:
     state: present


### PR DESCRIPTION
##### SUMMARY

- The `length` filter applied to a vaulted value produces an error "object of type 'AnsibleVaultEncryptedUnicode' has no len()"
- Use equivalent test for empty string.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role host-ocp4-provisioner