### PR TITLE
Fix error with empty owner tag for ec2

### DIFF
--- a/ansible/roles-infra/infra-ec2-template-generate/templates/cloud_template.j2
+++ b/ansible/roles-infra/infra-ec2-template-generate/templates/cloud_template.j2
@@ -237,7 +237,7 @@ Resources:
           Value: {{instance['name']}}{{loop.index}}.{{aws_dns_zone_private_chomped}}
 {%     endif %}
         - Key: "owner"
-          Value: "{{ email | default('unknownuser') }}"
+          Value: "{{ requester_email | default(email, true) | default(requester_username, true) | default('unknownuser', true) }}"
         - Key: "Project"
           Value: "{{project_tag}}"
         - Key: "{{project_tag}}"


### PR DESCRIPTION
##### SUMMARY

- Default owner tag to requester_email or requester_username
- Default owner to "unknownuser" if value is empty string

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role infra-ec2-template-generate