### PR TITLE
Add config based start/stop functionality to base-infra for ec2

### DIFF
--- a/ansible/configs/base-infra/lifecycle_hook_post_start.yml
+++ b/ansible/configs/base-infra/lifecycle_hook_post_start.yml
@@ -1,0 +1,11 @@
+---
+- name: Hook for post start validations etc
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  become: false
+  tasks:
+
+    - name: Validation checks hook
+      ansible.builtin.debug:
+        msg: "Insert post restart validations if required"

--- a/ansible/configs/base-infra/lifecycle_hook_post_stop.yml
+++ b/ansible/configs/base-infra/lifecycle_hook_post_stop.yml
@@ -1,0 +1,11 @@
+---
+- name: Hook for post stop cleanup and  validations etc
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  become: false
+  tasks:
+
+    - name: Validation checks hook
+      ansible.builtin.debug:
+        msg: "Insert post stop validations if required"

--- a/ansible/configs/base-infra/start.yml
+++ b/ansible/configs/base-infra/start.yml
@@ -21,7 +21,7 @@
         - name: Get all EC2 instances
           amazon.aws.ec2_instance_info:
             filters:
-              instance-state-name: [ "shutting-down", "stopping", "stopped" ]
+              instance-state-name: ["shutting-down", "stopping", "stopped"]
               "tag:guid": "{{ guid }}"
               "tag:env_type": "{{ env_type }}"
           register: r_stopped_instances

--- a/ansible/configs/base-infra/start.yml
+++ b/ansible/configs/base-infra/start.yml
@@ -1,0 +1,49 @@
+---
+- name: Start instances
+  hosts: localhost
+  gather_facts: false
+  become: false
+  environment:
+    AWS_ACCESS_KEY_ID: "{{ aws_access_key_id }}"
+    AWS_SECRET_ACCESS_KEY: "{{ aws_secret_access_key }}"
+    AWS_DEFAULT_REGION: "{{ aws_region_final | default(aws_region) }}"
+
+  tasks:
+
+    - name: Starting all instances
+      ansible.builtin.debug:
+        msg: "Starting all instances"
+
+    - name: Start all instances on ec2
+      when: cloud_provider == "ec2"
+      block:
+
+        - name: Get all EC2 instances
+          amazon.aws.ec2_instance_info:
+            filters:
+              instance-state-name: [ "shutting-down", "stopping", "stopped" ]
+              "tag:guid": "{{ guid }}"
+              "tag:env_type": "{{ env_type }}"
+          register: r_stopped_instances
+
+        - name: Ensure EC2 instances are running
+          when: r_stopped_instances.instances | length > 0
+          amazon.aws.ec2_instance:
+            instance_ids: "{{ __instance.instance_id }}"
+            state: started
+            wait: false
+          loop: "{{ r_stopped_instances.instances }}"
+          loop_control:
+            loop_var: __instance
+
+        - name: Wait until all EC2 instances are running
+          when: r_stopped_instances.instances | length > 0
+          amazon.aws.ec2_instance_info:
+            filters:
+              "tag:guid": "{{ guid }}"
+              "tag:env_type": "{{ env_type }}"
+              instance-state-name: running
+          register: r_running_instances
+          until: r_running_instances.instances | length | int >= r_stopped_instances.instances | length | int
+          delay: 10
+          retries: 60

--- a/ansible/configs/base-infra/stop.yml
+++ b/ansible/configs/base-infra/stop.yml
@@ -1,0 +1,49 @@
+---
+- name: Stop instances
+  hosts: localhost
+  gather_facts: false
+  become: false
+  environment:
+    AWS_ACCESS_KEY_ID: "{{ aws_access_key_id }}"
+    AWS_SECRET_ACCESS_KEY: "{{ aws_secret_access_key }}"
+    AWS_DEFAULT_REGION: "{{ aws_region_final | default(aws_region) }}"
+
+  tasks:
+
+    - name: Stopping all instances
+      ansible.builtin.debug:
+        msg: "Stopping all instances"
+
+    - name: Stopping all instances on ec2
+      when: cloud_provider == "ec2"
+      block:
+
+        - name: Get all EC2 instances
+          amazon.aws.ec2_instance_info:
+            filters:
+              instance-state-name: "running"
+              "tag:guid": "{{ guid }}"
+              "tag:env_type": "{{ env_type }}"
+          register: r_running_instances
+
+        - name: Ensure EC2 instances are stopped
+          when: r_running_instances.instances | length > 0
+          amazon.aws.ec2_instance:
+            instance_ids: "{{ __instance.instance_id }}"
+            state: stopped
+            wait: false
+          loop: "{{ r_running_instances.instances }}"
+          loop_control:
+            loop_var: __instance
+
+        - name: Wait until all EC2 instances are stopped
+          when: r_running_instances.instances | length > 0
+          amazon.aws.ec2_instance_info:
+            filters:
+              "tag:guid": "{{ guid }}"
+              "tag:env_type": "{{ env_type }}"
+              instance-state-name: stopped
+          register: r_running_instances
+          until: r_running_instances.instances | length | int >= r_running_instances.instances | length | int
+          delay: 10
+          retries: 60


### PR DESCRIPTION

##### SUMMARY

- Zero CIs failed to start after stop
- added base-infra ec2 start/stop code
- provided hooks for future deeper validation (ie did all my endpoints come up)

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME

configs/base-infra

##### ADDITIONAL INFORMATION
