### PR TITLE
Added var to customize registry storage on oVirt

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_external_odf/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_external_odf/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 become_override: false
 odf_channel: "stable-4.13"
+
+ocp4_workload_external_odf_registry_size: 100Gi

--- a/ansible/roles_ocp_workloads/ocp4_workload_external_odf/templates/pvc-imageregistry.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_external_odf/templates/pvc-imageregistry.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -5,8 +6,8 @@ metadata:
   namespace: openshift-image-registry
 spec:
   accessModes:
-    - ReadWriteOnce
+  - ReadWriteOnce
   resources:
     requests:
-      storage: 20Gi
+      storage: {{ ocp4_workload_external_odf_registry_size }}
   volumeMode: Filesystem


### PR DESCRIPTION
##### SUMMARY

Registry on OCP on oVirt had a hardcoded pvc size of 20Gi. Made a variable and bumped default to 100Gi.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_external_odf