### PR TITLE
fix concatenation for ssh key path 

### DIFF
--- a/ansible/roles-infra/infra-osp-template-generate/defaults/main.yaml
+++ b/ansible/roles-infra/infra-osp-template-generate/defaults/main.yaml
@@ -4,7 +4,7 @@ osp_default_rootfs_size: 30
 
 opentlc_admin_pub_keys: "{{ lookup('file', ssh_provision_key_path) }}"
 
-all_ssh_authorized_keys: "{{ opentlc_admin_pub_keys + [user_pub_key|d()] }}"
+all_ssh_authorized_keys: "{{ [opentlc_admin_pub_keys|default("")] + [user_pub_key|default("")] }}"
 
 create_unused_security_groups: false
 

--- a/ansible/roles-infra/infra-osp-template-generate/defaults/main.yaml
+++ b/ansible/roles-infra/infra-osp-template-generate/defaults/main.yaml
@@ -4,7 +4,7 @@ osp_default_rootfs_size: 30
 
 opentlc_admin_pub_keys: "{{ lookup('file', ssh_provision_key_path) }}"
 
-all_ssh_authorized_keys: "{{ [opentlc_admin_pub_keys|default("")] + [user_pub_key|default("")] }}"
+all_ssh_authorized_keys: "{{ [opentlc_admin_pub_keys|default('')] + [user_pub_key|default('')] }}"
 
 create_unused_security_groups: false
 


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
fix concatenation for ssh key path 
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
roles-infra/infra-osp-template-generate

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
