### PR TITLE
[ocp4_workload_cockroach_dbaas_amq_lab] Using become to set permissions for lab-user

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_cockroach_dbaas_amq_lab/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cockroach_dbaas_amq_lab/tasks/pre_workload.yml
@@ -28,6 +28,8 @@
     ocp4_workload_cockroach_cluster_id: "{{ ocp4_workload_cockroach_response.json.id }}"
 
 - name: Save cluster_id to a file on the bastion
+  become: true
+  become_user: lab-user
   copy:
     content: "{{ ocp4_workload_cockroach_cluster_id }}"
     dest: "~/.cockroach-cluster-id.txt"


### PR DESCRIPTION
##### SUMMARY

On OpenShift Virtualization connection is using cloud-user, so fix permission for lab-user it is not possible

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
ocp4_workload_cockroach_dbaas_amq_lab role

