### PR TITLE
Adds some changes to try get aap2 config working from aap2 ee

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/defaults/main.yml
@@ -28,6 +28,7 @@ lab_url: "https://labs.sysdeseng.com/5g-ran-deployments-on-ocp-lab/{{ ocp4_major
 # yamllint enable rule:line-length
 aap2_webconsole_user: "admin"
 aap2_automationactrl_url: "https://automation-aap.apps.hub.5g-deployment.lab"
+aap2_automationactrl_hostname: "automation-aap.apps.hub.5g-deployment.lab"
 # yamllint disable rule:line-length
 etc_hosts_records: "infra.5g-deployment.lab api.hub.5g-deployment.lab multicloud-console.apps.hub.5g-deployment.lab console-openshift-console.apps.hub.5g-deployment.lab oauth-openshift.apps.hub.5g-deployment.lab openshift-gitops-server-openshift-gitops.apps.hub.5g-deployment.lab assisted-service-multicluster-engine.apps.hub.5g-deployment.lab automation-hub-aap.apps.hub.5g-deployment.lab automation-aap.apps.hub.5g-deployment.lab api.sno1.5g-deployment.lab api.sno2.5g-deployment.lab"
 # yamllint enable rule:line-length

--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/workload.yml
@@ -1,6 +1,14 @@
 ---
 # Implement your Workload deployment tasks here
 
+# This is required for the aap2 to be able to connect to the
+# aap controller by using the local hostname
+- name: Set name resolution for the automation controller
+  delegate_to: localhost
+  ansible.builtin.lineinfile:
+    path: /etc/hosts
+    line: "{{ hypervisor_public_ip }} {{ aap2_automationactrl_hostname }}"
+
 - name: Ensure hub cluster is deployed via kcli
   ansible.builtin.shell:
     cmd: kcli create cluster openshift --pf hub.yml -P force=true
@@ -305,7 +313,7 @@
 # Configure AAP2 while SNO1 gets installed
 
 - name: Download manifest file
-#  delegate_to: localhost
+  delegate_to: localhost
   ansible.builtin.get_url:
     url: "{{ controller_manifest.url }}"
     dest: /tmp/aap_manifest.zip
@@ -327,8 +335,8 @@
 - name: Ensure Controller License is loaded
   ansible.builtin.include_role:
     name: infra.controller_configuration.license
-#    apply:
-#      delegate_to: localhost
+    apply:
+      delegate_to: localhost
   vars:
     controller_license:
       manifest_file: /tmp/aap_manifest.zip
@@ -340,13 +348,13 @@
     # yamllint enable rule:line-length
 
 - name: Ensure manifest file is deleted
-#  delegate_to: localhost
+  delegate_to: localhost
   ansible.builtin.file:
     path: /tmp/aap_manifest.zip
     state: absent
 
 - name: Ensure folder for AutomationController configs exists
-#  delegate_to: localhost
+  delegate_to: localhost
   ansible.builtin.file:
     path: /tmp/aap2configs/{{ item }}
     state: directory
@@ -363,7 +371,7 @@
     - "user_roles"
 
 - name: Ensure AutomationController configs are downloaded
-#  delegate_to: localhost
+  delegate_to: localhost
   ansible.builtin.get_url:
     url: "{{ item.url }}"
     dest: "{{ item.destination }}"
@@ -396,8 +404,8 @@
 - name: Ensure Controller configs are read
   ansible.builtin.include_role:
     name: infra.controller_configuration.filetree_read
-#    apply:
-#      delegate_to: localhost
+    apply:
+      delegate_to: localhost
   vars:
     filetree_controller_settings: "/tmp/aap2configs"
     filetree_controller_organizations: "/tmp/aap2configs"
@@ -459,7 +467,7 @@
   ansible.builtin.include_role:
     name: infra.controller_configuration.dispatch
     apply:
-#      delegate_to: localhost
+      delegate_to: localhost
       ignore_errors: "{{ item }}"
   vars:
     controller_configuration_projects_async_retries: 120
@@ -489,7 +497,7 @@
   delay: 10
 
 - name: Ensure folder for AutomationController configs is deleted
-#  delegate_to: localhost
+  delegate_to: localhost
   ansible.builtin.file:
     path: /tmp/aap2configs/
     state: absent


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Adds the changes required to make aap2 ee be able to reach our controller using a DNS entry in /etc/hosts

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4_workload_5gran_deployments_lab
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
