### PR TITLE
Update rhacm hypershift workload to support and require RHACM 2.9

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/defaults/main.yml
@@ -3,6 +3,8 @@ become_override: false
 ocp_username: system:admin
 silent: false
 
+# Minimum required RHACM version is 2.9.
+
 # Namespace on the hub to hold policies
 ocp4_workload_deploy_hosted_cluster_policies_namespace: rhdp-policies
 
@@ -24,7 +26,7 @@ ocp4_workload_deploy_hosted_cluster_aws_bucket_name: oidc-storage-hyper
 ocp4_workload_deploy_hosted_cluster_aws_bucket_region: us-east-2
 
 # OpenShift version to deploy
-ocp4_workload_deploy_hosted_cluster_version: "4.13.4"
+ocp4_workload_deploy_hosted_cluster_version: "4.14.2"
 
 # Base domain to deploy the cluster into
 # Full domain will be apps.{{ guid }}.{{ ocp4_workload_deploy_hosted_cluster_base_domain }}

--- a/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/meta/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   role_name: ocp4_workload_deploy_hosted_cluster
   author: Wolfgang Kulhanek
   description: |
-    Deploy an OpenShift cluster using a hosted control plane
+    Deploy an OpenShift cluster using a hosted control plane. Minimum required RHACM version is 2.9.
   license: MIT
   min_ansible_version: 2.9
   platforms: []

--- a/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/tasks/post_workload.yml
@@ -9,7 +9,7 @@
 # For deployment onto a dedicated cluster (as part of the
 # cluster deployment) set workload_shared_deployment to False
 # This is the default so it does not have to be set explicitely
-- name: post_workload tasks complete
+- name: Post_workload tasks complete
   ansible.builtin.debug:
     msg: "Post-Workload tasks completed successfully."
   when:
@@ -19,7 +19,7 @@
 # For RHDP deployment (onto a shared cluster) set
 # workload_shared_deployment to True
 # (in the deploy script or AgnosticV configuration)
-- name: post_workload tasks complete
+- name: Post_workload tasks complete
   ansible.builtin.debug:
     msg: "Post-Software checks completed successfully"
   when:

--- a/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/tasks/pre_workload.yml
@@ -9,7 +9,7 @@
 # For deployment onto a dedicated cluster (as part of the
 # cluster deployment) set workload_shared_deployment to False
 # This is the default so it does not have to be set explicitely
-- name: pre_workload tasks complete
+- name: Pre_workload tasks complete
   ansible.builtin.debug:
     msg: "Pre-Workload tasks completed successfully."
   when:
@@ -19,7 +19,7 @@
 # For RHDP deployment (onto a shared cluster) set
 # workload_shared_deployment to True
 # (in the deploy script or AgnosticV configuration)
-- name: pre_workload tasks complete
+- name: Pre_workload tasks complete
   ansible.builtin.debug:
     msg: "Pre-Software checks completed successfully"
   when:

--- a/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/tasks/remove_workload.yml
@@ -1,4 +1,5 @@
 ---
+# ------------------------------------------
 # Implement your workload removal tasks here
 # ------------------------------------------
 
@@ -6,7 +7,7 @@
   when: ocp4_workload_deploy_hosted_cluster_certmanager_enabled | bool
   kubernetes.core.k8s:
     state: absent
-    definition: "{{ lookup('template', item ) | from_yaml }}"
+    definition: "{{ lookup('template', item) | from_yaml }}"
   loop:
   - certmanager/policy.yaml.j2
   - certmanager/placement.yaml.j2
@@ -18,7 +19,7 @@
   when: ocp4_workload_deploy_hosted_cluster_user_quota | default( [] ) | length > 0
   kubernetes.core.k8s:
     state: absent
-    definition: "{{ lookup('template', item ) | from_yaml }}"
+    definition: "{{ lookup('template', item) | from_yaml }}"
   loop:
   - clusterresourcequota/placement.yaml.j2
   - clusterresourcequota/subscription.yaml.j2
@@ -62,14 +63,14 @@
   retries: 100
   ignore_errors: true
 
-- name: Run hypershift CLI to destroy hosted cluster
+- name: Run hcp CLI to destroy hosted cluster
   ansible.builtin.command: >-
