### PR TITLE
Change role OCP4_QUARKUS_SUPERHEROES_DEMO fix serverless & kafka errors

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/files/amqstreams_instance.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/files/amqstreams_instance.yaml
@@ -202,11 +202,15 @@ spec:
           name: kafka-metrics
           key: kafka-metrics-config.yml
     readinessProbe:
-      initialDelaySeconds: 15
-      timeoutSeconds: 5
+      initialDelaySeconds: 60
+      timeoutSeconds: 15
+      failureThreshold: 5
+      periodSeconds: 30
     livenessProbe:
-      initialDelaySeconds: 15
-      timeoutSeconds: 5
+      initialDelaySeconds: 60
+      timeoutSeconds: 15
+      failureThreshold: 5
+      periodSeconds: 30
   entityOperator:
     topicOperator: {}
     userOperator: {}
@@ -224,11 +228,15 @@ spec:
           name: kafka-metrics
           key: zookeeper-metrics-config.yml
     readinessProbe:
-      initialDelaySeconds: 15
-      timeoutSeconds: 5
+      initialDelaySeconds: 60
+      timeoutSeconds: 15
+      failureThreshold: 5
+      periodSeconds: 30
     livenessProbe:
-      initialDelaySeconds: 15
-      timeoutSeconds: 5
+      initialDelaySeconds: 60
+      timeoutSeconds: 15
+      failureThreshold: 5
+      periodSeconds: 30
 ---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/deploy_projects.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/deploy_projects.yml
@@ -11,12 +11,8 @@
           openshift.io/description: "Quarkus Superheroes for {{ t_app_version }} ({{ t_app_deployment_kind }})"
           openshift.io/display-name: "Quarkus Superheroes for {{ t_app_version }} ({{ t_app_deployment_kind }})"
 
-- name: "[{{ t_project_name }}] - deploy Kafka"
-  kubernetes.core.k8s:
-    namespace: "{{ t_project_name }}"
-    state: present
-    # yamllint disable-line rule:line-length
-    definition: "{{ lookup('file', '../files/amqstreams_instance.yaml') | from_yaml_all | list }}"
+- name: "[{{ t_project_name }}] - Install Kafka"
+  ansible.builtin.include_tasks: install_kafka.yml
 
 # Download and apply manifest
 - name: "[{{ t_project_name }}] - Download application manifest"

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/install_kafka.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/install_kafka.yml
@@ -1,0 +1,66 @@
+---
+- name: "[{{ t_project_name }}] - Install Kafka"
+  block:
+    - name: "[{{ t_project_name }}] - Deploy Kafka instance"
+      kubernetes.core.k8s:
+        namespace: "{{ t_project_name }}"
+        state: present
+        # yamllint disable-line rule:line-length
+        definition: "{{ lookup('file', '../files/amqstreams_instance.yaml') | from_yaml_all | list }}"
+
+    - name: "[{{ t_project_name }}] - Wait for Kafka"
+      kubernetes.core.k8s_info:
+        api_version: kafka.strimzi.io/v1beta2
+        kind: Kafka
+        name: fights-kafka
+        namespace: "{{ t_project_name }}"
+      register: r_kafka
+      retries: 200
+      delay: 15
+      until:
+        - r_kafka.resources | list | length == 1
+        - r_kafka.resources[0].status is defined
+        - r_kafka.resources[0].status.conditions is defined
+        # yamllint disable-line rule:line-length
+        - r_kafka.resources[0].status.conditions | selectattr('type', 'equalto', 'Ready') | map(attribute='status') | list | length == 1
+        # yamllint disable-line rule:line-length
+        - r_kafka.resources[0].status.conditions | selectattr('type', 'equalto', 'Ready') | map(attribute='status') | list | first | bool
+
+  rescue:
+    - name: "[{{ t_project_name }}] - Kill zookeeper pods"
+      kubernetes.core.k8s:
+        api_version: v1
+        kind: Pod
+        namespace: "{{ t_project_name }}"
+        state: absent
+        label_selectors:
+          - "app = fights-kafka"
+          - "strimzi.io/component-type = zookeeper"
+
+    - name: "[{{ t_project_name }}] - Kill kafka pods"
+      kubernetes.core.k8s:
+        api_version: v1
+        kind: Pod
+        namespace: "{{ t_project_name }}"
+        state: absent
+        label_selectors:
+          - "app = fights-kafka"
+          - "strimzi.io/component-type = kafka"
+
+    - name: "[{{ t_project_name }}] - Wait for Kafka after killing pods"
+      kubernetes.core.k8s_info:
+        api_version: kafka.strimzi.io/v1beta2
+        kind: Kafka
+        name: fights-kafka
+        namespace: "{{ t_project_name }}"
+      register: r_kafka
+      retries: 200
+      delay: 15
+      until:
+        - r_kafka.resources | list | length == 1
+        - r_kafka.resources[0].status is defined
+        - r_kafka.resources[0].status.conditions is defined
+        # yamllint disable-line rule:line-length
+        - r_kafka.resources[0].status.conditions | selectattr('type', 'equalto', 'Ready') | map(attribute='status') | list | length == 1
+        # yamllint disable-line rule:line-length
+        - r_kafka.resources[0].status.conditions | selectattr('type', 'equalto', 'Ready') | map(attribute='status') | list | first | bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/install_serverless.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/install_serverless.yml
@@ -44,3 +44,21 @@
     definition: "{{ lookup('file', item) | from_yaml_all }}"
   loop:
     - ./files/knative_serving.yaml
