### PR TITLE
Remove 50-cloud-init.conf file

### DIFF
--- a/ansible/configs/rosa-consolidated/default_vars.yml
+++ b/ansible/configs/rosa-consolidated/default_vars.yml
@@ -35,6 +35,8 @@ bastion_remove_insights_motd: false
 # Add a custom motd to the bastion. Only set when specified
 # bastion_custom_motd: Welcome to the Red Hat OpenShift Service on AWS Hands On Experience!
 
+# Remove the file /etc/ssh/sshd_config.d/50-cloud-init.conf
+# This file (on RHEL 9.3) prevents password logins to the bastion
 bastion_remove_cloud_init_conf: true
 
 # Deploy Rosa - set to false for manual installation

--- a/ansible/configs/rosa-consolidated/default_vars.yml
+++ b/ansible/configs/rosa-consolidated/default_vars.yml
@@ -35,6 +35,8 @@ bastion_remove_insights_motd: false
 # Add a custom motd to the bastion. Only set when specified
 # bastion_custom_motd: Welcome to the Red Hat OpenShift Service on AWS Hands On Experience!
 
+bastion_remove_cloud_init_conf: true
+
 # Deploy Rosa - set to false for manual installation
 rosa_deploy: true
 

--- a/ansible/configs/rosa-consolidated/pre_software.yml
+++ b/ansible/configs/rosa-consolidated/pre_software.yml
@@ -45,6 +45,12 @@
       regexp: '^ *PasswordAuthentication'
       path: /etc/ssh/sshd_config
 
+  - name: Remove 50-cloud-init.conf
+    when: bastion_remove_cloud_init_conf | default(true) | bool
+    ansible.builtin.file:
+      state: absent
+      path: /etc/ssh/sshd_config.d/50-cloud-init.conf
+
   - name: Restart sshd
     ansible.builtin.service:
       name: sshd


### PR DESCRIPTION
##### SUMMARY

This file gets created by RHEL 9.3 apparently and prevents login with a password. Removing if it's there.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rosa-consolidated