### PR TITLE
Add rosa_deploy_hcp to agnosticd vars

### DIFF
--- a/ansible/configs/rosa-consolidated/software.yml
+++ b/ansible/configs/rosa-consolidated/software.yml
@@ -121,6 +121,7 @@
           rosa_admin_user: "{{ _rosa_cluster_admin }}"
           rosa_admin_password: "{{ _rosa_cluster_admin_password }}"
           rosa_token_warning: "{{ rosa_token_warning }}"
+          rosa_deploy_hcp: "{{ rosa_deploy_hcp }}"
 
     - name: Print ROSA user data when ROSA has been installed
       when: print_agnosticd_user_info | default(true) | bool


### PR DESCRIPTION
##### SUMMARY

Added rosa_deploy_hcp to the agnosticd_user_data. This way showroom can present different lab instructions based on HCP status.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rosa-consolidated