### PR TITLE
[host-ocp4-assisted-installer] Use ocp4_installer_version variable for ai_cluster_version

### DIFF
--- a/ansible/roles/host-ocp4-assisted-installer/vars/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/vars/main.yaml
@@ -3,7 +3,7 @@ ai_pull_secret: "{{ ocp4_ai_pull_secret | to_json | to_json if ocp4_ai_pull_secr
 ai_offline_token: "{{ ocp4_ai_offline_token }}"
 ai_ssh_authorized_key: "{{ lookup('ansible.builtin.file', hostvars.localhost.ssh_provision_pubkey_path) }}"
 ai_cluster_name: "{{ guid }}"
-ai_cluster_version: "4.13"
+ai_cluster_version: "{{ ocp4_installer_version | default('4.13') }}"
 ai_cluster_iso_type: "minimal-iso"
 ai_control_plane_cores: 8
 ai_control_plane_memory: 16Gi


### PR DESCRIPTION
##### SUMMARY

As default, the variable ai_cluster_version was set to 4.13. To be more consistent, default now is  ocp4_installer_version 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
Role host-ocp4-assisted-installer
