### PR TITLE
Add Route53 support for Equinix/OpenShift Virtualization

### DIFF
--- a/ansible/cloud_providers/equinix_metal_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/equinix_metal_infrastructure_deployment.yml
@@ -31,7 +31,7 @@
     - create_ssh_config
   tasks:
     - name: Run infra-dns Role
-      when: cluster_dns_server is defined
+      when: cluster_dns_server is defined or route53_aws_zone_id is defined
       include_role:
         name: infra-dns
       vars:

--- a/ansible/cloud_providers/openshift_cnv_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/openshift_cnv_infrastructure_deployment.yml
@@ -43,7 +43,7 @@
   tasks:
 
     - name: Run infra-dns Role
-      when: cluster_dns_server is defined
+      when: cluster_dns_server is defined or route53_aws_zone_id is defined
       ansible.builtin.include_role:
         name: infra-dns
       vars:

--- a/ansible/configs/migrating-to-ocpvirt/post_infra.yml
+++ b/ansible/configs/migrating-to-ocpvirt/post_infra.yml
@@ -38,24 +38,14 @@
         hostname: bastion-vm
         groups: bastion-vm
 
-    - name: Create DNS entries for OpenShift FIPs
-      debug:
-        msg: Currently using {{ cluster_dns_zone }} on server {{ cluster_dns_server }}
-      when: ocp4_aio_use_ddns
-
     - set_fact:
         ocp_api_fip: "{{ hostvars['hypervisor']['public_ip_address'] }}"
-      when: ocp4_aio_use_ddns
 
     - set_fact:
         ocp_ingress_fip: "{{ hostvars['hypervisor']['public_ip_address'] }}"
-      when: ocp4_aio_use_ddns
-
-    - set_fact:
-        ocp_proxy_fip: "{{ hostvars['hypervisor']['public_ip_address'] }}"
-      when: ocp4_aio_use_ddns
 
     - name: Add DNS entry for OpenShift API and ingress
