### PR TITLE
Change role OCP4_QUARKUS_SUPERHEROES_DEMO add serverless capabilities

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/defaults/main.yml
@@ -34,9 +34,12 @@ ocp4_workload_quarkus_super_heroes_demo_service_project_names:
 - "event-statistics"
 - "ui-super-heroes"
 
+ocp4_workload_quarkus_super_heroes_demo_deployment_kinds:
+- "openshift"
+- "knative"
+
 ocp4_workload_quarkus_super_heroes_demo_infra_http_names:
 - "prometheus-operated"
-- "apicurio"
 
 ocp4_workload_quarkus_super_heroes_demo_infra_https_names:
 - "jaeger"

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/files/knative_serving.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/files/knative_serving.yaml
@@ -9,4 +9,3 @@ kind: KnativeServing
 metadata:
   name: knative-serving
   namespace: knative-serving
-  

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/files/knative_serving.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/files/knative_serving.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: knative-serving
+---
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: knative-serving
+  

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/files/serverless_subscription.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/files/serverless_subscription.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-serverless
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: serverless-operators
+  namespace: openshift-serverless
+spec: {}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: serverless-operator
+  namespace: openshift-serverless
+spec:
+  channel: stable
+  name: serverless-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/deploy_projects.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/deploy_projects.yml
@@ -98,4 +98,3 @@
     state: present
     # yamllint disable-line rule:line-length
     definition: "{{ lookup('template', '../templates/opentelemetry_collector_instance.yaml.j2') | from_yaml_all | list }}"
-    

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/deploy_projects.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/deploy_projects.yml
@@ -8,8 +8,8 @@
       metadata:
         name: "{{ t_project_name }}"
         annotations:
-          openshift.io/description: "Quarkus Superheroes for {{ t_app_version }}"
-          openshift.io/display-name: "Quarkus Superheroes for {{ t_app_version }}"
+          openshift.io/description: "Quarkus Superheroes for {{ t_app_version }} ({{ t_app_deployment_kind }})"
+          openshift.io/display-name: "Quarkus Superheroes for {{ t_app_version }} ({{ t_app_deployment_kind }})"
 
 - name: "[{{ t_project_name }}] - deploy Kafka"
   kubernetes.core.k8s:
@@ -20,18 +20,18 @@
 
 # Download and apply manifest
 - name: "[{{ t_project_name }}] - Download application manifest"
-  get_url:
+  ansible.builtin.get_url:
     # yamllint disable-line rule:line-length
-    url: "{{ ocp4_workload_quarkus_super_heroes_demo_github_raw_url }}/{{ t_app_version }}-openshift.yml"
+    url: "{{ ocp4_workload_quarkus_super_heroes_demo_github_raw_url }}/{{ t_app_version }}-{{ t_app_deployment_kind }}.yml"
     # yamllint disable-line rule:line-length
-    dest: "{{ ocp4_workload_quarkus_super_heroes_demo_temp_dir }}/{{ t_app_version }}-openshift.yml"
+    dest: "{{ ocp4_workload_quarkus_super_heroes_demo_temp_dir }}/{{ t_app_version }}-{{ t_app_deployment_kind }}.yml"
 
 - name: "[{{ t_project_name }}] - Apply application manifest"
   kubernetes.core.k8s:
     state: present
     namespace: "{{ t_project_name }}"
     # yamllint disable-line rule:line-length
-    src: "{{ ocp4_workload_quarkus_super_heroes_demo_temp_dir }}/{{ t_app_version }}-openshift.yml"
+    src: "{{ ocp4_workload_quarkus_super_heroes_demo_temp_dir }}/{{ t_app_version }}-{{ t_app_deployment_kind }}.yml"
 
 - name: "[{{ t_project_name }}] - Patch the app configs for Kafka"
   kubernetes.core.k8s:
@@ -78,11 +78,11 @@
     loop_var: t_app_name
 
 - name: "[{{ t_project_name }}] - install Prometheus"
-  include_tasks: install_prometheus.yml
+  ansible.builtin.include_tasks: install_prometheus.yml
   when: ocp4_workload_quarkus_super_heroes_demo_install_prometheus | bool
 
 - name: "[{{ t_project_name }}] - install Grafana"
-  include_tasks: install_grafana.yml
+  ansible.builtin.include_tasks: install_grafana.yml
   when: ocp4_workload_quarkus_super_heroes_demo_install_grafana | bool
 
 - name: "[{{ t_project_name }}] - install Jaeger"
