### PR TITLE
Update Serverless Workload for latest versions

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/defaults/main.yml
@@ -3,14 +3,10 @@ become_override: false
 ocp_username: opentlc-mgr
 silent: false
 
-# Defaults values below are for OpenShift Serverless v1.7.2 (GA)
+# Defaults values below are for OpenShift Serverless v1.30.x++
 
 # Channel to use for the OpenShift Serverless subscription
-# When not set (or set to "") use the default channel for the
-# OpenShift version this operator is installed on. If there is no matchin
-# version use the `defaultChannel`
-ocp4_workload_serverless_channel: ""
-# ocp4_workload_serverless_channel: "4.6"
+ocp4_workload_serverless_channel: stable
 
 # Set automatic InstallPlan approval. If set to false it is also suggested
 # to set the starting_csv to pin a specific version
@@ -24,14 +20,13 @@ ocp4_workload_serverless_automatic_install_plan_approval: true
 # empty to get the latest available in the channel at the time when
 # the catalog snapshot got created.
 ocp4_workload_serverless_starting_csv: ""
-# ocp4_workload_serverless_starting_csv: "serverless-operator.v1.10.0"
+# ocp4_workload_serverless_starting_csv: "serverless-operator.v1.30.0"
 
 # Wait for the deployment to finish - and check that it finished successfully
 ocp4_workload_serverless_wait_for_deploy: true
 
-# Install KNative Eventing? KNative Eventing is Tech Preview in 4.4 and 4.5.
-# Therefore default to false
-ocp4_workload_serverless_install_eventing: false
+# Install KNative Eventing
+ocp4_workload_serverless_install_eventing: true
 
 # --------------------------------
 # Operator Catalog Snapshot Settings
@@ -50,4 +45,4 @@ ocp4_workload_serverless_catalogsource_name: redhat-operators-snapshot-serverles
 ocp4_workload_serverless_catalog_snapshot_image: quay.io/gpte-devops-automation/olm_snapshot_redhat_catalog
 
 # Catalog snapshot image tag
-ocp4_workload_serverless_catalog_snapshot_image_tag: "v4.6_2020_10_28"
+ocp4_workload_serverless_catalog_snapshot_image_tag: v4.14_2023_12_04

--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/files/knative_eventing.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/files/knative_eventing.yaml
@@ -1,6 +1,0 @@
-apiVersion: operator.knative.dev/v1alpha1
-kind: KnativeEventing
-metadata:
-  name: knative-eventing
-  namespace: knative-eventing
-spec: {}

--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/files/knative_serving.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/files/knative_serving.yaml
@@ -1,6 +1,0 @@
-apiVersion: operator.knative.dev/v1alpha1
-kind: KnativeServing
-metadata:
-  name: knative-serving
-  namespace: knative-serving
-spec: {}

--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/main.yml
@@ -2,29 +2,29 @@
 # Do not modify this file
 
 - name: Running Pre Workload Tasks
-  include_tasks:
+  when: ACTION == "create" or ACTION == "provision"
+  ansible.builtin.include_tasks:
     file: ./pre_workload.yml
     apply:
       become: "{{ become_override | bool }}"
-  when: ACTION == "create" or ACTION == "provision"
 
 - name: Running Workload Tasks
-  include_tasks:
+  when: ACTION == "create" or ACTION == "provision"
+  ansible.builtin.include_tasks:
     file: ./workload.yml
     apply:
       become: "{{ become_override | bool }}"
-  when: ACTION == "create" or ACTION == "provision"
 
 - name: Running Post Workload Tasks
-  include_tasks:
+  when: ACTION == "create" or ACTION == "provision"
+  ansible.builtin.include_tasks:
     file: ./post_workload.yml
     apply:
       become: "{{ become_override | bool }}"
-  when: ACTION == "create" or ACTION == "provision"
 
 - name: Running Workload removal Tasks
-  include_tasks:
+  when: ACTION == "destroy" or ACTION == "remove"
+  ansible.builtin.include_tasks:
     file: ./remove_workload.yml
     apply:
       become: "{{ become_override | bool }}"
-  when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/post_workload.yml
@@ -1,9 +1,8 @@
 ---
 # Implement your Post Workload deployment tasks here
 
-
 # Leave this as the last task in the playbook.
-- name: post_workload tasks complete
-  debug:
-    msg: "Post-Workload Tasks completed successfully."
+- name: Post_workload tasks complete
   when: not silent|bool
+  ansible.builtin.debug:
+    msg: "Post-Workload Tasks completed successfully."

