### PR TITLE
[rhel-custom-security-content] Add kubernetes.core [rhel-graphical] Add ignore_errors

### DIFF
--- a/ansible/configs/rhel-custom-security-content/requirements.yml
+++ b/ansible/configs/rhel-custom-security-content/requirements.yml
@@ -6,3 +6,5 @@ collections:
   version: 4.6.1
 - name: ansible.posix
   version: 1.3.0
+- name: kubernetes.core
+  version: 2.3.0

--- a/ansible/roles/rhel-graphical/tasks/main.yml
+++ b/ansible/roles/rhel-graphical/tasks/main.yml
@@ -121,6 +121,7 @@
       dbus-launch --exit-with-session gsettings
       set org.gnome.shell welcome-dialog-last-shown-version '40.10'
     become_user: "{{ student_name }}"
+    ignore_errors: True
 
   - name: Copy TigerVNC service file
     command: "cp /lib/systemd/system/vncserver@.service /etc/systemd/system/vncserver@.service"


### PR DESCRIPTION

##### SUMMARY

Config rhel-custom-security-content misses kubernetes.core to deploy bookbag in shared cluster
Role rhel-graphical was created for a specific RHEL 9.X version, show the ignore welcome dialog task can be ignored for other versions

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
config rhel-custom-security-content
role rhel-graphical