### PR TITLE
adding retries for argocd secret associated with argocd instance for RHDH

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_mad_roadshow/tasks/rhdh-setup-variables.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mad_roadshow/tasks/rhdh-setup-variables.yml
@@ -6,6 +6,8 @@
     name: "{{ ocp4_workload_mad_roadshow_argo_instance_name }}-cluster"
     namespace: "{{ ocp4_workload_mad_roadshow_rhdh_namespace }}"
   register: r_argo_creds
+  retries: 40
+  delay: 10
   until:
   - r_argo_creds is defined
   - r_argo_creds.resources is defined


### PR DESCRIPTION
##### SUMMARY
There is a network latency that makes the cluster failed after not finding the secret. Adding a retry and delayed to resolve the issue. I can see the secret created in the cluster 20 seconds after the request is done.

##### ISSUE TYPE
- Feature Pull Request
Adding a retry for requesting the argocd secret associated to the ARGOCD instance for RHDH.

##### COMPONENT NAME
ocp4_workload_mad_roadshow
Module 7.

##### ADDITIONAL INFORMATION
There is a network latency that makes the cluster failed after not finding the secret. Adding a retry and delayed to resolve the issue. I can see the secret created in the cluster 20 seconds after the request is done.

TASK [ocp4_workload_mad_roadshow : Retrieve ArgoCD credentials] ****************
FAILED - RETRYING: [bastion.m2f29.internal]: Retrieve ArgoCD credentials (3 retries left).
FAILED - RETRYING: [bastion.m2f29.internal]: Retrieve ArgoCD credentials (2 retries left).
FAILED - RETRYING: [bastion.m2f29.internal]: Retrieve ArgoCD credentials (1 retries left).
fatal: [bastion.m2f29.internal]: FAILED! => {"api_found": true, "attempts": 3, "changed": false, "resources": []}
