### PR TITLE
Updates to only use packaged chart version and to specify proper chart version.

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/README.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/README.adoc
@@ -5,8 +5,7 @@
 ** Deploying to our OCP 410 shared OCP Cluster: <<shared_cluster>>
 * one or multiple OpenShift users, autodetected.
 * deploy the showroom helm chart https://github.com/rhpds/showroom-deployer/charts/showroom
-* If Argo CD is present, it will deploy via Application or ApplicationSet from templated manifests in this role.
-* If Argo CD is NOT present, it will deploy the Helm chart.
+* Supports deployment via OpenShift GitOps (ArgoCD) or a locally installed helm cli.
 
 .Integrating Showroom into your `config/env_type`
 * Setup your `config/env_type` to support Showroom on OCP <<env_type>>
@@ -46,6 +45,24 @@ It needs a bation, afaict.
         name: ocp4_workload_showroom
 ----
 
+== Picking Deployment Type
+
+If you don't pick a deployment type the default is helm cli locally (on the bastion).
+To use ArgoCD you need to give the right permissions to the system ArgoCd by using the workload and
+workload options as specified.
+
+[source,yaml]
+----
+# How to deploy Showroom. Options are `helm` and `argocd`
+# For `argocd' ocop4_workload_openshift_gitops must have been deployed first with the following options:
+#   ocp4_workload_openshift_gitops_channel: gitops-1.10
+#   ocp4_workload_openshift_gitops_setup_cluster_admin: true
+#   ocp4_workload_openshift_gitops_update_route_tls: true
+#   ocp4_workload_openshift_gitops_rbac_update: true
+# Deploying using `argocd` without these options will fail
+ocp4_workload_showroom_deployment_type: helm
+----
+
 == Enable Bastion Auto-SSH in your env_type/config
 
 . Make sure your env_type/config puts the following values in user_data:
@@ -53,7 +70,6 @@ It needs a bation, afaict.
 .Example
 [source,yaml]
 ----
-
 - name: Provide installed bastion data
   agnosticd_user_info:
     data:
@@ -64,7 +80,6 @@ It needs a bation, afaict.
 ----
 
 NOTE: Key based authentication is TODO
-
 
 [#shared_cluster]
 == Deploying Showroom to the Shared Cluster

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/defaults/main.yaml
@@ -28,17 +28,13 @@ ocp4_workload_showroom_service_name: showroom-proxy
 # Deploying using `argocd` without these options will fail
 ocp4_workload_showroom_deployment_type: helm
 
-# Helm Chart for Helm on bastion
+# Helm Chart to use for Showroom. This needs to be a packaged chart in a registry.
+# For the example below the source registry is https://github.com/rhpds/showroom-deployer
 ocp4_workload_showroom_chart_package_url: https://rhpds.github.io/showroom-deployer
 ocp4_workload_showroom_deployer_chart_name: showroom
-ocp4_workload_showroom_deployer_chart_version: "0.2.0"
+ocp4_workload_showroom_deployer_chart_version: "0.4.8"
 
-# Helm Chart for ArgoCD
-ocp4_workload_showroom_deployer_chart_repo_url: https://github.com/rhpds/showroom-deployer
-ocp4_workload_showroom_deployer_chart_repo_revision: main
-ocp4_workload_showroom_deployer_chart_repo_path: charts/showroom
-
-# URL to download Helm from if it's not already there
+# URL to download Helm from if it's not already there (for Helm type deployment)
 ocp4_workload_showroom_tools_root_url: >-
   https://mirror.openshift.com/pub/openshift-v4/clients
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/templates/application.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/templates/application.yaml.j2
@@ -20,9 +20,9 @@ spec:
       prune: true
       selfHeal: true
   source:
-    repoURL: {{ ocp4_workload_showroom_deployer_chart_repo_url }}
-    targetRevision: {{ ocp4_workload_showroom_deployer_chart_repo_revision }}
-    path: {{ ocp4_workload_showroom_deployer_chart_repo_path }}
+    repoURL: {{ ocp4_workload_showroom_chart_package_url }}
+    chart: {{ ocp4_workload_showroom_deployer_chart_name }}
+    targetRevision: {{ ocp4_workload_showroom_deployer_chart_version }}
     helm:
       values: |
         namespace:

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/templates/applicationset.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/templates/applicationset.yaml.j2
@@ -33,9 +33,9 @@ spec:
           prune: true
           selfHeal: true
       source:
-        repoURL: {{ ocp4_workload_showroom_deployer_chart_repo_url }}
-        targetRevision: {{ ocp4_workload_showroom_deployer_chart_repo_revision }} # main
-        path: {{ ocp4_workload_showroom_deployer_chart_repo_path }} # charts/showroom
+        repoURL: {{ ocp4_workload_showroom_chart_package_url }}
+        chart: {{ ocp4_workload_showroom_deployer_chart_name }}
+        targetRevision: {{ ocp4_workload_showroom_deployer_chart_version }}
         helm:
           values: |
             namespace:


### PR DESCRIPTION
##### SUMMARY

Updated README

Turns out the Argo deployment never used the chart version. Also it deployed from source code.

Changed ArgoCD deployment to also deploy the chart with a specified version.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_showroom