### PR TITLE
[roadshow-ocpvirt] Update post_infra.yml

### DIFF
--- a/ansible/configs/roadshow-ocpvirt/post_infra.yml
+++ b/ansible/configs/roadshow-ocpvirt/post_infra.yml
@@ -62,3 +62,7 @@
           dns: "*.apps"
       loop_control:
         label: item.name
+      register: _route53_record
+      retries: 10
+      delay: 60
+      until: _route53_record is succeeded


### PR DESCRIPTION
##### SUMMARY
Using Route53 throws the following error when limit is reached:
botocore.exceptions.ClientError: An error occurred (Throttling) when calling the ListResourceRecordSets operation (reached max retries: 4): Rate exceeded

This code it will retry every 60 seconds, 10 times

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
roadshow-ocpvirt config
