### PR TITLE
Increase wait for rosa cluster login

### DIFF
--- a/ansible/configs/rosa-consolidated/install_rosa_cluster_login.yml
+++ b/ansible/configs/rosa-consolidated/install_rosa_cluster_login.yml
@@ -38,7 +38,7 @@
     username: "{{ _rosa_cluster_admin }}"
     password: "{{ _rosa_cluster_admin_password }}"
   register: r_kube_auth
-  retries: 20
+  retries: 40
   delay: 20
   until:
   - r_kube_auth is defined


### PR DESCRIPTION
##### SUMMARY

Double wait time for ROSA cluster login to succeed. Adjustment based on failure/success history.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

rosa-consolidated config