@@ -98,3 +98,4 @@
     state: present
     # yamllint disable-line rule:line-length
     definition: "{{ lookup('template', '../templates/opentelemetry_collector_instance.yaml.j2') | from_yaml_all | list }}"
+    

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/install_amqstreams_operator.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/install_amqstreams_operator.yml
@@ -9,7 +9,7 @@
   register: r_amq_sub
 
 - name: show existing AMQ Streams sub
-  debug:
+  ansible.builtin.debug:
     msg: "existing AMQ Streams sub: {{ r_amq_sub }}"
 
 - name: Create AMQ Streams subscription

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/install_grafana.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/install_grafana.yml
@@ -9,7 +9,7 @@
   register: r_grafana_sub
 
 - name: "[{{ t_project_name }}] - show existing Grafana sub"
-  debug:
+  ansible.builtin.debug:
     msg: "existing Grafana sub: {{ r_grafana_sub }}"
 
 - name: "[{{ t_project_name }}] - Create Grafana subscription"

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/install_jaeger_operator.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/install_jaeger_operator.yml
@@ -9,7 +9,7 @@
   register: r_jaeger_sub
 
 - name: show existing Jaeger sub
-  debug:
+  ansible.builtin.debug:
     msg: "existing Jaeger sub: {{ r_jaeger_sub }}"
 
 - name: Create Jaeger subscription

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/install_opentelemetry_operator.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/install_opentelemetry_operator.yml
@@ -8,8 +8,8 @@
     namespace: openshift-operators
   register: r_otel_sub
 
-- name: show existing OpenTelemetry sub
-  debug:
+- name: Show existing OpenTelemetry sub
+  ansible.builtin.debug:
     msg: "existing OpenTelemetry sub: {{ r_otel_sub }}"
 
 - name: Create OpenTelemetry subscription

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/install_prometheus.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/install_prometheus.yml
@@ -9,7 +9,7 @@
   register: r_prom_sub
 
 - name: "[{{ t_project_name }}] - show existing Prometheus sub"
-  debug:
+  ansible.builtin.debug:
     msg: "existing Prometheus sub: {{ r_prom_sub }}"
 
 - name: "[{{ t_project_name }}] - Create Prometheus subscription"

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/install_serverless.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/install_serverless.yml
@@ -1,0 +1,46 @@
+---
+# Install Serverless for all workspaces
+- name: Look for Serverless subscription
+  kubernetes.core.k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: Subscription
+    name: openshift-serverless
+    namespace: openshift-operators
+  register: r_serverless_sub
+
+- name: Show existing OpenShift Serverless sub
+  ansible.builtin.debug:
+    msg: "existing OpenShift Serverless sub: {{ r_serverless_sub }}"
+
+- name: Create OpenShift Serverless subscription
+  kubernetes.core.k8s:
+    state: present
+    merge_type:
+      - strategic-merge
+      - merge
+    definition: "{{ lookup('file', item ) | from_yaml_all }}"
+  loop:
+    - ./files/serverless_subscription.yaml
+  when: r_serverless_sub.resources | list | length == 0
+
+# wait for Serverkess CRDs
+- name: Wait for Serving CRD
+  kubernetes.core.k8s_info:
+    api_version: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    name: knativeservings.operator.knative.dev
+  register: r_knserving_crd
+  retries: 200
+  delay: 10
+  until: r_knserving_crd.resources | list | length == 1
+
+# install serving
+- name: Install Knative Serving
+  kubernetes.core.k8s:
+    state: present
+    merge_type:
+      - strategic-merge
+      - merge
+    definition: "{{ lookup('file', item) | from_yaml_all }}"
+  loop:
+    - ./files/knative_serving.yaml

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/post_workload.yml
@@ -32,8 +32,6 @@
         - Apicurio Schema Registry: http://apicurio-{{ t_project_name }}.{{ route_subdomain }}
         - Prometheus: http://prometheus-operated-{{ t_project_name }}.{{ route_subdomain }}
         - Jaeger: https://jaeger-{{ t_project_name }}.{{ route_subdomain }}
-
-
   loop: "{{ t_projects_matrix }}"
 
 - name: Post_workload tasks complete

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/post_workload.yml
@@ -2,44 +2,26 @@
 # I disabled the line-length rule on the whole file because I can't simply
 # disable a line within a literal block scalar
 ---
-- name: "[JVM] - Verify everything is deployed correctly"
-  include_tasks: verify_workload.yml
+- name: "Verify everything is deployed correctly"
+  ansible.builtin.include_tasks: verify_workload.yml
   vars:
