### PR TITLE
Power down VMC VMs before deleting

### DIFF
--- a/ansible/configs/roadshow-ocpvirt/vcenter-remove-webapp-vms.yml
+++ b/ansible/configs/roadshow-ocpvirt/vcenter-remove-webapp-vms.yml
@@ -1,5 +1,20 @@
-- name: Create folder and VMs
+- name: Delete folder and VMs
   block:
+    - name: Power down the VMs
+      register: r_vmc_instances_off
+      community.vmware.vmware_guest:
+        folder: "/Workloads/{{env_type}}-{{ guid }}"
+        name: "{{ item }}"
+        state: "powered-off"
+      loop:
+        - haproxy
+        - winweb01
+        - winweb02
+        - database
+      until: r_vmc_instances_off is success
+      retries: 5
+      delay: 10
+
     - name: Remove the VMs
       register: r_vmc_instances
       community.vmware.vmware_guest:

--- a/tests/static/test-requirements.txt
+++ b/tests/static/test-requirements.txt
@@ -1,4 +1,4 @@
-ansible==2.9.15
+ansible==2.10.7
 appdirs==1.4.4
 astroid==2.4.2
 attrs==20.3.0


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Power down VMC VMs before deleting.  Sometimes delete fails because the VM is in a running state.

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
roadshow-ocpvirt

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
