### PR TITLE
[ocp4-workload-ccnrd-stable] Add retries to the oc command

### DIFF
--- a/ansible/roles/ocp4-workload-ccnrd-stable/tasks/create_project.yaml
+++ b/ansible/roles/ocp4-workload-ccnrd-stable/tasks/create_project.yaml
@@ -17,4 +17,4 @@
   retries: 6
   delay: 10
   register: oc_result
-  until: oc_result.rc == 0    
+  until: oc_result is success

--- a/ansible/roles/ocp4-workload-ccnrd-stable/tasks/create_project.yaml
+++ b/ansible/roles/ocp4-workload-ccnrd-stable/tasks/create_project.yaml
@@ -14,3 +14,7 @@
     oc adm policy add-scc-to-user anyuid -z default -n {{ name }}
     oc adm policy add-scc-to-user privileged -z default -n {{ name }}
     oc adm policy add-role-to-user admin {{ user }} -n {{ name }}
+  retries: 6
+  delay: 10
+  register: oc_result
+  until: oc_result.rc == 0    


### PR DESCRIPTION
##### SUMMARY

Workload are executed during OCP installation, sometimes the cluster is updating some components such as the apiserver, so it is possible it be unavailable for some seconds

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
Role ocp4-workload-ccnrd-stable


