### PR TITLE
Use ssh_provision_* variables by default

### DIFF
--- a/ansible/roles/bastion-student-user/tasks/main.yml
+++ b/ansible/roles/bastion-student-user/tasks/main.yml
@@ -42,7 +42,8 @@
   authorized_key:
     user: "{{ student_name }}"
     state: present
-    key: "{{ hostvars.localhost.env_authorized_key_content_pub }}"
+    key: "{{ hostvars.localhost.ssh_provision_pubkey_content 
+      | default(hostvars.localhost.env_authorized_key_content_pub) }}"
   when:
     - set_env_authorized_key | default(false) | bool
     - student_name is defined

--- a/ansible/roles/bastion-student-user/tasks/main.yml
+++ b/ansible/roles/bastion-student-user/tasks/main.yml
@@ -42,7 +42,7 @@
   authorized_key:
     user: "{{ student_name }}"
     state: present
-    key: "{{ hostvars.localhost.ssh_provision_pubkey_content 
+    key: "{{ hostvars.localhost.ssh_provision_pubkey_content
       | default(hostvars.localhost.env_authorized_key_content_pub) }}"
   when:
     - set_env_authorized_key | default(false) | bool

--- a/ansible/roles/set_env_authorized_key/tasks/main.yml
+++ b/ansible/roles/set_env_authorized_key/tasks/main.yml
@@ -8,7 +8,8 @@
 - name: copy the environment .pem key
   become: true
   copy:
-    src: "{{ hostvars.localhost.env_authorized_key_path }}"
+    src: "{{ hostvars.localhost.ssh_provision_key_path 
+      | default(hostvars.localhost.env_authorized_key_path) }}"
     dest: "/root/.ssh/{{ env_authorized_key }}.pem"
     owner: root
     group: root
@@ -18,7 +19,8 @@
 - name: copy the environment .pub key
   become: true
   copy:
-    content: "{{ hostvars.localhost.env_authorized_key_content_pub }}"
+    content: "{{ hostvars.localhost.ssh_provision_pubkey_content 
+      | default(hostvars.localhost.env_authorized_key_content_pub) }}"
     dest: "/root/.ssh/{{ env_authorized_key }}.pub"
     owner: root
     group: root
@@ -29,7 +31,8 @@
   authorized_key:
     user: "{{ ansible_user }}"
     state: present
-    key: "{{ hostvars.localhost.env_authorized_key_content_pub }}"
+    key: "{{ hostvars.localhost.ssh_provision_pubkey_content 
+      | default(hostvars.localhost.env_authorized_key_content_pub) }}"
 
 - name: Generate host .ssh/config Template
   become: false

--- a/ansible/roles/set_env_authorized_key/tasks/main.yml
+++ b/ansible/roles/set_env_authorized_key/tasks/main.yml
@@ -8,7 +8,7 @@
 - name: copy the environment .pem key
   become: true
   copy:
-    src: "{{ hostvars.localhost.ssh_provision_key_path 
+    src: "{{ hostvars.localhost.ssh_provision_key_path
       | default(hostvars.localhost.env_authorized_key_path) }}"
     dest: "/root/.ssh/{{ env_authorized_key }}.pem"
     owner: root
@@ -19,7 +19,7 @@
 - name: copy the environment .pub key
   become: true
   copy:
-    content: "{{ hostvars.localhost.ssh_provision_pubkey_content 
+    content: "{{ hostvars.localhost.ssh_provision_pubkey_content
       | default(hostvars.localhost.env_authorized_key_content_pub) }}"
     dest: "/root/.ssh/{{ env_authorized_key }}.pub"
     owner: root
@@ -31,7 +31,7 @@
   authorized_key:
     user: "{{ ansible_user }}"
     state: present
-    key: "{{ hostvars.localhost.ssh_provision_pubkey_content 
+    key: "{{ hostvars.localhost.ssh_provision_pubkey_content
       | default(hostvars.localhost.env_authorized_key_content_pub) }}"
 
 - name: Generate host .ssh/config Template


### PR DESCRIPTION
Avoiding the usage of `locate_env_authorized_key` role, using `set_env_authorized_key` fails because some variables are not set.

This PR is to use the ssh_provision_* variables