### PR TITLE
Fixing certificate configuration for Traefik proxy

### DIFF
--- a/ansible/roles/showroom/templates/ansible_runner_api_service/ansible_runner_api_service.j2
+++ b/ansible/roles/showroom/templates/ansible_runner_api_service/ansible_runner_api_service.j2
@@ -13,6 +13,8 @@ ansible-runner-api:
 
   labels:
     - "traefic.enable=true"
+    - "traefik.http.routers.entrypoints=runnersecure"
+    - "traefik.http.routers.ansible-runner-api.tls.certresolver=le"
     - "traefic.http.services.ansible-runner-api.loadbalancer.server.port={{ showroom_ansible_runner_api_port | default(8501) }}"
     - "traefik.http.routers.ansible-runner-api.rule=Host(`{{ showroom_host }}`) && PathPrefix(`{{ showroom_ansible_runner_path }}`)"
     - "traefik.http.routers.ansible-runner-api.middlewares=runner-stripprefix"

--- a/ansible/roles/showroom/templates/ansible_runner_api_service/ansible_runner_api_service.j2
+++ b/ansible/roles/showroom/templates/ansible_runner_api_service/ansible_runner_api_service.j2
@@ -13,7 +13,6 @@ ansible-runner-api:
 
   labels:
     - "traefic.enable=true"
-    - "traefik.http.routers.entrypoints=runnersecure"
     - "traefik.http.routers.ansible-runner-api.tls.certresolver=le"
     - "traefic.http.services.ansible-runner-api.loadbalancer.server.port={{ showroom_ansible_runner_api_port | default(8501) }}"
     - "traefik.http.routers.ansible-runner-api.rule=Host(`{{ showroom_host }}`) && PathPrefix(`{{ showroom_ansible_runner_path }}`)"


### PR DESCRIPTION
##### SUMMARY

Fixing certificate configuration to support SSL (HTTPS) Traefik proxy forwarding to the `ansible-runner-api` service

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Showroom
