### PR TITLE
Fix bookbag create project bug

### DIFF
--- a/ansible/roles/bookbag/tasks/workload.yaml
+++ b/ansible/roles/bookbag/tasks/workload.yaml
@@ -21,6 +21,7 @@
   # Work around https://github.com/ansible-collections/kubernetes.core/issues/623
   failed_when: >-
     r_create_bookbag_namespace is failed and
+    'cannot patch resource' not in r_create_bookbag_namespace.msg | default('') and
     'AlreadyExists' not in r_create_bookbag_namespace.msg | default('')
   until: r_create_bookbag_namespace is successful
   retries: 10


### PR DESCRIPTION
##### SUMMARY

Ansible attempts to patch the ProjectRequest after it is created and gets a 403 error. The namespace was already created by project request so this error can be safely ignored.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

bookbag role