### PR TITLE
Put missing CC back in showroom index.html

### DIFF
--- a/ansible/roles/showroom/templates/index.html.j2
+++ b/ansible/roles/showroom/templates/index.html.j2
@@ -1,5 +1,12 @@
 <!DOCTYPE html>
 <html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+{% if showroom_tab_services | length > 0 %}
+    <link rel="stylesheet" type="text/css" href="split.css">
+    <link rel="stylesheet" type="text/css" href="tabs.css">
+{% endif %}
+  </head>
     <body>
 {% if showroom_tab_services | length == 0 %}
         <iframe src="./modules/index.html" frameborder="0" style="position:fixed; top:0; left:0; bottom:0; right:0; width:100%; height:100%; border:none; margin:0; padding:0; overflow:hidden; z-index:999999;">


### PR DESCRIPTION

##### SUMMARY

Last showroom PR broke the css includes in index.html breaking tab rendering

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME

roles/showroom

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
