### PR TITLE
Add antora_playbook variable to ocp4_workload_showroom

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/defaults/main.yaml
@@ -14,6 +14,9 @@ ocp4_workload_showroom_namespace_display: Showroom Guide
 ocp4_workload_showroom_content_git_repo: https://github.com/rhpds/showroom_template_default.git
 ocp4_workload_showroom_content_git_repo_ref: main
 
+# Which Antora Playbook to use in the content repo
+ocp4_workload_showroom_content_antora_playbook: default-site.yml
+
 # Only display the content pane, no other tabs will be available
 ocp4_workload_showroom_content_only: false
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm.yaml
@@ -19,6 +19,7 @@
         user_data: "{{ _showroom_vars | to_nice_yaml(width=1337, default_style='\"') }}"
         repoUrl: "{{ ocp4_workload_showroom_content_git_repo }}"
         repoRef: "{{ ocp4_workload_showroom_content_git_repo_ref }}"
+        antoraPlaybook: {{ ocp4_workload_showroom_content_antora_playbook }}
         contentOnly: "{{ ocp4_workload_showroom_content_only | bool | string | lower }}"
       guid: "{{ guid }}"
       deployer:

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm.yaml
@@ -19,7 +19,7 @@
         user_data: "{{ _showroom_vars | to_nice_yaml(width=1337, default_style='\"') }}"
         repoUrl: "{{ ocp4_workload_showroom_content_git_repo }}"
         repoRef: "{{ ocp4_workload_showroom_content_git_repo_ref }}"
-        antoraPlaybook: {{ ocp4_workload_showroom_content_antora_playbook }}
+        antoraPlaybook: "{{ ocp4_workload_showroom_content_antora_playbook }}"
         contentOnly: "{{ ocp4_workload_showroom_content_only | bool | string | lower }}"
       guid: "{{ guid }}"
       deployer:

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/templates/application.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/templates/application.yaml.j2
@@ -57,6 +57,7 @@ spec:
         content:
           repoUrl: {{ ocp4_workload_showroom_content_git_repo }}
           repoRef: {{ ocp4_workload_showroom_content_git_repo_ref }}
+          antoraPlaybook: {{ ocp4_workload_showroom_content_antora_playbook }}
           contentOnly: "{{ ocp4_workload_showroom_content_only | string | lower }}"
           user_data: |-
             {{ _showroom_user_data | to_nice_yaml | indent(12) }}

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/templates/applicationset.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/templates/applicationset.yaml.j2
@@ -71,6 +71,7 @@ spec:
             content:
               repoUrl: {{ ocp4_workload_showroom_content_git_repo }}
               repoRef: {{ ocp4_workload_showroom_content_git_repo_ref }}
+              antoraPlaybook: {{ ocp4_workload_showroom_content_antora_playbook }}
               contentOnly: "{{ ocp4_workload_showroom_content_only | string | lower }}"
               user_data: |-
                 {{ _showroom_user_data | to_nice_yaml | indent(16) }}


### PR DESCRIPTION
##### SUMMARY

Helm chart has the capability to specify which Antora playbook to use from a content repo. Adding the variable ocp4_workload_showroom_content_antora_playbook to allow different playbooks for different showroom instances.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_showroom