-    t_project_name: "{{ ocp4_workload_quarkus_super_heroes_demo_project_name }}-java{{ item }}"
-  loop: "{{ ocp4_workload_quarkus_super_heroes_demo_java_versions | list }}"
+    t_project_name: "{{ ocp4_workload_quarkus_super_heroes_demo_project_name }}-{{ item[0] }}-{{ item[1] }}"
+  loop: "{{ t_projects_matrix }}"
 
-- name: "[Native] - Verify everything is deployed correctly"
-  include_tasks: verify_workload.yml
-  vars:
-    t_project_name: "{{ ocp4_workload_quarkus_super_heroes_demo_project_name }}-{{ ocp4_workload_quarkus_super_heroes_demo_native }}"
-
-- name: output demo info
+- name: Output demo info
   agnosticd_user_info:
     msg: |
       OpenShift credentials: {{ ocp_username }} / {{ ocp4_workload_quarkus_super_heroes_demo_ocp_password }}
       OpenShift/Kubernetes API (use with oc login): {{ master_url }}
       OpenShift Console URL: {{ console_url }}
 
-      There are 2 projects, each correlating to a version of the application as defined in {{ ocp4_workload_quarkus_super_heroes_demo_docs_link }}#versions:
+      There are 4 projects, 2 each for OpenShift and Knative variants.
+      
+      Each correlates to a version of the application as defined in {{ ocp4_workload_quarkus_super_heroes_demo_docs_link }}#versions:
 
-- name: Output JVM project info
+- name: Output project info
   vars:
-    t_project_name: "{{ ocp4_workload_quarkus_super_heroes_demo_project_name }}-java{{ item }}"
-  agnosticd_user_info:
-    msg: |
-      - {{ t_project_name }} ({{ console_url }}/topology/ns/{{ t_project_name }})
-        - Super Heroes UI: http://ui-super-heroes-{{ t_project_name }}.{{ route_subdomain }}
-        - Event statistics UI: http://event-statistics-{{ t_project_name }}.{{ route_subdomain }}
-        - Heroes service data UI: http://rest-heroes-{{ t_project_name }}.{{ route_subdomain }}
-        - Villains service data UI: http://rest-villains-{{ t_project_name }}.{{ route_subdomain }}
-        - Apicurio Schema Registry: http://apicurio-{{ t_project_name }}.{{ route_subdomain }}
-        - Prometheus: http://prometheus-operated-{{ t_project_name }}.{{ route_subdomain }}
-        - Jaeger: https://jaeger-{{ t_project_name }}.{{ route_subdomain }}
-  loop: "{{ ocp4_workload_quarkus_super_heroes_demo_java_versions | list }}"
-
-- name: Output Native project info
-  vars:
-    t_project_name: "{{ ocp4_workload_quarkus_super_heroes_demo_project_name }}-{{ ocp4_workload_quarkus_super_heroes_demo_native }}"
+    t_project_name: "{{ ocp4_workload_quarkus_super_heroes_demo_project_name }}-{{ item[0] }}-{{ item[1] }}"
   agnosticd_user_info:
     msg: |
       - {{ t_project_name }} ({{ console_url }}/topology/ns/{{ t_project_name }})
@@ -51,7 +33,10 @@
         - Prometheus: http://prometheus-operated-{{ t_project_name }}.{{ route_subdomain }}
         - Jaeger: https://jaeger-{{ t_project_name }}.{{ route_subdomain }}
 
-- name: post_workload tasks complete
-  debug:
+
+  loop: "{{ t_projects_matrix }}"
+
+- name: Post_workload tasks complete
+  ansible.builtin.debug:
     msg: "Post-Workload Tasks completed successfully."
   when: not silent | bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/post_workload.yml
@@ -16,7 +16,7 @@
       OpenShift Console URL: {{ console_url }}
 
       There are 4 projects, 2 each for OpenShift and Knative variants.
-      
+
       Each correlates to a version of the application as defined in {{ ocp4_workload_quarkus_super_heroes_demo_docs_link }}#versions:
 
 - name: Output project info

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/pre_workload.yml
@@ -27,19 +27,19 @@
   register: route_subdomain_r
 
 - name: set route_subdomain
-  set_fact:
+  ansible.builtin.set_fact:
     route_subdomain: "{{ route_subdomain_r.resources[0].status.domain }}"
 
 - name: set the master
-  set_fact:
+  ansible.builtin.set_fact:
     master_url: "{{ r_api_url.resources[0].status.apiServerURL }}"
 
 - name: set the console
-  set_fact:
+  ansible.builtin.set_fact:
     console_url: "https://{{ r_console_route.resources[0].spec.host }}"
 
