### PR TITLE
in helm_template kubeconfig use environment not parameter

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm.yaml
@@ -7,8 +7,9 @@
   ansible.builtin.include_tasks: setup-namespace.yaml
 
 - name: Render helm chart with values
+  environment:
+    KUBECONFIG: "{{ _showroom_kubeconfig | default(omit) }}"
   kubernetes.core.helm_template:
-    kubeconfig: "{{ _showroom_kubeconfig | default(omit) }}"
     chart_repo_url: "{{ ocp4_workload_showroom_chart_package_url }}"
     chart_ref: "{{ ocp4_workload_showroom_deployer_chart_name }}"
     chart_version: "{{ ocp4_workload_showroom_deployer_chart_version }}"


### PR DESCRIPTION
This has been failing for me on the controllers.

We can now deploy showroom to the shared cluster without a bastion.