### PR TITLE
Increasing retry more as task already have a valid until

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/tasks/workload.yml
@@ -41,7 +41,7 @@
       vars:
         _query: >-
           [?starts_with(spec.clusterServiceVersionNames[0], 'aap-operator')]
-      retries: 30
+      retries: 60
       delay: 10
       until:
         - r_aap_operator.resources | length > 0


### PR DESCRIPTION
##### SUMMARY
Increasing retry more as task already have a valid until and it is failing sometimes: https://tower.dark-tower-prod.infra.open.redhat.com/#/jobs/1613431/

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible/roles_ocp_workloads/ocp4_workload_ansible_automation_platform/tasks/workload.yml
