### PR TITLE
Add support to delete temporary admin user. Add check to not download kn when serving is not installed

### DIFF
--- a/ansible/configs/rosa-consolidated/default_vars.yml
+++ b/ansible/configs/rosa-consolidated/default_vars.yml
@@ -91,6 +91,11 @@ rosa_setup_cluster_admin: true
 # or to deploy workloads using the kubernetes.core collection
 rosa_setup_cluster_admin_login: false
 
+# Delete cluster admin after workloads have been executed
+# This is useful if one of the workloads sets up an alternative
+# authentication provider like Red Hat SSO or AWS Cognito
+rosa_setup_cluster_admin_delete_after_workloads: false
+
 # ROSA Cluster Settings
 # If these are not specified the defaults are used
 # If they are specified they have to be set to a supported value

--- a/ansible/configs/rosa-consolidated/post_software.yml
+++ b/ansible/configs/rosa-consolidated/post_software.yml
@@ -64,7 +64,17 @@
     ansible.builtin.include_role:
       name: bookbag
 
-- name: Step 005.4 Lock Bastion Security Group
+- name: Step 005.4 Delete temporary cluster admin
+  hosts: bastions
+  run_once: true
+  gather_facts: false
+  become: false
+  tasks:
+  - name: Delete cluster admin
+    when: rosa_setup_cluster_admin_delete_after_workloads | bool
+    ansible.builtin.command: "{{ rosa_binary_path }}/rosa delete admin --yes --cluster={{ rosa_cluster_name }}"
+
+- name: Step 005.5 Lock Bastion Security Group
   hosts: localhost
   connection: local
   gather_facts: false

--- a/ansible/configs/rosa-consolidated/software.yml
+++ b/ansible/configs/rosa-consolidated/software.yml
@@ -129,7 +129,9 @@
           rosa_ocp_cli_version: "{{ _rosa_ocp_cli_version }}"
 
     - name: Save ROSA admin user data when ROSA has been installed with admin user
-      when: rosa_setup_cluster_admin | default(false) | bool
+      when: 
+      - rosa_setup_cluster_admin | default(false) | bool
+      - not rosa_setup_cluster_admin_delete_after_workloads | default(false) | bool
       agnosticd_user_info:
         data:
           rosa_admin_user: "cluster-admin"

--- a/ansible/configs/rosa-consolidated/software.yml
+++ b/ansible/configs/rosa-consolidated/software.yml
@@ -129,7 +129,7 @@
           rosa_ocp_cli_version: "{{ _rosa_ocp_cli_version }}"
 
     - name: Save ROSA admin user data when ROSA has been installed with admin user
-      when: 
+      when:
       - rosa_setup_cluster_admin | default(false) | bool
       - not rosa_setup_cluster_admin_delete_after_workloads | default(false) | bool
       agnosticd_user_info:

--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/workload.yml
@@ -101,80 +101,83 @@
     - r_kn_eventing.resources[0].status.conditions[1].status is defined
     - r_kn_eventing.resources[0].status.conditions[1].status == "True"
 
-- name: Get kn ConsoleCLIDownload
-  kubernetes.core.k8s_info:
-    api_version: console.openshift.io/v1
-    kind: ConsoleCLIDownload
-    name: kn
-  register: r_kn_cli_download
-  retries: 20
-  delay: 5
-  ignore_errors: true
-  until:
-  - r_kn_cli_download.resources is defined
-  - r_kn_cli_download.resources | length > 0
-
-- name: Get kn download URL from ConsoleCLIDownload
-  when: r_kn_cli_download.resources | length > 0
-  ansible.builtin.set_fact:
-    __ocp4_workload_serverless_kn_url: >-
-      {{ r_kn_cli_download.resources[0] | to_json | from_json
-       | json_query("spec.links[?contains(href,'-linux-amd64')].href") | first }}
-
-- name: No ConsoleCLIDownload for kn - try Route instead
-  when: r_kn_cli_download.resources | length == 0
+- name: Install kn tool (only when serving is configured)
+  when: ocp4_workload_serverless_install_serving | default(true) | bool
   block:
-  - name: Get kn download route
+  - name: Get kn ConsoleCLIDownload
     kubernetes.core.k8s_info:
-      api_version: route.openshift.io/v1
-      kind: Route
-      name: kn-cli-downloads
-      namespace: knative-serving
-    register: r_kn_download
+      api_version: console.openshift.io/v1
+      kind: ConsoleCLIDownload
+      name: kn
+    register: r_kn_cli_download
+    retries: 20
+    delay: 5
+    ignore_errors: true
+    until:
+    - r_kn_cli_download.resources is defined
+    - r_kn_cli_download.resources | length > 0
 
