### PR TITLE
Update install-sso.yaml - double delay time

### DIFF
--- a/ansible/roles/ocp4-workload-eap8-workshop/tasks/install-sso.yaml
+++ b/ansible/roles/ocp4-workload-eap8-workshop/tasks/install-sso.yaml
@@ -46,7 +46,7 @@
     name: keycloaks.keycloak.org
   register: r_keycloak_crd
   retries: 200
-  delay: 10
+  delay: 20
   until: r_keycloak_crd.resources | list | length == 1
 
 # deploy sso CR


### PR DESCRIPTION
TASK [ocp4-workload-eap8-workshop : Wait for keycloak CRD to be ready] *********
fatal: [bastion.54fxw.internal]: FAILED! => {"msg": "The conditional check 'r_keycloak_crd.resources | list | length == 1' failed. The error was: error while evaluating conditional (r_keycloak_crd.resources | list | length == 1): 'dict object' has no attribute 'resources'. 'dict object' has no attribute 'resources'"}
 