-    hypershift destroy cluster aws
+    /usr/bin/hcp destroy cluster aws
       --name {{ ocp4_workload_deploy_hosted_cluster_name }}
       --infra-id {{ ocp4_workload_deploy_hosted_cluster_infra_id }}
       --secret-creds aws-credentials
       --namespace local-cluster
-  register: r_hypershift_destroy
+  register: r_hcp_destroy
   ignore_errors: true
 
 - name: Delete hosted cluster secrets
@@ -85,7 +86,7 @@
 
 # Leave this as the last task in the playbook.
 # --------------------------------------------
-- name: remove_workload tasks complete
+- name: Remove_workload tasks complete
   ansible.builtin.debug:
     msg: "Remove Workload tasks completed successfully."
   when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/tasks/setup_htpasswd_authentication.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/tasks/setup_htpasswd_authentication.yml
@@ -40,7 +40,7 @@
   - name: Generate user passwords array for common password
     ansible.builtin.set_fact:
       _ocp4_workload_deploy_hosted_cluster_user_passwords: >-
-        {{ _ocp4_workload_deploy_hosted_cluster_user_passwords + [ _ocp4_workload_deploy_hosted_cluster_user_password ] }}
+        {{ _ocp4_workload_deploy_hosted_cluster_user_passwords + [_ocp4_workload_deploy_hosted_cluster_user_password] }}
     loop: "{{ range(0, ocp4_workload_deploy_hosted_cluster_user_count, 1) | list }}"
 
 - name: Create temporary htpasswd file
@@ -54,12 +54,14 @@
     path: "{{ r_htpasswd.path }}"
     name: "{{ ocp4_workload_deploy_hosted_cluster_admin_user }}"
     password: "{{ _ocp4_workload_deploy_hosted_cluster_admin_password }}"
+    mode: "0664"
 
 - name: Add users and passwords to htpasswd file
   community.general.htpasswd:
     path: "{{ r_htpasswd.path }}"
     name: "{{ ocp4_workload_deploy_hosted_cluster_user_base }}{{ item + 1 }}"
-    password: "{{ _ocp4_workload_deploy_hosted_cluster_user_passwords[ item ] }}"
+    password: "{{ _ocp4_workload_deploy_hosted_cluster_user_passwords[item] }}"
+    mode: "0664"
   loop: "{{ range(0, ocp4_workload_deploy_hosted_cluster_user_count, 1) | list }}"
 
 - name: Read contents of htpasswd file
@@ -72,7 +74,7 @@
     path: "{{ r_htpasswd.path }}"
     state: absent
 
-- name: Ensure secret htpasswd-{{ guid }} is absent
+- name: Ensure htpasswd secret is absent
   kubernetes.core.k8s:
     state: absent
     api_version: v1
@@ -87,4 +89,4 @@
 - name: Create secret htpasswd-{{ guid }}
   kubernetes.core.k8s:
     state: present
-    definition: "{{ lookup('template', 'secret-htpasswd.yaml.j2' ) | from_yaml }}"
+    definition: "{{ lookup('template', 'secret-htpasswd.yaml.j2') | from_yaml }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/tasks/setup_oauth_certificate.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/tasks/setup_oauth_certificate.yml
@@ -29,4 +29,4 @@
     - r_ingresscontroller_cert.resources[0].data['tls.crt'] is defined
     kubernetes.core.k8s:
       state: present
-      definition: "{{ lookup('template', 'secret-oauth.yaml.j2' ) | from_yaml }}"
+      definition: "{{ lookup('template', 'secret-oauth.yaml.j2') | from_yaml }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_deploy_hosted_cluster/tasks/workload.yml
@@ -3,6 +3,40 @@
   ansible.builtin.debug:
     msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
 
