### PR TITLE
Increase retries for Gitea repository creation

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/tasks/workload.yml
@@ -226,7 +226,7 @@
         - "{{ ocp4_workload_gitea_operator_repositories_list | join(', ', attribute='repo') }}"
 
 # Leave this as the last task in the playbook.
-- name: workload tasks complete
+- name: Workload tasks complete
   ansible.builtin.debug:
     msg: "Workload Tasks completed successfully."
   when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/tasks/workload.yml
@@ -53,7 +53,7 @@
     - ocp4_workload_gitea_operator_user_number | int | default(0) > 0
     quiet: true
     fail_msg: >-
-      Migrating repositories requires more than one user to be created.
+      Migrating repositories requires at least one user to be created.
 
 #####################################################################
 # Install Gitea Operator
@@ -109,7 +109,7 @@
   - name: Create Gitea instance
     kubernetes.core.k8s:
       state: present
-      definition: "{{ lookup('template', 'gitea.yaml.j2' ) | from_yaml }}"
+      definition: "{{ lookup('template', 'gitea.yaml.j2') | from_yaml }}"
 
   - name: Wait for Gitea route to be available
     kubernetes.core.k8s_info:
@@ -145,7 +145,7 @@
       until:
       - r_gitea_admin_password.resources[0].status.adminSetupComplete is defined
       - r_gitea_admin_password.resources[0].status.adminSetupComplete | bool
-      retries: 60
+      retries: 90
       delay: 10
 
     - name: Print admin credentials if admin was created
@@ -215,7 +215,7 @@
         until:
         - r_gitea_repo_setup_complete.resources[0].status.repoMigrationComplete is defined
         - r_gitea_repo_setup_complete.resources[0].status.repoMigrationComplete | bool
-        retries: 60
+        retries: 120
         delay: 10
 
       - name: Print the repositories that were migrated


### PR DESCRIPTION
##### SUMMARY

Creating repositories with the Gitea operator timed out when it was more than 40 users. Doubled the timeout (and did a few minor cosmetic changes).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_gitea_operator