+
+- name: Wait for Knative Serving
+  kubernetes.core.k8s_info:
+    api_version: operator.knative.dev/v1beta1
+    kind: KnativeServing
+    name: knative-serving
+    namespace: knative-serving
+  register: r_knserving
+  retries: 200
+  delay: 15
+  until:
+    - r_knserving.resources | list | length == 1
+    - r_knserving.resources[0].status is defined
+    - r_knserving.resources[0].status.conditions is defined
+    # yamllint disable-line rule:line-length
+    - r_knserving.resources[0].status.conditions | selectattr('type', 'equalto', 'Ready') | map(attribute='status') | list | length == 1
+    # yamllint disable-line rule:line-length
+    - r_knserving.resources[0].status.conditions | selectattr('type', 'equalto', 'Ready') | map(attribute='status') | list | first | bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/post_workload.yml
@@ -10,7 +10,8 @@
 
 - name: Output demo info
   agnosticd_user_info:
-    msg: |
+    msg: |+
+      [%hardbreaks]
       OpenShift credentials: {{ ocp_username }} / {{ ocp4_workload_quarkus_super_heroes_demo_ocp_password }}
       OpenShift/Kubernetes API (use with oc login): {{ master_url }}
       OpenShift Console URL: {{ console_url }}
@@ -23,15 +24,16 @@
   vars:
     t_project_name: "{{ ocp4_workload_quarkus_super_heroes_demo_project_name }}-{{ item[0] }}-{{ item[1] }}"
   agnosticd_user_info:
-    msg: |
-      - {{ t_project_name }} ({{ console_url }}/topology/ns/{{ t_project_name }})
-        - Super Heroes UI: http://ui-super-heroes-{{ t_project_name }}.{{ route_subdomain }}
-        - Event statistics UI: http://event-statistics-{{ t_project_name }}.{{ route_subdomain }}
-        - Heroes service data UI: http://rest-heroes-{{ t_project_name }}.{{ route_subdomain }}
-        - Villains service data UI: http://rest-villains-{{ t_project_name }}.{{ route_subdomain }}
-        - Apicurio Schema Registry: http://apicurio-{{ t_project_name }}.{{ route_subdomain }}
-        - Prometheus: http://prometheus-operated-{{ t_project_name }}.{{ route_subdomain }}
-        - Jaeger: https://jaeger-{{ t_project_name }}.{{ route_subdomain }}
+    msg: |+
+      [%hardbreaks]
+      * {{ t_project_name }} ({{ console_url }}/topology/ns/{{ t_project_name }})
+      ** Super Heroes UI: http://ui-super-heroes-{{ t_project_name }}.{{ route_subdomain }}
+      ** Event statistics UI: http://event-statistics-{{ t_project_name }}.{{ route_subdomain }}
+      ** Heroes service data UI: http://rest-heroes-{{ t_project_name }}.{{ route_subdomain }}
+      ** Villains service data UI: http://rest-villains-{{ t_project_name }}.{{ route_subdomain }}
+      ** Apicurio Schema Registry: http://apicurio-{{ t_project_name }}.{{ route_subdomain }}
+      ** Prometheus: http://prometheus-operated-{{ t_project_name }}.{{ route_subdomain }}
+      ** Jaeger: https://jaeger-{{ t_project_name }}.{{ route_subdomain }}
   loop: "{{ t_projects_matrix }}"
 
 - name: Post_workload tasks complete

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/remove_workload.yml
@@ -78,6 +78,25 @@
   loop_control:
     loop_var: t_csv_name
 
+- name: Get Serverless cluster service versions
+  kubernetes.core.k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    namespace: openshift-serverless
+    kind: ClusterServiceVersion
+  register: r_serverless_cluster_service_versions
+
+- name: Remove Serverless cluster service versions
+  kubernetes.core.k8s:
+    api_version: operators.coreos.com/v1alpha1
+    namespace: openshift-serverless
+    kind: ClusterServiceVersion
+    name: "{{ t_csv_name }}"
+    state: absent
+  # yamllint disable-line rule:line-length
+  loop: "{{ r_serverless_cluster_service_versions | json_query('resources[*].metadata.name') | select('search', '^(serverless)') | list }}"
+  loop_control:
+    loop_var: t_csv_name
+
 - name: Delete temp dir
   file:
     state: absent


### PR DESCRIPTION
##### SUMMARY

Some enhancements and fixes:
- Waiting for the `KnativeServing` installation to finish before proceeding
- In each namespace, wait for the `Kafka` installation to finish, along with some failure handling in the case it doesn't provision correctly
- Nicer formatting in provision email

I tested this by pointing DEV to my local fork (see https://github.com/rhpds/agnosticv/pull/12928) and then ordering the DEV catalog item. I did this quite a few times before creating this PR.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
OCP4_QUARKUS_SUPERHEROES_DEMO
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```
╰─ ansible --version                                                             
ansible [core 2.16.0]
  config file = /Users/edeandre/workspaces/ansible/agnosticd/ansible.cfg
  configured module search path = ['/Users/edeandre/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /opt/homebrew/Cellar/ansible/9.0.1/libexec/lib/python3.12/site-packages/ansible
  ansible collection location = /Users/edeandre/.ansible/collections:/usr/share/ansible/collections
  executable location = /opt/homebrew/bin/ansible
  python version = 3.12.0 (main, Oct  2 2023, 12:03:24) [Clang 15.0.0 (clang-1500.0.40.1)] (/opt/homebrew/Cellar/ansible/9.0.1/libexec/bin/python)
  jinja version = 3.1.2
  libyaml = True
```
