### PR TITLE
[Roadshow] Remove Datacenter and ClusterComputeResource permissions

### DIFF
--- a/ansible/configs/roadshow-ocpvirt/default_vars_equinix_metal.yml
+++ b/ansible/configs/roadshow-ocpvirt/default_vars_equinix_metal.yml
@@ -31,8 +31,6 @@ student_name: lab-user
 
 vcenter_role: "Sandbox User"
 vcenter_permissions:
-  Datacenter: SDDC-Datacenter
-  ClusterComputeResource: Cluster-1
   Folder: "{{ env_type }}-{{ guid }}"
   Datastore: WorkloadDatastore
   Network: segment-migrating-to-ocpvirt


### PR DESCRIPTION
##### SUMMARY

To reduce the number of permissions, group permissions are set in the vsphere cluster

##### ISSUE TYPE
Feature

##### COMPONENT NAME
roadshow-ocpvirt config

