### PR TITLE
Fix agnosticd_user_info data for multiuser case in ocp4_workload_showroom

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/report-variables.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/report-variables.yaml
@@ -22,4 +22,6 @@
   agnosticd_user_info:
     msg: "Lab instructions: {{ _showroom_url }}"
     data:
+      lab_ui_url: "{{ _showroom_url }}"
       showroom_primary_view_url: "{{ _showroom_url }}"
+    user: "{{ _showroom_user | default(omit) }}"


### PR DESCRIPTION
##### SUMMARY

Fix ocp4_workload_showroom to set `user` and `lab_ui_url`

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role ocp4_workload_showroom