### PR TITLE
[ocp4_workload_cockroach_dbaas_amq_lab] Using output_dir to store cluster ID 

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_cockroach_dbaas_amq_lab/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cockroach_dbaas_amq_lab/tasks/pre_workload.yml
@@ -28,14 +28,10 @@
     ocp4_workload_cockroach_cluster_id: "{{ ocp4_workload_cockroach_response.json.id }}"
 
 - name: Save cluster_id to a file on the bastion
-  become: true
-  become_user: lab-user
+  delegate_to: localhost
   copy:
     content: "{{ ocp4_workload_cockroach_cluster_id }}"
-    dest: "~/.cockroach-cluster-id.txt"
-    owner: lab-user
-    group: users
-    mode: '0644'
+    dest: "{{ output_dir }}/cockroach-cluster-id.txt"
 
 # Leave these as the last tasks in the playbook
 # ---------------------------------------------

--- a/ansible/roles_ocp_workloads/ocp4_workload_cockroach_dbaas_amq_lab/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cockroach_dbaas_amq_lab/tasks/remove_workload.yml
@@ -7,6 +7,7 @@
     ocp4_workload_cockroach_cluster_id: "{{ lookup('ansible.builtin.file', output_dir + '/cockroach-cluster-id.txt') }}"
 
 - name: Delete cluster on Cockroach Labs Cloud
+  ignore_errors: true
   uri:
     url: "https://cockroachlabs.cloud/api/v1/clusters/{{ ocp4_workload_cockroach_cluster_id }}"
     method: DELETE

--- a/ansible/roles_ocp_workloads/ocp4_workload_cockroach_dbaas_amq_lab/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cockroach_dbaas_amq_lab/tasks/remove_workload.yml
@@ -2,14 +2,9 @@
 # Implement your workload removal tasks here
 # ------------------------------------------
 
-- name: Read cluster ID from file on the basion
-  ansible.builtin.shell:
-    cmd: cat ~/.cockroach-cluster-id.txt
-  register: ocp4_workload_cockroach_cluster_id_txt
-
 - name: Set cluster ID variable
   ansible.builtin.set_fact:
-    ocp4_workload_cockroach_cluster_id: "{{ ocp4_workload_cockroach_cluster_id_txt.stdout }}"
+    ocp4_workload_cockroach_cluster_id: "{{ lookup('ansible.builtin.file', output_dir + '/cockroach-cluster-id.txt') }}"
 
 - name: Delete cluster on Cockroach Labs Cloud
   uri:

--- a/ansible/roles_ocp_workloads/ocp4_workload_cockroach_dbaas_amq_lab/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cockroach_dbaas_amq_lab/tasks/remove_workload.yml
@@ -14,34 +14,6 @@
       Authorization: "Bearer {{ ocp4_workload_cockroach_dbaas_amq_lab_apikey }}"
     status_code: 200
 
-- name: Delete Cockroach SaaS database provider account
-  kubernetes.core.k8s:
-    state: absent
-    definition:
-      apiVersion: dbaas.redhat.com/v1beta1
-      kind: DBaaSInventory
-      metadata:
-        name: cockroach-saas-provider
-        namespace: openshift-dbaas-operator
-
-- name: Delete Cockroach SaaS database provider secret
-  kubernetes.core.k8s:
-    state: absent
-    definition:
-      apiVersion: v1
-      kind: Secret
-      metadata:
-        name: cockroach-saas-provider-credentials
-        namespace: openshift-dbaas-operator
-
-- name: Delete the crdb-kafka namespace
-  kubernetes.core.k8s:
-    state: absent
-    definition:
-      apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: crdb-kafka
 
 # Leave this as the last task in the playbook.
 # --------------------------------------------


### PR DESCRIPTION
##### SUMMARY

To be able to delete the cluster, we need to cluster ID. This PR stores the cluster_id inside the output_dir, which is restored for the destroy process

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
role ocp4_workload_cockroach_dbaas_amq_lab
