### PR TITLE
Updated to change destroy and lock bastion

### DIFF
--- a/ansible/configs/rosa-consolidated/default_vars.yml
+++ b/ansible/configs/rosa-consolidated/default_vars.yml
@@ -106,6 +106,10 @@ rosa_terraform_url: >-
 rosa_terraform_repo: https://github.com/openshift-cs/terraform-vpc-example
 rosa_terraform_repo_branch: main
 
+# Lockdown the Security Group for the Bastion to allow
+# ssh only from itself (showroom)
+rosa_lock_bastion_security_group: false
+
 # Extra software packages to install
 install_tektoncd_cli: false
 install_github_cli: false
@@ -139,6 +143,15 @@ showroom_deploy: false
 # will be created
 # showroom_user_password: ""
 # showroom_user_password_length: 16
+
+# User to log into Showroom (rosa)
+showroom_ssh_username: "{{ bastion_user_name }}"
+showroom_default_ssh_user: "{{ bastion_user_name }}"
+showroom_ssh_method: sshkey     # password | sshkey
+showroom_ssh_key_type: ed25519  # ed25519 | rsa
+# For method = password provide a password
+# showroom_ssh_password: "{{ _showroom_user_password }}"
+showroom_ssh_host: "bastion.{{ subdomain_base }}"
 
 # --------------------------------------------------------------------
 # Internal Vars. Don't set

--- a/ansible/configs/rosa-consolidated/destroy_env.yml
+++ b/ansible/configs/rosa-consolidated/destroy_env.yml
@@ -47,34 +47,45 @@
   tasks:
   - ansible.builtin.include_tasks: ec2_instances_start.yaml
 
-- name: Destroy ROSA
-  hosts: bastions
+- name: Destroy ROSA cluster(s)
+  hosts: localhost
   gather_facts: false
   become: false
   environment:
+    AWS_ACCESS_KEY_ID: "{{ aws_access_key_id }}"
+    AWS_SECRET_ACCESS_KEY: "{{ aws_secret_access_key }}"
     AWS_DEFAULT_REGION: "{{ aws_region }}"
   tasks:
-  - name: Check for ROSA binary
+  - name: Check for ROSA CLI
     ansible.builtin.stat:
       path: /usr/local/bin/rosa
     register: r_rosa_check
-    ignore_errors: true
 
-  - name: Cleanup existing ROSA clusters
-    when: r_rosa_check.stat.exists
-    block:
-    - name: Get a list of ROSA clusters in the account
-      ansible.builtin.command: >-
-        /usr/local/bin/rosa list clusters --output json
-      register: r_rosa_list
+  - name: Install ROSA CLI if it doesn't exist
+    when: not r_rosa_check.stat.exists | bool
+    ansible.builtin.include_tasks: install_rosa_cli.yml
 
-    - name: Print number of clusters to uninstall
-      ansible.builtin.debug:
-        msg: "Found {{ r_rosa_list.stdout | from_json | length }} clusters to uninstall"
+  - name: Setup ROSA token
+    when: rosa_token == ""
+    ansible.builtin.set_fact:
+      rosa_token: "{{ gpte_rosa_token }}"
 
-    - name: Try to gracefully uninstall ROSA cluster
-      ansible.builtin.include_tasks: uninstall_rosa.yml
-      loop: "{{ r_rosa_list.stdout | from_json }}"
+  - name: Login to ROSA
+    ansible.builtin.command: >-
+      /usr/local/bin/rosa login --token {{ rosa_token }}
+
+  - name: Get a list of ROSA clusters in the account
+    ansible.builtin.command: >-
+      /usr/local/bin/rosa list clusters --output json
+    register: r_rosa_list
+
+  - name: Print number of clusters to uninstall
+    ansible.builtin.debug:
+      msg: "Found {{ r_rosa_list.stdout | from_json | length }} clusters to uninstall"
+
+  - name: Try to gracefully uninstall ROSA cluster
+    ansible.builtin.include_tasks: uninstall_rosa.yml
+    loop: "{{ r_rosa_list.stdout | from_json }}"
 
 - name: Import cloud provider specific destroy playbook
   ansible.builtin.import_playbook: "../../cloud_providers/{{ cloud_provider }}_destroy_env.yml"

--- a/ansible/configs/rosa-consolidated/files/requirements_k8s.txt
+++ b/ansible/configs/rosa-consolidated/files/requirements_k8s.txt
@@ -9,6 +9,7 @@ cffi==1.15.1
 charset-normalizer==3.2.0
 colorama==0.4.4
 cryptography==41.0.4
+dnspython==2.4.2
 docutils==0.16
 google-auth==2.23.0
 idna==3.4

--- a/ansible/configs/rosa-consolidated/install_rosa_hcp.yml
+++ b/ansible/configs/rosa-consolidated/install_rosa_hcp.yml
@@ -35,6 +35,8 @@
       /usr/local/bin/terraform apply rosa.tfplan
     chdir: "~{{ ansible_user }}/terraform-vpc"
 
+# WKTBD: Save terraform-vpc directory
+#        in output-dir for destroy
 - name: Get created subnets
   ansible.builtin.command:
     cmd: >-

