### PR TITLE
ML Serverless - Change StorageCluster ApiVersion

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless_ml_workshop/files/storage-cluster.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless_ml_workshop/files/storage-cluster.yml
@@ -1,8 +1,8 @@
 ---
-apiVersion: odf.openshift.io/v1
+apiVersion: ocs.openshift.io/v1
 kind: StorageCluster
 metadata:
-  name: odf-storagecluster
+  name: storagecluster
   namespace: openshift-storage
 spec:
   storageDeviceSets:

--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless_ml_workshop/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless_ml_workshop/tasks/workload.yml
@@ -82,9 +82,9 @@
 
 - name: Wait until ODF cluster is created
   k8s_info:
-    api_version: odf.openshift.io/v1
+    api_version: ocs.openshift.io/v1
     kind: StorageCluster
-    name: odf-storagecluster
+    name: storagecluster
     namespace: openshift-storage
   register: r_odf_cluster
   retries: 72


### PR DESCRIPTION
##### SUMMARY
I had the wrong `apiVersion` when creating the `StorageCluster`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
OpenShift Serverless with ML Workshop