### PR TITLE
[ocp4-cluster] [cnv-resources] Improve inventory role and fix starting OCP4 on CNV

### DIFF
--- a/ansible/configs/ocp4-cluster/lifecycle_hook_post_start.yml
+++ b/ansible/configs/ocp4-cluster/lifecycle_hook_post_start.yml
@@ -34,6 +34,11 @@
       include_role:
         name: infra-azure-create-inventory
 
+    - name: Run infra-openshift-cnv-create-inventory Role
+      when: cloud_provider == 'openshift_cnv'
+      include_role:
+        name: infra-openshift-cnv-create-inventory
+
 - name: Set ansible_ssh_extra_args
   hosts:
     - all:!windows:!network

--- a/ansible/roles-infra/infra-openshift-cnv-create-inventory/tasks/create_inventory.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-create-inventory/tasks/create_inventory.yaml
@@ -2,6 +2,7 @@
 - name: Search for all running pods
   kubernetes.core.k8s_info:
     kind: VirtualMachineInstance
+    namespace: "{{ openshift_cnv_project_name }}"
   register: r_openshift_cnv_instances
   
     
@@ -16,7 +17,7 @@
   ansible.builtin.set_fact:
     local_bastion: "{{ item.metadata.name }}"
   when:
-    - '"result" in item and "bastions" in item.metadata.annotations.AnsibleGroup|default("")'
+    - '"bastions" in item.metadata.annotations.AnsibleGroup|default("")'
   ignore_errors: true
 
 - name: Expose bastion externally

--- a/ansible/roles-infra/infra-openshift-cnv-create-inventory/tasks/create_inventory.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-create-inventory/tasks/create_inventory.yaml
@@ -51,6 +51,7 @@
   ansible.builtin.add_host:
     name: "{{ item.metadata.name }}"
     shortname: "{{ item.metadata.name }}"
+    ansible_user: "{{ remote_user }}"
     ansible_ssh_host: "{{ item.metadata.name }}"
     ssh_port: "{{ r_expose_bastion.spec.ports.0.nodePort|default(omit) }}"
     private_ip_address: "{{ item.metadata.name }}"

--- a/ansible/roles-infra/infra-openshift-cnv-create-inventory/tasks/create_inventory.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-create-inventory/tasks/create_inventory.yaml
@@ -12,11 +12,11 @@
 
 # Find the bastion
 - name: Find the bastion in this batch of hosts
-  loop: "{{ r_openshift_cnv_instances | list }}"
+  loop: "{{ r_openshift_cnv_instances.resources | list }}"
   ansible.builtin.set_fact:
-    local_bastion: "{{ item.result.metadata.name }}"
+    local_bastion: "{{ item.metadata.name }}"
   when:
-    - '"result" in item and "bastions" in item.result.metadata.annotations.AnsibleGroup|default("")'
+    - '"result" in item and "bastions" in item.metadata.annotations.AnsibleGroup|default("")'
   ignore_errors: true
 
 - name: Expose bastion externally
@@ -46,17 +46,17 @@
   delay: "{{ openshift_cnv_delay }}"
 
 - name: Create inventory (add_host)
-  loop: "{{ r_openshift_cnv_instances | list }}"
+  loop: "{{ r_openshift_cnv_instances.resources | list }}"
   ansible.builtin.add_host:
-    name: "{{ item.result.metadata.name }}"
-    shortname: "{{ item.result.metadata.name }}"
-    ansible_ssh_host: "{{ item.result.metadata.name }}"
-    ssh_port: "{{ r_expose_bastion.result.spec.ports.0.nodePort|default(omit) }}"
-    private_ip_address: "{{ item.result.metadata.name }}"
+    name: "{{ item.metadata.name }}"
+    shortname: "{{ item.metadata.name }}"
+    ansible_ssh_host: "{{ item.metadata.name }}"
+    ssh_port: "{{ r_expose_bastion.spec.ports.0.nodePort|default(omit) }}"
+    private_ip_address: "{{ item.metadata.name }}"
     public_ip_address: "{{ openshift_cnv_ssh_address }}"
-    groups: "{{ item.result.metadata.annotations.AnsibleGroup }}"
+    groups: "{{ item.metadata.annotations.AnsibleGroup }}"
     bastion: "{{ local_bastion | default('') }}"
-    bastion_ssh_port: "{{ r_expose_bastion.result.spec.ports.0.nodePort|default(omit) }}"
+    bastion_ssh_port: "{{ r_expose_bastion.spec.ports.0.nodePort|default(omit) }}"
     # Specify if the node is isolated, so won't connect to it
-    isolated: "{{ item.result.metadata.annotations.isolated | default(false) }}"
-  when: "item.result.metadata.annotations.managed|default(True)|bool != False"
+    isolated: "{{ item.metadata.annotations.isolated | default(false) }}"
+  when: "item.metadata.annotations.managed|default(True)|bool != False"

