### PR TITLE
[host-lets-encrypt-certs-certbot] Improve path for credentials file

### DIFF
--- a/ansible/roles/host-lets-encrypt-certs-certbot/tasks/main.yml
+++ b/ansible/roles/host-lets-encrypt-certs-certbot/tasks/main.yml
@@ -9,7 +9,7 @@
   block:
     - name: Verify if AWS Credentials exist on the host
       stat:
-        path: "/home/{{ _certbot_user }}/.aws/credentials"
+        path: "{{ ('~' +_certbot_user + '/.aws/credentials') | expanduser }}"
       register: aws_credentials_result
 
     - name: Fail if AWS Credentials are not on the host
@@ -22,7 +22,7 @@
   block:
     - name: Verify if Azure Credentials exist on the host
       stat:
-        path: "/home/{{ _certbot_user }}/.azure.ini"
+        path: "{{ ('~' +_certbot_user + '/.azure.ini') | expanduser }}"
       register: azure_credentials_result
 
     - name: Fail if Azure Credentials are not on the host
@@ -35,7 +35,7 @@
   block:
     - name: Verify if GCP Credentials exist on the host
       stat:
-        path: "/home/{{ _certbot_user }}/.gcp/osServiceAccount.json"
+        path: "{{ ('~' +_certbot_user + '/.gcp/osServiceAccount.json') | expanduser }}"
       register: gcp_credentials_result
 
     - name: Fail if GCP Credentials are not on the host

--- a/ansible/roles/host-lets-encrypt-certs-certbot/tasks/main.yml
+++ b/ansible/roles/host-lets-encrypt-certs-certbot/tasks/main.yml
@@ -4,12 +4,17 @@
   set_fact:
     _certbot_dir: "{{ _certbot_remote_dir }}/certbot"
 
+- name: Get home directory for {{ _certbot_user }} user
+  ansible.builtin.getent:
+    database: passwd
+    key: "{{ _certbot_user }}"
+
 - name: Check on AWS credentials
   when: _certbot_dns_provider is match('route53')
   block:
     - name: Verify if AWS Credentials exist on the host
       stat:
-        path: "{{ ('~' +_certbot_user + '/.aws/credentials') | expanduser }}"
+        path: "{{ ansible_facts.getent_passwd[_certbot_user][-2] + '/.aws/credentials' }}"
       register: aws_credentials_result
 
     - name: Fail if AWS Credentials are not on the host
@@ -22,7 +27,7 @@
   block:
     - name: Verify if Azure Credentials exist on the host
       stat:
-        path: "{{ ('~' +_certbot_user + '/.azure.ini') | expanduser }}"
+        path: "{{ ansible_facts.getent_passwd[_certbot_user][-2] + '/.azure.ini' }}"
       register: azure_credentials_result
 
     - name: Fail if Azure Credentials are not on the host
@@ -35,7 +40,7 @@
   block:
     - name: Verify if GCP Credentials exist on the host
       stat:
-        path: "{{ ('~' +_certbot_user + '/.gcp/osServiceAccount.json') | expanduser }}"
+        path: "{{ ansible_facts.getent_passwd[_certbot_user][-2] + '/.gcp/osServiceAccount.json' }}"
       register: gcp_credentials_result
 
     - name: Fail if GCP Credentials are not on the host
@@ -49,7 +54,7 @@
     - name: Verify credential are present on host
       when: _certbot_dns_provider is match('rfc2136')
       stat:
-        path: /home/{{ _certbot_user }}/.rfc2136.ini
+        path: "{{ ansible_facts.getent_passwd[_certbot_user][-2] }}/.rfc2136.ini"
       register: ddns_credentials_result
 
     - name: Fail if DDNS credentials are missing

--- a/ansible/roles/host-lets-encrypt-certs-certbot/tasks/main.yml
+++ b/ansible/roles/host-lets-encrypt-certs-certbot/tasks/main.yml
@@ -14,7 +14,7 @@
   block:
     - name: Verify if AWS Credentials exist on the host
       stat:
-        path: "{{ ansible_facts.getent_passwd[_certbot_user][-2] + '/.aws/credentials' }}"
+        path: "{{ ansible_facts.getent_passwd[_certbot_user][4] + '/.aws/credentials' }}"
       register: aws_credentials_result
 
     - name: Fail if AWS Credentials are not on the host
@@ -27,7 +27,7 @@
   block:
     - name: Verify if Azure Credentials exist on the host
       stat:
-        path: "{{ ansible_facts.getent_passwd[_certbot_user][-2] + '/.azure.ini' }}"
+        path: "{{ ansible_facts.getent_passwd[_certbot_user][4] + '/.azure.ini' }}"
       register: azure_credentials_result
 
     - name: Fail if Azure Credentials are not on the host
@@ -40,7 +40,7 @@
   block:
     - name: Verify if GCP Credentials exist on the host
       stat:
-        path: "{{ ansible_facts.getent_passwd[_certbot_user][-2] + '/.gcp/osServiceAccount.json' }}"
+        path: "{{ ansible_facts.getent_passwd[_certbot_user][4] + '/.gcp/osServiceAccount.json' }}"
       register: gcp_credentials_result
 
     - name: Fail if GCP Credentials are not on the host
@@ -54,7 +54,7 @@
     - name: Verify credential are present on host
       when: _certbot_dns_provider is match('rfc2136')
       stat:
-        path: "{{ ansible_facts.getent_passwd[_certbot_user][-2] }}/.rfc2136.ini"
+        path: "{{ ansible_facts.getent_passwd[_certbot_user][4] }}/.rfc2136.ini"
       register: ddns_credentials_result
 
     - name: Fail if DDNS credentials are missing


### PR DESCRIPTION
##### SUMMARY

Currently is searching for /home/user/credential instead the HOMEUSER/credential, for example for /root/

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Role host-lets-encrypt-certs-certbot

