### PR TITLE
Remove top margin from showroom to prevent scroll

### DIFF
--- a/ansible/roles/showroom/templates/split.css
+++ b/ansible/roles/showroom/templates/split.css
@@ -19,7 +19,7 @@ body {
   border-top: 1px solid;
   border-color: Gainsboro;
   border-top-width: thin;
-  margin-top: 8px;
+  margin-top: 0px;
 }
 
 .split {


### PR DESCRIPTION
##### SUMMARY

Remove top margin from showroom content to prevent scrolling.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role showroom