### PR TITLE
[infra-common-ssh-config-generate] Add port to the bastion config + add openshift_cnv default user

### DIFF
--- a/ansible/roles-infra/infra-common-ssh-config-generate/defaults/main.yml
+++ b/ansible/roles-infra/infra-common-ssh-config-generate/defaults/main.yml
@@ -7,3 +7,4 @@ remote_user_map:
   gcp: gcpuser
   equinix_metal: root
   vmc: cloud-user
+  openshift_cnv: cloud-user

--- a/ansible/roles-infra/infra-common-ssh-config-generate/tasks/main.yml
+++ b/ansible/roles-infra/infra-common-ssh-config-generate/tasks/main.yml
@@ -44,6 +44,7 @@
          IdentityFile {{ ssh_provision_key_path | default(ssh_key) | default(infra_ssh_key) | default(ansible_ssh_private_key_file) | default(default_key_name) }}
          IdentitiesOnly yes
          User {{ remote_user }}
+         Port {{ hostvars[bastion_hostname].ssh_port | default(22) }}
          ControlMaster auto
          ControlPath /tmp/{{ guid }}-%r-%h-%p
          ControlPersist 5m


### PR DESCRIPTION
For CNV we are using a random port instead 22