### PR TITLE
Change enable root user to false. True caused unintended consequences.

### DIFF
--- a/ansible/roles/showroom/defaults/main.yml
+++ b/ansible/roles/showroom/defaults/main.yml
@@ -30,7 +30,7 @@ showroom_user_content_dir: "{{ showroom_user_home_dir }}/content"
 showroom_ssh_method: password         # password | config (ie via config && ssh key)
 showroom_ssh_key_type: ed25519        # ed25519 | rsa
 
-showroom_enable_root_ssh: true
+showroom_enable_root_ssh: false
   # showroom_default_ssh_user:
 showroom_lab_users:
   - "{{ showroom_default_ssh_user | default('rhel') }}"


### PR DESCRIPTION
##### SUMMARY

Change default for `showroom_enable_root_ssh` to false. Having the default as true made specifying users obsolete.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
showroom