### PR TITLE
migrating-to-ocpvirt/post_software.yaml add user.info.data vars

### DIFF
--- a/ansible/configs/migrating-to-ocpvirt/post_software.yml
+++ b/ansible/configs/migrating-to-ocpvirt/post_software.yml
@@ -142,6 +142,12 @@
   tasks:
     - name: Print Bastion Connection Information
       agnosticd_user_info:
+        data:
+          hypervisor_ip: "{{ hostvars['hypervisor']['public_ip_address'] }}"
+          ssh_user: "{{ student_name }}"
+          ssh_password: "{{ hostvars['hypervisor']['student_password'] }}"
+          ocp_console_url: "https://console-openshift-console.apps.{{ guid }}.{{ cluster_dns_zone }}"
+          ocp_admin_password: "{{ hostvars['localhost']['openshift_admin_password'] }}"
         msg: "{{ item }}"
       loop:
         - "Host you will be using for lab : {{ hostvars['hypervisor']['public_ip_address'] }}"


### PR DESCRIPTION
-->
##### SUMMARY

Add more vars into user.info.data for use with info-message and service-ready-message templates in AgV


##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
migrating-to-ocpvirt/post_software.yaml

##### ADDITIONAL INFORMATION
Adding to allow config to be compatible with community content CI, that needs extra vars exposed within the user.info.data

```
