### PR TITLE
[infra-vmc-sandbox] Remove assign individual permissions to hosts

### DIFF
--- a/ansible/roles-infra/infra-vmc-sandbox/tasks/create_access.yml
+++ b/ansible/roles-infra/infra-vmc-sandbox/tasks/create_access.yml
@@ -54,19 +54,3 @@
   retries: 5
   delay: 10  
   loop: "{{ vcenter_permissions_readonly | dict2items }}"
-
-- name: Assign user to roles for the hosts on VCenter
-  vmware_object_role_permission:
-    hostname: '{{ vcenter_hostname }}'
-    username: '{{ vcenter_username }}'
-    password: '{{ vcenter_password }}'
-    role: "{{ vcenter_role }}"
-    principal: "{{ env_type }}-{{ guid }}@{{ vcenter_domain }}"
-    recursive: False
-    object_name: "{{ item }}"
-    object_type: "HostSystem"
-  register: r_vmware_object_role_permission
-  until: r_vmware_object_role_permission is success
-  retries: 5
-  delay: 10  
-  loop: "{{ vcenter_hosts }}"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
infra-vmc-sandbox role

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below
Instead of assigning permissions by host do it for a group
```
