### PR TITLE
Add retries to ocp4_workload_rosa_policies

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rosa_policies/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rosa_policies/tasks/workload.yml
@@ -74,6 +74,9 @@
         kind: Authentication
         name: cluster
       register: r_authentication
+      until: r_authentication is successful
+      retries: 30
+      delay: 10
 
     - name: Set OIDC endpoint
       ansible.builtin.set_fact:


### PR DESCRIPTION
##### SUMMARY

Add retries to k8s_info task to get cluster authentication in ocp4_workload_rosa_policies

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role ocp4_workload_rosa_policies