--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/pre_workload.yml
@@ -2,7 +2,7 @@
 # Implement your Pre Workload deployment tasks here
 
 # Leave this as the last task in the playbook.
-- name: pre_workload tasks complete
-  debug:
-    msg: "Pre-Workload tasks completed successfully."
+- name: Pre_workload tasks complete
   when: not silent|bool
+  ansible.builtin.debug:
+    msg: "Pre-Workload tasks completed successfully."

--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/remove_workload.yml
@@ -15,7 +15,7 @@
   register: r_knative_eventing
 
 - name: Set API Version facts
-  ansible_builtin_set_fact:
+  ansible.builtin.set_fact:
     _ocp4_workload_serverless_knative_serving_api_version: "{{ r_knative_serving.resources[0].status.storedVersions[0] | default('v1beta1') }}"
     _ocp4_workload_serverless_knative_eventing_api_version: "{{ r_knative_eventing.resources[0].status.storedVersions[0] | default('v1beta1') }}"
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/remove_workload.yml
@@ -1,24 +1,43 @@
 ---
 # Implement your Workload removal tasks here
+- name: Get API Version for KNativeServing
+  kubernetes.core.k8s_info:
+    api_version: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    name: knativeservings.operator.knative.dev
+  register: r_knative_serving
+
+- name: Get API Version for KNativeEventing
+  kubernetes.core.k8s_info:
+    api_version: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    name: knativeeventings.operator.knative.dev
+  register: r_knative_eventing
+
+- name: Set API Version facts
+  ansible_builtin_set_fact:
+    _ocp4_workload_serverless_knative_serving_api_version: "{{ r_knative_serving.resources[0].status.storedVersions[0] | default('v1beta1') }}"
+    _ocp4_workload_serverless_knative_eventing_api_version: "{{ r_knative_eventing.resources[0].status.storedVersions[0] | default('v1beta1') }}"
+
 - name: Remove Knative Serving Installation
-  k8s:
+  kubernetes.core.k8s:
     state: absent
-    api_version: operator.knative.dev/v1alpha1
+    api_version: "operator.knative.dev/{{ _ocp4_workload_serverless_knative_serving_api_version }}"
     kind: KnativeServing
     name: knative-serving
     namespace: knative-serving
 
 - name: Remove Knative Eventing Installation
   when: ocp4_workload_serverless_install_eventing | bool
-  k8s:
+  kubernetes.core.k8s:
     state: absent
-    api_version: operator.knative.dev/v1alpha1
+    api_version: "operator.knative.dev/{{ _ocp4_workload_serverless_knative_eventing_api_version }}"
     kind: KnativeEventing
     name: knative-eventing
     namespace: knative-eventing
 
 - name: Wait until all KNative Serving pods have been removed
-  k8s_info:
+  kubernetes.core.k8s_info:
     api_version: v1
     kind: Pod
     namespace: knative-serving
@@ -31,7 +50,7 @@
 
 - name: Wait until all KNative Eventing pods have been removed
   when: ocp4_workload_serverless_install_eventing | bool
-  k8s_info:
+  kubernetes.core.k8s_info:
     api_version: v1
     kind: Pod
     namespace: knative-eventing
@@ -42,24 +61,19 @@
   delay: 5
   until: r_knative_eventing_pods.resources | length == 0
 
-- name: Remove knative-serving project
-  k8s:
+- name: Remove knative namespaces
+  kubernetes.core.k8s:
     state: absent
-    api_version: project.openshift.io/v1
-    kind: Project
-    name: knative-serving
-
-- name: Remove knative-eventing project
-  when: ocp4_workload_serverless_install_eventing | bool
-  k8s:
-    state: absent
-    api_version: project.openshift.io/v1
-    kind: Project
-    name: knative-eventing
+    api_version: v1
+    kind: Namespace
+    name: "{{ item }}"
+  loop:
+  - knative-serving
+  - knative-eventing
 
 - name: Remove kn and kn bash completion
   become: true
-  file:
+  ansible.builtin.file:
     state: absent
     path: "{{ item }}"
   loop:
@@ -67,7 +81,7 @@
   - /etc/bash_completion.d/kn
 
 - name: Remove Operator
-  include_role:
+  ansible.builtin.include_role:
     name: install_operator
   vars:
     install_operator_action: remove
@@ -77,14 +91,14 @@
     install_operator_catalog: redhat-operators
     install_operator_automatic_install_plan_approval: "{{ ocp4_workload_serverless_automatic_install_plan_approval | default(true) }}"
     install_operator_starting_csv: "{{ ocp4_workload_serverless_starting_csv }}"
