### PR TITLE
[host-ocp4-assisted-installer] Improve setting variable ocp4_client_url

### DIFF
--- a/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
@@ -5,11 +5,20 @@
 
 - name: Set URLs for OpenShift GA releases (specific version)
   when:
-    - not ocp4_installer_use_dev_preview | default(false) | bool
     - (ocp4_installer_version | string).split('.') | length >= 3
   ansible.builtin.set_fact:
     ocp4_client_url: >-
       {{ '{0}/ocp/{1}/openshift-client-linux-{1}.tar.gz'.format(
+        ocp4_installer_root_url | default("https://mirror.openshift.com/pub/openshift-v4/clients"),
+        ocp4_installer_version
+      ) }}
+
+- name: Set URLs for OpenShift GA releases (latest stable)
+  when:
+  - (ocp4_installer_version | string).split('.') | length == 2
+  set_fact:
+    ocp4_client_url: >-
+      {{ '{0}/ocp/stable-{1}/openshift-client-linux.tar.gz'.format(
         ocp4_installer_root_url | default("https://mirror.openshift.com/pub/openshift-v4/clients"),
         ocp4_installer_version
       ) }}


### PR DESCRIPTION
##### SUMMARY

Allow to specify version x.y instead only allow x.y.z

Remove condition _ocp4_installer_use_dev_preview_ because is not used

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
roles/host-ocp4-assisted-installer

