### PR TITLE
Add support for Repo Ref to Showroom Workload

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/README.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/README.adoc
@@ -28,6 +28,7 @@ infra_workloads:
 [source,yaml]
 ----
 ocp4_workload_showroom_content_git_repo: "https://github.com/rhpds/showroom_template_default.git"
+ocp4_workload_showroom_content_git_ref: main
 ----
 
 [#env_type]
@@ -97,4 +98,5 @@ NOTE: Key based authentication is TODO
 # --------------------------------------------------------------------
 showroom_deploy_shared_cluster_enable: true <2>
 ocp4_workload_showroom_content_git_repo: https://github.com/rhpds/showroom_template_default.git
+ocp4_workload_showroom_content_git_ref: main
 ----

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/defaults/main.yaml
@@ -11,6 +11,7 @@ ocp4_workload_showroom_namespace_display: Showroom Guide
 
 # Content repository to be rendered as lab instructions
 ocp4_workload_showroom_content_git_repo: https://github.com/rhpds/showroom_template_default.git
+ocp4_workload_showroom_content_git_ref: main
 
 # Log into bastion automatically from terminal
 ocp4_workload_showroom_auto_ssh_bastion_login_enable: false

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm.yaml
@@ -22,6 +22,8 @@
       value_type: "string"
     - value: "content.repoUrl={{ ocp4_workload_showroom_content_git_repo }}"
       value_type: "string"
+    - value: "content.repoRef={{ ocp4_workload_showroom_content_git_ref }}"
+      value_type: "string"
     - value: "terminal.wetty.autoSshToBastion={{ ocp4_workload_showroom_auto_ssh_bastion_login_enable }}"
       value_type: "string"
     - value: "terminal.wetty.sshAuth=password"

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/templates/application.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/templates/application.yaml.j2
@@ -41,5 +41,6 @@ spec:
             sshUser: {{ _showroom_user_data.bastion_ssh_user_name }}
         content:
           repoUrl: {{ ocp4_workload_showroom_content_git_repo }}
+          repoRef: {{ ocp4_workload_showroom_content_git_ref }}
           user_data: |-
             {{ _showroom_user_data | to_nice_yaml | indent(12) }}

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/templates/applicationset.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/templates/applicationset.yaml.j2
@@ -54,5 +54,6 @@ spec:
                 sshUser: {{ _showroom_user_data.bastion_ssh_user_name }}
             content:
               repoUrl: {{ ocp4_workload_showroom_content_git_repo }}
+              repoRef: {{ ocp4_workload_showroom_content_git_ref }}
               user_data: |
                   {% raw %}{{- .userData | nindent 4}}{% endraw %}


### PR DESCRIPTION
##### SUMMARY

Showroom Workload was missing support for content repo ref - while the Helm Charts actually support that variable.

Fixed.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_showroom