### PR TITLE
Update Deploy Hosted Cluster for OCP 4 and RHACM 2.9

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/defaults/main.yml
@@ -3,6 +3,8 @@ become_override: false
 ocp_username: system:admin
 silent: false
 
+# Minimum required RHACM version is 2.9.
+
 # Namespace on the hub to hold policies
 ocp4_workload_deploy_hosted_cluster_policies_namespace: rhdp-policies
 
@@ -24,7 +26,7 @@ ocp4_workload_deploy_hosted_cluster_aws_bucket_name: oidc-storage-hyper
 ocp4_workload_deploy_hosted_cluster_aws_bucket_region: us-east-2
 
 # OpenShift version to deploy
-ocp4_workload_deploy_hosted_cluster_version: "4.13.4"
+ocp4_workload_deploy_hosted_cluster_version: "4.14.2"
 
 # Base domain to deploy the cluster into
 # Full domain will be apps.{{ guid }}.{{ ocp4_workload_deploy_hosted_cluster_base_domain }}

--- a/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/meta/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   role_name: ocp4_workload_deploy_hosted_cluster
   author: Wolfgang Kulhanek
   description: |
-    Deploy an OpenShift cluster using a hosted control plane
+    Deploy an OpenShift cluster using a hosted control plane. Minimum required RHACM version is 2.9.
   license: MIT
   min_ansible_version: 2.9
   platforms: []

--- a/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/tasks/post_workload.yml
@@ -9,7 +9,7 @@
 # For deployment onto a dedicated cluster (as part of the
 # cluster deployment) set workload_shared_deployment to False
 # This is the default so it does not have to be set explicitely
-- name: post_workload tasks complete
+- name: Post_workload tasks complete
   ansible.builtin.debug:
     msg: "Post-Workload tasks completed successfully."
   when:
@@ -19,7 +19,7 @@
 # For RHDP deployment (onto a shared cluster) set
 # workload_shared_deployment to True
 # (in the deploy script or AgnosticV configuration)
-- name: post_workload tasks complete
+- name: Post_workload tasks complete
   ansible.builtin.debug:
     msg: "Post-Software checks completed successfully"
   when:

--- a/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/tasks/pre_workload.yml
@@ -9,7 +9,7 @@
 # For deployment onto a dedicated cluster (as part of the
 # cluster deployment) set workload_shared_deployment to False
 # This is the default so it does not have to be set explicitely
-- name: pre_workload tasks complete
+- name: Pre_workload tasks complete
   ansible.builtin.debug:
     msg: "Pre-Workload tasks completed successfully."
   when:
@@ -19,7 +19,7 @@
 # For RHDP deployment (onto a shared cluster) set
 # workload_shared_deployment to True
 # (in the deploy script or AgnosticV configuration)
-- name: pre_workload tasks complete
+- name: Pre_workload tasks complete
   ansible.builtin.debug:
     msg: "Pre-Software checks completed successfully"
   when:

--- a/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/tasks/remove_workload.yml
@@ -1,4 +1,5 @@
 ---
+# ------------------------------------------
 # Implement your workload removal tasks here
 # ------------------------------------------
 
@@ -6,7 +7,7 @@
   when: ocp4_workload_deploy_hosted_cluster_certmanager_enabled | bool
   kubernetes.core.k8s:
     state: absent
-    definition: "{{ lookup('template', item ) | from_yaml }}"
+    definition: "{{ lookup('template', item) | from_yaml }}"
   loop:
   - certmanager/policy.yaml.j2
   - certmanager/placement.yaml.j2
@@ -18,7 +19,7 @@
   when: ocp4_workload_deploy_hosted_cluster_user_quota | default( [] ) | length > 0
   kubernetes.core.k8s:
     state: absent
-    definition: "{{ lookup('template', item ) | from_yaml }}"
+    definition: "{{ lookup('template', item) | from_yaml }}"
   loop:
   - clusterresourcequota/placement.yaml.j2
   - clusterresourcequota/subscription.yaml.j2
@@ -62,14 +63,14 @@
   retries: 100
   ignore_errors: true
 
-- name: Run hypershift CLI to destroy hosted cluster
+- name: Run hcp CLI to destroy hosted cluster
   ansible.builtin.command: >-
