### PR TITLE
make default resource group region variable

### DIFF
--- a/ansible/roles/open-env-azure-add-user-to-subscription/tasks/main.yml
+++ b/ansible/roles/open-env-azure-add-user-to-subscription/tasks/main.yml
@@ -89,7 +89,7 @@
         auth_source: env
         subscription_id: "{{ subscription_id }}"
         name: "openenv-{{ guid }}"
-        location: eastus
+        location: "{{ azure_region }}"
         state: present
         tags:
           guid: "{{ guid }}"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
