### PR TITLE
[host-lets-encrypt-certs-certbot] Allow specify account URL for certbot

### DIFF
--- a/ansible/roles/host-lets-encrypt-certs-certbot/tasks/main.yml
+++ b/ansible/roles/host-lets-encrypt-certs-certbot/tasks/main.yml
@@ -164,11 +164,26 @@
     - "{{ _certbot_dir }}/logs"
     - "{{ _certbot_dir }}/renewal-hooks"
     - "{{ _certbot_dir }}/renewal-hooks/deploy"
-
+     
   - name: Request Certificates from Let's Encrypt (force or no cache)
     when:
     - _certbot_force_issue|bool or not _certbot_setup_complete|bool
     block:
+    - name: Download Let's Encrypt  account file 
+      get_url:
+        url: "{{ certbot_account_url }}"
+        dest: "{{ _certbot_dir }}/account.tar"
+        url_username: "{{ certbot_account_download_user | default(omit) }}"
+        url_password: "{{ certbot_account_download_password | default(omit) }}"
+        force_basic_auth: true
+      when: certbot_account_url is defined
+
+    - name: Extract Let's Encrypt account file
+      unarchive:
+        copy: false
+        src: "{{ _certbot_dir }}/account.tar"
+        dest: "{{ _certbot_dir }}"
+      when: certbot_account_url is defined
     # Get Intermediary CA Certificate.
     # This is also used in the SSO configuration!
     - name: Get Let's Encrypt Intermediary CA Certificate
@@ -216,6 +231,18 @@
       - name: Remove archive from server
         file:
           name: "/tmp/certbot.tgz"
+          state: absent
+
+      - name: Clean Let's Encrypt account files
+        when: certbot_account_url is defined
+        block:
+          - name: Remove account file from server
+            file:
+              name: "{{ _certbot_dir }}/account.tar"
+              state: absent
+      - name: Remove Let's Encrypt account directory from server
+        file:
+          name: "{{ _certbot_dir }}/accounts"
           state: absent
 
 - name: Install the certificates into {{ _certbot_install_dir }}


### PR DESCRIPTION
##### SUMMARY

This PR allows to have a created account hosted in a URL (protected with username/password) to use to request domains, that will reduce the errors on OpenShift Virtualization (where the egress IP is always the same for the worker)

You can create a maximum of 10 [Accounts per IP Address](https://letsencrypt.org/docs/too-many-registrations-for-this-ip/) per 3 hours. You can create a maximum of 500 Accounts per IP Range within an IPv6 /48 per 3 hours. Hitting either account rate limit is very rare, and we recommend that large integrators prefer a design [using one account for many customers](https://letsencrypt.org/docs/integration-guide/). Exceeding these limits is reported with the error message too many registrations for this IP or too many registrations for this IP range.

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
Role host-lets-encrypt-certs-certbot