### PR TITLE
Make base-infra bastion name a var for RHEL Zero

### DIFF
--- a/ansible/configs/base-infra/Makefile
+++ b/ansible/configs/base-infra/Makefile
@@ -94,5 +94,5 @@ bounce: ## Bounce the deploy IE stop then start
 bounce: stop start
 
 relog: ## Zero out the ANSIBLE_LOG_PATH log file
-	rm $(OUTPUT_DIR)/aap2sbox0$(SANDBOX)/base-app2-infra-sbox0$(SANDBOX).log
+	rm $(OUTPUT_DIR)/$(ENV_TYPE)_$(GUID).log
 

--- a/ansible/configs/base-infra/default_vars_ec2.yml
+++ b/ansible/configs/base-infra/default_vars_ec2.yml
@@ -24,7 +24,7 @@ bastion_instance_type: t3a.medium
 
 instances:
 
-  - name: bastion
+  - name: "{{ bastion_hostname | default('bastion') }}"
     count: 1
     unique: true
     public_dns: true


### PR DESCRIPTION

##### SUMMARY

Minor - allow bastion name to be set as a var e.g. for RHEL Zero

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

configs/base-infra

##### ADDITIONAL INFORMATION
