### PR TITLE
Revert "Update workload.yml to upgrade IPA server"

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_tl500/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_tl500/tasks/workload.yml
@@ -15,7 +15,6 @@
 - name: Install IPA
   command: >-
     helm upgrade --install ipa redhat-cop/ipa --namespace=ipa \
-      --set image=quay.io/freeipa/freeipa-server:fedora-39-4.11.1 \
       --create-namespace --set app_domain={{ ocp4_workload_tl500_apps_domain }} \
       --set admin_password={{ tl500_ldap_admin_password | quote }} \
       --set ocp_auth.enabled=true \


### PR DESCRIPTION
Reverts redhat-cop/agnosticd#7631

As actual code updated on helm-charts: https://github.com/redhat-cop/helm-charts/pull/463, we don't need this one.