### PR TITLE
[host-ocp4-assisted-installer] Delete failed installer pods 

### DIFF
--- a/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
@@ -535,6 +535,30 @@
             group: users
             mode: 0600
 
+    - name: Find installer Pods in Error Status with label app=installer
+      environment:
+        KUBECONFIG: /home/{{ ansible_user }}/{{ cluster_name }}/auth/kubeconfig    
+      kubernetes.core.k8s_info:
+        kind: Pod
+        label_selectors:
+          - app=installer
+        field_selectors:
+          - status.phase=Failed
+      register: pod_info
+
+    - name: Delete Error Pods
+      kubernetes.core.k8s:
+        definition:
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: "{{ pod.metadata.name }}"
+            namespace: "{{ pod.metadata.namespace }}"
+        state: absent
+      loop: "{{ pod_info.resources }}"
+      loop_control:
+        loop_var: pod
+
     - name: Create OpenShift Bash completion file
       become: true
       ansible.builtin.shell: oc completion bash >/etc/bash_completion.d/openshift

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
@@ -535,33 +535,33 @@
             group: users
             mode: 0600
 
-    - name: Find installer Pods in Error Status with label app=installer
-      environment:
-        KUBECONFIG: /home/{{ ansible_user }}/{{ cluster_name }}/auth/kubeconfig    
-      kubernetes.core.k8s_info:
-        kind: Pod
-        label_selectors:
-          - app=installer
-        field_selectors:
-          - status.phase=Failed
-      register: pod_info
-
-    - name: Delete Error Pods
-      kubernetes.core.k8s:
-        definition:
-          apiVersion: v1
-          kind: Pod
-          metadata:
-            name: "{{ pod.metadata.name }}"
-            namespace: "{{ pod.metadata.namespace }}"
-        state: absent
-      loop: "{{ pod_info.resources }}"
-      loop_control:
-        loop_var: pod
-
     - name: Create OpenShift Bash completion file
       become: true
       ansible.builtin.shell: oc completion bash >/etc/bash_completion.d/openshift
 
+- name: Find installer Pods in Error Status with label app=installer
+  environment:
+    KUBECONFIG: /home/{{ ansible_user }}/{{ cluster_name }}/auth/kubeconfig    
+  kubernetes.core.k8s_info:
+    kind: Pod
+    label_selectors:
+      - app=installer
+    field_selectors:
+      - status.phase=Failed
+  register: pod_info
+
+- name: Delete Error Pods
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: "{{ pod.metadata.name }}"
+        namespace: "{{ pod.metadata.namespace }}"
+    state: absent
+  loop: "{{ pod_info.resources }}"
+  loop_control:
+    loop_var: pod
+    
 - name: Gather and Print cluster info
   ansible.builtin.import_tasks: print_cluster_info.yml


### PR DESCRIPTION
##### SUMMARY

The installer and revision-pruner pods are one-shot pods. The Cluster Operator will perform retries when needed. The Completed and Error status pods can be deleted if there is no error reported in the corresponding Cluster Operator.

Check: https://access.redhat.com/solutions/6488041

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
host-ocp4-assisted-installer config
