### PR TITLE
Add latest-upgrade, add terraform cleanup

### DIFF
--- a/ansible/configs/rosa-consolidated/default_vars.yml
+++ b/ansible/configs/rosa-consolidated/default_vars.yml
@@ -43,10 +43,16 @@ rosa_cluster_name: "rosa-{{ guid }}"
 # Options are:
 # - "": default version (usually not the latest)
 # - latest: latest available version as reported by 'rosa list versions'
+# - latest-upgrade: latest available version minus one to provision
+#                   an environment that is upgradeable
 # - 4.x.x: A specific version. Definitely only set for special
 #          cases because specific versions routinely disappear from
 #          the list of available versions
 rosa_version: ""
+# Set the base of the version to be upgraded from when using `latest-upgrade` for rosa_version.
+# The logic will search for the latest version within that base
+# version that has available_upgrades set (use 'rosa list versions -o json' for examples)
+rosa_version_base: "openshift-v4.14"
 
 # ROSA CLI version
 rosa_installer_version: latest
@@ -100,7 +106,7 @@ rosa_install_helm: true
 
 # Install terraform on the bastion (necessary for HCP deploy)
 rosa_install_terraform: true
-rosa_terraform_version: "1.5.7"
+rosa_terraform_version: "1.6.3"
 rosa_terraform_url: >-
   https://releases.hashicorp.com/terraform/{{ rosa_terraform_version }}/terraform_{{ rosa_terraform_version }}_linux_amd64.zip
 rosa_terraform_repo: https://github.com/openshift-cs/terraform-vpc-example
@@ -160,6 +166,7 @@ _rosa_cluster_admin: ""
 _rosa_cluster_admin_password: ""
 _rosa_hcp_regions: ""
 _rosa_version_to_install: ""
+_rosa_version_to_upgrade_to: ""
 _rosa_ocp_cli_version: ""
 _rosa_create_cluster_extra_args: ""
 _showroom_user_password: ""

--- a/ansible/configs/rosa-consolidated/install_rosa_cli.yml
+++ b/ansible/configs/rosa-consolidated/install_rosa_cli.yml
@@ -4,7 +4,8 @@
     url: "{{ rosa_installer_url }}"
     dest: /tmp/rosa-linux.tar.gz
 
-# --no-same-owner https://github.com/habitat-sh/builder/issues/365#issuecomment-382862233
+# --no-same-owner:
+# https://github.com/habitat-sh/builder/issues/365#issuecomment-382862233
 - name: Unzip rosa-linux.tar.gz
   become: true
   ansible.builtin.unarchive:
@@ -12,10 +13,10 @@
     dest: "{{ rosa_binary_path }}"
     remote_src: true
     owner: root
-    group: root
+    # group: root # setting group fails in EE.
     mode: u=rwx,go=rx
     extra_opts:
-      - --no-same-owner
+    - --no-same-owner
 
 - name: cleanup archive file
   ansible.builtin.file:

--- a/ansible/configs/rosa-consolidated/install_rosa_common_pre.yml
+++ b/ansible/configs/rosa-consolidated/install_rosa_common_pre.yml
@@ -42,11 +42,28 @@
     _rosa_version_to_install: "{{ (r_rosa_versions.stdout | from_json) [0].raw_id }}"
     _rosa_ocp_cli_version: "{{ (r_rosa_versions.stdout | from_json) [0].raw_id }}"
 
+- name: Set ROSA version to latest available that can be upgraded
+  when: rosa_version | default("") == "latest-upgrade"
+  block:
+  - name: Find upgradable version
+    ansible.builtin.set_fact:
+      _rosa_version_to_install: "{{ r_rosa_versions.stdout | from_json | community.general.json_query(query) | first }}"
+      _rosa_ocp_cli_version: "{{ r_rosa_versions.stdout | from_json | community.general.json_query(query) | first }}"
+    vars:
+      query: "[?starts_with(id, '{{ rosa_version_base }}') && available_upgrades != `null`].raw_id"
+
+  - name: Find version to upgrade to
+    ansible.builtin.set_fact:
+      _rosa_version_next: "{{ r_rosa_versions.stdout | from_json | community.general.json_query(query) | first }}"
+    vars:
+      query: "[?starts_with(id, '{{ rosa_version_base }}') && available_upgrades != `null`].available_upgrades [0]"
+
 - name: Print ROSA version to install
   ansible.builtin.debug:
     msg: "{{ item }}"
   loop:
   - "ROSA Version to be installed: {{ _rosa_version_to_install }}"
