### PR TITLE
[host-ocp4-assisted-installer] remove api_vip and ingress_vip

### DIFF
--- a/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
@@ -279,10 +279,8 @@
         cluster_networks:
           - cidr: "10.132.0.0/14"
             host_prefix: 23
-        api_vip: "{{ ai_network_prefix }}.100"
         api_vips:
           - ip: "{{ ai_network_prefix }}.100"
-        ingress_vip: "{{ ai_network_prefix }}.101"
         ingress_vips:
           - ip: "{{ ai_network_prefix }}.101"
       register: newcluster


### PR DESCRIPTION

##### SUMMARY

New API doesnt include api_vip and ingress_vip


##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
host-ocp4-assisted-installer role
