### PR TITLE
DIL Streaming - add line 17 `when item = 1" bug fix

### DIFF
--- a/ansible/roles/ocp4-workload-dil-streaming/tasks/provision_userprojects.yaml
+++ b/ansible/roles/ocp4-workload-dil-streaming/tasks/provision_userprojects.yaml
@@ -14,6 +14,7 @@
   k8s:
     state: present
     resource_definition: "{{ lookup('template', 'pod-exec-role.yaml.j2') }}"
+  when: item == "1"
 
 - name: Give {{ num_users }} users access to projects
   k8s:


### PR DESCRIPTION
https://aap2-prod-us-east-2.aap.infra.demo.redhat.com/#/jobs/playbook/15687/output 

Fix for
TASK [ocp-workload-terminal : Create Project terminal] *************************
FAILED - RETRYING: [bastion.f94rs.internal]: Create Project terminal (5 retries left).
FAILED - RETRYING: [bastion.f94rs.internal]: Create Project terminal (4 retries left).
FAILED - RETRYING: [bastion.f94rs.internal]: Create Project terminal (3 retries left).
FAILED - RETRYING: [bastion.f94rs.internal]: Create Project terminal (2 retries left).
FAILED - RETRYING: [bastion.f94rs.internal]: Create Project terminal (1 retries left).
failed: [bastion.f94rs.internal] (item=./templates/project.j2) => {"ansible_loop_var": "item", "attempts": 5, "changed": false, "item": "./templates/project.j2", "msg": "Failed to find exact match for project.openshift.io/v1.Project by [kind, name, singularName, shortNames]"}