### PR TITLE
[host-ocp4-assisted-installer] Adding a retry for Route53 calls

### DIFF
--- a/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
@@ -105,6 +105,10 @@
             zone: "{{ cluster_dns_zone  }}"
             value: "{{ full_svc_masters.resources[0].status.loadBalancer.ingress[0].ip }}"
             type: A
+          register: r_route53_add_record
+          until: r_route53_add_record is successed
+          retries: 10
+          delay: 30
 
         - name: Add A dns record - workers
           when: cluster_dns_server is defined
@@ -134,6 +138,10 @@
             zone: "{{ cluster_dns_zone  }}"
             value: "{{ full_svc_masters.resources[0].status.loadBalancer.ingress[0].ip }}"
             type: A
+          register: r_route53_add_record
+          until: r_route53_add_record is successed
+          retries: 10
+          delay: 30
 
     - name: Configure a full cluster
       when: worker_instance_count|int > 0
@@ -186,6 +194,10 @@
             zone: "{{ cluster_dns_zone  }}"
             value: "{{ full_svc_masters.resources[0].status.loadBalancer.ingress[0].ip }}"
             type: A
+          register: r_route53_add_record
+          until: r_route53_add_record is successed
+          retries: 10
+          delay: 30
 
 
         - name: Add the service (type LoadBalancer) for Full Clusters - workers
@@ -236,6 +248,10 @@
             zone: "{{ cluster_dns_zone  }}"
             value: "{{ full_svc_workers.resources[0].status.loadBalancer.ingress[0].ip }}"
             type: A
+          register: r_route53_add_record
+          until: r_route53_add_record is successed
+          retries: 10
+          delay: 30
 
     - name: Create OVN secondary network
       kubernetes.core.k8s:

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
@@ -106,7 +106,7 @@
             value: "{{ full_svc_masters.resources[0].status.loadBalancer.ingress[0].ip }}"
             type: A
           register: r_route53_add_record
-          until: r_route53_add_record is successed
+          until: r_route53_add_record is sucess
           retries: 10
           delay: 30
 
@@ -139,7 +139,7 @@
             value: "{{ full_svc_masters.resources[0].status.loadBalancer.ingress[0].ip }}"
             type: A
           register: r_route53_add_record
-          until: r_route53_add_record is successed
+          until: r_route53_add_record is sucess
           retries: 10
           delay: 30
 
@@ -195,7 +195,7 @@
             value: "{{ full_svc_masters.resources[0].status.loadBalancer.ingress[0].ip }}"
             type: A
           register: r_route53_add_record
-          until: r_route53_add_record is successed
+          until: r_route53_add_record is sucess
           retries: 10
           delay: 30
 
@@ -249,7 +249,7 @@
             value: "{{ full_svc_workers.resources[0].status.loadBalancer.ingress[0].ip }}"
             type: A
           register: r_route53_add_record
-          until: r_route53_add_record is successed
+          until: r_route53_add_record is sucess
           retries: 10
           delay: 30
 

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
@@ -106,7 +106,7 @@
             value: "{{ full_svc_masters.resources[0].status.loadBalancer.ingress[0].ip }}"
             type: A
           register: r_route53_add_record
-          until: r_route53_add_record is sucess
+          until: r_route53_add_record is success
           retries: 10
           delay: 30
 
@@ -139,7 +139,7 @@
             value: "{{ full_svc_masters.resources[0].status.loadBalancer.ingress[0].ip }}"
             type: A
           register: r_route53_add_record
-          until: r_route53_add_record is sucess
+          until: r_route53_add_record is success
           retries: 10
           delay: 30
 
@@ -195,7 +195,7 @@
             value: "{{ full_svc_masters.resources[0].status.loadBalancer.ingress[0].ip }}"
             type: A
           register: r_route53_add_record
-          until: r_route53_add_record is sucess
+          until: r_route53_add_record is success
           retries: 10
           delay: 30
 
@@ -249,7 +249,7 @@
             value: "{{ full_svc_workers.resources[0].status.loadBalancer.ingress[0].ip }}"
             type: A
           register: r_route53_add_record
-          until: r_route53_add_record is sucess
+          until: r_route53_add_record is success
           retries: 10
           delay: 30
 


### PR DESCRIPTION
##### SUMMARY

Some deployments are failing with the following error: botocore.exceptions.ClientError: An error occurred (Throttling) when calling the ListResourceRecordSets operation (reached max retries: 4): Rate exceeded

This PR is to add a somes retries with 30 seconds delay

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
host-ocp4-assisted-installer role
