### PR TITLE
[host-ocp4-assisted-installer] Specify version on the infrastructure too

### DIFF
--- a/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
@@ -281,6 +281,7 @@
         name: "{{ cluster_name }}-infra-env"
         image_type: "{{ ai_cluster_iso_type }}"
         cluster_id: "{{ newcluster.result.id }}"
+        openshift_version: "{{ ai_cluster_version }}"
         ssh_authorized_key: "{{ ai_ssh_authorized_key }}"
         offline_token: "{{ ai_offline_token }}"
         pull_secret: "{{ ai_pull_secret }}"


### PR DESCRIPTION

##### SUMMARY

Doing a deployment of a old version of OCP, it was detected by default the infrastructure call is using a newer image instead the specific version. This solves that bug

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
roles/host-ocp4-assisted-installer

##### ADDITIONAL INFORMATION
https://issues.redhat.com/browse/MGMT-16180