### PR TITLE
Azure support for Showroom OCP, and shared cluster support:wq

### DIFF
--- a/ansible/cloud_providers/azure_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/azure_infrastructure_deployment.yml
@@ -154,7 +154,9 @@
           - "bastion_password: {{ generated_password }}"
         data:
           bastion_ssh_command: "ssh {{ remote_user }}@bastion.{{ guid }}.{{ cluster_dns_zone }}"
-          bastion_password: "{{ generated_password }}"
+          bastion_public_hostname: "bastion.{{ guid }}.{{ cluster_dns_zone }}"
+          bastion_ssh_password: "{{ generated_password }}"
+          bastion_ssh_user_name: "{{ remote_user }}"
           common_password: "{{ generated_password }}"
           ssh_password: "{{ generated_password }}"
           ssh_username: "{{ remote_user }}"

--- a/ansible/configs/open-environment-azure-subscription/README.adoc
+++ b/ansible/configs/open-environment-azure-subscription/README.adoc
@@ -3,6 +3,10 @@
 This config will allocate a pre-configured Azure subscription to a user on demand and grant the 'Contributor'
 role.
 
+== Some helpful variables:
+
+`azure_vm_rhel_sku: "9_3"`: sets the version of RHEL to deploy
+
 == Running the Ansible Playbook
 
 You can run the playbook with the following arguments to overwrite the default variable values:

--- a/ansible/configs/open-environment-azure-subscription/default_vars.yml
+++ b/ansible/configs/open-environment-azure-subscription/default_vars.yml
@@ -100,6 +100,7 @@ rhel_vm_size: Standard_DS1_v2
 rhel_publisher: RedHat
 rhel_offer: RHEL
 rhel_sku: "9_1"
+azure_bastion_rhel_sku: "{{ rhel_sku }}"
 rhel_version: latest
 # Only set plan info if you actually need it
 #rhel_plan_name: ""

--- a/ansible/configs/open-environment-azure-subscription/post_software.yml
+++ b/ansible/configs/open-environment-azure-subscription/post_software.yml
@@ -136,8 +136,10 @@
           azure_service_principal_id: "{{ azapp.applications[0].app_id }}"
           azure_service_principal_password: "{{ azpass }}"
           azure_tenant_id: "{{ azure_tenant }}"
-          bastion_password: "{{ generated_password }}"
           bastion_ssh_command: "ssh {{ remote_user }}@bastion.{{ guid }}.{{ cluster_dns_zone }}"
+          bastion_public_hostname: "bastion.{{ guid }}.{{ cluster_dns_zone }}"
+          bastion_ssh_user_name: "ssh {{ remote_user }}"
+          bastion_ssh_password: "{{ generated_password }}"
           generated_password: "{{ generated_password }}"
           guid: "{{ guid }}"
 
@@ -147,7 +149,9 @@
       agnosticd_user_info:
         data:
           bastion_ssh_command: "ssh {{ remote_user }}@bastion.{{ guid }}.{{ azure_root_dns_zone }}"
-          bastion_password: "{{ generated_password }}"
+          bastion_public_hostname: "bastion.{{ guid }}.{{ cluster_dns_zone }}"
+          bastion_ssh_user_name: "{{ remote_user }}"
+          bastion_ssh_password: "{{ generated_password }}"
 
 - name: Showroom Install
   hosts: bastions
@@ -155,28 +159,13 @@
   become: true
   tasks:
     - name: Deploy Showroom
+      when: showroom_deploy | default(false) | bool
       vars:
         showroom_host: "bastion.{{ guid }}.{{ azure_root_dns_zone }}"
         showroom_component_name: "aro-ilt"
         generated_password: "{{ hostvars['localhost']['generated_password'] }}"
-      when: showroom_deploy | default(false) | bool
       include_role:
         name: showroom
-
-- name: Bookbag
-  hosts: localhost
-  connection: local
-  gather_facts: false
-  become: false
-  environment:
-    KUBECONFIG: "{{ output_dir }}/.kube/config"
-  tasks:
-    - name: Deploy Bookbag
-      when: deploy_bookbag | bool
-      include_role:
-        name: bookbag
-      vars:
-        ACTION: create
 
 - name: Step 002 Post Software
   hosts: localhost

