### PR TITLE
New asset_injector role and update to base-infra using it

### DIFF
--- a/ansible/configs/base-infra/pre_software.yml
+++ b/ansible/configs/base-infra/pre_software.yml
@@ -62,8 +62,8 @@
       ansible.builtin.include_role:
         name: user-create-ansible-service-account
 
-    - name: Inject assets into bastion
-      when: 
+    - name: Inject assets onto host(s)
+      when:
         - asset_injector_assets is defined
         - asset_injector_assets | length > 0
       ansible.builtin.include_role:

--- a/ansible/configs/base-infra/pre_software.yml
+++ b/ansible/configs/base-infra/pre_software.yml
@@ -62,6 +62,13 @@
       ansible.builtin.include_role:
         name: user-create-ansible-service-account
 
+    - name: Inject assets into bastion
+      when: 
+        - asset_injector_assets is defined
+        - asset_injector_assets | length > 0
+      ansible.builtin.include_role:
+        name: asset_injector
+
 - name: PreSoftware flight-check
   hosts: localhost
   connection: local

--- a/ansible/roles/asset_injector/README.adoc
+++ b/ansible/roles/asset_injector/README.adoc
@@ -1,0 +1,89 @@
+== asset_injector
+
+Injects assets, or artifacts, into a target host. Assets can be sourced from a variety of locations, including git, http, templates, and local files.
+
+=== Requirements
+
+N/A - these are basic ansible modules that should be available in any ansible installation.
+
+(Future support for say `S3` bucket objects will require the `amazon.aws` collection to be installed for example)
+
+=== Role Variables
+
+Only 1 var `asset_injector_assets ` is required, which is a list of assets to inject. Each asset is a dictionary with the following keys:
+
+[source,yaml]
+----
+asset_injector_assets:
+
+    - name: Multi Tier App multi-tier-app-deployer
+      src: https://github.com/tonykay/multi-tier-app-deployer.git
+      dest: /home/devops/multi-tier-app-deployer
+      type: git
+      scm_ref: main
+      owner: devops
+      
+    - name: Docker inventory
+      type: http
+      src: https://raw.githubusercontent.com/tonykay/multi-tier-app-deployer/main/inventory-docker
+      dest: /home/devops/docker-inventory
+      owner: devops
+      group: users
+      mode: u=rw,g=r,o=r
+
+    - name: AAP2 Manifest
+      type: http
+      dest: /home/devops/manifest_31_10_2022.zip
+      src: https://example.com/assets/manifest_31_10_2022.zip
+      url_username: "{{ url_username }}"
+      url_password: "{{ url_password }}"
+      dest: /home/devops/manifest.zip
+      owner: devops
+      group: users
+      mode: u=rw,g=r,o=r
+
+    - name: Copy local stuff
+      type: 'copy'
+      src: ./file/Makefile
+      dest: /home/devops/Makefile
+      owner: devops
+      group: users
+      mode: u=rw,g=r,o=r
+
+    - name: Make ssh config
+      type: 'template'
+      src: ./files/ssh_config.j2
+      dest: /home/devops/ssh-config
+      owner: devops
+      group: users
+      mode: "u=r,g-rwx,o-rwx"
+----
+
+=== Dependencies
+
+N/A
+
+=== Example Playbook
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+[source,yaml]
+----
+- hosts: servers
+  tasks:
+
+    - name: Inject assets
+      when: 
+        - asset_injector_asset is defined
+        - asset_injector_asset | length > 0
+      include_role: 
+        name: asset_injector
+----
+
+=== License
+
+BSD
+
+== Author Information
+
+tony kay tok@redhat.com

--- a/ansible/roles/asset_injector/tasks/main.yml
+++ b/ansible/roles/asset_injector/tasks/main.yml
@@ -1,0 +1,61 @@
+---
+
+- name: Clone Git repositories
+  when: _asset.type == 'git'
+  ansible.builtin.git:
+    repo: "{{ _asset.src }}"
+    dest: "{{ _asset.dest }}"
+    version: "{{ _asset.scm_ref | default('main') }}"
+  loop: "{{ asset_injector_assets }}"
+  loop_control:
+    loop_var: _asset
+  become_user: "{{ _asset.owner | default(omit) }}"
+  tags:
+    - asset_injector_git
+
+- name: Fetch files vim HTTP server
+  when: _asset.type == 'http'
+  ansible.builtin.get_url:
+    url: "{{ _asset.src }}"
+    dest: "{{ _asset.dest }}"
+    url_username: "{{ _asset.url_username | default(omit) }}"
+    url_password: "{{ _asset.url_password | default(omit) }}"
+    force_basic_auth: true
+    owner: "{{ _asset.owner }}"
+    group: "{{ _asset.group }}"
+    mode: "{{ _asset.mode | default(omit) }}"
+  loop: "{{ asset_injector_assets }}"
+  loop_control:
+    loop_var: _asset
+  tags:
+    - asset_injector_http
+
+- name: Copy local files
+  when: _asset.type == 'copy'
+  ansible.builtin.copy:
+    src: "{{ _asset.src }}"
+    dest: "{{ _asset.dest }}"
+    owner: "{{ _asset.owner }}"
+    group: "{{ _asset.group }}"
+    mode: "{{ _asset.mode }}"
+  loop: "{{ asset_injector_assets }}"
+  loop_control:
+    loop_var: _asset
+  tags:
+    - asset_injector_copy
+
+- name: Inject local templates
+  when: _asset.type == 'template'
+  ansible.builtin.template:
+    src: "{{ _asset.src }}"
+    dest: "{{ _asset.dest }}"
+    owner: "{{ _asset.owner }}"
+    group: "{{ _asset.group }}"
+    mode: "{{ _asset.mode }}"
+  loop: "{{ asset_injector_assets }}"
+  loop_control:
+    loop_var: _asset
+  tags:
+    - asset_injector_template
+# TODO:
+# s3, and other sources

--- a/ansible/roles/asset_injector/tasks/main.yml
+++ b/ansible/roles/asset_injector/tasks/main.yml
@@ -57,5 +57,3 @@
     loop_var: _asset
   tags:
     - asset_injector_template
-# TODO:
-# s3, and other sources


### PR DESCRIPTION
##### SUMMARY

Adds role asset_injector

Allows developers to create a single dictionary to inject assets via

- git
- copy (local files to remote)
- get_url
- template

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

roles/asset_injector

##### ADDITIONAL INFORMATION