-    install_operator_catalogsource_setup: "{{ ocp4_workload_serverless_use_catalog_snapshot | default(false)}}"
+    install_operator_catalogsource_setup: "{{ ocp4_workload_serverless_use_catalog_snapshot | default(false) }}"
     install_operator_catalogsource_name: "{{ ocp4_workload_serverless_catalogsource_name | default('') }}"
     install_operator_catalogsource_namespace: openshift-operators
     install_operator_catalogsource_image: "{{ ocp4_workload_serverless_catalog_snapshot_image | default('') }}"
     install_operator_catalogsource_image_tag: "{{ ocp4_workload_serverless_catalog_snapshot_image_tag | default('') }}"
 
 # Leave this as the last task in the playbook.
-- name: remove_workload tasks complete
-  debug:
-    msg: "Remove Workload tasks completed successfully."
+- name: Remove_workload tasks complete
   when: not silent|bool
+  ansible.builtin.debug:
+    msg: "Remove Workload tasks completed successfully."

--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/workload.yml
@@ -1,11 +1,11 @@
 ---
 # Implement your Workload deployment tasks here
 - name: Setting up workload for user
-  debug:
+  ansible.builtin.debug:
     msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
 
 - name: Install Operator
-  include_role:
+  ansible.builtin.include_role:
     name: install_operator
   vars:
     install_operator_action: install
@@ -15,24 +15,45 @@
     install_operator_catalog: redhat-operators
     install_operator_automatic_install_plan_approval: "{{ ocp4_workload_serverless_automatic_install_plan_approval | default(true) }}"
     install_operator_starting_csv: "{{ ocp4_workload_serverless_starting_csv }}"
-    install_operator_catalogsource_setup: "{{ ocp4_workload_serverless_use_catalog_snapshot | default(false)}}"
+    install_operator_catalogsource_setup: "{{ ocp4_workload_serverless_use_catalog_snapshot | default(false) }}"
     install_operator_catalogsource_name: "{{ ocp4_workload_serverless_catalogsource_name | default('') }}"
     install_operator_catalogsource_namespace: openshift-operators
     install_operator_catalogsource_image: "{{ ocp4_workload_serverless_catalog_snapshot_image | default('') }}"
     install_operator_catalogsource_image_tag: "{{ ocp4_workload_serverless_catalog_snapshot_image_tag | default('') }}"
 
-- name: Create knative-serving namespace and KNative Serving object
-  k8s:
+- name: Get API Version for KNativeServing
+  kubernetes.core.k8s_info:
+    api_version: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    name: knativeservings.operator.knative.dev
+  register: r_knative_serving
+
+- name: Get API Version for KNativeEventing
+  kubernetes.core.k8s_info:
+    api_version: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    name: knativeeventings.operator.knative.dev
+  register: r_knative_eventing
+
+- name: Set API Version facts
+  ansible.builtin.set_fact:
+    _ocp4_workload_serverless_knative_serving_api_version: "{{ r_knative_serving.resources[0].status.storedVersions[0] }}"
+    _ocp4_workload_serverless_knative_eventing_api_version: "{{ r_knative_eventing.resources[0].status.storedVersions[0] }}"
+
+- name: Create knative-serving namespace
+  kubernetes.core.k8s:
     state: present
-    definition: "{{ lookup('file', item ) | from_yaml }}"
-  loop:
-  - ns-knative-serving.yaml
-  - knative_serving.yaml
+    definition: "{{ lookup('file', 'ns-knative-serving.yaml') | from_yaml }}"
+
+- name: Create KNative Serving object
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('template', 'knative_serving.yaml.j2') | from_yaml }}"
 
 - name: Wait until KNative Serving installation is complete
   when: ocp4_workload_serverless_wait_for_deploy | bool
-  k8s_info:
-    api_version: operator.knative.dev/v1alpha1
+  kubernetes.core.k8s_info:
+    api_version: "operator.knative.dev/{{ _ocp4_workload_serverless_knative_serving_api_version }}"
     kind: KnativeServing
     name: knative-serving
     namespace: knative-serving
@@ -52,18 +73,20 @@
 - name: Install KNative Eventing
   when: ocp4_workload_serverless_install_eventing | bool
   block:
-  - name: Create knative-eventing namespace and KNative Eventing object
-    k8s:
+  - name: Create knative-eventing namespace
+    kubernetes.core.k8s:
       state: present
