### PR TITLE
Use smarter code to wait for GitOps Operator to be ready

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rollouts_workshop/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rollouts_workshop/tasks/workload.yml
@@ -45,13 +45,7 @@
 - name: Create Gitops Operator Subscription
   kubernetes.core.k8s:
     state: present
-    merge_type:
-      - stategic-merge
-      - merge
-    definition: "{{ lookup('file', item ) | from_yaml }}"
-  loop:
-    - ./files/gitops-operator/subscription.yaml
-  when: r_gitops_sub.resources | list | length == 0
+    definition: "{{ lookup('file', 'gitops-operator/subscription.yaml') | from_yaml }}"
 
 - name: Sleep for 60 seconds
   wait_for:
@@ -68,12 +62,12 @@
 - name: Give application-controller cluster-admin permissions
   kubernetes.core.k8s:
     state: present
-    src: "./files/gitops-operator/application-controller-rolebinding.yaml"
+    definition: "{{ lookup('file', 'gitops-operator/application-controller-rolebinding.yaml') | from_yaml }}"
 
 - name: Deploy ConfigurationManagementPlugin Configuration
   kubernetes.core.k8s:
     state: present
-    src: "./files/gitops-operator/setenv-cmp-plugin-cm.yaml"
+    definition: "{{ lookup('file', 'gitops-operator/setenv-cmp-plugin-cm.yaml') | from_yaml }}"
 
 - name: Update openshift-gitops-instance
   kubernetes.core.k8s:
@@ -92,13 +86,15 @@
     - openshift-gitops-repo-server
     - openshift-gitops-server
 
-- name: Deploy infra applications
+- name: Deploy Pipeline operator
   kubernetes.core.k8s:
     state: present
-    src: "{{ item }}"
-  with_items:
-    - "./files/applications/pipelines-operator.yaml"
-    - "./files/applications/web-terminal-operator.yaml"
+    definition: "{{ lookup('file', 'applications/pipelines-operator.yaml') | from_yaml }}"
+
+- name: Deploy Web Terminal operator
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('file', 'applications/web-terminal-operator.yaml') | from_yaml }}"
 
 # Todo: Check health of apps
 - name: Wait 30 seconds for deployment

--- a/ansible/roles_ocp_workloads/ocp4_workload_rollouts_workshop/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rollouts_workshop/tasks/workload.yml
@@ -47,9 +47,27 @@
     state: present
     definition: "{{ lookup('file', 'gitops-operator/subscription.yaml') | from_yaml }}"
 
-- name: Sleep for 60 seconds
-  wait_for:
-    timeout: 60
+- name: Wait until the openshift-gitops namespace is created
+  kubernetes.core.k8s_info:
+    kind: Namespace
+    wait: yes
+    name: openshift-gitops
+    wait_sleep: 10
+    wait_timeout: 360
+
+- name: Wait for deployments
+  kubernetes.core.k8s_info:
+    kind: Deployment
+    wait: yes
+    name: "{{ item }}"
+    namespace: openshift-gitops
+    wait_sleep: 5
+    wait_timeout: 120
+  with_items:
+    - cluster
+    - openshift-gitops-server
+    - openshift-gitops-repo-server
+    - openshift-gitops-redis
 
 - name: Check that all deployments are up and running
   command: "oc rollout status deployment {{ item }} -n openshift-gitops"


### PR DESCRIPTION
##### SUMMARY

Added smarter code to wait for GitOps Operator to be up and running instead of dumb sleep for X

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_rollouts_workshop

##### ADDITIONAL INFORMATION

Discussed with Josh