-  - name: Get kn download URL from Route
-    when:
-    - r_kn_download.resources is defined
-    - r_kn_download.resources | length > 0
+  - name: Get kn download URL from ConsoleCLIDownload
+    when: r_kn_cli_download.resources | length > 0
     ansible.builtin.set_fact:
-      __ocp4_workload_serverless_kn_url: "{{ r_kn_download.resources[0].status.ingress[0].host }}/amd64/linux/kn-linux-amd64.tar.gz"
+      __ocp4_workload_serverless_kn_url: >-
+        {{ r_kn_cli_download.resources[0] | to_json | from_json
+        | json_query("spec.links[?contains(href,'-linux-amd64')].href") | first }}
 
-- name: Install kn cli tool if a download URL was found
-  when: __ocp4_workload_serverless_kn_url is defined
-  block:
-  - name: Download kn cli tool
-    ansible.builtin.get_url:
-      url: "{{ __ocp4_workload_serverless_kn_url }}"
-      validate_certs: false
-      dest: /tmp/kn-linux-amd64.tar.gz
-      mode: "o=rw,g=rw"
-    register: r_kn
-    until: r_kn is success
-    retries: 10
-    delay: 10
+  - name: No ConsoleCLIDownload for kn - try Route instead
+    when: r_kn_cli_download.resources | length == 0
+    block:
+    - name: Get kn download route
+      kubernetes.core.k8s_info:
+        api_version: route.openshift.io/v1
+        kind: Route
+        name: kn-cli-downloads
+        namespace: knative-serving
+      register: r_kn_download
 
-  - name: Install kn CLI on bastion
-    become: true
-    ansible.builtin.unarchive:
-      src: /tmp/kn-linux-amd64.tar.gz
-      remote_src: true
-      dest: /usr/bin
-      mode: "o=rwx,g=rwx,o=rx"
-      owner: root
-      group: root
-    args:
-      creates: /usr/bin/kn
+    - name: Get kn download URL from Route
+      when:
+      - r_kn_download.resources is defined
+      - r_kn_download.resources | length > 0
+      ansible.builtin.set_fact:
+        __ocp4_workload_serverless_kn_url: "{{ r_kn_download.resources[0].status.ingress[0].host }}/amd64/linux/kn-linux-amd64.tar.gz"
 
-  - name: Remove downloaded file
-    ansible.builtin.file:
-      state: absent
-      path: /tmp/kn-linux-amd64.tar.gz
+  - name: Install kn cli tool if a download URL was found
+    when: __ocp4_workload_serverless_kn_url is defined
+    block:
+    - name: Download kn cli tool
+      ansible.builtin.get_url:
+        url: "{{ __ocp4_workload_serverless_kn_url }}"
+        validate_certs: false
+        dest: /tmp/kn-linux-amd64.tar.gz
+        mode: "o=rw,g=rw"
+      register: r_kn
+      until: r_kn is success
+      retries: 10
+      delay: 10
 
-  - name: Create kn bash completion file
-    become: true
-    ansible.builtin.shell: /usr/bin/kn completion bash >/etc/bash_completion.d/kn
-    args:
-      creates: /etc/bash_completion.d/kn
+    - name: Install kn CLI on bastion
+      become: true
+      ansible.builtin.unarchive:
+        src: /tmp/kn-linux-amd64.tar.gz
+        remote_src: true
+        dest: /usr/bin
+        mode: "o=rwx,g=rwx,o=rx"
+        owner: root
+        group: root
+      args:
+        creates: /usr/bin/kn
+
+    - name: Remove downloaded file
+      ansible.builtin.file:
+        state: absent
+        path: /tmp/kn-linux-amd64.tar.gz
+
+    - name: Create kn bash completion file
+      become: true
+      ansible.builtin.shell: /usr/bin/kn completion bash >/etc/bash_completion.d/kn
+      args:
+        creates: /etc/bash_completion.d/kn
 
 # Leave this as the last task in the playbook.
 - name: Workload tasks complete


### PR DESCRIPTION
##### SUMMARY

Add option to delete the temporary admin user from the ROSA cluster. This is useful if other authentication has been configured in a workload.

Add check to not download kn tool when KN Serving has not been configured for serverless.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
rosa-consolidated
ocp4_workload_serverless