### PR TITLE
Fixing traefik configuration for ansible-runner-api

### DIFF
--- a/ansible/roles/showroom/templates/ansible_runner_api_service/ansible_runner_api_service.j2
+++ b/ansible/roles/showroom/templates/ansible_runner_api_service/ansible_runner_api_service.j2
@@ -13,8 +13,8 @@ ansible-runner-api:
 
   labels:
     - "traefic.enable=true"
-    - "traefic.http.services.runner.loadbalancer.server.port={{ showroom_ansible_runner_api_port | default(8501) }}"
-    - "traefik.http.routers.runner.rule=Host(`{{ showroom_host }}`) && PathPrefix(`{{ showroom_ansible_runner_path }}`)"
-    - "traefik.http.routers.runner.middlewares=runner-stripprefix"
+    - "traefic.http.services.ansible-runner-api.loadbalancer.server.port={{ showroom_ansible_runner_api_port | default(8501) }}"
+    - "traefik.http.routers.ansible-runner-api.rule=Host(`{{ showroom_host }}`) && PathPrefix(`{{ showroom_ansible_runner_path }}`)"
+    - "traefik.http.routers.ansible-runner-api.middlewares=runner-stripprefix"
     - "traefik.http.middlewares.runner-stripprefix.stripprefix.prefixes={{ showroom_ansible_runner_path }}"
 


### PR DESCRIPTION
##### SUMMARY

There is a bug introduced by the https://github.com/redhat-cop/agnosticd/pull/7585 which prevents `Traefik` to route traffic correctly to the `ansible-runner-api`. This PR should fix it. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Showroom/ansible-runner-api