-    hypershift destroy cluster aws
+    /usr/bin/hcp destroy cluster aws
       --name {{ ocp4_workload_deploy_hosted_cluster_name }}
       --infra-id {{ ocp4_workload_deploy_hosted_cluster_infra_id }}
       --secret-creds aws-credentials
       --namespace local-cluster
-  register: r_hypershift_destroy
+  register: r_hcp_destroy
   ignore_errors: true
 
 - name: Delete hosted cluster secrets
@@ -85,7 +86,7 @@
 
 # Leave this as the last task in the playbook.
 # --------------------------------------------
-- name: remove_workload tasks complete
+- name: Remove_workload tasks complete
   ansible.builtin.debug:
     msg: "Remove Workload tasks completed successfully."
   when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/tasks/setup_htpasswd_authentication.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/tasks/setup_htpasswd_authentication.yml
@@ -40,7 +40,7 @@
   - name: Generate user passwords array for common password
     ansible.builtin.set_fact:
       _ocp4_workload_deploy_hosted_cluster_user_passwords: >-
-        {{ _ocp4_workload_deploy_hosted_cluster_user_passwords + [ _ocp4_workload_deploy_hosted_cluster_user_password ] }}
+        {{ _ocp4_workload_deploy_hosted_cluster_user_passwords + [_ocp4_workload_deploy_hosted_cluster_user_password] }}
     loop: "{{ range(0, ocp4_workload_deploy_hosted_cluster_user_count, 1) | list }}"
 
 - name: Create temporary htpasswd file
@@ -54,12 +54,14 @@
     path: "{{ r_htpasswd.path }}"
     name: "{{ ocp4_workload_deploy_hosted_cluster_admin_user }}"
     password: "{{ _ocp4_workload_deploy_hosted_cluster_admin_password }}"
+    mode: "0664"
 
 - name: Add users and passwords to htpasswd file
   community.general.htpasswd:
     path: "{{ r_htpasswd.path }}"
     name: "{{ ocp4_workload_deploy_hosted_cluster_user_base }}{{ item + 1 }}"
-    password: "{{ _ocp4_workload_deploy_hosted_cluster_user_passwords[ item ] }}"
+    password: "{{ _ocp4_workload_deploy_hosted_cluster_user_passwords[item] }}"
+    mode: "0664"
   loop: "{{ range(0, ocp4_workload_deploy_hosted_cluster_user_count, 1) | list }}"
 
 - name: Read contents of htpasswd file
@@ -72,7 +74,7 @@
     path: "{{ r_htpasswd.path }}"
     state: absent
 
-- name: Ensure secret htpasswd-{{ guid }} is absent
+- name: Ensure htpasswd secret is absent
   kubernetes.core.k8s:
     state: absent
     api_version: v1
@@ -87,4 +89,4 @@
 - name: Create secret htpasswd-{{ guid }}
   kubernetes.core.k8s:
     state: present
-    definition: "{{ lookup('template', 'secret-htpasswd.yaml.j2' ) | from_yaml }}"
+    definition: "{{ lookup('template', 'secret-htpasswd.yaml.j2') | from_yaml }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/tasks/setup_oauth_certificate.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/tasks/setup_oauth_certificate.yml
@@ -29,4 +29,4 @@
     - r_ingresscontroller_cert.resources[0].data['tls.crt'] is defined
     kubernetes.core.k8s:
       state: present
-      definition: "{{ lookup('template', 'secret-oauth.yaml.j2' ) | from_yaml }}"
+      definition: "{{ lookup('template', 'secret-oauth.yaml.j2') | from_yaml }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/tasks/workload.yml
@@ -3,6 +3,40 @@
   ansible.builtin.debug:
     msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
 
