### PR TITLE
[host-ocp4-assisted-installer] Add kubeadmin password to the user_info

### DIFF
--- a/ansible/roles/host-ocp4-assisted-installer/tasks/print_cluster_info.yml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/print_cluster_info.yml
@@ -7,7 +7,7 @@
 - name: Set user data for kubeadmin password
   agnosticd_user_info:
     data:
-      openshift_kubeadmin_password: "{{ r_slurp_kubeadmin_password.content | b64decode }}
+      openshift_kubeadmin_password: "{{ r_slurp_kubeadmin_password.content | b64decode }}"
 
 - name: Get console route
   environment:

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/print_cluster_info.yml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/print_cluster_info.yml
@@ -1,4 +1,14 @@
 ---
+- name: Get kubeadmin password
+  ansible.builtin.slurp:
+    path: /home/{{ ansible_user }}/{{ cluster_name }}/auth/kubeadmin-password
+  register: r_slurp_kubeadmin_password
+
+- name: Set user data for kubeadmin password
+  agnosticd_user_info:
+    data:
+      openshift_kubeadmin_password: "{{ r_slurp_kubeadmin_password.content | b64decode }}
+
 - name: Get console route
   environment:
     KUBECONFIG: /home/{{ ansible_user }}/{{ cluster_name }}/auth/kubeconfig


### PR DESCRIPTION
##### SUMMARY

To keep compability with the host-ocp4-installer, it is needed to save this password to the user_data

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
host-ocp4-assisted-installer config