### PR TITLE
remove firewall rules before running ocp uninstall

### DIFF
--- a/ansible/configs/ocp4-cluster/destroy_env_gcp.yml
+++ b/ansible/configs/ocp4-cluster/destroy_env_gcp.yml
@@ -49,6 +49,14 @@
   tasks:
     - include_tasks: gcp_instances_start.yml
 
+- name: Destroy firewall rules that openshift-installer created but can't handle
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  become: false
+  tasks:
+    - include_tasks: gcp_fw_destroy.yml
+
 - name: Have the OpenShift installer cleanup what it did
   hosts: bastions
   gather_facts: false

--- a/ansible/configs/ocp4-cluster/gcp_fw_destroy.yml
+++ b/ansible/configs/ocp4-cluster/gcp_fw_destroy.yml
@@ -15,6 +15,5 @@
     service_account_file: "{{ gcp_credentials_file }}"
     project: "{{ gcp_project_id }}"
     name: "{{ item.name }}"
-    zone: "{{ item.zone }}"
     state: absent
   loop: "{{ r_firewall_info.resources }}"

--- a/ansible/configs/ocp4-cluster/gcp_fw_destroy.yml
+++ b/ansible/configs/ocp4-cluster/gcp_fw_destroy.yml
@@ -1,0 +1,19 @@
+---
+- name: Find k8s Firewall Rules in GCP
+  google.cloud.gcp_compute_firewall_info:
+    auth_kind: "{{ gcp_auth_type }}"
+    service_account_file: "{{ gcp_credentials_file }}"
+    project: "{{ gcp_project_id }}"
+  register: r_firewall_info
+
+- name: Delete k8s Firewall Rules in GCP
+  when:
+    - r_firewall_info.resources | length > 0
+    - item.name.startswith('k8s-')
+  google.cloud.gcp_compute_instance:
+    auth_kind: "{{ gcp_auth_type }}"
+    service_account_file: "{{ gcp_credentials_file }}"
+    project: "{{ gcp_project_id }}"
+    name: "{{ item.name }}"
+    state: absent
+  loop: "{{ r_firewall_info.resources }}"

--- a/ansible/configs/ocp4-cluster/gcp_fw_destroy.yml
+++ b/ansible/configs/ocp4-cluster/gcp_fw_destroy.yml
@@ -10,10 +10,11 @@
   when:
     - r_firewall_info.resources | length > 0
     - item.name.startswith('k8s-')
-  google.cloud.gcp_compute_instance:
+  google.cloud.gcp_compute_firewall:
     auth_kind: "{{ gcp_auth_type }}"
     service_account_file: "{{ gcp_credentials_file }}"
     project: "{{ gcp_project_id }}"
     name: "{{ item.name }}"
+    zone: "{{ item.zone }}"
     state: absent
   loop: "{{ r_firewall_info.resources }}"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
For some reason OCP creates firewall rules in GCP that the OCP installer cannot destroy causing the destroy to fail.  This will fix that problem.

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4-cluster

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
