### PR TITLE
remove guid search for instances in gcp lifecycle

### DIFF
--- a/ansible/roles-infra/infra-gcp-lifecycle/tasks/initialize.yml
+++ b/ansible/roles-infra/infra-gcp-lifecycle/tasks/initialize.yml
@@ -5,24 +5,11 @@
     CLOUDSDK_CONFIG: "{{ output_dir }}/.gcloud-{{ guid }}"
     CLOUDSDK_CORE_PROJECT: "{{ gcp_project_id }}"
   block:
-    - name: Get all instances that match the guid (ocp4-workshop)
-      when: env_type == 'ocp4-cluster'
-      command: >-
-        gcloud compute instances list --filter="name~'cluster-{{ guid }}'" --format="json(name,machineType,zone,status,networkInterfaces[0].accessConfigs[0].natIP)"
-      register: g_allinstances
-
-    - name: Set allinstances fact from guid search
-      when: env_type == 'ocp4-cluster'
-      ansible.builtin.set_fact:
-        allinstances: "{{ g_allinstances }}"
-
-    - name: Get all instances in the GCP sandbox (project)
-      when: env_type == 'open-environment-gcp'
+    - name: Get all instances in the GCP project
       command: >-
         gcloud compute instances list --format="json(name,machineType,zone,status,networkInterfaces[0].accessConfigs[0].natIP)"
       register: p_allinstances
 
     - name: Set allinstances fact from project search
-      when: env_type == 'open-environment-gcp'
       ansible.builtin.set_fact:
         allinstances: "{{ p_allinstances }}"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
now that all ocp environments are in their own project, remove guid search for instances in gcp lifecycle when running lifecycle tasks

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
roles-infra/infra-gcp-lifecycle

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
