### PR TITLE
[OCP 4.14] Fix ip_forward

### DIFF
--- a/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
@@ -242,7 +242,7 @@
         content: "{{lookup('ansible.builtin.file', 'files/sysctl-control-plane.yaml') | b64encode }}"
         file_name: "98_sysctl-control-plane.yaml"
         folder: "openshift"
-      when: ai_cluster_version is version_compare('4.14.0', '>=')
+      when: ai_cluster_version is version_compare('4.14', '>=')
 
     - name: Enable ip_forwarding for workers
       rhpds.assisted_installer.create_manifest:
@@ -251,7 +251,7 @@
         content: "{{lookup('ansible.builtin.file', 'files/sysctl-control-plane.yaml') | b64encode }}"
         file_name: "98_sysctl-workers.yaml"
         folder: "openshift"
-      when: ai_cluster_version is version_compare('4.14.0', '>=')
+      when: ai_cluster_version is version_compare('4.14', '>=')
 
     - name: Generate mac addresses for control plane
       ansible.builtin.set_fact:

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
@@ -248,7 +248,7 @@
       rhpds.assisted_installer.create_manifest:
         cluster_id: "{{ newcluster.result.id }}"
         offline_token: "{{ ai_offline_token }}"
-        content: "{{lookup('ansible.builtin.file', 'files/sysctl-control-plane.yaml') | b64encode }}"
+        content: "{{lookup('ansible.builtin.file', 'files/sysctl-workers.yaml') | b64encode }}"
         file_name: "98_sysctl-workers.yaml"
         folder: "openshift"
       when: ai_cluster_version is version_compare('4.14', '>=')

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
@@ -8,11 +8,6 @@
     - not ocp4_installer_use_dev_preview | default(false) | bool
     - (ocp4_installer_version | string).split('.') | length >= 3
   ansible.builtin.set_fact:
-    ocp4_installer_url: >-
-      {{ '{0}/ocp/{1}/openshift-install-linux-{1}.tar.gz'.format(
-        ocp4_installer_root_url | default("https://mirror.openshift.com/pub/openshift-v4/clients"),
-        ocp4_installer_version
-      ) }}
     ocp4_client_url: >-
       {{ '{0}/ocp/{1}/openshift-client-linux-{1}.tar.gz'.format(
         ocp4_installer_root_url | default("https://mirror.openshift.com/pub/openshift-v4/clients"),
@@ -239,6 +234,24 @@
         content: "{{lookup('ansible.builtin.file', 'files/network_config.yaml') | b64encode }}"
         file_name: "cluster-network-03-config.yml"
         folder: "openshift"
+
+    - name: Enable ip_forwarding for control plane
+      rhpds.assisted_installer.create_manifest:
+        cluster_id: "{{ newcluster.result.id }}"
+        offline_token: "{{ ai_offline_token }}"
+        content: "{{lookup('ansible.builtin.file', 'files/sysctl-control-plane.yaml') | b64encode }}"
+        file_name: "98_sysctl-control-plane.yaml"
+        folder: "openshift"
+      when: ai_cluster_version is version_compare('4.14.0', '>=')
+
+    - name: Enable ip_forwarding for workers
+      rhpds.assisted_installer.create_manifest:
+        cluster_id: "{{ newcluster.result.id }}"
+        offline_token: "{{ ai_offline_token }}"
+        content: "{{lookup('ansible.builtin.file', 'files/sysctl-control-plane.yaml') | b64encode }}"
+        file_name: "98_sysctl-workers.yaml"
+        folder: "openshift"
+      when: ai_cluster_version is version_compare('4.14.0', '>=')
 
     - name: Generate mac addresses for control plane
       ansible.builtin.set_fact:


### PR DESCRIPTION
Version 4.14 disables ip_forward by default, this adds manifests to enable on workers and control planes

It removes variable ocp4_installer_url what is not in use