+#############################################################################
+# Prerequisite Checks
+#############################################################################
+
+- name: Ensure RHACM MultiClusterHub is deployed
+  kubernetes.core.k8s_info:
+    api_version: operator.open-cluster-management.io/v1
+    kind: MultiClusterHub
+    name: multiclusterhub
+    namespace: open-cluster-management
+  register: r_rhacm_multiclusterhub
+
+- name: Assert that MultiClusterHub is available
+  ansible.builtin.assert:
+    that:
+    - r_rhacm_multiclusterhub.resources | length == 1
+    - r_rhacm_multiclusterhub.resources[0].status.phase is defined
+    - r_rhacm_multiclusterhub.resources[0].status is defined
+    - r_rhacm_multiclusterhub.resources[0].status.phase == "Running"
+    quiet: true
+    fail_msg: "MultiClusterHub not found on cluster. Can not continue."
+    success_msg: "MultiClusterHub found on cluster. Ready to set up Hypershift."
+
+- name: Assert that MultiClusterHub is version 2.9.0 or higher
+  ansible.builtin.assert:
+    that: "r_rhacm_multiclusterhub.resources[0].status.currentVersion is version('2.9.0', '>=')"
+    quiet: true
+    fail_msg: "MultiClusterHub not at version 2.9.0 or higher. Please upgrade your RHACM. Can not continue."
+    success_msg: "MultiClusterHub found on cluster in version 2.9.0 or higher. Ready to set up Hypershift."
+
+#############################################################################
+# Set up resources on hosting cluster
+#############################################################################
+
 - name: Setup htpasswd authentication
   when: ocp4_workload_deploy_hosted_cluster_authentication | default('none') == 'htpasswd'
   ansible.builtin.include_tasks: setup_htpasswd_authentication.yml
@@ -19,15 +53,19 @@
     namespace: local-cluster
   register: r_hosted_cluster
 
+#############################################################################
+# Deploy hosted cluster
+#############################################################################
+
 - name: Deploy hosted cluster {{ _ocp4_workload_rhacm_hypershift_cluster_name }}
   when: r_hosted_cluster.resources | length == 0
   block:
   # This command expects AWS credentials, base domain, pull secret and SSH keys in
   # secret `aws-credentials` in namespace `local-cluster` as set up by the
   # workload `ocp4_workload_rhacm_hypershift`
-  - name: Run hypershift CLI to deploy hosted cluster
+  - name: Run hcp CLI to deploy hosted cluster
     ansible.builtin.command: >-
-      hypershift create cluster aws
+      /usr/bin/hcp create cluster aws
         --name {{ ocp4_workload_deploy_hosted_cluster_name }}
         --infra-id {{ ocp4_workload_deploy_hosted_cluster_infra_id }}
         --region {{ ocp4_workload_deploy_hosted_cluster_aws_region }}
@@ -44,7 +82,7 @@
         --namespace local-cluster
         --secret-creds aws-credentials
         --auto-repair
-    register: r_hypershift_create_cluster
+    register: r_hcp_create_cluster
 
   - name: Print hypershift command output
     ansible.builtin.debug:
@@ -52,15 +90,15 @@
     loop:
     - "STDOUT:"
     - "--------------------------------------------------------"
-    - "{{ r_hypershift_create_cluster.stdout }}"
+    - "{{ r_hcp_create_cluster.stdout }}"
     - ""
     - "STDERR:"
     - "--------------------------------------------------------"
-    - "{{ r_hypershift_create_cluster.stderr }}"
+    - "{{ r_hcp_create_cluster.stderr }}"
     - "--------------------------------------------------------"
 
   - name: Abort
-    when: r_hypershift_create_cluster.rc > 0
+    when: r_hcp_create_cluster.rc > 0
     ansible.builtin.fail:
       msg: "Cluster creation failed. Aborting."
 
@@ -83,6 +121,10 @@
   ansible.builtin.set_fact:
     _ocp4_workload_deploy_hosted_cluster_console_url: >-
       https://console-openshift-console.apps.{{ ocp4_workload_deploy_hosted_cluster_name }}.{{ ocp4_workload_deploy_hosted_cluster_base_domain }}
+
+#############################################################################
+# Deploy post install configuration
+#############################################################################
 
 - name: Ensure that the policy namespaces exist on the hub
   kubernetes.core.k8s:
@@ -116,6 +158,10 @@
   - clusterresourcequota/managedclustersetbinding.yaml.j2
   - clusterresourcequota/subscription.yaml.j2
   - clusterresourcequota/application.yaml.j2