+#############################################################################
+# Prerequisite Checks
+#############################################################################
+
+- name: Ensure RHACM MultiClusterHub is deployed
+  kubernetes.core.k8s_info:
+    api_version: operator.open-cluster-management.io/v1
+    kind: MultiClusterHub
+    name: multiclusterhub
+    namespace: open-cluster-management
+  register: r_rhacm_multiclusterhub
+
+- name: Assert that MultiClusterHub is available
+  ansible.builtin.assert:
+    that:
+    - r_rhacm_multiclusterhub.resources | length == 1
+    - r_rhacm_multiclusterhub.resources[0].status.phase is defined
+    - r_rhacm_multiclusterhub.resources[0].status is defined
+    - r_rhacm_multiclusterhub.resources[0].status.phase == "Running"
+    quiet: true
+    fail_msg: "MultiClusterHub not found on cluster. Can not continue."
+    success_msg: "MultiClusterHub found on cluster. Ready to set up Hypershift."
+
+- name: Assert that MultiClusterHub is version 2.9.0 or higher
+  ansible.builtin.assert:
+    that: "r_rhacm_multiclusterhub.resources[0].status.currentVersion is version('2.9.0', '>=')"
+    quiet: true
+    fail_msg: "MultiClusterHub not at version 2.9.0 or higher. Please upgrade your RHACM. Can not continue."
+    success_msg: "MultiClusterHub found on cluster in version 2.9.0 or higher. Ready to set up Hypershift."
+
+#############################################################################
+# Set up resources on hosting cluster
+#############################################################################
+
 - name: Setup htpasswd authentication
   when: ocp4_workload_deploy_hosted_cluster_authentication | default('none') == 'htpasswd'
   ansible.builtin.include_tasks: setup_htpasswd_authentication.yml
@@ -19,15 +53,19 @@
     namespace: local-cluster
   register: r_hosted_cluster
 
+#############################################################################
+# Deploy hosted cluster
+#############################################################################
+
 - name: Deploy hosted cluster {{ _ocp4_workload_rhacm_hypershift_cluster_name }}
   when: r_hosted_cluster.resources | length == 0
   block:
   # This command expects AWS credentials, base domain, pull secret and SSH keys in
   # secret `aws-credentials` in namespace `local-cluster` as set up by the
   # workload `ocp4_workload_rhacm_hypershift`
-  - name: Run hypershift CLI to deploy hosted cluster
+  - name: Run hcp CLI to deploy hosted cluster
     ansible.builtin.command: >-
-      hypershift create cluster aws
+      /usr/bin/hcp create cluster aws
         --name {{ ocp4_workload_deploy_hosted_cluster_name }}
         --infra-id {{ ocp4_workload_deploy_hosted_cluster_infra_id }}
         --region {{ ocp4_workload_deploy_hosted_cluster_aws_region }}
@@ -44,7 +82,7 @@
         --namespace local-cluster
         --secret-creds aws-credentials
         --auto-repair
-    register: r_hypershift_create_cluster
+    register: r_hcp_create_cluster
 
   - name: Print hypershift command output
     ansible.builtin.debug:
@@ -52,15 +90,15 @@
     loop:
     - "STDOUT:"
     - "--------------------------------------------------------"
-    - "{{ r_hypershift_create_cluster.stdout }}"
+    - "{{ r_hcp_create_cluster.stdout }}"
     - ""
     - "STDERR:"
     - "--------------------------------------------------------"
-    - "{{ r_hypershift_create_cluster.stderr }}"
+    - "{{ r_hcp_create_cluster.stderr }}"
     - "--------------------------------------------------------"
 
   - name: Abort
-    when: r_hypershift_create_cluster.rc > 0
+    when: r_hcp_create_cluster.rc > 0
     ansible.builtin.fail:
       msg: "Cluster creation failed. Aborting."
 
@@ -83,6 +121,10 @@
   ansible.builtin.set_fact:
     _ocp4_workload_deploy_hosted_cluster_console_url: >-
       https://console-openshift-console.apps.{{ ocp4_workload_deploy_hosted_cluster_name }}.{{ ocp4_workload_deploy_hosted_cluster_base_domain }}
+
+#############################################################################
+# Deploy post install configuration
+#############################################################################
 
 - name: Ensure that the policy namespaces exist on the hub
   kubernetes.core.k8s:
@@ -116,6 +158,10 @@
   - clusterresourcequota/managedclustersetbinding.yaml.j2
   - clusterresourcequota/subscription.yaml.j2
   - clusterresourcequota/application.yaml.j2
+
+#############################################################################
+# Save agnosticd information
+#############################################################################
 
 - name: Save common information
   agnosticd_user_info:


### PR DESCRIPTION
##### SUMMARY

RHACM 2.9 has a lot of changes. Updated workload to deploy a hosted cluster to a shared hosting cluster to support (and require) RHACM 2.9. Cleaned up a few things as well.

This workload is only used in one catalog item (Workshop Hypershift) which will be updated next.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_deploy_hosted_cluster