--- a/ansible/configs/open-environment-azure-subscription/post_software.yml
+++ b/ansible/configs/open-environment-azure-subscription/post_software.yml
@@ -154,18 +154,13 @@
           bastion_ssh_password: "{{ generated_password }}"
 
 - name: Showroom Install
-  hosts: bastions
   gather_facts: false
   become: true
   tasks:
     - name: Deploy Showroom
-      when: showroom_deploy | default(false) | bool
-      vars:
-        showroom_host: "bastion.{{ guid }}.{{ azure_root_dns_zone }}"
-        showroom_component_name: "aro-ilt"
-        generated_password: "{{ hostvars['localhost']['generated_password'] }}"
+      when: showroom_deploy_shared_cluster_enable | default(false) | bool
       include_role:
-        name: showroom
+        name: ocp4_workload_showroom
 
 - name: Step 002 Post Software
   hosts: localhost

--- a/ansible/configs/open-environment-azure-subscription/post_software.yml
+++ b/ansible/configs/open-environment-azure-subscription/post_software.yml
@@ -153,10 +153,6 @@
           bastion_ssh_user_name: "{{ remote_user }}"
           bastion_ssh_password: "{{ generated_password }}"
 
-- name: Showroom Install
-  gather_facts: false
-  become: true
-  tasks:
     - name: Deploy Showroom
       when: showroom_deploy_shared_cluster_enable | default(false) | bool
       include_role:

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/README.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/README.adoc
@@ -1,0 +1,47 @@
+== Deploying OpenShift and want Showroom deployed on it?
+
+. Add the ocp4_workload_showroom infra role to your CI:
+
+[source,yaml]
+====
+infra_workloads:
+[ ... all your other infra roles ... ]
+- ocp4_workload_showroom
+====
+
+== Which repo of antora and asciidoc to deploy
+
+[source,yaml]
+====
+ocp4_workload_showroom_content_git_repo: "https://github.com/rhpds/showroom_template_default.git"
+====
+
+== Enable Bastion Auto-SSH in your env_type/config
+
+. Make sure your env_type/config puts the following in user_data:
+
+.Example
+[source,yaml]
+====
+    - name: Provide installed bastion data
+      agnosticd_user_info:
+        data:
+          bastion_ssh_command: "ssh {{ remote_user }}@bastion.{{ guid }}.{{ azure_root_dns_zone }}"
+          bastion_public_hostname: "bastion.{{ guid }}.{{ cluster_dns_zone }}"
+          bastion_ssh_user_name: "{{ remote_user }}"
+          bastion_ssh_password: "{{ generated_password }}"
+
+====
+
+
+== No OCP installed in your env_type/config?
+
+. Add the following to your config's post_software.yml
+
+[source,yaml]
+====
+    - name: Deploy Showroom
+      when: showroom_deploy_shared_cluster_enable | default(false) | bool
+      include_role:
+        name: ocp4_workload_showroom
+====

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/README.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/README.adoc
@@ -1,4 +1,12 @@
-== Deploying OpenShift and want Showroom deployed on it?
+= Showroom for OCP
+
+* one or multiple OpenShift users.
+* deploy the showroom helm chart https://github.com/rhpds/showroom-deployer/charts/showroom
+* If Argo CD is present, it will deploy via Application or ApplicationSet from templated manifests in this role.
+* If Argo CD is NOT present, it will deploy the Helm chart.
+* deploys to your cluster or the shared cluster
+
+== Are you deploying OpenShift and want Showroom deployed on it?
 
 . Add the ocp4_workload_showroom infra role to your CI:
 
@@ -6,10 +14,10 @@
 ====
 infra_workloads:
 [ ... all your other infra roles ... ]
-- ocp4_workload_showroom
+- ocp4_workload_showroom   # last
 ====
 
-== Which repo of antora and asciidoc to deploy
+== Which "showroom" repo of antora and asciidoc to deploy?
 
 [source,yaml]
 ====
@@ -18,30 +26,49 @@ ocp4_workload_showroom_content_git_repo: "https://github.com/rhpds/showroom_temp
 
 == Enable Bastion Auto-SSH in your env_type/config
 
-. Make sure your env_type/config puts the following in user_data:
+. Make sure your env_type/config puts the following values in user_data:
 
 .Example
 [source,yaml]
 ====
