### PR TITLE
Add checks for DevWorkspace subs and crds 

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_voteapp/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_voteapp/tasks/workload.yml
@@ -1,4 +1,27 @@
 ---
-- name: pause for 5 minutes
-  pause:
-    minutes: 5
+- name: "DevWorkspace operator - Get Installed CSV"
+  kubernetes.core.k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: Subscription
+    name: devworkspace-operator-fast-devspaces-catalogsource-openshift-devspaces
+    namespace: openshift-devspaces
+  register: r_devworkspace_subscription
+  retries: 30
+  delay: 10
+  until:
+    - r_devworkspace_subscription.resources[0].status.currentCSV is defined
+    - r_devworkspace_subscription.resources[0].status.currentCSV | length > 0
+
+- name: "DevWorkspace operator - Wait until CSV is installed"
+  kubernetes.core.k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    name: "{{ r_devworkspace_subscription.resources[0].status.currentCSV }}"
+    namespace: openshift-devspaces
+  register: r_devworkspace_csv
+  retries: 40
+  delay: 30
+  until:
+    - r_devworkspace_csv.resources[0].status.phase is defined
+    - r_devworkspace_csv.resources[0].status.phase | length > 0
+    - r_devworkspace_csv.resources[0].status.phase == "Succeeded"

--- a/ansible/roles_ocp_workloads/ocp4_workload_voteapp/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_voteapp/tasks/workload.yml
@@ -1,4 +1,4 @@
 ---
-- name: print debug message
-  ansible.builtin.debug:
-    msg: "hello vote app"
+- name: pause for 5 minutes
+  pause:
+    minutes: 5


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
This change, in combination with [this](https://github.com/blues-man/vote-app-gitops/commit/3ad185c7f7ee55ee22936a359fd2a02f227f2109), will fix a bug we have where all devworkspaces are not up and running and admins need to be restart the cluster (or just sync devspaces argo apps).

This code will check if DevWorkspace Operator is successfully installed and if CRDs are available  

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
Add DevWorkspace installation checks

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
role ocp4_workload_voteapp

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->

