### PR TITLE
[infra-vmc-resources] Move parameter to proper place

### DIFF
--- a/ansible/roles-infra/infra-vmc-resources/tasks/create_public_ip_and_nat.yaml
+++ b/ansible/roles-infra/infra-vmc-resources/tasks/create_public_ip_and_nat.yaml
@@ -56,9 +56,9 @@
     headers:
       csp-auth-token: "{{ _nsxt_token }}"
     body_format: json
-    group_type: ["IPAddress"]
     body:
       display_name: "Lab Public IPS"
+      group_type: ["IPAddress"]
       expression:
       - resource_type: "IPAddressExpression"
         ip_addresses: "{{ _lab_public_ips_new }}"


### PR DESCRIPTION

##### SUMMARY

I put incorrectly the parameter, it should be inside the body

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
infra-vmc-resources Role