+      when: cluster_dns_server is defined
       nsupdate:
         server: >-
           {{ cluster_dns_server
@@ -75,8 +65,24 @@
           dns: "api"
         - name: "{{ ocp_ingress_fip }}"
           dns: "*.apps"
-        - name: "{{ ocp_proxy_fip }}"
-          dns: "proxy"
       loop_control:
         label: item.name
-      when: ocp4_aio_use_ddns
+
+    - name: Add DNS entry for OpenShift API and ingress
+      when: route53_aws_zone_id is defined
+      route53:
+        state: present
+        aws_access_key_id: "{{ route53_aws_access_key_id }}"
+        aws_secret_access_key: "{{ route53_aws_secret_access_key }}"
+        hosted_zone_id: "{{ route53_aws_zone_id }}"
+        record: "{{ item.dns }}.{{ guid }}.{{ cluster_dns_zone  }}"
+        zone: "{{ cluster_dns_zone  }}"
+        value: "{{ item.name }}"
+        type: A
+      loop:
+        - name: "{{ ocp_api_fip }}"
+          dns: "api"
+        - name: "{{ ocp_ingress_fip }}"
+          dns: "*.apps"
+      loop_control:
+        label: item.name

--- a/ansible/configs/migrating-to-ocpvirt/post_infra.yml
+++ b/ansible/configs/migrating-to-ocpvirt/post_infra.yml
@@ -75,7 +75,7 @@
         aws_access_key_id: "{{ route53_aws_access_key_id }}"
         aws_secret_access_key: "{{ route53_aws_secret_access_key }}"
         hosted_zone_id: "{{ route53_aws_zone_id }}"
-        record: "{{ item.dns }}.{{ guid }}.{{ cluster_dns_zone  }}"
+        record: "{{ item.dns }}.{{ guid }}.{{ cluster_dns_zone }}"
         zone: "{{ cluster_dns_zone  }}"
         value: "{{ item.name }}"
         type: A

--- a/ansible/configs/migrating-to-ocpvirt/pre_software.yml
+++ b/ansible/configs/migrating-to-ocpvirt/pre_software.yml
@@ -77,19 +77,27 @@
       include_role:
         name: bastion-student-user
 
-    - name: Copy credentials to host temporarily
-      template:
-        src: ./files/rfc2136.ini.j2
-        dest: /home/lab-user/.rfc2136.ini
+
+    - name: Write Route53 credentials into /root/.aws/credentials
+      blockinfile:
+        dest: "/root/.aws/credentials"
+        create: true
+        owner: "root"
+        group: "root"
+        mode: 0600
+        content: |
+          [default]
+          aws_access_key_id={{ route53_aws_access_key_id }}
+          aws_secret_access_key={{ route53_aws_secret_access_key }}
 
     - name: Request Both Let's Encrypt Static and Wildcard Certificates
       include_role:
         name: host-lets-encrypt-certs-certbot
       vars:
-        _certbot_domain: "api.{{ guid }}.dynamic.opentlc.com"
-        _certbot_wildcard_domain: "*.apps.{{ guid }}.dynamic.opentlc.com"
+        _certbot_domain: "api.{{ guid }}.{{ cluster_dns_zone }}"
+        _certbot_wildcard_domain: "*.apps.{{ guid }}.{{ cluster_dns_zone }}"
         _certbot_production: True
-        _certbot_dns_provider: "rfc2136"
+        _certbot_dns_provider: "route53"
         _certbot_remote_dir: "/root"
         _certbot_cache_cert_file: "/tmp/server.cert"
         _certbot_cache_key_file: "/tmp/server.key"
@@ -99,6 +107,11 @@
         _certbot_renew_automatically: False
         _certbot_force_issue: False
         _certbot_user: "lab-user"
+
+    - name: Remove credentials once LE certs complete
+      file:
+        state: absent
+        path: "/root/.aws"
 
     - name: Remove credentials once LE certs complete
       file:

--- a/ansible/configs/migrating-to-ocpvirt/pre_software.yml
+++ b/ansible/configs/migrating-to-ocpvirt/pre_software.yml
@@ -79,6 +79,7 @@
 
 
     - name: Write Route53 credentials into /home/lab-user/.aws/credentials
+      become_user: lab-user
       blockinfile:
         dest: "/home/lab-user/.aws/credentials"
         create: true
@@ -90,6 +91,7 @@
           aws_secret_access_key={{ route53_aws_secret_access_key }}
 
     - name: Request Both Let's Encrypt Static and Wildcard Certificates
+      become_user: lab-user
       include_role:
         name: host-lets-encrypt-certs-certbot
       vars:
@@ -97,7 +99,7 @@
         _certbot_wildcard_domain: "*.apps.{{ guid }}.{{ cluster_dns_zone }}"
         _certbot_production: True
         _certbot_dns_provider: "route53"
-        _certbot_remote_dir: "/root"
+        _certbot_remote_dir: "/home/lab-user/"
         _certbot_cache_cert_file: "/tmp/server.cert"
         _certbot_cache_key_file: "/tmp/server.key"
         _certbot_cache_ca_file: "/tmp/server_ca.cer"
@@ -108,15 +110,10 @@
         _certbot_user: "lab-user"
 
     - name: Remove credentials once LE certs complete
+      become_user: lab-user
       file:
         state: absent
-        path: "/root/.aws"
-
-    - name: Remove credentials once LE certs complete
-      file:
-        state: absent
-        path: /home/lab-user/.rfc2136.ini
-      when: _certbot_setup_complete
+        path: "/home/lab-user/.aws"
 
     - name: Deploy base software
       include_role:

--- a/ansible/configs/migrating-to-ocpvirt/pre_software.yml
+++ b/ansible/configs/migrating-to-ocpvirt/pre_software.yml
@@ -79,7 +79,6 @@
 
 
     - name: Write Route53 credentials into /home/lab-user/.aws/credentials
-      become_user: lab-user
       blockinfile:
         dest: "/home/lab-user/.aws/credentials"
         create: true
@@ -91,7 +90,6 @@
           aws_secret_access_key={{ route53_aws_secret_access_key }}
 
     - name: Request Both Let's Encrypt Static and Wildcard Certificates
-      become_user: lab-user
       include_role:
         name: host-lets-encrypt-certs-certbot
       vars:
@@ -110,7 +108,6 @@
         _certbot_user: "lab-user"
 
     - name: Remove credentials once LE certs complete
-      become_user: lab-user
       file:
         state: absent
         path: "/home/lab-user/.aws"

--- a/ansible/configs/migrating-to-ocpvirt/pre_software.yml
+++ b/ansible/configs/migrating-to-ocpvirt/pre_software.yml
@@ -82,7 +82,7 @@
       blockinfile:
         dest: "/home/lab-user/.aws/credentials"
         create: true
-        owner: "{{ lab-user }}"
+        owner: "lab-user"
         mode: 0600
         content: |
           [default]

--- a/ansible/configs/migrating-to-ocpvirt/pre_software.yml
+++ b/ansible/configs/migrating-to-ocpvirt/pre_software.yml
@@ -78,12 +78,11 @@
         name: bastion-student-user
 
 
-    - name: Write Route53 credentials into /root/.aws/credentials
+    - name: Write Route53 credentials into /home/lab-user/.aws/credentials
       blockinfile:
-        dest: "/root/.aws/credentials"
+        dest: "/home/lab-user/.aws/credentials"
         create: true
-        owner: "root"
-        group: "root"
+        owner: "{{ lab-user }}"
         mode: 0600
         content: |
           [default]

--- a/ansible/configs/migrating-to-ocpvirt/pre_software.yml
+++ b/ansible/configs/migrating-to-ocpvirt/pre_software.yml
@@ -83,7 +83,7 @@
         dest: "/root/.aws/credentials"
         create: true
         owner: "root"
-        mode: 0600
+        mode: u=rw,g=,o=
         content: |
           [default]
           aws_access_key_id={{ route53_aws_access_key_id }}

--- a/ansible/configs/migrating-to-ocpvirt/pre_software.yml
+++ b/ansible/configs/migrating-to-ocpvirt/pre_software.yml
@@ -78,11 +78,11 @@
         name: bastion-student-user
 
 
-    - name: Write Route53 credentials into /home/lab-user/.aws/credentials
+    - name: Write Route53 credentials into /root/.aws/credentials
       blockinfile:
-        dest: "/home/lab-user/.aws/credentials"
+        dest: "/root/.aws/credentials"
         create: true
-        owner: "lab-user"
+        owner: "root"
         mode: 0600
         content: |
           [default]
@@ -97,7 +97,7 @@
         _certbot_wildcard_domain: "*.apps.{{ guid }}.{{ cluster_dns_zone }}"
         _certbot_production: True
         _certbot_dns_provider: "route53"
-        _certbot_remote_dir: "/home/lab-user/"
+        _certbot_remote_dir: "/root/"
         _certbot_cache_cert_file: "/tmp/server.cert"
         _certbot_cache_key_file: "/tmp/server.key"
         _certbot_cache_ca_file: "/tmp/server_ca.cer"
@@ -105,12 +105,12 @@
         _certbot_cache_archive_file: "/tmp/certbot.tar.gz"
         _certbot_renew_automatically: False
         _certbot_force_issue: False
-        _certbot_user: "lab-user"
+        _certbot_user: "root"
 
     - name: Remove credentials once LE certs complete
       file:
         state: absent
-        path: "/home/lab-user/.aws"
+        path: "/root/.aws"
 
     - name: Deploy base software
       include_role:

--- a/ansible/configs/roadshow-ocpvirt/post_infra.yml
+++ b/ansible/configs/roadshow-ocpvirt/post_infra.yml
@@ -45,38 +45,25 @@
 
     - set_fact:
         ocp_api_fip: "{{ hostvars['hypervisor']['public_ip_address'] | default(hostvars[groups.bastions.0].public_ip_address) }}"
-      when: ocp4_aio_use_ddns
 
     - set_fact:
         ocp_ingress_fip: "{{ hostvars['hypervisor']['public_ip_address'] | default(hostvars[groups.bastions.0].public_ip_address) }}"
-      when: ocp4_aio_use_ddns
-
-    - set_fact:
-        ocp_proxy_fip: "{{ hostvars['hypervisor']['public_ip_address'] | default(hostvars[groups.bastions.0].public_ip_address) }}"
-      when: ocp4_aio_use_ddns
 
     - name: Add DNS entry for OpenShift API and ingress
-      nsupdate:
-        server: >-
-          {{ cluster_dns_server
-          | ipaddr
-          | ternary(cluster_dns_server, lookup('dig', cluster_dns_server))
-          }}
-        zone: "{{ cluster_dns_zone }}"
-        record: "{{ item.dns }}.{{ guid }}"
-        type: A
-        ttl: 5
-        port: "{{ cluster_dns_port | d('53') }}"
+      when: route53_aws_zone_id is defined
+      route53:
+        state: present
+        aws_access_key_id: "{{ route53_aws_access_key_id }}"
+        aws_secret_access_key: "{{ route53_aws_secret_access_key }}"
+        hosted_zone_id: "{{ route53_aws_zone_id }}"
+        record: "{{ item.dns }}.{{ guid }}.{{ cluster_dns_zone }}"
+        zone: "{{ cluster_dns_zone  }}"
         value: "{{ item.name }}"
-        key_name: "{{ ddns_key_name }}"
-        key_secret: "{{ ddns_key_secret }}"
+        type: A
       loop:
         - name: "{{ ocp_api_fip }}"
           dns: "api"
         - name: "{{ ocp_ingress_fip }}"
           dns: "*.apps"
-        - name: "{{ ocp_proxy_fip }}"
-          dns: "proxy"
       loop_control:
         label: item.name
-      when: ocp4_aio_use_ddns

--- a/ansible/configs/roadshow-ocpvirt/pre_software.yml
+++ b/ansible/configs/roadshow-ocpvirt/pre_software.yml
@@ -57,23 +57,40 @@
       yum:
         name: "certbot"
 
-    - name: Generate certificate using certbot
-      command: >
-        certbot certonly  --standalone
-        -d console-openshift-console.apps.{{ guid }}.dynamic.opentlc.com,oauth-openshift.apps.{{ guid }}.dynamic.opentlc.com,virt-openshift-mtv.apps.{{ guid }}.dynamic.opentlc.com
-        -m josegonz@redhat.com --agree-tos -n
-      retries: 30
-      delay: 30
+    - name: Write Route53 credentials into /root/.aws/credentials
+      blockinfile:
+        dest: "/root/.aws/credentials"
+        create: true
+        owner: "root"
+        mode: 0600
+        content: |
+          [default]
+          aws_access_key_id={{ route53_aws_access_key_id }}
+          aws_secret_access_key={{ route53_aws_secret_access_key }}
 
-    - name: Fetch letsencrypt SSL certificates to transfer to the bastion node
-      fetch:
-        src: "/etc/letsencrypt/archive/console-openshift-console.apps.{{ guid }}.dynamic.opentlc.com/{{ item }}"
-        dest: "{{ output_dir }}/{{ item }}"
-        flat: yes
-      loop:
-        - chain1.pem
-        - cert1.pem
-        - privkey1.pem
+    - name: Request Both Let's Encrypt Static and Wildcard Certificates
+      include_role:
+        name: host-lets-encrypt-certs-certbot
+      vars:
+        _certbot_domain: "api.{{ guid }}.{{ cluster_dns_zone }}"
+        _certbot_wildcard_domain: "*.apps.{{ guid }}.{{ cluster_dns_zone }}"
+        _certbot_production: True
+        _certbot_dns_provider: "route53"
+        _certbot_remote_dir: "/root/"
+        _certbot_cache_cert_file: "/tmp/server.cert"
+        _certbot_cache_key_file: "/tmp/server.key"
+        _certbot_cache_ca_file: "/tmp/server_ca.cer"
+        _certbot_cache_fullchain_file: "/tmp/fullchain.cer"
+        _certbot_cache_archive_file: "/tmp/certbot.tar.gz"
+        _certbot_renew_automatically: False
+        _certbot_force_issue: False
+        _certbot_user: "root"
+
+    - name: Remove credentials once LE certs complete
+      file:
+        state: absent
+        path: "/root/.aws"
+
 
     - name: install mariadb client
       yum:

--- a/ansible/configs/roadshow-ocpvirt/pre_software.yml
+++ b/ansible/configs/roadshow-ocpvirt/pre_software.yml
@@ -62,7 +62,7 @@
         dest: "/root/.aws/credentials"
         create: true
         owner: "root"
-        mode: 0600
+        mode: u=rw,g=,o=
         content: |
           [default]
           aws_access_key_id={{ route53_aws_access_key_id }}

--- a/ansible/configs/roadshow-ocpvirt/templates/httpd/ssl.conf
+++ b/ansible/configs/roadshow-ocpvirt/templates/httpd/ssl.conf
@@ -14,8 +14,8 @@ SSLEngine on
 SSLHonorCipherOrder on
 SSLCipherSuite PROFILE=SYSTEM
 SSLProxyCipherSuite PROFILE=SYSTEM
-SSLCertificateFile /etc/letsencrypt/live/console-openshift-console.apps.{{ guid }}.{{ cluster_dns_zone }}/fullchain.pem
-SSLCertificateKeyFile /etc/letsencrypt/live/console-openshift-console.apps.{{ guid }}.{{ cluster_dns_zone }}/privkey.pem
+SSLCertificateFile /root/certbot/config/live/api.{{ guid }}.{{ cluster_dns_zone }}/fullchain.pem
+SSLCertificateKeyFile /root/certbot/config/live/api.{{ guid }}.{{ cluster_dns_zone }}/privkey.pem
 SetEnvIf Request_URI /api/proxy/plugin/forklift-console-plugin/ forklift
 RequestHeader set Host "console-openshift-console.apps.ocp.example.com" env=!forklift
 RequestHeader set Referer "https://console-openshift-console.apps.ocp.example.com" env=!forklift
@@ -50,8 +50,8 @@ LogLevel warn
 SSLEngine on
 SSLCipherSuite PROFILE=SYSTEM
 SSLProxyCipherSuite PROFILE=SYSTEM
-SSLCertificateFile /etc/letsencrypt/live/console-openshift-console.apps.{{ guid }}.{{ cluster_dns_zone }}/fullchain.pem
-SSLCertificateKeyFile /etc/letsencrypt/live/console-openshift-console.apps.{{ guid }}.{{ cluster_dns_zone }}/privkey.pem
+SSLCertificateFile /root/certbot/config/live/api.{{ guid }}.{{ cluster_dns_zone }}/fullchain.pem
+SSLCertificateKeyFile /root/certbot/config/live/api.{{ guid }}.{{ cluster_dns_zone }}/privkey.pem
 RequestHeader set Host "oauth-openshift.apps.ocp.example.com"
 ProxyPreserveHost Off
 SSLProxyEngine on
@@ -76,8 +76,8 @@ SSLEngine on
 SSLHonorCipherOrder on
 SSLCipherSuite PROFILE=SYSTEM
 SSLProxyCipherSuite PROFILE=SYSTEM
-SSLCertificateFile /etc/letsencrypt/live/console-openshift-console.apps.{{ guid }}.{{ cluster_dns_zone }}/fullchain.pem
-SSLCertificateKeyFile /etc/letsencrypt/live/console-openshift-console.apps.{{ guid }}.{{ cluster_dns_zone }}/privkey.pem
+SSLCertificateFile /root/certbot/config/live/api.{{ guid }}.{{ cluster_dns_zone }}/fullchain.pem
+SSLCertificateKeyFile /root/certbot/config/live/api.{{ guid }}.{{ cluster_dns_zone }}/privkey.pem
 #RequestHeader set Referer "https://zzzzz.apps.ocp.example.com"
 #RequestHeader set Origin "https://zzzzz.apps.ocp.example.com"
 ProxyPreserveHost On

--- a/ansible/roles-infra/infra-dns/tasks/nested_loop.yml
+++ b/ansible/roles-infra/infra-dns/tasks/nested_loop.yml
@@ -40,8 +40,8 @@
       when: route53_aws_zone_id is defined
       route53:
         state: present
-        aws_access_key: "{{ route53_aws_access_key_id }}"
-        aws_secret_key: "{{ route53_aws_secret_access_key }}"
+        aws_access_key_id: "{{ route53_aws_access_key_id }}"
+        aws_secret_access_key: "{{ route53_aws_secret_access_key }}"
         hosted_zone_id: "{{ route53_aws_zone_id }}"
         record: "{{ _instance_name }}.{{ guid }}"
         zone: "{{ cluster_dns_zone  }}"
@@ -81,8 +81,8 @@
         loop_var: _alt_name
       route53:
         state: present
-        aws_access_key: "{{ route53_aws_access_key_id }}"
-        aws_secret_key: "{{ route53_aws_secret_access_key }}"
+        aws_access_key_id: "{{ route53_aws_access_key_id }}"
+        aws_secret_access_key: "{{ route53_aws_secret_access_key }}"
         hosted_zone_id: "{{ route53_aws_zone_id }}"
         record: "{{ _alt_name }}{{_index}}.{{ guid }}"
         zone: "{{ cluster_dns_zone  }}"
@@ -115,8 +115,8 @@
       when: route53_aws_zone_id is defined
       route53:
         state: absent
-        aws_access_key: "{{ route53_aws_access_key_id }}"
-        aws_secret_key: "{{ route53_aws_secret_access_key }}"
+        aws_access_key_id: "{{ route53_aws_access_key_id }}"
+        aws_secret_access_key: "{{ route53_aws_secret_access_key }}"
         hosted_zone_id: "{{ route53_aws_zone_id }}"
         record: "{{ _instance_name }}.{{ guid }}"
         zone: "{{ cluster_dns_zone  }}"
@@ -152,8 +152,8 @@
         loop_var: _alt_name
       route53:
         state: absent
-        aws_access_key: "{{ route53_aws_access_key_id }}"
-        aws_secret_key: "{{ route53_aws_secret_access_key }}"
+        aws_access_key_id: "{{ route53_aws_access_key_id }}"
+        aws_secret_access_key: "{{ route53_aws_secret_access_key }}"
         hosted_zone_id: "{{ route53_aws_zone_id }}"
         record: "{{ _alt_name }}{{_index}}.{{ guid }}"
         zone: "{{ cluster_dns_zone  }}"

--- a/ansible/roles-infra/infra-dns/tasks/nested_loop.yml
+++ b/ansible/roles-infra/infra-dns/tasks/nested_loop.yml
@@ -19,6 +19,7 @@
           is {{ vars[infra_dns_inventory_var] | json_query(find_ip_query) }}
 
     - name: DNS entry ({{ _dns_state | default('present') }})
+      when: cluster_dns_server is defined
       nsupdate:
         server: >-
           {{ cluster_dns_server
@@ -35,13 +36,25 @@
         key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
         key_secret: "{{ ddns_key_secret }}"
 
+    - name: DNS entry ({{ _dns_state | default('present') }})
+      when: route53_aws_zone_id is defined
+      route53:
+        state: present
+        aws_access_key: "{{ route53_aws_access_key_id }}"
+        aws_secret_key: "{{ route53_aws_secret_access_key }}"
+        hosted_zone_id: "{{ route53_aws_zone_id }}"
+        record: "{{ _instance_name }}.{{ guid }}"
+        zone: "{{ cluster_dns_zone  }}"
+        value: "{{ vars[infra_dns_inventory_var] | json_query(find_ip_query) }}"
+        type: A
+
     - name: Add public_dns entry to host
       add_host:
         name: "{{ _instance_name }}"
         public_dns_name: "{{ _instance_name }}.{{ guid }}.{{ cluster_dns_zone }}"
 
     - name: DNS alternative entry ({{ _dns_state | default('present') }})
-      when: _alt_names | length > 0
+      when: cluster_dns_server is defined and_alt_names | length > 0
       loop: "{{ _alt_names }}"
       loop_control:
         loop_var: _alt_name
@@ -61,10 +74,27 @@
         key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
         key_secret: "{{ ddns_key_secret }}"
 
+    - name: DNS alternative entry ({{ _dns_state | default('present') }})
+      when: route53_aws_zone_id is defined
+      loop: "{{ _alt_names }}"
+      loop_control:
+        loop_var: _alt_name
+      route53:
+        state: present
+        aws_access_key: "{{ route53_aws_access_key_id }}"
+        aws_secret_key: "{{ route53_aws_secret_access_key }}"
+        hosted_zone_id: "{{ route53_aws_zone_id }}"
+        record: "{{ _alt_name }}{{_index}}.{{ guid }}"
+        zone: "{{ cluster_dns_zone  }}"
+        value: "{{ vars[infra_dns_inventory_var] | json_query(find_ip_query) }}"
+        type: A
+
+
 # When state == absent, don't use inventory var (should not be needed)
 - when: _dns_state == 'absent'
   block:
     - name: DNS entry ({{ _dns_state | default('present') }})
+      when: cluster_dns_server is defined
       nsupdate:
         server: >-
           {{ cluster_dns_server
@@ -81,8 +111,20 @@
         key_secret: "{{ ddns_key_secret }}"
         state: absent
 
+    - name: DNS entry ({{ _dns_state | default('present') }})
+      when: route53_aws_zone_id is defined
+      route53:
+        state: absent
+        aws_access_key: "{{ route53_aws_access_key_id }}"
+        aws_secret_key: "{{ route53_aws_secret_access_key }}"
+        hosted_zone_id: "{{ route53_aws_zone_id }}"
+        record: "{{ _instance_name }}.{{ guid }}"
+        zone: "{{ cluster_dns_zone  }}"
+        value: "{{ vars[infra_dns_inventory_var] | json_query(find_ip_query) }}"
+        type: A
+
     - name: DNS alternative entry ({{ _dns_state | default('present') }})
-      when: _alt_names | length > 0
+      when: cluster_dns_server is defined and _alt_names | length > 0
       loop: "{{ _alt_names }}"
       loop_control:
         loop_var: _alt_name
@@ -102,3 +144,18 @@
         key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
         key_secret: "{{ ddns_key_secret }}"
         state: absent
+
+    - name: DNS alternative entry ({{ _dns_state | default('present') }})
+      when: route53_aws_zone_id is defined
+      loop: "{{ _alt_names }}"
+      loop_control:
+        loop_var: _alt_name
+      route53:
+        state: absent
+        aws_access_key: "{{ route53_aws_access_key_id }}"
+        aws_secret_key: "{{ route53_aws_secret_access_key }}"
+        hosted_zone_id: "{{ route53_aws_zone_id }}"
+        record: "{{ _alt_name }}{{_index}}.{{ guid }}"
+        zone: "{{ cluster_dns_zone  }}"
+        value: "{{ vars[infra_dns_inventory_var] | json_query(find_ip_query) }}"
+        type: A

--- a/ansible/roles-infra/infra-dns/tasks/nested_loop.yml
+++ b/ansible/roles-infra/infra-dns/tasks/nested_loop.yml
@@ -43,7 +43,7 @@
         aws_access_key_id: "{{ route53_aws_access_key_id }}"
         aws_secret_access_key: "{{ route53_aws_secret_access_key }}"
         hosted_zone_id: "{{ route53_aws_zone_id }}"
-        record: "{{ _instance_name }}.{{ guid }}"
+        record: "{{ _instance_name }}.{{ guid }}.{{ cluster_dns_zone  }}"
         zone: "{{ cluster_dns_zone  }}"
         value: "{{ vars[infra_dns_inventory_var] | json_query(find_ip_query) }}"
         type: A

--- a/ansible/roles-infra/infra-dns/tasks/pre_checks.yml
+++ b/ansible/roles-infra/infra-dns/tasks/pre_checks.yml
@@ -1,13 +1,29 @@
 ---
-- when: >-
-    cluster_dns_server is not defined
-    or cluster_dns_zone is not defined
-    or ddns_key_name is not defined
-    or ddns_key_secret is not defined
-  fail:
-    msg: |
-      All the following variables must be defined:
-      - cluster_dns_server
-      - cluster_dns_zone
-      - ddns_key_name
-      - ddns_key_secret
+- name: Check variables when ddns is used
+  when: cluster_dns_server is defined
+  block:
+    - when: >-
+        cluster_dns_zone is not defined
+        or ddns_key_name is not defined
+        or ddns_key_secret is not defined
+      fail:
+        msg: |
+          All the following variables must be defined:
+          - cluster_dns_zone
+          - ddns_key_name
+          - ddns_key_secret
+
+
+- name: Check variables when route53 is used
+  when: route53_aws_zone_id is defined
+  block:
+    - when: >-
+        route53_aws_access_key_id is not defined
+        or route53_aws_secret_access_key is not defined
+        or cluster_dns_zone is not defined
+      fail:
+        msg: |
+          All the following variables must be defined:
+          - route53_aws_access_key_id
+          - route53_aws_secret_access_key
+          - cluster_dns_zone

--- a/ansible/roles/host-lets-encrypt-certs-certbot/tasks/main.yml
+++ b/ansible/roles/host-lets-encrypt-certs-certbot/tasks/main.yml
@@ -9,7 +9,7 @@
   block:
     - name: Verify if AWS Credentials exist on the host
       stat:
-        path: "{{ ('~' +_certbot_user + '/.aws/credentials') | expanduser }}"
+        path: "/home/{{ _certbot_user }}/.aws/credentials"
       register: aws_credentials_result
 
     - name: Fail if AWS Credentials are not on the host
@@ -22,7 +22,7 @@
   block:
     - name: Verify if Azure Credentials exist on the host
       stat:
-        path: "{{ ('~' +_certbot_user + '/.azire/omo') | expanduser }}"
+        path: "/home/{{ _certbot_user }}/.azure.ini"
       register: azure_credentials_result
 
     - name: Fail if Azure Credentials are not on the host

--- a/ansible/roles/host-lets-encrypt-certs-certbot/tasks/main.yml
+++ b/ansible/roles/host-lets-encrypt-certs-certbot/tasks/main.yml
@@ -9,7 +9,7 @@
   block:
     - name: Verify if AWS Credentials exist on the host
       stat:
-        path: "/home/{{ _certbot_user }}/.aws/credentials"
+        path: "{{ ('~' +_certbot_user + '/.aws/credentials') | expanduser }}"
       register: aws_credentials_result
 
     - name: Fail if AWS Credentials are not on the host
@@ -22,7 +22,7 @@
   block:
     - name: Verify if Azure Credentials exist on the host
       stat:
-        path: "/home/{{ _certbot_user }}/.azure.ini"
+        path: "{{ ('~' +_certbot_user + '/.azire/omo') | expanduser }}"
       register: azure_credentials_result
 
     - name: Fail if Azure Credentials are not on the host


### PR DESCRIPTION
##### SUMMARY

Currently we are using nsupdate/ddns for the labs running on baremetal, this PR configures configures the role infra-dns and the configs: migrating-to-ocpvirt and ocpvirtroadshow

##### ISSUE TYPE
- Enhance Pull Request


##### COMPONENT NAME

- Cloud providers: Equinix and OpenShift CNV
- Role infra-dns
- Config migrating-to-ocpvirt 
- Config roadshow-ocpvirt


