### PR TITLE
Fix showroom terminal scroll

### DIFF
--- a/ansible/roles/showroom/templates/tabs.css
+++ b/ansible/roles/showroom/templates/tabs.css
@@ -38,4 +38,6 @@
   padding: 6px 12px;
   border: 1px solid #ccc;
   border-top: none;
+  /* 100% - height of the tab above */
+  height: calc(100% - 50px);
 }


### PR DESCRIPTION
##### SUMMARY

Fix CSS for showroom role to prevent the terminal tab from scrolling.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role showroom