### PR TITLE
Fix wrong showroom default vars

### DIFF
--- a/ansible/configs/rosa-consolidated/default_vars.yml
+++ b/ansible/configs/rosa-consolidated/default_vars.yml
@@ -131,8 +131,8 @@ deploy_bookbag: false
 # Deploy Showroom - if true the showroom_git_* vars need to
 # be set accordingly
 showroom_deploy: false
-showroom_git_repo: https://github.com/rhpds/showroom-rosa-ops-hoe.git
-showroom_git_ref: main
+# showroom_git_repo: https://github.com/rhpds/showroom-rosa-ops-hoe.git
+# showroom_git_ref: main
 
 # Internal Vars. Don't set
 _rosa_cluster_admin: ""

--- a/ansible/configs/rosa-consolidated/default_vars.yml
+++ b/ansible/configs/rosa-consolidated/default_vars.yml
@@ -119,6 +119,8 @@ infra_workloads: []
 # --------------------------------------------------------------------
 # Bookbag
 # --------------------------------------------------------------------
+# Deploy Bookbag - if true the bookbag_git_* vars need to
+# be set accordingly
 deploy_bookbag: false
 # bookbag_git_repo: https://github.com/rhpds/rosa-ilt.git
 # bookbag_git_version: main
@@ -126,11 +128,11 @@ deploy_bookbag: false
 # --------------------------------------------------------------------
 # Showroom
 # --------------------------------------------------------------------
+# Deploy Showroom - if true the showroom_git_* vars need to
+# be set accordingly
 showroom_deploy: false
-showroom_git_repo: https://github.com/rhpds/aro-ilt.git
-showroom_tab_services:
-- single_terminal
-- docs_aro
+showroom_git_repo: https://github.com/rhpds/showroom-rosa-ops-hoe.git
+showroom_git_ref: main
 
 # Internal Vars. Don't set
 _rosa_cluster_admin: ""


### PR DESCRIPTION
##### SUMMARY

Even though the default to deploy showroom was false the other default vars were set causing havoc when they weren't overridden by a config.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rosa-consolidated