### PR TITLE
Adding traefik configuration to ansible-runtime-api

### DIFF
--- a/ansible/roles/showroom/defaults/main.yml
+++ b/ansible/roles/showroom/defaults/main.yml
@@ -39,6 +39,7 @@ showroom_lab_users:
 showroom_ansible_runner_api: false
 showroom_ansible_runner_api_port: 8501
 showroom_ansible_runner_image: quay.io/makirill/ansible-runtime-api
+showroom_ansible_runner_path: "/runner"
 
 showroom_container_compose_template: compose_default_template.j2
 

--- a/ansible/roles/showroom/templates/ansible_runner_api_service/ansible_runner_api_service.j2
+++ b/ansible/roles/showroom/templates/ansible_runner_api_service/ansible_runner_api_service.j2
@@ -8,3 +8,13 @@ ansible-runner-api:
     - "{{ showroom_user_home_dir }}/content/runtime-automation/:/app/runtime-automation:ro"
   restart: "always"
 
+  environment:
+    - ROOT_PATH={{ showroom_ansible_runner_path }}
+
+  labels:
+    - "traefic.enable=true"
+    - "traefic.http.services.runner.loadbalancer.server.port={{ showroom_ansible_runner_api_port | default(8501) }}"
+    - "traefik.http.routers.runner.rule=Host(`{{ showroom_host }}`) && PathPrefix(`{{ showroom_ansible_runner_path }}`)"
+    - "traefik.http.routers.runner.middlewares=runner-stripprefix"
+    - "traefik.http.middlewares.runner-stripprefix.stripprefix.prefixes={{ showroom_ansible_runner_path }}"
+


### PR DESCRIPTION
##### SUMMARY

This change adds traefic configuration for `ansible-runner-api`. Default path will be `https://<showroom URL>/runner/docs` but can be configured with the `showroom_ansible_runner_path` variable.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Showroom/ansible_runner_api_service

