### PR TITLE
OpenShift Serverless ML Ops - Fix Zookeeper Timeout Error

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless_ml_workshop/files/kafka-cluster.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless_ml_workshop/files/kafka-cluster.yml
@@ -32,3 +32,9 @@ spec:
     storage:
       type: ephemeral
     replicas: 3
+    jvmOptions:
+      javaSystemProperties:
+        - name: zookeeper.ssl.hostnameVerification
+          value: "false"
+        - name: zookeeper.ssl.quorum.hostnameVerification
+          value: "false"


### PR DESCRIPTION
##### SUMMARY
Relax ssl to allow zookeeper to be able to connect as per https://github.com/strimzi/strimzi-kafka-operator/issues/3692

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
OpenShift Serverless with ML Workshop
