### PR TITLE
email is not set in a Zero environment

### DIFF
--- a/ansible/configs/rosa-consolidated/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/rosa-consolidated/files/cloud_providers/ec2_cloud_template.j2
@@ -233,7 +233,7 @@ Resources:
           Value: {{instance['name']}}{{loop.index}}.{{aws_dns_zone_private_chomped}}
 {%     endif %}
         - Key: "owner"
-          Value: "{{ email | default('unknownuser') }}"
+          Value: "{{ email | default('notset') }}"
         - Key: "Project"
           Value: "{{project_tag}}"
         - Key: "{{project_tag}}"
@@ -369,7 +369,7 @@ Resources:
   StudentUser:
     Type: AWS::IAM::User
     Properties:
-      UserName: "{{ email | default(owner) }}-{{ guid }}"
+      UserName: "{{ email | default('notset') }}-{{ guid }}"
       Policies:
         - PolicyName: AccessAll
           PolicyDocument:


### PR DESCRIPTION
##### SUMMARY

The fields `owner` and `email` are not set in a Zero environment. Setting defaults.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rosa-consolidated