### PR TITLE
Add retries for fetching output dir from S3

### DIFF
--- a/ansible/roles/agnosticd_restore_output_dir/tasks/fetch-from-s3-aws_s3.yml
+++ b/ansible/roles/agnosticd_restore_output_dir/tasks/fetch-from-s3-aws_s3.yml
@@ -18,4 +18,7 @@
     r_get_output_dir_archive is failed
     and 'does not exist' not in r_get_output_dir_archive.msg
     and 'Could not find the key' not in r_get_output_dir_archive.msg
+  until: r_get_output_dir_archive is successful
+  retries: 10
+  delay: 5
 ...

--- a/ansible/roles/agnosticd_restore_output_dir/tasks/fetch-from-s3-s3_object.yml
+++ b/ansible/roles/agnosticd_restore_output_dir/tasks/fetch-from-s3-s3_object.yml
@@ -19,4 +19,7 @@
     and r_get_output_dir_archive.error.code | default(0) | int != 403
     and 'does not exist' not in r_get_output_dir_archive.msg
     and 'Could not find the key' not in r_get_output_dir_archive.msg
+  until: r_get_output_dir_archive is successful
+  retries: 10
+  delay: 5
 ...


### PR DESCRIPTION
##### SUMMARY

Add retries for fetching output_dir archive from S3. Sometimes, albeit rarely, Amazon S3 cannot be reached and causes a failure that can be addressed with a simple retry.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role `agnosticd_restore_output_dir`