### PR TITLE
Add support to deploy a policy shell script as root

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rosa_policies/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rosa_policies/defaults/main.yml
@@ -7,5 +7,7 @@ ocp4_workload_rosa_policies_aws_user_name: rosa-student
 ocp4_workload_rosa_policies_repo: https://github.com/rhpds/rosa-policies
 ocp4_workload_rosa_policies_repo_branch: main
 ocp4_workload_rosa_policies_to_apply:
-- rosa-student
-- microsweeper
+- name: rosa-student
+  run_as_root: false
+- name: microsweeper
+  run_as_root: false

--- a/ansible/roles_ocp_workloads/ocp4_workload_rosa_policies/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rosa_policies/tasks/workload.yml
@@ -102,8 +102,9 @@
       AWS_ACCOUNT_ID: "{{ student_aws_account_id }}"
       OIDC_ENDPOINT: "{{ oidc_endpoint }}"
     ansible.builtin.command:
-      cmd: "~{{ ansible_user }}/rosa-policies/{{ item }}.sh"
+      cmd: "{% if item.run_as_root | bool %}sudo --preserve-env {% endif %}~{{ ansible_user }}/rosa-policies/{{ item.name }}.sh"
     loop: "{{ ocp4_workload_rosa_policies_to_apply }}"
+    ignore_errors: true
 
 - name: Remove full AWS credentials
   become: true


### PR DESCRIPTION
##### SUMMARY

Need to run a few of the rosa policies shell scripts as root. Adding that capability.

BREAKING CHANGE:

The list of policies to apply changed from a simple YAML list to a dictionary...

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_rosa_policies