### PR TITLE
Simple fix to podman network task name

### DIFF
--- a/ansible/roles/showroom/tasks/20-showroom-user-setup.yml
+++ b/ansible/roles/showroom/tasks/20-showroom-user-setup.yml
@@ -80,7 +80,7 @@
         XDG_RUNTIME_DIR: "/run/user/{{ showroom_user_uid }}"
         DBUS_SESSION_BUS_ADDRESS: "unix:path=/run/user/{{ showroom_user_uid }}/bus"
 
-    - name: "Create a Podman network {{ showroom_podman_network }}"
+    - name: Create a Podman network for showroom and traefik
       containers.podman.podman_network:
         name: "{{ showroom_podman_network | default('showroom_network') }}"
         state: present


### PR DESCRIPTION

##### SUMMARY

Simplify a showroom task name, for when var not set

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

roles/showroom

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
