### PR TITLE
Increase the wait time for ODF to install

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless_ml_workshop/tasks/install_odf_operator.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless_ml_workshop/tasks/install_odf_operator.yaml
@@ -27,8 +27,8 @@
   vars:
     _query: >-
       [?ends_with(spec.clusterServiceVersionNames[0], 'rhodf')]
-  retries: 30
-  delay: 5
+  retries: 60
+  delay: 30
   until:
   - r_install_plans.resources | default([]) | length > 0
   - r_install_plans.resources | to_json | from_json | json_query(_query)


### PR DESCRIPTION
##### SUMMARY
The last deployment took ~22 minutes to fully install ODF.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
OpenShift Serverless with ML Workshop