### PR TITLE
Make the var report more robust for cross cloud use

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/report-variables.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/report-variables.yaml
@@ -25,9 +25,10 @@
     data:
       showroom_url: "{{ _showroom_url }}"
       showroom_primary_view_url: "{{ _showroom_url }}/"
-      bastion_public_hostname: "bastion.{{ guid }}.{{ cluster_dns_zone }}"
-      bastion_ssh_user_name: "{{ remote_user }}"
-      bastion_ssh_password: "{{ generated_password }}"
+      bastion_public_hostname: "bastion.{{ guid }}.{{ cluster_dns_zone | default(_alt_cluster_dns_zone) }}"
+      bastion_ssh_user_name: "{{ remote_user | default('not_set') }}"
+      bastion_ssh_password: "{{ generated_password | default(common_password) | default('not_set') }}"
   vars:
     _route: "{{ r_showroom_route.resources[0] }}"
     _showroom_url: "https://{{ _route.spec.host }}/"
+    _alt_cluster_dns_zone: "{{ subdomain_base | default('not_set') }}"


### PR DESCRIPTION

##### SUMMARY

ocp_workload_showroom role fails on ec2 as some vars were Azure-specific
Changes add support for ec2 and safe defaults for a cloud_provider not using the desired vars

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

roles/ocp_workload_showroom

##### ADDITIONAL INFORMATION
