### PR TITLE
Reorder to create the Postgres and Tomcat VM in sequence in MAD Dev

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_mad_roadshow/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mad_roadshow/tasks/workload.yml
@@ -146,7 +146,7 @@
     - kubevirt/clusterrole.yaml.j2
     # Single shared legacy VM
     - kubevirt/legacy-namespace.yaml.j2
-    - kubevirt/legacy-application.yaml.j2
+    - kubevirt/legacy-postgresql-application.yaml.j2
     # VMs for all users
     - kubevirt/applicationset.yaml.j2
 
@@ -177,6 +177,14 @@
         "Legacy PostgreSQL VM IP Address:    {{ _ocp4_workload_mad_roadshow_postgresql_ip }}"
         "Legacy PostgreSQL VM user name:     {{ ocp4_workload_mad_roadshow_vm_user_name }}"
         "Legacy PostgreSQL VM user password: {{ ocp4_workload_mad_roadshow_vm_user_password }}"
+
+  - name: Create a legacy tomcat VM
+    when: ocp4_workload_mad_roadshow_kubevirt_vm_deploy | bool
+    kubernetes.core.k8s:
+      state: present
+      definition: "{{ lookup('template', item ) | from_yaml_all | list }}"
+    loop:
+    - kubevirt/legacy-tomcat-application.yaml.j2
 
   - name: Look up Legacy Tomcat on CNV with ClusterIP
     kubernetes.core.k8s_info:

--- a/ansible/roles_ocp_workloads/ocp4_workload_mad_roadshow/templates/kubevirt/legacy-postgresql-application.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mad_roadshow/templates/kubevirt/legacy-postgresql-application.yaml.j2
@@ -40,38 +40,3 @@ spec:
         tolerations:
         {{ ocp4_workload_mad_roadshow_kubevirt_vm_tolerations | to_yaml }}
 {% endif %}
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  name: legacy-tomcat
-  namespace: openshift-gitops
-spec:
-  project: default
-  destination:
-    namespace: "{{ ocp4_workload_mad_roadshow_legacy_namespace }}"
-    server: 'https://kubernetes.default.svc'
-  syncPolicy:
-    automated: {}
-  source:
-    repoURL: {{ ocp4_workload_mad_roadshow_kubevirt_vm_repo }}
-    targetRevision: {{ ocp4_workload_mad_roadshow_kubevirt_tomcat_vm_repo_tag }}
-    path: {{ ocp4_workload_mad_roadshow_kubevirt_tomcat_vm_repo_path }}
-    helm:
-      values: |
-        fullnameOverride: tomcat
-        staticIP: {{ ocp4_workload_mad_roadshow_kubevirt_tomcat_vm_ip }}
-        resources:
-          requests:
-            memory: {{ ocp4_workload_mad_roadshow_kubevirt_vm_memory }}
-            cpu: '{{ ocp4_workload_mad_roadshow_kubevirt_vm_cpu }}'
-        image:
-          url: {{ ocp4_workload_mad_roadshow_kubevirt_tomcat_image_location }}
-{% if ocp4_workload_mad_roadshow_kubevirt_vm_node_selector | length > 0 %}
-        nodeSelector:
-          {{ ocp4_workload_mad_roadshow_kubevirt_vm_node_selector | to_yaml }}
-{% endif %}
-{% if ocp4_workload_mad_roadshow_kubevirt_vm_tolerations | length > 0 %}
-        tolerations:
-        {{ ocp4_workload_mad_roadshow_kubevirt_vm_tolerations | to_yaml }}
-{% endif %}

--- a/ansible/roles_ocp_workloads/ocp4_workload_mad_roadshow/templates/kubevirt/legacy-tomcat-application.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mad_roadshow/templates/kubevirt/legacy-tomcat-application.yaml.j2
@@ -1,0 +1,35 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: legacy-tomcat
+  namespace: openshift-gitops
+spec:
+  project: default
+  destination:
+    namespace: "{{ ocp4_workload_mad_roadshow_legacy_namespace }}"
+    server: 'https://kubernetes.default.svc'
+  syncPolicy:
+    automated: {}
+  source:
+    repoURL: {{ ocp4_workload_mad_roadshow_kubevirt_vm_repo }}
+    targetRevision: {{ ocp4_workload_mad_roadshow_kubevirt_tomcat_vm_repo_tag }}
+    path: {{ ocp4_workload_mad_roadshow_kubevirt_tomcat_vm_repo_path }}
+    helm:
+      values: |
+        fullnameOverride: tomcat
+        staticIP: {{ ocp4_workload_mad_roadshow_kubevirt_tomcat_vm_ip }}
+        resources:
+          requests:
+            memory: {{ ocp4_workload_mad_roadshow_kubevirt_vm_memory }}
+            cpu: '{{ ocp4_workload_mad_roadshow_kubevirt_vm_cpu }}'
+        image:
+          url: {{ ocp4_workload_mad_roadshow_kubevirt_tomcat_image_location }}
+{% if ocp4_workload_mad_roadshow_kubevirt_vm_node_selector | length > 0 %}
+        nodeSelector:
+          {{ ocp4_workload_mad_roadshow_kubevirt_vm_node_selector | to_yaml }}
+{% endif %}
+{% if ocp4_workload_mad_roadshow_kubevirt_vm_tolerations | length > 0 %}
+        tolerations:
+        {{ ocp4_workload_mad_roadshow_kubevirt_vm_tolerations | to_yaml }}
+{% endif %}


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Reorder to create the Postgres and Tomcat VM in sequence in MAD Dev
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
