### PR TITLE
Add missing passlib library to requirements

### DIFF
--- a/ansible/configs/ocp4-cluster/files/requirements_k8s_el9.txt
+++ b/ansible/configs/ocp4-cluster/files/requirements_k8s_el9.txt
@@ -21,6 +21,7 @@ MarkupSafe==2.1.3
 oauthlib==3.2.2
 openshift==0.13.2
 packaging==23.2
+passlib==1.7.4
 pyasn1==0.5.0
 pyasn1-modules==0.3.0
 pycparser==2.21


### PR DESCRIPTION
##### SUMMARY

ocp4-cluster has a new requirements file for the k8s virtualenv on RHEL 9.

It was missing `passlib` - which means that the authentication workload failed.

Re-adding library.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-cluster