### PR TITLE
Added prelim support for ansible-runner-api orchestration to showroom

### DIFF
--- a/ansible/roles/showroom/defaults/main.yml
+++ b/ansible/roles/showroom/defaults/main.yml
@@ -35,6 +35,10 @@ showroom_enable_root_ssh: false
 showroom_lab_users:
   - "{{ showroom_default_ssh_user | default('rhel') }}"
 
+# Enable the showroom_ansible_runner_api?
+showroom_ansible_runner_api: false
+showroom_ansible_runner_api_port: 8501
+
 showroom_container_compose_template: compose_default_template.j2
 
 showroom_base_services:

--- a/ansible/roles/showroom/templates/ansible_runner_api_service/ansible_runner_api_service.j2
+++ b/ansible/roles/showroom/templates/ansible_runner_api_service/ansible_runner_api_service.j2
@@ -1,0 +1,10 @@
+ansible-runner-api:
+  image: docker.io/tonykay/ansible-runner-api:0.0.1
+  container_name: ansible-runner-api
+  hostname: ansible-runner-api
+  ports:
+    - "{{ showroom_ansible_runner_api_port | default(8501) }}:80"
+  volumes:
+    - "{{ showroom_user_home_dir }}/content/playbooks/:/app/scripts:ro"
+  restart: "always"
+

--- a/ansible/roles/showroom/templates/compose_default_template.j2
+++ b/ansible/roles/showroom/templates/compose_default_template.j2
@@ -15,6 +15,14 @@ services:
 
 {% endfor %}
 
+{% if showroom_ansible_runner_api %}
+{% macro fake_indent_op() %}
+{% include 'ansible_runner_api_service/ansible_runner_api_service.j2' ignore missing %}
+{% endmacro %}
+  {{ fake_indent_op() | indent(2) }}
+
+{% endif %}
+
 {% for service in showroom_tab_services %}
 {% macro fake_indent_op() %}
 {% include 'service_' + service + '/service_' + service + '.j2' ignore missing %}


### PR DESCRIPTION

##### SUMMARY

Showroom role, starting with Zero Touch, will support the use of an extensible API to run playbooks and scripts:

- setup (before modules and/or labs)
- validators/graders
- teardown etc

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME

roles/showroom

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