+  - "ROSA Version available to be upgraded to: {{ _rosa_version_next | default('not set') }}"
   - "OCP CLI to be installed: {{ _rosa_ocp_cli_version}}"
 
 - name: Generate cluster admin password

--- a/ansible/configs/rosa-consolidated/install_rosa_hcp.yml
+++ b/ansible/configs/rosa-consolidated/install_rosa_hcp.yml
@@ -35,8 +35,18 @@
       /usr/local/bin/terraform apply rosa.tfplan
     chdir: "~{{ ansible_user }}/terraform-vpc"
 
-# WKTBD: Save terraform-vpc directory
-#        in output-dir for destroy
+- name: Save Terraform directory
+  ansible.builtin.archive:
+    path: "~{{ ansible_user }}/terraform-vpc"
+    dest: "~{{ ansible_user }}/terraform-vpc.tar.gz"
+    format: gz
+
+- name: Transfer terraform directory archive and save in output dir
+  ansible.builtin.fetch:
+    src: "~{{ ansible_user }}/terraform-vpc.tar.gz"
+    dest: "{{ output_dir }}/"
+    flat: true
+
 - name: Get created subnets
   ansible.builtin.command:
     cmd: >-

--- a/ansible/configs/rosa-consolidated/requirements.yml
+++ b/ansible/configs/rosa-consolidated/requirements.yml
@@ -3,9 +3,9 @@ collections:
 - name: kubernetes.core
   version: 2.4.0
 - name: amazon.aws
-  version: 6.2.0
+  version: 6.4.0
 - name: community.general
-  version: 7.2.1
+  version: 7.4.0
 - name: ansible.posix
   version: 1.5.4
 - name: community.okd

--- a/ansible/configs/rosa-consolidated/software.yml
+++ b/ansible/configs/rosa-consolidated/software.yml
@@ -126,6 +126,9 @@
           rosa_admin_password: "{{ _rosa_cluster_admin_password }}"
           rosa_token_warning: "{{ rosa_token_warning }}"
           rosa_deploy_hcp: "{{ rosa_deploy_hcp }}"
+          rosa_version: "{{ _rosa_version_to_install }}"
+          rosa_version_next: "{{ _rosa_version_next | default('none') }}"
+          rosa_ocp_cli_version: "{{ _rosa_ocp_cli_version }}"
 
     - name: Print ROSA user data when ROSA has been installed
       when: print_agnosticd_user_info | default(true) | bool

--- a/ansible/configs/rosa-consolidated/uninstall_rosa.yml
+++ b/ansible/configs/rosa-consolidated/uninstall_rosa.yml
@@ -40,8 +40,32 @@
     until: r_terraform is success
     delay: 30
 
-  # WKTBD: Restore terraform-vpc directory from output dir to /tmp/terraform-vpc
-  #        change directory to restored directory /tmp/terraform-vpc
+  - name: Restore terraform-vpc directory from output-dir
+    become: true
+    ansible.builtin.unarchive:
+      src: "{{ output_dir }}/terraform-vpc.tar.gz"
+      dest: "/tmp/"
+      remote_src: false
+      extra_opts:
+      - --no-same-owner
+
+  # - name: Remove old providers
+  #   ansible.builtin.file:
+  #     state: absent
+  #     path: "{{ item }}"
+  #   loop:
+  #   - /tmp/terraform-vpc/.terraform
+  #   - /tmp/terraform-vpc/.terraform.lock.hcl
+
+  # - name: Run terraform init
+  #   ansible.builtin.command:
+  #     cmd: /usr/local/bin/terraform init
+  #     chdir: "/tmp/terraform-vpc/"
+  #   register: r_output
+
+  # - name: Print output
+  #   ansible.builtin.debug:
+  #     msg: "{{ r_output }}"
 
   - name: Run Terraform destroy
     ansible.builtin.command:
@@ -50,5 +74,10 @@
           -var region={{ aws_region }}
           -var cluster_name=rosa-{{ guid }}
           -auto-approve
-      chdir: "~{{ ansible_user }}/terraform-vpc"
+      chdir: "/tmp/terraform-vpc/"
     ignore_errors: true
+    register: r_output_destroy
+
+  - name: Print Terraform destroy output
+    ansible.builtin.debug:
+      msg: "{{ r_output_destroy }}"


### PR DESCRIPTION
##### SUMMARY

Added capability to install the latest upgradable version for any given major version.

Also added logic to save terraform-vpc directory to output-dir and restore it into the EE - however destroy doesn't work... no biggie right now since sandbox-nuke should take care of terraform resources.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
rosa-consolidated