### PR TITLE
Fix SSH config from cloud-init: rm line about PasswordAuthentication

### DIFF
--- a/ansible/configs/rosa-consolidated/pre_software.yml
+++ b/ansible/configs/rosa-consolidated/pre_software.yml
@@ -45,11 +45,12 @@
       regexp: '^ *PasswordAuthentication'
       path: /etc/ssh/sshd_config
 
-  - name: Remove 50-cloud-init.conf
+  - name: Remove PasswordAuthentication line from 50-cloud-init.conf
     when: bastion_remove_cloud_init_conf | default(true) | bool
-    ansible.builtin.file:
-      state: absent
+    ansible.builtin.lineinfile:
       path: /etc/ssh/sshd_config.d/50-cloud-init.conf
+      regexp: PasswordAuthentication
+      state: absent
 
   - name: Restart sshd
     ansible.builtin.service:

--- a/ansible/roles/bastion-student-user/tasks/main.yml
+++ b/ansible/roles/bastion-student-user/tasks/main.yml
@@ -54,6 +54,13 @@
     regexp: '^ *PasswordAuthentication'
     path: /etc/ssh/sshd_config
 
+- name: Remove PasswordAuthentication line from 50-cloud-init.conf
+  when: bastion_remove_cloud_init_conf | default(true) | bool
+  ansible.builtin.lineinfile:
+    path: /etc/ssh/sshd_config.d/50-cloud-init.conf
+    regexp: PasswordAuthentication
+    state: absent
+
 - name: Disable root password authentication
   lineinfile:
     line: PermitRootLogin without-password


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
When using the bastion-student role, we want to enable password authentication.

Remove the configuration that forbids PasswordAuthentication in Cloud
init ssh file:

```
[root@bastion sshd_config.d]# cat /etc/ssh/sshd_config.d/50-cloud-init.conf
PasswordAuthentication no
```

Patch the rosa config: Don't delete the file but use lineinfile module to remove only that line, as that file may be used for other puprose later.

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
