### PR TITLE
[ocp4-workload-homeroomlab-starter-guides] Fix agnosticd_user_info

### DIFF
--- a/ansible/roles/ocp4-workload-homeroomlab-starter-guides/tasks/post_workload.yml
+++ b/ansible/roles/ocp4-workload-homeroomlab-starter-guides/tasks/post_workload.yml
@@ -16,9 +16,12 @@
     - "Lab access (Homeroom Route) URL to give to students:"
     - "https://homeroom-{{ project_name }}.{{ route_subdomain }}"
     - ""
-  data:
-    homeroom_route: "https://homeroom-{{ project_name }}.{{ route_subdomain }}"
   when: not silent | bool
+  
+- name: set workshop info
+  agnosticd_user_info:
+    data:
+      homeroom_route: "https://homeroom-{{ project_name }}.{{ route_subdomain }}"
 
 - name: Output per-user workshop info
   when: ocp4_workload_homeroomlab_starter_guides_per_user_info_enable | bool

--- a/ansible/roles/ocp4-workload-homeroomlab-starter-guides/tasks/post_workload.yml
+++ b/ansible/roles/ocp4-workload-homeroomlab-starter-guides/tasks/post_workload.yml
@@ -17,7 +17,7 @@
     - "https://homeroom-{{ project_name }}.{{ route_subdomain }}"
     - ""
   when: not silent | bool
-  
+
 - name: set workshop info
   agnosticd_user_info:
     data:


### PR DESCRIPTION

##### SUMMARY

TASK [ocp4-workload-homeroomlab-starter-guides : Running Post Workload Tasks] ***
ERROR! conflicting action statements: agnosticd_user_info, data
The error appears to be in '/runner/project/ansible/roles/ocp4-workload-homeroomlab-starter-guides/tasks/post_workload.yml': line 9, column 3, but may
be elsewhere in the file depending on the exact syntax problem.


##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
ocp4-workload-homeroomlab-starter-guides

