### PR TITLE
remove emitting generated_password when there's no azure bastion

### DIFF
--- a/ansible/configs/open-environment-azure-subscription/post_software.yml
+++ b/ansible/configs/open-environment-azure-subscription/post_software.yml
@@ -139,8 +139,6 @@
         bastion_ssh_command: "ssh {{ remote_user }}@bastion.{{ guid }}.{{ cluster_dns_zone }}"
         bastion_public_hostname: "bastion.{{ guid }}.{{ cluster_dns_zone }}"
         bastion_ssh_user_name: "{{ remote_user }}"
-        bastion_ssh_password: "{{ generated_password }}"
-        generated_password: "{{ generated_password }}"
         guid: "{{ guid }}"
 
   - name: Provide installed bastion data


### PR DESCRIPTION
Azure bastions require a "generated_password".
But when there's no bastion in the env_type, then there's no generated password, and a failure.