### PR TITLE
Remove "Ensuring AWS region is defined" task from OCP workload roles

### DIFF
--- a/ansible/roles/ocp4-workload-camel3-workshop/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-camel3-workshop/tasks/pre_workload.yml
@@ -1,11 +1,6 @@
 ---
 # Implement your Pre Workload deployment tasks here
 
-# - name: Ensuring AWS region is defined
-#   fail:
-#     msg: "This workload requires aws_region to be defined. Exiting..."
-#   when: (aws_region is not defined) and (ocp_workload_test is undefined)
-
 - name: usercount debug
   debug:
     msg: "Debugging num_users {{ num_users }}"

--- a/ansible/roles/ocp4-workload-ccnrd-cuttingedge/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-ccnrd-cuttingedge/tasks/pre_workload.yml
@@ -1,11 +1,6 @@
 ---
 # Implement your Pre Workload deployment tasks here
 
-- name: Ensuring AWS region is defined
-  fail:
-    msg: "This workload requires aws_region to be defined. Exiting..."
-  when: aws_region is not defined
-
 - name: usercount debug
   debug:
     msg: "Debugging num_users {{ num_users }}"

--- a/ansible/roles/ocp4-workload-ccnrd-stable/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-ccnrd-stable/tasks/pre_workload.yml
@@ -1,11 +1,6 @@
 ---
 # Implement your Pre Workload deployment tasks here
 
-- name: Ensuring AWS region is defined
-  fail:
-    msg: "This workload requires aws_region to be defined. Exiting..."
-  when: aws_region is not defined
-
 - name: usercount debug
   debug:
     msg: "Debugging num_users {{ num_users }}"

--- a/ansible/roles/ocp4-workload-chaos-engineering-workshop/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-chaos-engineering-workshop/tasks/pre_workload.yml
@@ -1,11 +1,6 @@
 ---
 # Implement your Pre Workload deployment tasks here
 
-- name: Ensuring AWS region is defined
-  fail:
-    msg: "This workload requires aws_region to be defined. Exiting..."
-  when: aws_region is not defined
-
 - name: usercount debug
   debug:
     msg: "Debugging user_count {{ user_count }}"

--- a/ansible/roles/ocp4-workload-debugging-workshop/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-debugging-workshop/tasks/pre_workload.yml
@@ -1,11 +1,6 @@
 ---
 # Implement your Pre Workload deployment tasks here
 
-- name: Ensuring AWS region is defined
-  fail:
-    msg: "This workload requires aws_region to be defined. Exiting..."
-  when: aws_region is not defined
-
 - name: usercount debug
   debug:
     msg: "Debugging user_count {{ user_count }}"

--- a/ansible/roles/ocp4-workload-dil-streaming/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-dil-streaming/tasks/pre_workload.yml
@@ -1,11 +1,6 @@
 ---
 # Implement your Pre Workload deployment tasks here
 
-- name: Ensuring AWS region is defined
-  fail:
-    msg: "This workload requires aws_region to be defined. Exiting..."
-  when: (aws_region is not defined) and (ocp_workload_test is undefined)
-
 - name: usercount debug
   debug:
     msg: "Debugging num_users {{ num_users }}"

--- a/ansible/roles/ocp4-workload-jdg-workshop/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-jdg-workshop/tasks/pre_workload.yml
@@ -1,11 +1,6 @@
 ---
 # Implement your Pre Workload deployment tasks here
 
-- name: Ensuring AWS region is defined
-  fail:
-    msg: "This workload requires aws_region to be defined. Exiting..."
-  when: aws_region is not defined
-
 - name: usercount debug
   debug:
     msg: "Debugging num_users {{ num_users }}"

--- a/ansible/roles/ocp4-workload-quarkus-workshop/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/tasks/pre_workload.yml
@@ -1,11 +1,6 @@
 ---
 # Implement your Pre Workload deployment tasks here
 
-- name: Ensuring AWS region is defined
-  fail:
-    msg: "This workload requires aws_region to be defined. Exiting..."
-  when: aws_region is not defined
-
 - name: usercount debug
   debug:
     msg: "Debugging num_users {{ num_users }}"

--- a/ansible/roles/ocp4-workload-sso-workshop/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-sso-workshop/tasks/pre_workload.yml
@@ -1,11 +1,6 @@
 ---
 # Implement your Pre Workload deployment tasks here
 
-- name: Ensuring AWS region is defined
-  fail:
-    msg: "This workload requires aws_region to be defined. Exiting..."
-  when: aws_region is not defined
-
 - name: usercount debug
   debug:
     msg: "Debugging num_users {{ num_users }}"


### PR DESCRIPTION
##### SUMMARY
Many OCP workloads are checking if the aws_region is defined, this is against of the idea of agnostic (to be able to deploy in multiple clouds) and it looks it was defined in one role and copied to others without the need.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-workload-camel3-workshop
ocp4-workload-ccnrd-cuttingedge
ocp4-workload-ccnrd-stable
ocp4-workload-chaos-engineering-workshop
ocp4-workload-debezium-demo
ocp4-workload-debugging-workshop
ocp4-workload-dil-streaming
ocp4-workload-jdg-workshop
ocp4-workload-quarkus-workshop
ocp4-workload-sso-workshop

##### ADDITIONAL INFORMATION
Needed in the migration of CI to OpenShift Virtualization