--- a/ansible/configs/rosa-consolidated/lock_bastion_security_group.yml
+++ b/ansible/configs/rosa-consolidated/lock_bastion_security_group.yml
@@ -1,0 +1,53 @@
+---
+- name: Get bastion IP address
+  ansible.builtin.set_fact:
+    ocp4_workload_rosa_lockdown_bastion_bastion_ip_address: "{{ lookup('dig', 'bastion.' + subdomain_base) }}"
+
+- name: Debug bastion IP address
+  ansible.builtin.debug:
+    msg: "Bastion IP: {{ ocp4_workload_rosa_lockdown_bastion_bastion_ip_address }}"
+
+- name: Retrieve VPC for bastion
+  amazon.aws.ec2_vpc_net_info:
+    filters:
+      tag:Name: "{{ subdomain_base }}"
+  register: r_vpcs
+
+- name: Print VPC id and name
+  ansible.builtin.debug:
+    msg: "VPC ID: {{ r_vpcs.vpcs[0].vpc_id }}, Name: {{ r_vpcs.vpcs[0].tags.Name }}"
+
+- name: Retrieve BastionSG security group
+  amazon.aws.ec2_security_group_info:
+    filters:
+      tag:Name: BastionSG
+  register: r_security_groups
+
+- name: Print security group name
+  ansible.builtin.debug:
+    msg: "{{ r_security_groups.security_groups[0].group_name }}"
+
+# Lock Security group to just the bastion IP
+# and the two ports for Showroom (80 for Let's Encrypt, 443 for Traefik)
+- name: Update Security Group
+  amazon.aws.ec2_security_group:
+    state: present
+    name: "{{ r_security_groups.security_groups[0].group_name }}"
+    description: "{{ r_security_groups.security_groups[0].description }}"
+    vpc_id: "{{ r_vpcs.vpcs[0].vpc_id }}"
+    purge_rules: true
+    rules:
+    - ports:
+      - 22
+      proto: tcp
+      cidr_ip: "{{ ocp4_workload_rosa_lockdown_bastion_bastion_ip_address }}/32"
+    - ports:
+      - 80
+      - 443
+      proto: tcp
+      cidr_ip: "0.0.0.0/0"
+  register: r_sg
+
+- name: Debug SG
+  ansible.builtin.debug:
+    msg: "{{ r_sg }}"

--- a/ansible/configs/rosa-consolidated/post_software.yml
+++ b/ansible/configs/rosa-consolidated/post_software.yml
@@ -52,10 +52,6 @@
       - name: Call Showroom role
         vars:
           common_password: "{{ _showroom_user_password }}"
-          ssh_command: ssh "{{ bastion_user_name }}@bastion.{{ subdomain_base }}"
-          ssh_password: "{{ rosa_user_password }}"
-          ssh_username: "{{ bastion_user_name }}"
-          targethost: "bastion.{{ subdomain_base }}"
         ansible.builtin.include_role:
           name: showroom
 
@@ -71,6 +67,20 @@
       ACTION: create
     ansible.builtin.include_role:
       name: bookbag
+
+- name: Step 005.4 Lock Bastion Security Group
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  become: false
+  environment:
+    AWS_ACCESS_KEY_ID: "{{ aws_access_key_id }}"
+    AWS_SECRET_ACCESS_KEY: "{{ aws_secret_access_key }}"
+    AWS_DEFAULT_REGION: "{{ aws_region_final | default(aws_region) }}"
+  tasks:
+  - name: Lock Bastion Security Group
+    when: rosa_lock_bastion_security_group | default(false) | bool
+    ansible.builtin.include_tasks: lock_bastion_security_group.yml
 
 - name: PostSoftware flight-check
   hosts: localhost

--- a/ansible/configs/rosa-consolidated/uninstall_rosa.yml
+++ b/ansible/configs/rosa-consolidated/uninstall_rosa.yml
@@ -24,11 +24,31 @@
 
 - name: Destroy Terraform resources for HCP
   when: rosa_deploy_hcp | default(false) | bool
-  ansible.builtin.command:
-    cmd: >-
-      /usr/local/bin/terraform destroy
-        -var region={{ aws_region }}
-        -var cluster_name=rosa-{{ guid }}
-        -auto-approve
-    chdir: "~{{ ansible_user }}/terraform-vpc"
-  ignore_errors: true
+  block:
+  - name: Install Terraform
+    when: rosa_install_terraform | default(true) | bool
+    become: true
+    ansible.builtin.unarchive:
+      src: "{{ rosa_terraform_url }}"
+      remote_src: true
+      dest: /usr/local/bin
+      mode: "0775"
+      owner: root
+      group: root
+    retries: 10
+    register: r_terraform
+    until: r_terraform is success
+    delay: 30
+
+  # WKTBD: Restore terraform-vpc directory from output dir to /tmp/terraform-vpc
+  #        change directory to restored directory /tmp/terraform-vpc
+
+  - name: Run Terraform destroy
+    ansible.builtin.command:
+      cmd: >-
+        /usr/local/bin/terraform destroy
+          -var region={{ aws_region }}
+          -var cluster_name=rosa-{{ guid }}
+          -auto-approve
+      chdir: "~{{ ansible_user }}/terraform-vpc"
+    ignore_errors: true


### PR DESCRIPTION
##### SUMMARY

Fix showroom calls and switch to ssh key instead of password.
Add capability to lock down bastion VM with security group
Change destroy to run in EE rather than on (now unreachable) bastion VM.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
rosa-consolidated