### PR TITLE
OpenShift Serverless ML Ops - Fix ODF Installation Check

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless_ml_workshop/tasks/install_odf_operator.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless_ml_workshop/tasks/install_odf_operator.yaml
@@ -26,7 +26,7 @@
   register: r_install_plans
   vars:
     _query: >-
-      [?starts_with(spec.clusterServiceVersionNames[0], 'odf')]
+      [?ends_with(spec.clusterServiceVersionNames[0], 'rhodf')]
   retries: 30
   delay: 5
   until:
@@ -38,7 +38,7 @@
     ocp4_workload_serverless_ml_workshop_odf_install_plan_name: "{{ r_install_plans.resources | to_json | from_json | json_query(query) }}"
   vars:
     query: >-
-      [?starts_with(spec.clusterServiceVersionNames[0], 'odf')].metadata.name|[0]
+      [?ends_with(spec.clusterServiceVersionNames[0], 'rhodf')].metadata.name|[0]
 
 - name: Get InstallPlan
   k8s_info:


### PR DESCRIPTION
##### SUMMARY
The check for ODF intermittently fails depending on which CVS is first in the list.  Instead change the check to look for something that is consistent across all CVS.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
OpenShift Serverless with ML Workshop