### PR TITLE
[ee-multicloud-public] Adding kubevirt.core

### DIFF
--- a/tools/execution_environments/ee-multicloud-public/requirements.yml
+++ b/tools/execution_environments/ee-multicloud-public/requirements.yml
@@ -46,5 +46,7 @@ collections:
 # From requirements.txt
 - name: kubernetes.core
 
+- name: kubevirt.core
+
 # openstacksdk>=1.0.0
 - name: openstack.cloud


### PR DESCRIPTION
##### SUMMARY

More and more CI are moving to CNV, so we need kubevirt.core for the stopping the VMs

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
EE ee-multicloud-public


