### PR TITLE
Add vars to remove insights motd - and add custom motd - on bastion

### DIFF
--- a/ansible/configs/rosa-consolidated/default_vars.yml
+++ b/ansible/configs/rosa-consolidated/default_vars.yml
@@ -29,6 +29,12 @@ bastion_user_enable_sudo: false
 bastion_user_password: ""
 bastion_user_password_length: 12
 
+# Remove motd (register for insights) prompt from bastion
+bastion_remove_insights_motd: false
+
+# Add a custom motd to the bastion. Only set when specified
+# bastion_custom_motd: Welcome to the Red Hat OpenShift Service on AWS Hands On Experience!
+
 # Deploy Rosa - set to false for manual installation
 rosa_deploy: true
 

--- a/ansible/configs/rosa-consolidated/pre_software.yml
+++ b/ansible/configs/rosa-consolidated/pre_software.yml
@@ -50,6 +50,21 @@
       name: sshd
       state: restarted
 
+  - name: Remove register for insights motd
+    when: bastion_remove_insights_motd | bool
+    ansible.builtin.file:
+      state: absent
+      path: /etc/motd.d/insights-client
+
+  - name: Add a custom motd to the bastion
+    when: bastion_custom_motd | default("") | length > 0
+    ansible.builtin.copy:
+      dest: /etc/motd.d/agnosticd
+      owner: root
+      group: root
+      mode: "o=rw,g=rw,o=r"
+      content: "{{ bastion_custom_motd }}"
+
 - name: PreSoftware flight-check
   hosts: localhost
   connection: local


### PR DESCRIPTION
##### SUMMARY

On a default RHEL installation a prompt is shown upon login to register with insights.

Add two vars:
- bastion_remove_insights_motd: false
- bastion_custom_motd: Welcome to the Red Hat OpenShift Service on AWS Hands On Experience!

to customize the text.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
rosa-consolidated