### PR TITLE
[OCP workloads] Remove bastion_fqdn variable and fix indents

### DIFF
--- a/ansible/roles/ocp4-workload-chaos-engineering-workshop/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-chaos-engineering-workshop/tasks/pre_workload.yml
@@ -39,18 +39,14 @@
   set_fact:
     route_subdomain: "{{ r_ingress_config.resources[0].spec.domain }}"
 
-- name: set bastion_fqdn
-  set_fact:
-    bastion_fqdn: "{{ subdomain_base }}"
 
 - name: debug values
   debug:
     msg:
-    - "master URL: {{ master_url }}"
-    - "console URL: {{ console_url }}"
-    - "route subdomain: {{ route_subdomain }}"
-    - "ocp_username: {{ ocp_username }}"
-    - "bastion host: {{ bastion_fqdn }}"
+      - "master URL: {{ master_url }}"
+      - "console URL: {{ console_url }}"
+      - "route subdomain: {{ route_subdomain }}"
+      - "ocp_username: {{ ocp_username }}"
 
 # Leave this as the last task in the playbook.
 - name: pre_workload tasks complete

--- a/ansible/roles/ocp4-workload-debezium-demo/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-debezium-demo/tasks/pre_workload.yml
@@ -35,24 +35,15 @@
   set_fact:
     route_subdomain: "{{ r_ingress_config.resources[0].spec.domain }}"
 
-- name: set bastion_fqdn
-  set_fact:
-    bastion_fqdn: "{{ subdomain_base }}"
-  when: ocp_workload_test is undefined
 
 - name: debug values
   debug:
     msg:
-    - "master URL: {{ master_url }}"
-    - "console URL: {{ console_url }}"
-    - "route subdomain: {{ route_subdomain }}"
-    - "ocp_username: {{ ocp_username }}"
+      - "master URL: {{ master_url }}"
+      - "console URL: {{ console_url }}"
+      - "route subdomain: {{ route_subdomain }}"
+      - "ocp_username: {{ ocp_username }}"
 
-- name: debug bastion_host
-  debug:
-    msg:
-    - "bastion host: {{ bastion_fqdn }}"
-  when: bastion_fqdn is defined
 
 # Leave this as the last task in the playbook.
 - name: pre_workload tasks complete

--- a/ansible/roles/ocp4-workload-debugging-workshop/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-debugging-workshop/tasks/pre_workload.yml
@@ -42,10 +42,10 @@
 - name: debug values
   debug:
     msg:
-    - "master URL: {{ master_url }}"
-    - "console URL: {{ console_url }}"
-    - "route subdomain: {{ route_subdomain }}"
-    - "ocp_username: {{ ocp_username }}"
+      - "master URL: {{ master_url }}"
+      - "console URL: {{ console_url }}"
+      - "route subdomain: {{ route_subdomain }}"
+      - "ocp_username: {{ ocp_username }}"
 
 # Leave this as the last task in the playbook.
 - name: pre_workload tasks complete

--- a/ansible/roles/ocp4-workload-debugging-workshop/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-debugging-workshop/tasks/pre_workload.yml
@@ -39,10 +39,6 @@
   set_fact:
     route_subdomain: "{{ r_ingress_config.resources[0].spec.domain }}"
 
-- name: set bastion_fqdn
-  set_fact:
-    bastion_fqdn: "{{ subdomain_base }}"
-
 - name: debug values
   debug:
     msg:
@@ -50,7 +46,6 @@
     - "console URL: {{ console_url }}"
     - "route subdomain: {{ route_subdomain }}"
     - "ocp_username: {{ ocp_username }}"
-    - "bastion host: {{ bastion_fqdn }}"
 
 # Leave this as the last task in the playbook.
 - name: pre_workload tasks complete

--- a/ansible/roles/ocp4-workload-dil-streaming/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-dil-streaming/tasks/pre_workload.yml
@@ -38,24 +38,13 @@
   set_fact:
     route_subdomain: "{{ route_subdomain_r.resources[0].spec.domain | trim }}"
 
