### PR TITLE
Change showroom role for new version of ansible-runtime-api

### DIFF
--- a/ansible/roles/showroom/defaults/main.yml
+++ b/ansible/roles/showroom/defaults/main.yml
@@ -38,6 +38,7 @@ showroom_lab_users:
 # Enable the showroom_ansible_runner_api?
 showroom_ansible_runner_api: false
 showroom_ansible_runner_api_port: 8501
+showroom_ansible_runner_image: quay.io/makirill/ansible-runtime-api
 
 showroom_container_compose_template: compose_default_template.j2
 

--- a/ansible/roles/showroom/templates/ansible_runner_api_service/ansible_runner_api_service.j2
+++ b/ansible/roles/showroom/templates/ansible_runner_api_service/ansible_runner_api_service.j2
@@ -1,10 +1,10 @@
 ansible-runner-api:
-  image: docker.io/tonykay/ansible-runner-api:0.0.1
+  image: {{ showroom_ansible_runner_image }}:{{ showroom_ansible_runner_image_tag | default('latest') }}
   container_name: ansible-runner-api
   hostname: ansible-runner-api
   ports:
     - "{{ showroom_ansible_runner_api_port | default(8501) }}:80"
   volumes:
-    - "{{ showroom_user_home_dir }}/content/playbooks/:/app/scripts:ro"
+    - "{{ showroom_user_home_dir }}/content/runtime-automation/:/app/runtime-automation:ro"
   restart: "always"
 


### PR DESCRIPTION
##### SUMMARY

Updated the `ansible-runtime-api` to use new image and fixed paths for mounted volumes

##### ISSUE TYPE
- Bugfix Pull Request
