### PR TITLE
Added ansible.utils for sap-hana config

### DIFF
--- a/ansible/configs/sap-hana/requirements.yml
+++ b/ansible/configs/sap-hana/requirements.yml
@@ -14,3 +14,5 @@ collections:
   version: 1.3.0
 - name: openstack.cloud
   version: 1.7.2
+- name: ansible.utils
+  version: 2.11.0


### PR DESCRIPTION
The storage role used in this config has been changed and it now uses the module ansible.utils.update_fact

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