-- name: set bastion_fqdn
-  set_fact:
-    bastion_fqdn: "{{ subdomain_base }}"
-  when: ocp_workload_test is undefined
-
 - name: debug values
   debug:
     msg:
-    - "master URL: {{ master_url }}"
-    - "console URL: {{ console_url }}"
-    - "route subdomain: {{ route_subdomain }}"
-    - "ocp_username: {{ ocp_username }}"
-
-- name: debug bastion_host
-  debug:
-    msg:
-    - "bastion host: {{ bastion_fqdn }}"
-  when: bastion_fqdn is defined
+      - "master URL: {{ master_url }}"
+      - "console URL: {{ console_url }}"
+      - "route subdomain: {{ route_subdomain }}"
+      - "ocp_username: {{ ocp_username }}"
 
 # Leave this as the last task in the playbook.
 - name: pre_workload tasks complete

--- a/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/pre_workload.yml
@@ -34,7 +34,7 @@
   retries: 5
   delay: 10
   until:
-  - route_subdomain_r.resources[0].spec.domain is defined
+    - route_subdomain_r.resources[0].spec.domain is defined
 
 - name: Set the default route subdomain of the cluster as a fact
   set_fact:
@@ -47,17 +47,12 @@
 - set_fact:
     kubeadmin_password: "{{ kubeadmin_password_r.stdout | trim }}"
 
-- name: set bastion_fqdn
-  set_fact:
-    bastion_fqdn: bastion.{{ subdomain_base }}
-
 - debug:
     msg:
     - "{{ api_url }}"
     - "{{ master_url }}"
     - "{{ route_subdomain }}"
     - "{{ ocp_username }}"
-    - "{{ bastion_fqdn }}"
     - "{{ kubeadmin_password }}"
 
 # Leave this as the last task in the playbook.

--- a/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-workshop-admin-storage/tasks/pre_workload.yml
@@ -49,11 +49,11 @@
 
 - debug:
     msg:
-    - "{{ api_url }}"
-    - "{{ master_url }}"
-    - "{{ route_subdomain }}"
-    - "{{ ocp_username }}"
-    - "{{ kubeadmin_password }}"
+      - "{{ api_url }}"
+      - "{{ master_url }}"
+      - "{{ route_subdomain }}"
+      - "{{ ocp_username }}"
+      - "{{ kubeadmin_password }}"
 
 # Leave this as the last task in the playbook.
 - name: pre_workload tasks complete

--- a/ansible/roles/ocp4-workload-workshop-dashboard-cluster-admin-student/tasks/pre_workload.yml
+++ b/ansible/roles/ocp4-workload-workshop-dashboard-cluster-admin-student/tasks/pre_workload.yml
@@ -46,18 +46,13 @@
 - set_fact:
     kubeadmin_password: "{{ kubeadmin_password_r.stdout | trim }}"
 
-- name: set bastion_fqdn
-  set_fact:
-    bastion_fqdn: bastion.{{ subdomain_base }}
-
 - debug:
     msg:
-    - "{{ api_url }}"
-    - "{{ master_url }}"
-    - "{{ route_subdomain }}"
-    - "{{ ocp_username }}"
-    - "{{ bastion_fqdn }}"
-    - "{{ kubeadmin_password }}"
+      - "{{ api_url }}"
+      - "{{ master_url }}"
+      - "{{ route_subdomain }}"
+      - "{{ ocp_username }}"
+      - "{{ kubeadmin_password }}"
 
 # Leave this as the last task in the playbook.
 - name: pre_workload tasks complete


### PR DESCRIPTION
##### SUMMARY

Variable bastion_fqdn was set on several OCP workloads and it is not used anywhere. Furthermore, it was using the "subdomain_base" variable which is not always set and the bastion format is not always bastion.domain

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
roles/ocp4-workload-chaos-engineering-workshop
roles/ocp4-workload-debezium-demo
roles/ocp4-workload-debugging-workshop
roles/ocp4-workload-dil-streaming
roles/ocp4-workload-workshop-admin-storage
roles/ocp4-workload-workshop-dashboard-cluster-admin-student