### PR TITLE
Add_check_for_old_argocd

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/README.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/README.adoc
@@ -55,6 +55,7 @@ workload options as specified.
 ----
 # How to deploy Showroom. Options are `helm` and `argocd`
 # For `argocd' ocop4_workload_openshift_gitops must have been deployed first with the following options:
+# (OpenShift GitOps 1.10 or newer is preferred but it should work just as well with older versions)
 #   ocp4_workload_openshift_gitops_channel: gitops-1.10
 #   ocp4_workload_openshift_gitops_setup_cluster_admin: true
 #   ocp4_workload_openshift_gitops_update_route_tls: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/defaults/main.yaml
@@ -21,6 +21,7 @@ ocp4_workload_showroom_service_name: showroom-proxy
 
 # How to deploy Showroom. Options are `helm` and `argocd`
 # For `argocd' ocop4_workload_openshift_gitops must have been deployed first with the following options:
+# (OpenShift GitOps 1.10 or newer is preferred but it should work just as well with older versions)
 #   ocp4_workload_openshift_gitops_channel: gitops-1.10
 #   ocp4_workload_openshift_gitops_setup_cluster_admin: true
 #   ocp4_workload_openshift_gitops_update_route_tls: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/workload.yml
@@ -29,8 +29,16 @@
       namespace: openshift-gitops
     register: r_argocd_present
 
+  - name: Check if an older ArgoCD has been installed
+    kubernetes.core.k8s_info:
+      api_version: argoproj.io/v1alpha1
+      kind: ArgoCD
+      name: openshift-gitops
+      namespace: openshift-gitops
+    register: r_old_argocd_present
+
   - name: Fail if no ArgoCD detected
-    when: not r_argocd_present.resources | default([]) | length == 1
+    when: not (r_argocd_present.resources | default([]) | length == 1 or r_old_argocd_present.resources | default([]) | length == 1)
     ansible.builtin.fail:
       msg: "ArgoCD Deployment requested yet no default ArgoCD installation found."
 


### PR DESCRIPTION
##### SUMMARY

Check if ArgoCD was present only worked for OpenShift GitOps 1.10. Adding check for older versions as well to support older OpenShift versions that can't run 1.10.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_showroom