-- name: debug values
-  debug:
+- name: ansible.builtin.debug values
+  ansible.builtin.debug:
     msg:
       - "master URL: {{ master_url }}"
       - "console URL: {{ console_url }}"
@@ -47,6 +47,6 @@
       - "ocp_username: {{ ocp_username }}"
 
 - name: pre_workload tasks complete
-  debug:
+  ansible.builtin.debug:
     msg: "Pre-Workload tasks completed successfully."
   when: not silent | bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/remove_workload.yml
@@ -1,24 +1,29 @@
 ---
-- name: Remove JVM projects
+- name: Remove projects
   vars:
     # yamllint disable-line rule:line-length
-    t_project_name: "{{ ocp4_workload_quarkus_super_heroes_demo_project_name }}-java{{ item }}"
+    t_project_name: "{{ ocp4_workload_quarkus_super_heroes_demo_project_name }}-{{ item[0] }}-{{ item[1] }}"
   kubernetes.core.k8s:
     api_version: project.openshift.io/v1
     kind: Project
     name: "{{ t_project_name }}"
     state: absent
-  # yamllint disable-line rule:line-length
-  loop: "{{ ocp4_workload_quarkus_super_heroes_demo_java_versions | list }}"
+  loop: "{{ t_projects_matrix }}"
 
-- name: Remove Native project
-  vars:
-    # yamllint disable-line rule:line-length
-    t_project_name: "{{ ocp4_workload_quarkus_super_heroes_demo_project_name }}-{{ ocp4_workload_quarkus_super_heroes_demo_native }}"
+- name: Remove Knative serving
   kubernetes.core.k8s:
-    api_version: project.openshift.io/v1
-    kind: Project
-    name: "{{ t_project_name }}"
+    api_version: operator.knative.dev/v1beta1
+    kind: KnativeServing
+    name: knative-serving
+    namespace: knative-serving
+    state: absent
+
+- name: Remove OpenShift Serverless
+  kubernetes.core.k8s:
+    api_version: operators.coreos.com/v1alpha1
+    kind: Subscription
+    name: serverless-operator
+    namespace: openshift-serverless
     state: absent
 
 - name: Remove operator subscriptions
@@ -69,6 +74,6 @@
     path: "{{ ocp4_workload_quarkus_super_heroes_demo_temp_dir }}"
 
 - name: remove_workload tasks complete
-  debug:
+  ansible.builtin.debug:
     msg: "Remove Workload tasks completed successfully."
   when: not silent | bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/remove_workload.yml
@@ -1,4 +1,14 @@
 ---
+- name: Calculate app versions
+  ansible.builtin.set_fact:
+    # yamllint disable-line rule:line-length
+    t_app_versions: "{{ ['java'] | product(ocp4_workload_quarkus_super_heroes_demo_java_versions) | map('join') + [ocp4_workload_quarkus_super_heroes_demo_native] | list }}"
+
+- name: Calculate projects
+  ansible.builtin.set_fact:
+    # yamllint disable-line rule:line-length
+    t_projects_matrix: "{{ t_app_versions | product(ocp4_workload_quarkus_super_heroes_demo_deployment_kinds) | list }}"
+
 - name: Remove projects
   vars:
     # yamllint disable-line rule:line-length

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/verify_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/verify_workload.yml
@@ -8,7 +8,7 @@
   register: r_svc
   until: r_svc.status == 200
   retries: 50
-  delay: 10
+  delay: 15
   loop: "{{ ocp4_workload_quarkus_super_heroes_demo_service_project_names }}"
   loop_control:
     loop_var: t_app_name
@@ -21,7 +21,7 @@
   register: r_svc
   until: r_svc.status == 200
   retries: 50
-  delay: 10
+  delay: 15
   loop: "{{ ocp4_workload_quarkus_super_heroes_demo_infra_http_names }}"
   loop_control:
     loop_var: t_infra_name
@@ -34,7 +34,7 @@
   register: r_svc
   until: r_svc.status == 200
   retries: 50
-  delay: 10
+  delay: 15
   loop: "{{ ocp4_workload_quarkus_super_heroes_demo_infra_https_names }}"
   loop_control:
     loop_var: t_infra_name

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/workload.yml
@@ -2,7 +2,7 @@
 # Access for admin
 
 - name: Give access to opentlc-mgr
-  shell: oc adm policy add-cluster-role-to-user cluster-admin opentlc-mgr
+  ansible.builtin.shell: oc adm policy add-cluster-role-to-user cluster-admin opentlc-mgr
 
 - name: Install Cert Manager
   kubernetes.core.k8s:
