### PR TITLE
ee-ansible-workshop

### DIFF
--- a/tools/execution_environments/ee-ansible-workshop/requirements.yml
+++ b/tools/execution_environments/ee-ansible-workshop/requirements.yml
@@ -9,6 +9,7 @@ collections:
 - name: ansible.posix
 - name: ansible.utils
 - name: ansible.workshops
+  version: 1.0.18
 
 - name: awx.awx
 


### PR DESCRIPTION

##### SUMMARY
Adding version for ansible.workshop collection-

Reason: By default ansible.workshop collection picks old version (1.0.11) and CI needs latest version (1.0.18).

##### ISSUE TYPE

- Bugfix Pull Request



##### COMPONENT NAME
Execution Environment- ee-ansible-workshop