### PR TITLE
[host-ocp4-assisted-installer] Increase default cores/memory values for workers

### DIFF
--- a/ansible/roles/host-ocp4-assisted-installer/vars/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/vars/main.yaml
@@ -7,8 +7,8 @@ ai_cluster_version: "4.13"
 ai_cluster_iso_type: "minimal-iso"
 ai_control_plane_cores: 8
 ai_control_plane_memory: 16Gi
-ai_workers_cores: 12
-ai_workers_memory: 32Gi
+ai_workers_cores: 16
+ai_workers_memory: 64Gi
 ai_ocp_namespace: "{{ env_type }}-{{ guid }}"
 ai_ocp_vmname_sno: "sno-{{ cluster_name }}"
 ai_ocp_vmname_master_prefix: "control-plane-{{ cluster_name }}"


### PR DESCRIPTION
##### SUMMARY

Increasing default values to 16 cores and 64GB RAM for workers

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
host-ocp4-assisted-installer role
