### PR TITLE
[infra-dns] Add retries to route53 call

### DIFF
--- a/ansible/roles-infra/infra-dns/tasks/nested_loop.yml
+++ b/ansible/roles-infra/infra-dns/tasks/nested_loop.yml
@@ -88,6 +88,10 @@
         zone: "{{ cluster_dns_zone  }}"
         value: "{{ vars[infra_dns_inventory_var] | json_query(find_ip_query) }}"
         type: A
+      register: _route53_record
+      retries: 10
+      delay: "{{ 60|random(start=5, step=1) }}"
+      until: _route53_record is succeeded
 
 
 # When state == absent, don't use inventory var (should not be needed)


### PR DESCRIPTION
##### SUMMARY

Migrating most of the labs to use Route53 instead to use nsupdate, is causing to reach some limits

This PR adds a retry

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
infra-dns Role