@@ -11,13 +11,13 @@
     definition: "{{ lookup('file', '../files/cert_manager_subscription.yaml') | from_yaml_all | list }}"
 
 - name: Install AMQ Streams
-  include_tasks: install_amqstreams_operator.yml
+  ansible.builtin.include_tasks: install_amqstreams_operator.yml
 
 - name: Install OpenTelemetry
-  include_tasks: install_opentelemetry_operator.yml
+  ansible.builtin.include_tasks: install_opentelemetry_operator.yml
 
 - name: Install Jaeger
-  include_tasks: install_jaeger_operator.yml
+  ansible.builtin.include_tasks: install_jaeger_operator.yml
 
 - name: Install container security
   kubernetes.core.k8s:
@@ -25,23 +25,29 @@
     # yamllint disable-line rule:line-length
     definition: "{{ lookup('file', '../files/container_security_subscription.yaml') | from_yaml }}"
 
-- name: Deploy JVM projects
-  include_tasks: deploy_projects.yml
+- name: Install OpenShift Serverless
+  ansible.builtin.include_tasks: install_serverless.yml
+
+- name: Calculate app versions
+  ansible.builtin.set_fact:
+    # yamllint disable-line rule:line-length
+    t_app_versions: "{{ ['java'] | product(ocp4_workload_quarkus_super_heroes_demo_java_versions) | map('join') + [ocp4_workload_quarkus_super_heroes_demo_native] | list }}"
+
+- name: Calculate projects
+  ansible.builtin.set_fact:
+    # yamllint disable-line rule:line-length
+    t_projects_matrix: "{{ t_app_versions | product(ocp4_workload_quarkus_super_heroes_demo_deployment_kinds) | list }}"
+
+- name: Deploy projects
+  ansible.builtin.include_tasks: deploy_projects.yml
   vars:
     # yamllint disable-line rule:line-length
-    t_project_name: "{{ ocp4_workload_quarkus_super_heroes_demo_project_name }}-java{{ item }}"
-    t_app_version: "java{{ item }}"
-  # yamllint disable-line rule:line-length
-  loop: "{{ ocp4_workload_quarkus_super_heroes_demo_java_versions | list }}"
+    t_project_name: "{{ ocp4_workload_quarkus_super_heroes_demo_project_name }}-{{ item[0] }}-{{ item[1] }}"
+    t_app_version: "{{ item[0] }}"
+    t_app_deployment_kind: "{{ item[1] }}"
+  loop: "{{ t_projects_matrix }}"
 
-- name: Deploy Native project
-  include_tasks: deploy_projects.yml
-  vars:
-    # yamllint disable-line rule:line-length
-    t_project_name: "{{ ocp4_workload_quarkus_super_heroes_demo_project_name }}-{{ ocp4_workload_quarkus_super_heroes_demo_native }}"
-    t_app_version: "{{ ocp4_workload_quarkus_super_heroes_demo_native }}"
-
-- name: workload tasks complete
-  debug:
+- name: Workload tasks complete
+  ansible.builtin.debug:
     msg: "Workload Tasks completed successfully."
   when: not silent | bool


### PR DESCRIPTION
##### SUMMARY

Some enhancements to the `OCP4_QUARKUS_SUPERHEROES_DEMO` role:
- Installation of the OpenShift Serverless Operator & Knative serving capabilities
- Additional installation of the knative versions of the applications

I tested this by pointing DEV to my local fork (see https://github.com/rhpds/agnosticv/pull/12892) and then ordering the DEV catalog item.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
OCP4_QUARKUS_SUPERHEROES_DEMO

##### ADDITIONAL INFORMATION
```
╰─ ansible --version
ansible [core 2.15.5]
  config file = /Users/edeandre/workspaces/ansible/agnosticd/ansible/ansible.cfg
  configured module search path = ['/Users/edeandre/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /opt/homebrew/Cellar/ansible/8.5.0/libexec/lib/python3.11/site-packages/ansible
  ansible collection location = /Users/edeandre/.ansible/collections:/usr/share/ansible/collections
  executable location = /opt/homebrew/bin/ansible
  python version = 3.11.6 (main, Oct  2 2023, 13:45:54) [Clang 15.0.0 (clang-1500.0.40.1)] (/opt/homebrew/Cellar/ansible/8.5.0/libexec/bin/python)
  jinja version = 3.1.2
  libyaml = True

╰─ pip freeze                 
zsh: command not found: pip
```
