### PR TITLE
Add failsafe for CLI version

### DIFF
--- a/ansible/configs/rosa-consolidated/install_ocp_cli.yml
+++ b/ansible/configs/rosa-consolidated/install_ocp_cli.yml
@@ -1,4 +1,11 @@
 ---
+- name: Make sure OCP CLI version is set
+  when:
+  - _rosa_ocp_cli_version is defined
+  - _rosa_ocp_cli_version | length == 0
+  ansible.builtin.set_fact:
+    _rosa_ocp_cli_version: "latest"
+
 - name: Set URL for specific OpenShift Client
   when: _rosa_ocp_cli_version is defined
   ansible.builtin.set_fact:


### PR DESCRIPTION
##### SUMMARY

Needed a failsafe for the case where ROSA is not installed yet the ocp cli version was not set otherwise. Set to latest in that case.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rosa-consolidated