### PR TITLE
Generate a random password for showroom user

### DIFF
--- a/ansible/configs/rosa-consolidated/default_vars.yml
+++ b/ansible/configs/rosa-consolidated/default_vars.yml
@@ -134,10 +134,19 @@ showroom_deploy: false
 # showroom_git_repo: https://github.com/rhpds/showroom-rosa-ops-hoe.git
 # showroom_git_ref: main
 
+# Set a password for the showroom user
+# If not set then a password with given length (default 16 characters)
+# will be created
+# showroom_user_password: ""
+# showroom_user_password_length: 16
+
+# --------------------------------------------------------------------
 # Internal Vars. Don't set
+# --------------------------------------------------------------------
 _rosa_cluster_admin: ""
 _rosa_cluster_admin_password: ""
 _rosa_hcp_regions: ""
 _rosa_version_to_install: ""
 _rosa_ocp_cli_version: ""
 _rosa_create_cluster_extra_args: ""
+_showroom_user_password: ""

--- a/ansible/configs/rosa-consolidated/post_software.yml
+++ b/ansible/configs/rosa-consolidated/post_software.yml
@@ -25,19 +25,39 @@
     when: showroom_deploy | default(false) | bool
     block:
     - name: Set Ansible Python interpreter to system python
-      set_fact:
+      ansible.builtin.set_fact:
         ansible_python_interpreter: /usr/libexec/platform-python
 
     - name: Deploy Showroom
       when: showroom_deploy | default(false) | bool
-      vars:
-        common_password: "{{ rosa_user_password }}"
-        ssh_command: ssh "{{ bastion_user_name }}@bastion.{{ subdomain_base }}"
-        ssh_password: "{{ rosa_user_password }}"
-        ssh_username: "{{ bastion_user_name }}"
-        targethost: "bastion.{{ subdomain_base }}"
-      ansible.builtin.include_role:
-        name: showroom
+      block:
+
+      # Workaround to generate a showroom password to avoid
+      # reusing the rosa user's password. Can be removed
+      # once Showroom uses SSH keys to log into the terminal
+      - name: Generate showroom user password
+        when: showroom_user_password | default("") | length == 0
+        ansible.builtin.set_fact:
+          _showroom_user_password: >-
+            {{ lookup('password', '/dev/null chars=ascii_letters,digits '
+                ~ 'length=' ~ showroom_user_password_length | default(16)
+            ) }}
+
+      - name: Use provided admin password
+        when: showroom_user_password | default("") | length > 0
+        ansible.builtin.set_fact:
+          _showroom_user_password: >-
+            {{ showroom_user_password }}
+
+      - name: Call Showroom role
+        vars:
+          common_password: "{{ _showroom_user_password }}"
+          ssh_command: ssh "{{ bastion_user_name }}@bastion.{{ subdomain_base }}"
+          ssh_password: "{{ rosa_user_password }}"
+          ssh_username: "{{ bastion_user_name }}"
+          targethost: "bastion.{{ subdomain_base }}"
+        ansible.builtin.include_role:
+          name: showroom
 
 - name: Step 005.3 Lab Documentation (Bookbag)
   hosts: localhost

--- a/ansible/configs/rosa-consolidated/post_software.yml
+++ b/ansible/configs/rosa-consolidated/post_software.yml
@@ -43,7 +43,7 @@
                 ~ 'length=' ~ showroom_user_password_length | default(16)
             ) }}
 
-      - name: Use provided admin password
+      - name: Use provided showroom user password
         when: showroom_user_password | default("") | length > 0
         ansible.builtin.set_fact:
           _showroom_user_password: >-


### PR DESCRIPTION
##### SUMMARY

Currently showroom uses the `common_password` variable to designate the password for the showroom user. Until @ankay fixes that and provides a dedicated variable generate a random password for just the showroom user to avoid reusing the rosa user's password.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rosa-consolidated