### PR TITLE
Fix rosa-consolidated version logic

### DIFF
--- a/ansible/configs/rosa-consolidated/default_vars.yml
+++ b/ansible/configs/rosa-consolidated/default_vars.yml
@@ -48,7 +48,7 @@ rosa_cluster_name: "rosa-{{ guid }}"
 # - 4.x.x: A specific version. Definitely only set for special
 #          cases because specific versions routinely disappear from
 #          the list of available versions
-rosa_version: ""
+rosa_version: default
 # Set the base of the version to be upgraded from when using `latest-upgrade` for rosa_version.
 # The logic will search for the latest version within that base
 # version that has available_upgrades set (use 'rosa list versions -o json' for examples)

--- a/ansible/configs/rosa-consolidated/install_rosa_common_pre.yml
+++ b/ansible/configs/rosa-consolidated/install_rosa_common_pre.yml
@@ -18,45 +18,60 @@
 - name: Get available ROSA versions
   ansible.builtin.command: >-
     {{ rosa_binary_path }}/rosa list versions --output json
+    {% if rosa_deploy_hcp | bool %}--hosted-cp{% endif %}
   register: r_rosa_versions
 
 - name: Set default ROSA version
+  when:
+  - rosa_version == "default"
   ansible.builtin.set_fact:
     _rosa_version_to_install: ""
     _rosa_ocp_cli_version: >-
-      {{ (r_rosa_versions.stdout | from_json | json_query(query)) [0].raw_id }}
+      {{ (r_rosa_versions.stdout | from_json | json_query(_query)) [0].raw_id }}
   vars:
-    query: "[?default==`true`]"
+    _query: "[?default==`true`]"
 
-- name: Set ROSA version to install to specific version
+- name: Set ROSA version to install specific version
   when:
-  - rosa_version | default("") | length > 0
-  - rosa_version | default("") != "latest"
+  - rosa_version not in ("default", "latest", "latest-upgrade")
   ansible.builtin.set_fact:
     _rosa_version_to_install: "{{ rosa_version }}"
     _rosa_ocp_cli_version: "{{ rosa_version }}"
 
-- name: Set ROSA version to latest available
-  when: rosa_version | default("") == "latest"
+- name: Set ROSA version to latest available for {{ rosa_version_base }}
+  when: rosa_version == "latest"
+  vars:
+    _query: "[?starts_with(id, '{{ rosa_version_base }}')] | [0]"
+    _latest_version: "{{ r_rosa_versions.stdout | from_json | community.general.json_query(_query) }}"
   ansible.builtin.set_fact:
-    _rosa_version_to_install: "{{ (r_rosa_versions.stdout | from_json) [0].raw_id }}"
-    _rosa_ocp_cli_version: "{{ (r_rosa_versions.stdout | from_json) [0].raw_id }}"
+    _rosa_version_to_install: "{{ _latest_version.raw_id }}"
+    _rosa_ocp_cli_version: "{{ _latest_version.raw_id }}"
 
-- name: Set ROSA version to latest available that can be upgraded
-  when: rosa_version | default("") == "latest-upgrade"
+- name: Set ROSA version to latest upgradable version available for {{ rosa_version_base }}
+  when: rosa_version == "latest-upgrade"
+  vars:
+    _query: "[?starts_with(id, '{{ rosa_version_base }}') && available_upgrades != `null`] | [0]"
+    _latest_upgrade_version: "{{ r_rosa_versions.stdout | from_json | community.general.json_query(_query) }}"
   block:
-  - name: Find upgradable version
-    ansible.builtin.set_fact:
-      _rosa_version_to_install: "{{ r_rosa_versions.stdout | from_json | community.general.json_query(query) | first }}"
-      _rosa_ocp_cli_version: "{{ r_rosa_versions.stdout | from_json | community.general.json_query(query) | first }}"
-    vars:
-      query: "[?starts_with(id, '{{ rosa_version_base }}') && available_upgrades != `null`].raw_id"
+  - name: Fail if no upgradable version was found for {{ rosa_version_base }}
+    when: _latest_upgrade_version | default("") == ""
+    fail:
+      msg: "No upgradable version found for {{ rosa_version_base }}"
 
-  - name: Find version to upgrade to
+  - name: Set upgradable version facts
     ansible.builtin.set_fact:
-      _rosa_version_next: "{{ r_rosa_versions.stdout | from_json | community.general.json_query(query) | first }}"
+      _rosa_version_to_install: "{{ _latest_upgrade_version.raw_id }}"
+      _rosa_ocp_cli_version: "{{ _latest_upgrade_version.raw_id }}"
+      _rosa_version_next: "{{ _latest_upgrade_version.available_upgrades[0] }}"
+
+  rescue:
+  - name: Fallback to latest ROSA version available for {{ rosa_version_base }}
     vars:
-      query: "[?starts_with(id, '{{ rosa_version_base }}') && available_upgrades != `null`].available_upgrades [0]"
+      _query: "[?starts_with(id, '{{ rosa_version_base }}')] | [0]"
+      _latest_version: "{{ r_rosa_versions.stdout | from_json | community.general.json_query(_query) }}"
+    ansible.builtin.set_fact:
+      _rosa_version_to_install: "{{ _latest_version.raw_id }}"
+      _rosa_ocp_cli_version: "{{ _latest_version.raw_id }}"
 
 - name: Print ROSA version to install
   ansible.builtin.debug:


### PR DESCRIPTION
##### SUMMARY

- `rosa_version` default is specified with "default" rather than empty string to be compatible with parameters.
- Get available versions uses `--hosted-cp` flag when `rosa_deploy_hcp` is set to true.
- `rosa_version: latest` respects the value of `rosa_version_base`
- `rosa_version: latest-upgrade` falls back to latest if no upgrade is available

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Config rosa-consolidated