-    - name: Provide installed bastion data
-      agnosticd_user_info:
-        data:
-          bastion_ssh_command: "ssh {{ remote_user }}@bastion.{{ guid }}.{{ azure_root_dns_zone }}"
-          bastion_public_hostname: "bastion.{{ guid }}.{{ cluster_dns_zone }}"
-          bastion_ssh_user_name: "{{ remote_user }}"
-          bastion_ssh_password: "{{ generated_password }}"
 
+- name: Provide installed bastion data
+  agnosticd_user_info:
+    data:
+      bastion_ssh_command: "ssh {{ remote_user }}@bastion.{{ guid }}.{{ azure_root_dns_zone }}"
+      bastion_public_hostname: "bastion.{{ guid }}.{{ cluster_dns_zone }}"
+      bastion_ssh_user_name: "{{ remote_user }}"
+      bastion_ssh_password: "{{ generated_password }}"
 ====
 
+NOTE: Key based authentication is TODO
 
-== No OCP installed in your env_type/config?
+== Deploying showroom to the shared cluster
 
-. Add the following to your config's post_software.yml
+Are you not deploying OpenShift with your config/env_type ?
 
+. Add the following to your config/env-type's post_software.yml.
+It needs a bation, afaict.
+
+.`config/env_type/post_software.yml`
 [source,yaml]
 ====
     - name: Deploy Showroom
       when: showroom_deploy_shared_cluster_enable | default(false) | bool
       include_role:
         name: ocp4_workload_showroom
+====
+
+. Add the following to AgnosticV
+
+.AgnosticV
+[source,yaml]
+====
+#include /includes/secrets/showroom-shared-410.yaml <1>
+
+# --------------------------------------------------------------------
+# Showroom
+# --------------------------------------------------------------------
+showroom_deploy_shared_cluster_enable: true <2>
+ocp4_workload_showroom_content_git_repo: https://github.com/rhpds/showroom_template_default.git
 ====

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/defaults/main.yaml
@@ -16,7 +16,7 @@ ocp4_workload_showroom_deployer_chart_repo_revision: "main"
 ocp4_workload_showroom_deployer_chart_repo_path: "charts/showroom"
 ocp4_workload_showroom_deployer_chart_version: '0.2.0'
 
-ocp4_workload_showroom_auto_ssh_bastion_login_enable: true
+ocp4_workload_showroom_auto_ssh_bastion_login_enable: false
 
 ocp4_workload_showroom_image_name: "showroom-{{ guid | default('00') }}"
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/pre_workload.yml
@@ -4,9 +4,9 @@
 
 - name: If deploying to a remote OCP write kubeconfig if requested
   when:
-    - ocp4_workload_showroom_openshift_api_ca_cert is defined
-    - ocp4_workload_showroom_openshift_api_token is defined
-    - ocp4_workload_showroom_openshift_api_url is defined
+    - showroom_openshift_api_ca_cert is defined
+    - showroom_openshift_api_token is defined
+    - showroom_openshift_api_url is defined
   block:
     - name: Create temporary file for kubeconfig
       ansible.builtin.tempfile:
@@ -26,8 +26,8 @@
           clusters:
           - name: cluster
             cluster:
-              server: {{ ocp4_workload_showroom_openshift_api_url | to_json }}
-              certificate-authority-data: {{ ocp4_workload_showroom_openshift_api_ca_cert | b64encode | to_json }}
+              server: {{ showroom_openshift_api_url | to_json }}
+              certificate-authority-data: {{ showroom_openshift_api_ca_cert | b64encode | to_json }}
           contexts:
           - name: context
             context:
@@ -37,7 +37,7 @@
           users:
           - name: user
             user:
-              token: {{ ocp4_workload_showroom_openshift_api_token | to_json }}
+              token: {{ showroom_openshift_api_token | to_json }}
 
 - name: Prepare Generic Variables
   ansible.builtin.include_tasks: prepare-variables.yaml


### PR DESCRIPTION
- make bastion autologin false by default
- add bastion user_data to match ocp4_workload_showroom
- launch showroom on the shared cluster
- move run showroom stanza to localhost
- fix names of showroom_openshift_api_ vars
- start readme
- add more human readable value for rhel_sku, azure_bastion_rhel_sku
- azure subs readme improvments
- First proper showroom readme
