### PR TITLE
Removes kubeadmin user once cluster has been deployed

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_telco_hypershift_lab/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_telco_hypershift_lab/tasks/workload.yml
@@ -9,6 +9,15 @@
   register: result
   failed_when: result.rc != 0 and ("Remove existing directory" not in result.stderr)
 
+- name: Remove kubeadmin user
+  kubernetes.core.k8s:
+    kubeconfig: /root/.kcli/clusters/management/auth/kubeconfig
+    state: absent
+    api_version: v1
+    kind: Secret
+    namespace: kube-system
+    name: kubeadmin
+
 - name: Wait until LVMCluster is ready
   kubernetes.core.k8s_info:
     kubeconfig: /root/.kcli/clusters/management/auth/kubeconfig


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Removes the kubeadmin webui user once cluster has been  deployed
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4_workload_telco_hypershift_lab

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