+
+#############################################################################
+# Save agnosticd information
+#############################################################################
 
 - name: Save common information
   agnosticd_user_info:

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/defaults/main.yml
@@ -3,29 +3,11 @@ become_override: false
 ocp_username: opentlc-mgr
 silent: false
 
+# Minimum required RHACM version is 2.9
+
 ocp4_workload_rhacm_hypershift_s3_bucket_name: "oidc-storage-{{ guid }}"
 ocp4_workload_rhacm_hypershift_s3_bucket_region: us-east-2
 ocp4_workload_rhacm_key_pair_name: hypershift
-
-# Install HyperShift Operator Patch
-# Allows for development images to be deployed. Usually false
-# When set to true make sure all the *_image_sha values are set as well
-ocp4_workload_rhacm_hypershift_hcp_operator_patch: false
-
-# Where to get the images from
-ocp4_workload_rhacm_hypershift_hcp_registry: quay.io/rokejungrh
-ocp4_workload_rhacm_hypershift_hcp_registry_image_tag: "0421"
-
-# Image tags
-ocp4_workload_rhacm_hypershift_apiserver_network_proxy_image_tag: "{{ ocp4_workload_rhacm_hypershift_hcp_registry_image_tag }}"
-ocp4_workload_rhacm_hypershift_aws_encryption_provider_image_tag: "{{ ocp4_workload_rhacm_hypershift_hcp_registry_image_tag }}"
-ocp4_workload_rhacm_hypershift_cluster_api_image_tag: "{{ ocp4_workload_rhacm_hypershift_hcp_registry_image_tag }}"
-ocp4_workload_rhacm_hypershift_cluster_api_provider_agent_image_tag: "{{ ocp4_workload_rhacm_hypershift_hcp_registry_image_tag }}"
-ocp4_workload_rhacm_hypershift_cluster_api_provider_aws_image_tag: "{{ ocp4_workload_rhacm_hypershift_hcp_registry_image_tag }}"
-ocp4_workload_rhacm_hypershift_cluster_api_provider_azure_image_tag: "{{ ocp4_workload_rhacm_hypershift_hcp_registry_image_tag }}"
-ocp4_workload_rhacm_hypershift_cluster_api_provider_kubevirt_image_tag: "{{ ocp4_workload_rhacm_hypershift_hcp_registry_image_tag }}"
-ocp4_workload_rhacm_hypershift_hypershift_cli_image_tag: "{{ ocp4_workload_rhacm_hypershift_hcp_registry_image_tag }}"
-ocp4_workload_rhacm_hypershift_hypershift_operator_image_tag: "{{ ocp4_workload_rhacm_hypershift_hcp_registry_image_tag }}"
 
 # Optionally deploy Hypershift cluster(s)
 # Set to an empty array for none (default)
@@ -47,7 +29,7 @@ ocp4_workload_rhacm_hypershift_deploy_clusters: []
 # ocp4_workload_rhacm_hypershift_deploy_clusters:
 # - name: development
 #   infra_id: dev-{{ guid }}
-#   ocp_release: 4.13.4
+#   ocp_release: 4.14.2
 #   control_plane_availability: SingleReplica
 #   infra_availability: SingleReplica
 #   etcd_storage_class: gp3-csi
@@ -65,7 +47,7 @@ ocp4_workload_rhacm_hypershift_deploy_clusters: []
 
 # - name: production
 #   infra_id: prod-{{ guid }}
-#   ocp_release: 4.12.8
+#   ocp_release: 4.13.11
 #   control_plane_availability: HighlyAvailable
 #   infra_availability: HighlyAvailable
 #   etcd_storage_class: gp3-csi

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/meta/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   role_name: ocp4_workload_rhacm_hypershift
   author: Wolfgang Kulhanek (wkulhane@redhat.com)
   description: |
-    Set up Hypershift on an existing RHACM installation
+    Set up Hypershift on an existing RHACM installation. Minimum required RHACM version is 2.9
   license: MIT
   min_ansible_version: 2.9
   platforms: []
@@ -13,4 +13,5 @@ galaxy_info:
   - acm
   - rhacm
   - hypershift
