### PR TITLE
Fixes, tweaks, enhancements to how showroom handles ssh for lab users

### DIFF
--- a/ansible/roles/showroom/defaults/main.yml
+++ b/ansible/roles/showroom/defaults/main.yml
@@ -33,7 +33,7 @@ showroom_ssh_key_type: ed25519        # ed25519 | rsa
 showroom_enable_root_ssh: false
   # showroom_default_ssh_user:
 showroom_lab_users:
-  - "{{ showroom_default_ssh_user | default('student') }}"
+  - "{{ showroom_default_ssh_user | default('rhel') }}"
 
 showroom_container_compose_template: compose_default_template.j2
 

--- a/ansible/roles/showroom/tasks/20-showroom-user-setup.yml
+++ b/ansible/roles/showroom/tasks/20-showroom-user-setup.yml
@@ -7,7 +7,7 @@
     name: "{{ showroom_user | default('showroom') }}"
     home: "{{ showroom_user_home_dir }}"
     uid: "{{ showroom_user_uid }}"
-    password: "{{ common_password | password_hash('sha512') }}"
+    password: "{{ showroom_user_password | default(common_password) | password_hash('sha512') }}"
 
 - name: Setup persistent working directory
   ansible.builtin.file:
@@ -50,7 +50,8 @@
     - name: Enable root password for both machinectl privileges and ssh access
       ansible.builtin.user:
         name: root
-        password: "{{ generated_password | default(common_password) | password_hash('sha512') }}"
+        password: |-
+          {{ showroom_user_password | default(generated_password) | default(common_password) | password_hash('sha512') }}
 
     - name: Configure ssh for root when showroom_enable_root_ssh is true
       when: showroom_enable_root_ssh | default(false) | bool
@@ -63,11 +64,6 @@
             line: 'PermitRootLogin yes'
             backrefs: true
 
-        - name: Restarting sshd to reconfigure post root ssh enablement in prior task
-          ansible.builtin.systemd:
-            name: sshd
-            state: restarted
-
     - name: "Start --user {{ showroom_user }} podman.socket for traefik"
       ansible.builtin.shell: "loginctl enable-linger $USER; systemctl --user enable podman.socket --now"
       become: true
@@ -75,7 +71,7 @@
       become_method: community.general.machinectl
       vars:
         ansible_user: root
-        ansible_become_pass: "{{ generated_password | default(common_password) }}"
+        ansible_become_pass: "{{ showroom_user_password | default(generated_password) | default(common_password) }}"
       environment:
         XDG_RUNTIME_DIR: "/run/user/{{ showroom_user_uid }}"
         DBUS_SESSION_BUS_ADDRESS: "unix:path=/run/user/{{ showroom_user_uid }}/bus"

--- a/ansible/roles/showroom/tasks/20-showroom-user-setup.yml
+++ b/ansible/roles/showroom/tasks/20-showroom-user-setup.yml
@@ -51,7 +51,7 @@
       ansible.builtin.user:
         name: root
         password: |-
-          {{ showroom_user_password | default(generated_password) | default(common_password) | password_hash('sha512') }}
+          {{ showroom_user_password | d(generated_password) | default(common_password) | password_hash('sha512') }}
 
     - name: Configure ssh for root when showroom_enable_root_ssh is true
       when: showroom_enable_root_ssh | default(false) | bool

--- a/ansible/roles/showroom/tasks/22-showroom-users-security.yml
+++ b/ansible/roles/showroom/tasks/22-showroom-users-security.yml
@@ -1,6 +1,26 @@
 ---
 
 - name: Implement internal sshkeys and configs for showroom access
+  when: showroom_ssh_method == "password"
+  block:
+
+    - name: Enable ssh password authentication
+      ansible.builtin.lineinfile:
+        path: /etc/ssh/sshd_config
+        regexp: '^PasswordAuthentication'
+        line: 'PasswordAuthentication yes'
+        backrefs: true
+
+    - name: Set correct password for showroom ssh accounts
+      ansible.builtin.user:
+        name: "{{ __showroom_lab_user }}"
+        password: |-
+          {{ showroom_user_password | default(common_password) | password_hash('sha512') }}
+      loop: "{{ showroom_lab_users }}"
+      loop_control:
+        loop_var: __showroom_lab_user
+
+- name: Implement internal sshkeys and configs for showroom access
   when: showroom_ssh_method == "sshkey"
   block:
 
@@ -36,3 +56,9 @@
         owner: "{{ showroom_user }}"
         group: "{{ showroom_user_group }}"
         mode: u=rw,g-rwx,o-rwx
+          
+- name: Restart sshd to pickup all/any changes 
+  ansible.builtin.systemd:
+    name: sshd
+    state: restarted
+

--- a/ansible/roles/showroom/tasks/22-showroom-users-security.yml
+++ b/ansible/roles/showroom/tasks/22-showroom-users-security.yml
@@ -56,9 +56,8 @@
         owner: "{{ showroom_user }}"
         group: "{{ showroom_user_group }}"
         mode: u=rw,g-rwx,o-rwx
-          
-- name: Restart sshd to pickup all/any changes 
+
+- name: Restart sshd to pickup all/any changes
   ansible.builtin.systemd:
     name: sshd
     state: restarted
-

--- a/ansible/roles/showroom/templates/service_single_terminal/service_single_terminal.j2
+++ b/ansible/roles/showroom/templates/service_single_terminal/service_single_terminal.j2
@@ -7,15 +7,15 @@ terminal-01:
     - "{{ showroom_user_home_dir }}/.ssh:{{ showroom_user_home_dir }}/.ssh"
 {% endif %}
   command:
-{% if showroom_ssh_method == 'sshkey' %}
-    - "--ssh-config={{ showroom_user_home_dir }}/.ssh/config"
-    - "--ssh-key={{ showroom_user_home_dir }}/.ssh/id_{{ showroom_ssh_key_type }}"
-    - "--ssh-auth=publickey"
 {% if showroom_enable_root_ssh %}
     - "--ssh-user=root"
 {% else %}
     - "--ssh-user={{ showroom_ssh_username | default(f_user_data.default_ssh_username) | default(f_user_data.ssh_username) }}"
 {% endif %}
+{% if showroom_ssh_method == 'sshkey' %}
+    - "--ssh-config={{ showroom_user_home_dir }}/.ssh/config"
+    - "--ssh-key={{ showroom_user_home_dir }}/.ssh/id_{{ showroom_ssh_key_type }}"
+    - "--ssh-auth=publickey"
 {% elif showroom_ssh_method == 'password' %}
     - "--ssh-pass={{ showroom_ssh_password | default(f_user_data.default_ssh_password) | default(f_user_data.ssh_password) }}"
 {% endif %}


### PR DESCRIPTION
##### SUMMARY

Adds cleaner support for sshkeys in showroom

- enables both passwords and sshkeys as tty auth
- cleans up setting passwords (depreciates common_+password etc)

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME

roles/showroom

##### ADDITIONAL INFORMATION
