### PR TITLE
[host-ocp4-assisted-installer] Share external IP between masters and workers

### DIFF
--- a/ansible/roles/host-ocp4-assisted-installer/templates/masters_svc.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/templates/masters_svc.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 kind: Service
 metadata:
-  #  annotations:
-  #    metallb.universe.tf/address-pool: ip-addresspool
+  annotations:
+    metallb.universe.tf/allow-shared-ip: "svc-{{ guid }}"
   name: "{{ svcname }}"
   namespace: {{ namespace }}
 spec:


### PR DESCRIPTION
##### SUMMARY

Currently an external IP is used for the control plane (6443/api) and the workers (80/443). This PR allows to use the same

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
Role host-ocp4-assisted-installer