+  - hcp
 dependencies: []

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/tasks/create_hypershift_cluster.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/tasks/create_hypershift_cluster.yml
@@ -24,9 +24,9 @@
 - name: Deploy hosted cluster {{ _ocp4_workload_rhacm_hypershift_cluster_name }}
   when: r_hosted_cluster.resources | length == 0
   block:
-  - name: Run hypershift CLI to deploy hosted cluster
+  - name: Run hcp CLI to deploy hosted cluster
     ansible.builtin.command: >-
-      /usr/bin/hypershift create cluster aws
+      /usr/bin/hcp create cluster aws
         --name {{ _ocp4_workload_rhacm_hypershift_cluster_name }}
         --infra-id {{ _ocp4_workload_rhacm_hypershift_cluster_infra_id }}
         --region {{ _ocp4_workload_rhacm_hypershift_cluster_region }}
@@ -43,24 +43,15 @@
         --namespace local-cluster
         --secret-creds aws-credentials
         --auto-repair
-    register: r_hypershift_create_cluster
+    register: r_hcp_create_cluster
     ignore_errors: true
 
-  - name: Print hypershift command output
+  - name: Print hcp command output
     ansible.builtin.debug:
-      msg: "{{ item }}"
-    loop:
-    - "STDOUT:"
-    - "--------------------------------------------------------"
-    - "{{ r_hypershift_create_cluster.stdout }}"
-    - ""
-    - "STDERR:"
-    - "--------------------------------------------------------"
-    - "{{ r_hypershift_create_cluster.stderr }}"
-    - "--------------------------------------------------------"
+      msg: "{{ r_hcp_create_cluster.stdout }}"
 
   - name: Abort
-    when: r_hypershift_create_cluster.rc > 0
+    when: r_hcp_create_cluster.rc > 0
     ansible.builtin.fail:
       msg: "Cluster creation failed. Aborting."
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/tasks/workload.yml
@@ -10,7 +10,7 @@
 
 - name: Ensure RHACM MultiClusterHub is deployed
   kubernetes.core.k8s_info:
-    api_version: operator.open-cluster-management.io/v1
+    api_version: "operator.open-cluster-management.io/v1"
     kind: MultiClusterHub
     name: multiclusterhub
     namespace: open-cluster-management
@@ -23,8 +23,16 @@
     - r_rhacm_multiclusterhub.resources[0].status.phase is defined
     - r_rhacm_multiclusterhub.resources[0].status is defined
     - r_rhacm_multiclusterhub.resources[0].status.phase == "Running"
+    # quiet: true
     fail_msg: "MultiClusterHub not found on cluster. Can not continue."
     success_msg: "MultiClusterHub found on cluster. Ready to set up Hypershift."
+
+- name: Assert that MultiClusterHub is version 2.9.0 or higher
+  ansible.builtin.assert:
+    that: "r_rhacm_multiclusterhub.resources[0].status.currentVersion is version('2.9.0', '>=')"
+    quiet: true
+    fail_msg: "MultiClusterHub not at version 2.9.0 or higher. Please upgrade your RHACM. Can not continue."
+    success_msg: "MultiClusterHub found on cluster in version 2.9.0 or higher. Ready to set up Hypershift."
 
 #############################################################################
 # AWS S3 bucket setup
@@ -72,34 +80,26 @@
 #############################################################################
 # Enable HyperShift Tech Preview
 #############################################################################
-- name: Enable HyperShift Tech Preview
-  kubernetes.core.k8s:
-    state: patched
-    api_version: multicluster.openshift.io/v1
-    kind: MultiClusterEngine
-    name: multiclusterengine
-    definition:
-      spec:
-        overrides:
-          components:
-          - name: hypershift-preview
-            enabled: true
-          - name: hypershift-local-hosting
-            enabled: true
 
-- name: Create ManagedClusterAddon
-  kubernetes.core.k8s:
-    state: present
-    definition: "{{ lookup('file', 'managedclusteraddon.yaml') }}"
+# - name: Enable HyperShift Tech Preview
+#   kubernetes.core.k8s:
+#     state: patched
+#     api_version: multicluster.openshift.io/v1
+#     kind: MultiClusterEngine
+#     name: multiclusterengine
+#     definition:
+#       spec:
+#         overrides:
+#           components:
+#           - name: hypershift-preview
+#             enabled: true
+#           - name: hypershift-local-hosting
+#             enabled: true
 
