### PR TITLE
Update GitOps subscription to 1.11 for Rollouts Workshop

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rollouts_workshop/files/gitops-operator/subscription.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rollouts_workshop/files/gitops-operator/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openshift-gitops-operator
   namespace: openshift-gitops-operator
 spec:
-  channel: gitops-1.10
+  channel: gitops-1.11
   installPlanApproval: Automatic
   name: openshift-gitops-operator
   source: redhat-operators


### PR DESCRIPTION
##### SUMMARY

Update the GitOps Operator to 1.11

##### ISSUE TYPE
- New config Pull Request

##### COMPONENT NAME
OpenShift Rollouts Workshop

##### ADDITIONAL INFORMATION
The update to 1.11 is necessary to get Rollouts 1.6 which enables the usage of the Prometheus metric instead of the hacky way we were doing it with the Web metric previously.