### PR TITLE
host-ocp4-provisioner: Install AWS v2

### DIFF
--- a/ansible/roles/host-ocp4-provisioner/tasks/ec2_prereqs.yml
+++ b/ansible/roles/host-ocp4-provisioner/tasks/ec2_prereqs.yml
@@ -2,28 +2,28 @@
 
 - name: Get awscli bundle
   get_url:
-    url: https://s3.amazonaws.com/aws-cli/{{ aws_cli_bundle_filename }}
-    dest: /tmp/awscli-bundle.zip
+    url: https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip
+    dest: /tmp/awscliv2.zip
 
-- name: Unzip {{ aws_cli_bundle_filename }}
+- name: Unzip awscliv2.zip
   unarchive:
-    src: /tmp/awscli-bundle.zip
+    src: /tmp/awscliv2.zip
     dest: /tmp/
     remote_src: true
 
 - name: Install awscli
   become: true
-  command: /tmp/awscli-bundle/install -i /usr/local/aws -b /bin/aws
+  command: /tmp/aws/install
   args:
-    creates: /usr/local/aws
+    creates: /usr/local/bin/aws
 
 - name: cleanup archive and tmp files
   file:
     path: "{{ item }}"
     state: absent
   loop:
-    - /tmp/awscli-bundle
-    - /tmp/{{ aws_cli_bundle_filename }}
+    - /tmp/aws
+    - /tmp/awscliv2.zip
 
 - name: Create .aws directory
   become: false


### PR DESCRIPTION
Use the new V2 bundle instead of pip to install AWS

Fix the issue:

```
TASK [host-ocp4-provisioner : Install awscli] **********************************
fatal: [shared-414bastion.shared-414.internal]: FAILED! => {"changed": true, "cmd": ["/tmp/awscli-bundle/install", "-i", "/usr/local/aws", "-b", "/bin/aws"], "delta": "0:00:05.002540", "end": "2023-11-24 12:52:29.732703", "msg": "non-zero return code", "rc": 1, "start": "2023-11-24 12:52:24.730163", "stderr": "Traceback (most recent call last):\n  File \"/tmp/awscli-bundle/install\", line 257, in <module>\n    main()\n  File \"/tmp/awscli-bundle/install\", line 237, in main\n    pip_install_packages(opts.install_dir)\n  File \"/tmp/awscli-bundle/install\", line 147, in pip_install_packages\n    _install_setup_deps(python, '.')\n  File \"/tmp/awscli-bundle/install\", line 166, in _install_setup_deps\n    run(\n  File \"/tmp/awscli-bundle/install\", line 87, in run\n    raise BadRCError(\"Bad rc (%s) for cmd '%s': %s\" % (\n__main__.BadRCError: Bad rc (2) for cmd '/usr/local/aws/bin/python -m pip install --no-binary :all: --no-cache-dir --no-index --find-links file://. setuptools_scm-3.3.3.tar.gz': Looking in links: file://.\nProcessing ./setuptools_scm-3.3.3.tar.gz\nERROR: Exception:\nTraceback (most recent call last):\n  File \"/usr/local/aws/lib64/python3.9/site-packages/pip/_internal/utils/unpacking.py\", line 198, in untar_file\n    tarfile.data_filter(member.replace(name=fn), location)\nAttributeError: module 'tarfile' has no attribute 'data_filter'\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"/usr/local/aws/lib64/python3.9/site-packages/pip/_internal/cli/base_command.py\", line 173, in _main\n    status = self.run(options, args)\n  File \"/usr/local/aws/lib64/python3.9/site-packages/pip/_internal/cli/req_command.py\", line 203, in wrapper\n    return func(self, options, args)\n  File \"/usr/local/aws/lib64/python3.9/site-packages/pip/_internal/commands/install.py\", line 315, in run\n    requirement_set = resolver.resolve(\n  File \"/usr/local/aws/lib64/python3.9/site-packages/pip/_internal/resolution/resolvelib/resolver.py\", line 75, in resolve\n    collected = self.factory.collect_root_requirements(root_reqs)\n  File \"/usr/local/aws/lib64/python3.9/site-packages/pip/_internal/resolution/resolvelib/factory.py\", line 474, in collect_root_requirements\n    req = self._make_requirement_from_install_req(\n  File \"/usr/local/aws/lib64/python3.9/site-packages/pip/_internal/resolution/resolvelib/factory.py\", line 436, in _make_requirement_from_install_req\n    cand = self._make_candidate_from_link(\n  File \"/usr/local/aws/lib64/python3.9/site-packages/pip/_internal/resolution/resolvelib/factory.py\", line 207, in _make_candidate_from_link\n    self._link_candidate_cache[link] = LinkCandidate(\n  File \"/usr/local/aws/lib64/python3.9/site-packages/pip/_internal/resolution/resolvelib/candidates.py\", line 295, in __init__\n    super().__init__(\n  File \"/usr/local/aws/lib64/python3.9/site-packages/pip/_internal/resolution/resolvelib/candidates.py\", line 156, in __init__\n    self.dist = self._prepare()\n  File \"/usr/local/aws/lib64/python3.9/site-packages/pip/_internal/resolution/resolvelib/candidates.py\", line 227, in _prepare\n    dist = self._prepare_distribution()\n  File \"/usr/local/aws/lib64/python3.9/site-packages/pip/_internal/resolution/resolvelib/candidates.py\", line 305, in _prepare_distribution\n    return self._factory.preparer.prepare_linked_requirement(\n  File \"/usr/local/aws/lib64/python3.9/site-packages/pip/_internal/operations/prepare.py\", line 508, in prepare_linked_requirement\n    return self._prepare_linked_requirement(req, parallel_builds)\n  File \"/usr/local/aws/lib64/python3.9/site-packages/pip/_internal/operations/prepare.py\", line 550, in _prepare_linked_requirement\n    local_file = unpack_url(\n  File \"/usr/local/aws/lib64/python3.9/site-packages/pip/_internal/operations/prepare.py\", line 249, in unpack_url\n    unpack_file(file.path, location, file.content_type)\n  File \"/usr/local/aws/lib64/python3.9/site-packages/pip/_internal/utils/unpacking.py\", line 263, in unpack_file\n    untar_file(filename, location)\n  File \"/usr/local/aws/lib64/python3.9/site-packages/pip/_internal/utils/unpacking.py\", line 199, in untar_file\n    except tarfile.LinkOutsideDestinationError:\nAttributeError: module 'tarfile' has no attribute 'LinkOutsideDestinationError'", "stderr_lines": ["Traceback (most recent call last):", "  File \"/tmp/awscli-bundle/install\", line 257, in <module>", "    main()", "  File \"/tmp/awscli-bundle/install\", line 237, in main", "    pip_install_packages(opts.install_dir)", "  File \"/tmp/awscli-bundle/install\", line 147, in pip_install_packages", "    _install_setup_deps(python, '.')", "  File \"/tmp/awscli-bundle/install\", line 166, in _install_setup_deps", "    run(", "  File \"/tmp/awscli-bundle/install\", line 87, in run", "    raise BadRCError(\"Bad rc (%s) for cmd '%s': %s\" % (", "__main__.BadRCError: Bad rc (2) for cmd '/usr/local/aws/bin/python -m pip install --no-binary :all: --no-cache-dir --no-index --find-links file://. setuptools_scm-3.3.3.tar.gz': Looking in links: file://.", "Processing ./setuptools_scm-3.3.3.tar.gz", "ERROR: Exception:", "Traceback (most recent call last):", "  File \"/usr/local/aws/lib64/python3.9/site-packages/pip/_internal/utils/unpacking.py\", line 198, in untar_file", "    tarfile.data_filter(member.replace(name=fn), location)", "AttributeError: module 'tarfile' has no attribute 'data_filter'", "", "During handling of the above exception, another exception occurred:", "", "Traceback (most recent call last):", "  File \"/usr/local/aws/lib64/python3.9/site-packages/pip/_internal/cli/base_command.py\", line 173, in _main", "    status = self.run(options, args)", "  File \"/usr/local/aws/lib64/python3.9/site-packages/pip/_internal/cli/req_command.py\", line 203, in wrapper", "    return func(self, options, args)", "  File \"/usr/local/aws/lib64/python3.9/site-packages/pip/_internal/commands/install.py\", line 315, in run", "    requirement_set = resolver.resolve(", "  File \"/usr/local/aws/lib64/python3.9/site-packages/pip/_internal/resolution/resolvelib/resolver.py\", line 75, in resolve", "    collected = self.factory.collect_root_requirements(root_reqs)", "  File \"/usr/local/aws/lib64/python3.9/site-packages/pip/_internal/resolution/resolvelib/factory.py\", line 474, in collect_root_requirements", "    req = self._make_requirement_from_install_req(", "  File \"/usr/local/aws/lib64/python3.9/site-packages/pip/_internal/resolution/resolvelib/factory.py\", line 436, in _make_requirement_from_install_req", "    cand = self._make_candidate_from_link(", "  File \"/usr/local/aws/lib64/python3.9/site-packages/pip/_internal/resolution/resolvelib/factory.py\", line 207, in _make_candidate_from_link", "    self._link_candidate_cache[link] = LinkCandidate(", "  File \"/usr/local/aws/lib64/python3.9/site-packages/pip/_internal/resolution/resolvelib/candidates.py\", line 295, in __init__", "    super().__init__(", "  File \"/usr/local/aws/lib64/python3.9/site-packages/pip/_internal/resolution/resolvelib/candidates.py\", line 156, in __init__", "    self.dist = self._prepare()", "  File \"/usr/local/aws/lib64/python3.9/site-packages/pip/_internal/resolution/resolvelib/candidates.py\", line 227, in _prepare", "    dist = self._prepare_distribution()", "  File \"/usr/local/aws/lib64/python3.9/site-packages/pip/_internal/resolution/resolvelib/candidates.py\", line 305, in _prepare_distribution", "    return self._factory.preparer.prepare_linked_requirement(", "  File \"/usr/local/aws/lib64/python3.9/site-packages/pip/_internal/operations/prepare.py\", line 508, in prepare_linked_requirement", "    return self._prepare_linked_requirement(req, parallel_builds)", "  File \"/usr/local/aws/lib64/python3.9/site-packages/pip/_internal/operations/prepare.py\", line 550, in _prepare_linked_requirement", "    local_file = unpack_url(", "  File \"/usr/local/aws/lib64/python3.9/site-packages/pip/_internal/operations/prepare.py\", line 249, in unpack_url", "    unpack_file(file.path, location, file.content_type)", "  File \"/usr/local/aws/lib64/python3.9/site-packages/pip/_internal/utils/unpacking.py\", line 263, in unpack_file", "    untar_file(filename, location)", "  File \"/usr/local/aws/lib64/python3.9/site-packages/pip/_internal/utils/unpacking.py\", line 199, in untar_file", "    except tarfile.LinkOutsideDestinationError:", "AttributeError: module 'tarfile' has no attribute 'LinkOutsideDestinationError'"], "stdout": "Running cmd: /bin/python -m venv /usr/local/aws\nRunning cmd: /usr/local/aws/bin/python -m pip install --no-binary :all: --no-cache-dir --no-index --find-links file://. setuptools_scm-3.3.3.tar.gz", "stdout_lines": ["Running cmd: /bin/python -m venv /usr/local/aws", "Running cmd: /usr/local/aws/bin/python -m pip install --no-binary :all: --no-cache-dir --no-index --find-links file://. setuptools_scm-3.3.3.tar.gz"]}
```

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