-      definition: "{{ lookup('file', item ) | from_yaml }}"
-    loop:
-    - ns-knative-eventing.yaml
-    - knative_eventing.yaml
+      definition: "{{ lookup('file', 'ns-knative-eventing.yaml') | from_yaml }}"
+
+  - name: Create knative-eventing namespace and KNative Eventing object
+    kubernetes.core.k8s:
+      state: present
+      definition: "{{ lookup('template', 'knative_eventing.yaml.j2') | from_yaml }}"
 
   - name: Wait until KNative Eventing installation is complete
     when: ocp4_workload_serverless_wait_for_deploy | bool
-    k8s_info:
-      api_version: operator.knative.dev/v1alpha1
+    kubernetes.core.k8s_info:
+      api_version: "operator.knative.dev/{{ _ocp4_workload_serverless_knative_eventing_api_version }}"
       kind: KnativeEventing
       name: knative-eventing
       namespace: knative-eventing
@@ -77,7 +100,7 @@
     - r_kn_eventing.resources[0].status.conditions[1].status == "True"
 
 - name: Get kn ConsoleCLIDownload
-  k8s_info:
+  kubernetes.core.k8s_info:
     api_version: console.openshift.io/v1
     kind: ConsoleCLIDownload
     name: kn
@@ -91,7 +114,7 @@
 
 - name: Get kn download URL from ConsoleCLIDownload
   when: r_kn_cli_download.resources | length > 0
-  set_fact:
+  ansible.builtin.set_fact:
     __ocp4_workload_serverless_kn_url: >-
       {{ r_kn_cli_download.resources[0] | to_json | from_json
        | json_query("spec.links[?contains(href,'-linux-amd64')].href") | first }}
@@ -100,7 +123,7 @@
   when: r_kn_cli_download.resources | length == 0
   block:
   - name: Get kn download route
-    k8s_info:
+    kubernetes.core.k8s_info:
       api_version: route.openshift.io/v1
       kind: Route
       name: kn-cli-downloads
@@ -111,18 +134,18 @@
     when:
     - r_kn_download.resources is defined
     - r_kn_download.resources | length > 0
-    set_fact:
+    ansible.builtin.set_fact:
       __ocp4_workload_serverless_kn_url: "{{ r_kn_download.resources[0].status.ingress[0].host }}/amd64/linux/kn-linux-amd64.tar.gz"
 
 - name: Install kn cli tool if a download URL was found
   when: __ocp4_workload_serverless_kn_url is defined
   block:
   - name: Download kn cli tool
-    get_url:
+    ansible.builtin.get_url:
       url: "{{ __ocp4_workload_serverless_kn_url }}"
       validate_certs: false
       dest: /tmp/kn-linux-amd64.tar.gz
-      mode: 0660
+      mode: "o=rw,g=rw"
     register: r_kn
     until: r_kn is success
     retries: 10
@@ -130,29 +153,29 @@
 
   - name: Install kn CLI on bastion
     become: true
-    unarchive:
+    ansible.builtin.unarchive:
       src: /tmp/kn-linux-amd64.tar.gz
       remote_src: true
       dest: /usr/bin
-      mode: 0775
+      mode: "o=rwx,g=rwx,o=rx"
       owner: root
       group: root
     args:
       creates: /usr/bin/kn
 
   - name: Remove downloaded file
-    file:
+    ansible.builtin.file:
       state: absent
       path: /tmp/kn-linux-amd64.tar.gz
 
   - name: Create kn bash completion file
     become: true
-    shell: /usr/bin/kn completion bash >/etc/bash_completion.d/kn
+    ansible.builtin.shell: /usr/bin/kn completion bash >/etc/bash_completion.d/kn
     args:
       creates: /etc/bash_completion.d/kn
 
 # Leave this as the last task in the playbook.
-- name: workload tasks complete
-  debug:
-    msg: "Workload Tasks completed successfully."
+- name: Workload tasks complete
   when: not silent|bool
+  ansible.builtin.debug:
+    msg: "Workload Tasks completed successfully."

--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/templates/knative_eventing.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/templates/knative_eventing.yaml.j2
@@ -1,0 +1,5 @@
+apiVersion: "operator.knative.dev/{{ _ocp4_workload_serverless_knative_eventing_api_version }}"
+kind: KnativeEventing
+metadata:
+  name: knative-eventing
+  namespace: knative-eventing

--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/templates/knative_serving.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/templates/knative_serving.yaml.j2
@@ -1,0 +1,5 @@
+apiVersion: "operator.knative.dev/{{ _ocp4_workload_serverless_knative_serving_api_version }}"
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: knative-serving


### PR DESCRIPTION
##### SUMMARY

workload was failing to deploy because of API version changes in recent serverless releases.

Added logic to retrieve the apiVersion from the CRDs.

Also modernized the code by FQDN modules etc.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_serverless