### PR TITLE
[roadshow-ocpvirt config] Prepare config to dont use prebuilt images

### DIFF
--- a/ansible/configs/roadshow-ocpvirt/post_software.yml
+++ b/ansible/configs/roadshow-ocpvirt/post_software.yml
@@ -24,7 +24,6 @@
       delay: 30
 
     - name: Post tasks
-      when: not build_lab|bool
       block:
         - name: Make .kube directory
           ansible.builtin.file:

--- a/ansible/configs/roadshow-ocpvirt/pre_software.yml
+++ b/ansible/configs/roadshow-ocpvirt/pre_software.yml
@@ -137,49 +137,47 @@
   hosts: bastion-vm
   gather_facts: false
   tasks:
-    - when: build_lab|bool
-      block:
-        - include_role:
-            name: ocp4_aio_deploy_bastion
-          vars:
-            ocp4_aio_ssh_key: "{{ lookup('file', '{{ output_dir }}/{{ guid }}_id_rsa.pub' ) }}"
-          when: cloud_provider == 'equinix_metal'
+    - include_role:
+        name: ocp4_aio_deploy_bastion
+      vars:
+        ocp4_aio_ssh_key: "{{ lookup('file', '{{ output_dir }}/{{ guid }}_id_rsa.pub' ) }}"
+      when: cloud_provider == 'equinix_metal'
 
-        - include_role:
-            name: ocp4_aio_deploy_bastion
-          vars:
-            ocp4_aio_ssh_key: "{{ lookup('file', hostvars['localhost']['env_authorized_key_path_pub']) }}"
-          when: cloud_provider == 'ec2'
+    - include_role:
+        name: ocp4_aio_deploy_bastion
+      vars:
+        ocp4_aio_ssh_key: "{{ lookup('file', hostvars['localhost']['env_authorized_key_path_pub']) }}"
+      when: cloud_provider == 'ec2'
 
 
-        - name: Copy letsencrypt files
-          copy:
-            src: "{{ output_dir }}/{{ item }}"
-            dest: "/root/{{ item }}"
-          loop:
-            - chain1.pem
-            - cert1.pem
-            - privkey1.pem
+    - name: Copy letsencrypt files
+      copy:
+        src: "{{ output_dir }}/{{ item }}"
+        dest: "/root/{{ item }}"
+      loop:
+        - chain1.pem
+        - cert1.pem
+        - privkey1.pem
 
-        - name: Install httpd
-          yum:
-            name: httpd
+    - name: Install httpd
+      yum:
+        name: httpd
 
-        - name: Start and enable httpd
-          service:
-            name: httpd
-            state: restarted
-            enabled: yes
+    - name: Start and enable httpd
+      service:
+        name: httpd
+        state: restarted
+        enabled: yes
 
-        - name: Download required files for the lab
-          get_url:
-            url: "https://www.opentlc.com/download/ocp4_virt_foundations/{{ item }}"
-            dest: "/var/www/html/{{ item }}"
-            owner: apache
-            group: apache
-          loop:
-            - Fedora35.qcow2
-            - Windows2019.iso
+    - name: Download required files for the lab
+      get_url:
+        url: "https://www.opentlc.com/download/ocp4_virt_foundations/{{ item }}"
+        dest: "/var/www/html/{{ item }}"
+        owner: apache
+        group: apache
+      loop:
+        - Fedora35.qcow2
+        - Windows2019.iso
 
 
 - name: PreSoftware flight-check

--- a/ansible/configs/roadshow-ocpvirt/software.yml
+++ b/ansible/configs/roadshow-ocpvirt/software.yml
@@ -18,7 +18,6 @@
       setup:
 
     - name: deploy OCP
-      when: build_lab|bool
       include_role:
         name: ocp4_aio_deploy_ocp
       vars:


### PR DESCRIPTION
##### SUMMARY

When build_lab variable was false, some tasks were not performed as was imaged based installation. Now we want to don't use prebuilt images

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
roadshow-ocpvirt config config

