### PR TITLE
Add vars to showroom workload to set resources for terminal containers

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/defaults/main.yaml
@@ -25,6 +25,12 @@ ocp4_workload_showroom_content_only: false
 # - "": No terminal deployed
 ocp4_workload_showroom_terminal_type: showroom
 
+# Requests and limits for the terminal pod (same vars for either showroom or wetty)
+ocp4_workload_showroom_terminal_requests_cpu: 500m
+ocp4_workload_showroom_terminal_requests_memory: 256Mi
+ocp4_workload_showroom_terminal_limits_cpu: 500m
+ocp4_workload_showroom_terminal_limits_memory: 1Gi
+
 # Showroom Terminal Image. Options include:
 # - quay.io/rhpds/openshift-showroom-terminal-ocp:latest
 # - quay.io/rhpds/openshift-showroom-terminal-rosa:latest
@@ -55,7 +61,7 @@ ocp4_workload_showroom_deployment_type: helm
 ocp4_workload_showroom_chart_package_url: https://rhpds.github.io/showroom-deployer
 ocp4_workload_showroom_deployer_chart_name: showroom-single-pod
 # Available versions are at https://github.com/rhpds/showroom-deployer/releases
-ocp4_workload_showroom_deployer_chart_version: "1.0.0"
+ocp4_workload_showroom_deployer_chart_version: "1.0.1"
 
 # URL to download Helm from if it's not already there (for Helm type deployment)
 ocp4_workload_showroom_tools_root_url: https://mirror.openshift.com/pub/openshift-v4/clients

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm.yaml
@@ -26,9 +26,23 @@
       terminal:
         setup: "{{ (true if ocp4_workload_showroom_terminal_type | default('') == 'showroom' else false) | bool | string | lower }}"
         image: "{{ ocp4_workload_showroom_terminal_image }}"
+        resources:
+          requests:
+            cpu: "{{ ocp4_workload_showroom_terminal_requests_cpu }}"
+            memory: "{{ ocp4_workload_showroom_terminal_requests_memory }}"
+          limits:
+            cpu: "{{ ocp4_workload_showroom_terminal_limits_cpu }}"
+            memory: "{{ ocp4_workload_showroom_terminal_limits_memory }}"
       wetty:
         setup: "{{ (true if ocp4_workload_showroom_terminal_type | default('') == 'wetty' else false) | bool | string | lower }}"
         image: "{{ ocp4_workload_showroom_wetty_image }}"
+        resources:
+          requests:
+            cpu: "{{ ocp4_workload_showroom_terminal_requests_cpu }}"
+            memory: "{{ ocp4_workload_showroom_terminal_requests_memory }}"
+          limits:
+            cpu: "{{ ocp4_workload_showroom_terminal_limits_cpu }}"
+            memory: "{{ ocp4_workload_showroom_terminal_limits_memory }}"
         ssh:
           autoSshToBastion: "{{ (true if ocp4_workload_showroom_wetty_ssh_bastion_login | bool else false) | bool | string | lower }}"
           sshAuth: password

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/templates/application.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/templates/application.yaml.j2
@@ -31,9 +31,23 @@ spec:
         terminal:
           setup: "{{ ('true' if ocp4_workload_showroom_terminal_type == 'showroom' else 'false') | string | lower }}"
           image: {{ ocp4_workload_showroom_terminal_image }}
+          resources:
+            requests:
+              cpu: "{{ ocp4_workload_showroom_terminal_requests_cpu }}"
+              memory: "{{ ocp4_workload_showroom_terminal_requests_memory }}"
+            limits:
+              cpu: "{{ ocp4_workload_showroom_terminal_limits_cpu }}"
+              memory: "{{ ocp4_workload_showroom_terminal_limits_memory }}"
         wetty:
           setup: "{{ ('true' if ocp4_workload_showroom_terminal_type == 'wetty' else 'false') | string | lower }}"
           image: {{ ocp4_workload_showroom_wetty_image }}
+          resources:
+            requests:
+              cpu: "{{ ocp4_workload_showroom_terminal_requests_cpu }}"
+              memory: "{{ ocp4_workload_showroom_terminal_requests_memory }}"
+            limits:
+              cpu: "{{ ocp4_workload_showroom_terminal_limits_cpu }}"
+              memory: "{{ ocp4_workload_showroom_terminal_limits_memory }}"
           ssh:
             sshHost: {{ _showroom_user_data.bastion_public_hostname }}
             autoSshToBastion: "{{ ('true' if ocp4_workload_showroom_wetty_ssh_bastion_login | bool else 'false') | string | lower }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/templates/applicationset.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/templates/applicationset.yaml.j2
@@ -45,9 +45,23 @@ spec:
             terminal:
               setup: "{{ ('true' if ocp4_workload_showroom_terminal_type == 'showroom' else 'false') | string | lower }}"
               image: {{ ocp4_workload_showroom_terminal_image }}
+              resources:
+                requests:
+                  cpu: "{{ ocp4_workload_showroom_terminal_requests_cpu }}"
+                  memory: "{{ ocp4_workload_showroom_terminal_requests_memory }}"
+                limits:
+                  cpu: "{{ ocp4_workload_showroom_terminal_limits_cpu }}"
+                  memory: "{{ ocp4_workload_showroom_terminal_limits_memory }}"
             wetty:
               setup: "{{ ('true' if ocp4_workload_showroom_terminal_type == 'wetty' else 'false') | string | lower }}"
               image: {{ ocp4_workload_showroom_wetty_image }}
+              resources:
+                requests:
+                  cpu: "{{ ocp4_workload_showroom_terminal_requests_cpu }}"
+                  memory: "{{ ocp4_workload_showroom_terminal_requests_memory }}"
+                limits:
+                  cpu: "{{ ocp4_workload_showroom_terminal_limits_cpu }}"
+                  memory: "{{ ocp4_workload_showroom_terminal_limits_memory }}"
               ssh:
                 sshHost: {{ _showroom_user_data.bastion_public_hostname }}
                 autoSshToBastion: "{{ ('true' if ocp4_workload_showroom_wetty_ssh_bastion_login | bool else 'false') | string | lower }}"


### PR DESCRIPTION
##### SUMMARY

Some lab environments need more CPU or Memory than the default in the Showroom Helm Chart. This PR adds the capability to specify resources for the terminal container.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_showroom