-#############################################################################
-# Patch Hypershift Images (workaround until S3 patch made it into product)
-#############################################################################
-- name: Patch Hypershift Images
-  when: ocp4_workload_rhacm_hypershift_hcp_operator_patch | bool
-  kubernetes.core.k8s:
-    state: present
-    definition: "{{ lookup('template', 'hypershift-override-images.yaml.j2') }}"
+# - name: Create ManagedClusterAddon
+#   kubernetes.core.k8s:
+#     state: present
+#     definition: "{{ lookup('file', 'managedclusteraddon.yaml') }}"
 
 #############################################################################
 # Configure HyperShift
@@ -131,106 +131,88 @@
     definition: "{{ lookup('template', 'secret-aws-credentials.yaml.j2') }}"
 
 #############################################################################
-# Install Hypershift CLI
+# Install HCP CLI
 #############################################################################
 
-- name: Wait until Hypershift CLI download deployment is ready
+- name: Wait until HCP CLI download deployment is ready
   kubernetes.core.k8s_info:
     api_version: v1
     kind: Deployment
     namespace: multicluster-engine
-    name: hypershift-cli-download
-  register: r_hypershift_cli_deployment
+    name: hcp-cli-download
+  register: r_hcp_cli_deployment
   retries: 60
   delay: 30
   until:
-  - r_hypershift_cli_deployment.resources | length | int > 0
-  - r_hypershift_cli_deployment.resources[0].status.readyReplicas is defined
-  - r_hypershift_cli_deployment.resources[0].status.readyReplicas | int == r_hypershift_cli_deployment.resources[0].spec.replicas | int
+  - r_hcp_cli_deployment.resources | length | int > 0
+  - r_hcp_cli_deployment.resources[0].status.readyReplicas is defined
+  - r_hcp_cli_deployment.resources[0].status.readyReplicas | int == r_hcp_cli_deployment.resources[0].spec.replicas | int
 
-- name: Get Hypershift CLI download URl
+- name: Get HCP CLI download URL
   kubernetes.core.k8s_info:
     api_version: console.openshift.io/v1
     kind: ConsoleCLIDownload
-    name: hypershift-cli-download
-  register: r_hypershift_cli_download
+    name: hcp-cli-download
+  register: r_hcp_cli_download
   retries: 20
   delay: 10
-  until: r_hypershift_cli_download.resources | length > 0
+  until: r_hcp_cli_download.resources | length > 0
 
-- name: Set Hypershift CLI download URL
-  when: r_hypershift_cli_download.resources | length > 0
+- name: Set HCP CLI download URL
+  when: r_hcp_cli_download.resources | length > 0
   ansible.builtin.set_fact:
-    _ocp4_workload_rhacm_hypershift_cli_url: >-
-      {{ r_hypershift_cli_download.resources[0] | to_json | from_json
+    _ocp4_workload_rhacm_hcp_cli_url: >-
+      {{ r_hcp_cli_download.resources[0] | to_json | from_json
       | json_query("spec.links[?contains(href,'/linux/amd64')].href") | first }}
 
-- name: Download Hypershift CLI tool
+- name: Download HCP CLI
   ansible.builtin.get_url:
-    url: "{{ _ocp4_workload_rhacm_hypershift_cli_url }}"
+    url: "{{ _ocp4_workload_rhacm_hcp_cli_url }}"
     validate_certs: false
-    dest: /tmp/hypershift.tar.gz
+    dest: /tmp/hcp.tar.gz
     mode: 0660
-  register: r_hypershift_cli
-  until: r_hypershift_cli is success
+  register: r_hcp_cli
+  until: r_hcp_cli is success
   retries: 10
   delay: 10
 
-- name: Get currently installed RHACM version
-  kubernetes.core.k8s_info:
-    api_version: operators.coreos.com/v1alpha1
-    kind: ClusterServiceVersion
-    namespace: open-cluster-management
-    label_selectors:
-    - "operators.coreos.com/advanced-cluster-management.open-cluster-management ="
-  register: r_rhacm_csv
+# - name: Get currently installed RHACM version
+#   kubernetes.core.k8s_info:
+#     api_version: operators.coreos.com/v1alpha1
+#     kind: ClusterServiceVersion
+#     namespace: open-cluster-management
+#     label_selectors:
+#     - "operators.coreos.com/advanced-cluster-management.open-cluster-management ="
+#   register: r_rhacm_csv
 
-# Strip first 5 directories if RHACM is 2.7 or earlier
-# Archive contains `remote-source/app/bin/linux/amd64/hypershift`
-- name: Install Hypershift CLI on bastion (RHACM 2.7 or earlier)
-  when: r_rhacm_csv.resources[0].spec.version is version_compare('2.8.0', '<')
+- name: Install HCP CLI on bastion
   become: true
   ansible.builtin.unarchive:
-    src: /tmp/hypershift.tar.gz
+    src: /tmp/hcp.tar.gz
     remote_src: true
     dest: /usr/bin
-    mode: 0775
-    owner: root
-    group: root
-    extra_opts:
-      --strip-components=5
-  args:
-    creates: /usr/bin/hypershift
-
-# Regular extract if RHACM is 2.8 or newser
-# Archive contains `./hypershift`
-- name: Install Hypershift CLI on bastion (RHACM 2.8 or newer)
-  when: r_rhacm_csv.resources[0].spec.version is version_compare('2.8.0', '>=')
-  become: true
-  ansible.builtin.unarchive:
-    src: /tmp/hypershift.tar.gz
-    remote_src: true
-    dest: /usr/bin
-    mode: 0775
+    mode: "0775"
     owner: root
     group: root
   args:
-    creates: /usr/bin/hypershift
+    creates: /usr/bin/hcp
 
 - name: Remove downloaded file
   ansible.builtin.file:
     state: absent
-    path: /tmp/hypershift.tar.gz
+    path: /tmp/hcp.tar.gz
 
-- name: Setup hypershift bash completion
+- name: Setup HCP CLI bash completion
   become: true
-  ansible.builtin.shell: "/usr/bin/hypershift completion bash >/etc/bash_completion.d/hypershift"
+  ansible.builtin.shell: "/usr/bin/hcp completion bash >/etc/bash_completion.d/hcp"
   args:
-    creates: /etc/bash_completion.d/hypershift
+    creates: /etc/bash_completion.d/hcp
 
 #############################################################################
 # Set up RHDP Configuration
+# Automatically configure newly deployed HCP clusters
 #############################################################################
+
 - name: Set up RHDP Configuration
   when: ocp4_workload_rhacm_hypershift_rhdp_policies_setup | bool
   kubernetes.core.k8s:
@@ -251,6 +233,7 @@
 #############################################################################
 # Set up ManagedClusterSet Policies
 #############################################################################
+
 - name: Set up ManagedClusterSet
   when: ocp4_workload_rhacm_hypershift_managed_cluster_set_setup | bool
   kubernetes.core.k8s:
@@ -260,6 +243,24 @@
   - managedclusterset/namespace-submariner-broker.yaml.j2
   - managedclusterset/managedclusterset.yaml.j2
   - managedclusterset/managedclustersetbinding.yaml.j2
+
+#############################################################################
+# Wait for ConfigMap kube-public/oidc-storage-provider-s3-config to be
+# available before proceeding
+#############################################################################
+
+- name: Wait for ConfigMap kube-public/oidc-storage-provider-s3-config
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: ConfigMap
+    name: oidc-storage-provider-s3-config
+    namespace: kube-public
+  register: r_oidc_configmap
+  until:
+  - r_oidc_configmap.resources is defined
+  - r_oidc_configmap.resources | length > 0
+  retries: 60
+  delay: 10
 
 #############################################################################
 # Deploy managed HyperShift clusters


### PR DESCRIPTION
##### SUMMARY

Update workload rhacm_hypershift to support (and require) RHACM 2.9.

This will break the following AgnosticV configs:
- POC_HYPERSHIFT_GITOPS
- HANDS_ON_OCP_PLUS_WKSP
- OCP4_ACM_HYPERSHIFT (I own that and will update)

A new tag for those configs will require updating the clusters to OCP 4.14 and RHACM 2.9.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_rhacm_hypershift