### PR TITLE
Fix bad paths to files in argo rollouts workshop

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rollouts_workshop/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rollouts_workshop/tasks/workload.yml
@@ -44,7 +44,7 @@
 
 - name: deploy-gitops-operator
   k8s:
-    src: files/gitops-operator/subscription.yaml
+    src: gitops-operator/subscription.yaml
     state: present
 
 - name: Sleep for 60 seconds
@@ -62,12 +62,12 @@
 - name: Give application-controller cluster-admin permissions
   kubernetes.core.k8s:
     state: present
-    src: files/gitops-operator/application-controller-rolebinding.yaml
+    src: gitops-operator/application-controller-rolebinding.yaml
 
 - name: Deploy ConfigurationManagementPlugin Configuration
   kubernetes.core.k8s:
     state: present
-    src: files/gitops-operator/setenv-cmp-plugin-cm.yaml
+    src: gitops-operator/setenv-cmp-plugin-cm.yaml
 
 - name: Update openshift-gitops-instance
   kubernetes.core.k8s:
@@ -91,8 +91,8 @@
     state: present
     src: "{{ item }}"
   with_items:
-    - files/applications/pipelines-operator.yaml
-    - files/applications/web-terminal-operator.yaml
+    - applications/pipelines-operator.yaml
+    - applications/web-terminal-operator.yaml
 
 # Todo: Check health of apps
 - name: Wait 30 seconds for deployment


### PR DESCRIPTION
##### SUMMARY

Fixes bad paths in argo rollouts workshop

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

Removes the leading `files/` that was inherited from my standalone playbook since agnosticD resolves to files without it.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workloads_rollouts_workshop

##### ADDITIONAL INFORMATION

Discussed with Josh