### PR TITLE
Fixes some tasks not moved to remote for 5gran

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/workload.yml
@@ -305,7 +305,7 @@
 # Configure AAP2 while SNO1 gets installed
 
 - name: Download manifest file
-  delegate_to: localhost
+#  delegate_to: localhost
   ansible.builtin.get_url:
     url: "{{ controller_manifest.url }}"
     dest: /tmp/aap_manifest.zip
@@ -340,13 +340,13 @@
     # yamllint enable rule:line-length
 
 - name: Ensure manifest file is deleted
-  delegate_to: localhost
+#  delegate_to: localhost
   ansible.builtin.file:
     path: /tmp/aap_manifest.zip
     state: absent
 
 - name: Ensure folder for AutomationController configs exists
-  delegate_to: localhost
+#  delegate_to: localhost
   ansible.builtin.file:
     path: /tmp/aap2configs/{{ item }}
     state: directory
@@ -363,7 +363,7 @@
     - "user_roles"
 
 - name: Ensure AutomationController configs are downloaded
-  delegate_to: localhost
+#  delegate_to: localhost
   ansible.builtin.get_url:
     url: "{{ item.url }}"
     dest: "{{ item.destination }}"
@@ -489,7 +489,7 @@
   delay: 10
 
 - name: Ensure folder for AutomationController configs is deleted
-  delegate_to: localhost
+#  delegate_to: localhost
   ansible.builtin.file:
     path: /tmp/aap2configs/
     state: absent


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes some tasks that were still being delegated to localhost.
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4_workload_5gran_deployments_lab
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