--- a/ansible/roles-infra/infra-openshift-cnv-create-inventory/tasks/create_inventory.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-create-inventory/tasks/create_inventory.yaml
@@ -1,4 +1,10 @@
 ---
+- name: Search for all running pods
+  kubernetes.core.k8s_info:
+    kind: VirtualMachineInstance
+  register: r_openshift_cnv_instances
+  
+    
 - name: Debug OpenShift CNV Instances fact
   ansible.builtin.debug:
     var: r_openshift_cnv_instances

--- a/ansible/roles-infra/infra-openshift-cnv-create-inventory/tasks/create_inventory.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-create-inventory/tasks/create_inventory.yaml
@@ -42,7 +42,7 @@
         type: NodePort
   register: r_expose_bastion
   when: local_bastion|default(False)
-  until: r_expose_bastion is success
+  until: r_expose_bastion is success and r_expose_bastion.spec.ports.0.nodePort|default(False)
   retries: "{{ openshift_cnv_retries }}"
   delay: "{{ openshift_cnv_delay }}"
 

--- a/ansible/roles-infra/infra-openshift-cnv-create-inventory/tasks/create_inventory.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-create-inventory/tasks/create_inventory.yaml
@@ -42,7 +42,7 @@
         type: NodePort
   register: r_expose_bastion
   when: local_bastion|default(False)
-  until: r_expose_bastion is success and r_expose_bastion.spec.ports.0.nodePort|default(False)
+  until: r_expose_bastion is success
   retries: "{{ openshift_cnv_retries }}"
   delay: "{{ openshift_cnv_delay }}"
 
@@ -53,7 +53,7 @@
     shortname: "{{ item.metadata.name }}"
     ansible_user: "{{ remote_user }}"
     ansible_ssh_host: "{{ item.metadata.name }}"
-    ssh_port: "{{ r_expose_bastion.spec.ports.0.nodePort|default(omit) }}"
+    ssh_port: "{{ r_expose_bastion.result.spec.ports.0.nodePort|default(omit) }}"
     private_ip_address: "{{ item.metadata.name }}"
     public_ip_address: "{{ openshift_cnv_ssh_address }}"
     groups: "{{ item.metadata.annotations.AnsibleGroup | default(omit) }}"

--- a/ansible/roles-infra/infra-openshift-cnv-create-inventory/tasks/create_inventory.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-create-inventory/tasks/create_inventory.yaml
@@ -61,4 +61,4 @@
     bastion_ssh_port: "{{ r_expose_bastion.result.spec.ports.0.nodePort|default(omit) }}"
     # Specify if the node is isolated, so won't connect to it
     isolated: "{{ item.metadata.annotations.isolated | default(false) }}"
-  when: "item.metadata.annotations.managed|default(True)|bool != False"
+  when: item.metadata.annotations.managed | default(true) | bool

--- a/ansible/roles-infra/infra-openshift-cnv-create-inventory/tasks/create_inventory.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-create-inventory/tasks/create_inventory.yaml
@@ -55,7 +55,7 @@
     ssh_port: "{{ r_expose_bastion.spec.ports.0.nodePort|default(omit) }}"
     private_ip_address: "{{ item.metadata.name }}"
     public_ip_address: "{{ openshift_cnv_ssh_address }}"
-    groups: "{{ item.metadata.annotations.AnsibleGroup }}"
+    groups: "{{ item.metadata.annotations.AnsibleGroup | default(omit) }}"
     bastion: "{{ local_bastion | default('') }}"
     bastion_ssh_port: "{{ r_expose_bastion.spec.ports.0.nodePort|default(omit) }}"
     # Specify if the node is isolated, so won't connect to it

--- a/ansible/roles-infra/infra-openshift-cnv-create-inventory/tasks/create_inventory.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-create-inventory/tasks/create_inventory.yaml
@@ -58,7 +58,7 @@
     public_ip_address: "{{ openshift_cnv_ssh_address }}"
     groups: "{{ item.metadata.annotations.AnsibleGroup | default(omit) }}"
     bastion: "{{ local_bastion | default('') }}"
-    bastion_ssh_port: "{{ r_expose_bastion.spec.ports.0.nodePort|default(omit) }}"
+    bastion_ssh_port: "{{ r_expose_bastion.result.spec.ports.0.nodePort|default(omit) }}"
     # Specify if the node is isolated, so won't connect to it
     isolated: "{{ item.metadata.annotations.isolated | default(false) }}"
   when: "item.metadata.annotations.managed|default(True)|bool != False"

--- a/ansible/roles-infra/infra-openshift-cnv-create-inventory/tasks/create_inventory.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-create-inventory/tasks/create_inventory.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Search for all running pods
   kubernetes.core.k8s_info:
-    kind: VirtualMachineInstance
+    kind: VirtualMachine
     namespace: "{{ openshift_cnv_project_name }}"
   register: r_openshift_cnv_instances
   


### PR DESCRIPTION
If the cluster was stopped after created and started after 24 hours, then the cluster was not starting properly because the CSR was not approved