### PR TITLE
Remove key_name  - Ansible Windows Workshop

### DIFF
--- a/ansible/configs/ansible-windows-workshop/default_vars.yml
+++ b/ansible/configs/ansible-windows-workshop/default_vars.yml
@@ -33,7 +33,6 @@ ftl_use_python3: true
 # Role: set_env_authorized_key
 # -------------------------------------------------
 set_env_authorized_key: true
-key_name: opentlc_admin_backdoor.pem
 deploy_local_ssh_config_location: "{{output_dir}}/"
 env_authorized_key: "{{guid}}key"
 ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem


### PR DESCRIPTION

TASK [create_ssh_provision_key : Ensure key_name is not defined] ***************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "WARNING: key_name is DEPRECATED and should not be defined when using new create_ssh_provision_key role."}
...ignoring 