### PR TITLE
Ansibe RIPU workshop Config as Code adjustment

### DIFF
--- a/ansible/roles/ansible_bu_setup_workshop/tasks/common/generic_cac_subtasks_init.yml
+++ b/ansible/roles/ansible_bu_setup_workshop/tasks/common/generic_cac_subtasks_init.yml
@@ -1,0 +1,12 @@
+---
+- name: Initialize dynamic_retry_count
+  ansible.builtin.set_fact:
+    dynamic_retry_count: 0
+
+- name: "Display current loop role"
+  ansible.builtin.debug:
+    msg: "Begin Controller CaC loop role: {{ controller_infra_vars }}"
+
+- ansible.builtin.include_tasks: generic_cac_subtasks_retry.yml
+...
+

--- a/ansible/roles/ansible_bu_setup_workshop/tasks/common/generic_cac_subtasks_retry.yml
+++ b/ansible/roles/ansible_bu_setup_workshop/tasks/common/generic_cac_subtasks_retry.yml
@@ -1,0 +1,26 @@
+---
+# https://devpress.csdn.net/cicd/62ec1d2689d9027116a10320.html
+- name: Controller CaC workloads Task Group
+  block:
+    - name: Increment retry count
+      ansible.builtin.set_fact:
+        dynamic_retry_count: "{{ dynamic_retry_count | int + 1 }}"
+
+    # - name: This task executes after each failed attempt
+    #   ansible.builtin.include_tasks: some_other_task_resume.yml
+    #   when: dynamic_retry_count | int != 1
+
+    - name: Deploy controller-infra workload
+      ansible.builtin.include_role:
+        name: "{{ controller_infra_vars }}"
+
+  rescue:
+    - ansible.builtin.fail:
+        msg: Maximum retries of grouped tasks reached
+      when: dynamic_retry_count | int == 5
+
+    - ansible.builtin.debug:
+        msg: "Controller CaC {{ controller_infra_vars }} Task Group failed, retry count: {{ dynamic_retry_count }}"
+
+    - ansible.builtin.include_tasks: generic_cac_subtasks_retry.yml
+...

--- a/ansible/roles/ansible_bu_setup_workshop/tasks/ripu.yml
+++ b/ansible/roles/ansible_bu_setup_workshop/tasks/ripu.yml
@@ -77,111 +77,102 @@
     _controller_url: "https://{{ aap_auth.controller_host | default(aap_controller_web_url) }}"
     _controller_username: "{{ aap_auth.controller_username | default(aap_controller_admin_user) | default('admin') }}"
     _controller_password: "{{ aap_auth.controller_password | default(aap_controller_admin_password) }}"
+    controller_request_timeout: "250"
+    controller_configuration_projects_async_retries: 60
+    controller_configuration_projects_async_delay: 5
+    controller_infra_workloads:
+      - infra.controller_configuration.credential_types
+      - infra.controller_configuration.execution_environments
+      - infra.controller_configuration.projects
+      - infra.controller_configuration.project_update
+      - infra.controller_configuration.job_templates
+    controller_validate_certs: "{{ aap_auth.controller_verify_ssl | default('true') }}"
+    controller_credential_types:
+      - name: GitHub_Personal_Access_Token
+        description: Credential for GitHub repo operations automation
+        kind: cloud
+        inputs:
+          fields:
+            - type: string
+              id: personal_access_token
+              label: Personal Access Token
+              secret: true
+              help_text: GitHub Personal Access Token
+              multiline: true
+          required:
+            - personal_access_token
+        injectors:
+          env:
+            MY_PA_TOKEN: !unsafe '{{ personal_access_token }}'
+    controller_projects:
+      - name: Project Leapp
+        organization: Default
+        scm_update_on_launch: false
+        scm_update_cache_timeout: 3600
+        scm_type: git
+        scm_url: "{{ ripu_project_scm_url }}"
+        scm_branch: "{{ ripu_project_scm_branch }}"
+        default_environment: ripu workshop execution environment
+    controller_templates:
+      - name: Z / CaC / Controller
+        project: Project Leapp
+        playbook: controller_cac.yml
+        inventory: Workshop Inventory
+        execution_environment: Default execution environment
+        credentials:
+          - Controller Credential
+        extra_vars:
+          controller_configuration_projects_async_retries: 60
+          controller_configuration_projects_async_delay: 5
+    controller_execution_environments:
+      - name: ripu workshop execution environment
+        image: registry.redhat.io/ansible-automation-platform-24/ee-supported-rhel8:latest
   block:
-    - name: Run SETUP / Controller job template
+    - name: Turn on AWX_COLLECTIONS_ENABLED on controller
+      awx.awx.settings:
+        name: AWX_COLLECTIONS_ENABLED
+        value: true
+        controller_username: "{{ _controller_username }}"
+        controller_password: "{{ _controller_username }}"
+        controller_host: "{{ _controller_url }}"
+        validate_certs: "{{ controller_validate_certs }}"
+
+    - name: Deploy controller-infra workloads
+      ansible.builtin.include_tasks: common/generic_cac_subtasks_init.yml
+      loop: "{{ controller_infra_workloads }}"
+      loop_control:
+        loop_var: controller_infra_vars
+      when:
+        - controller_infra_workloads | d("") | length >0
+
+    - name: Run Z / CaC / Controller job template
       awx.awx.job_launch:
-        job_template: "SETUP / Controller"
+        job_template: "Z / CaC / Controller"
+        controller_username: "{{ _controller_username }}"
+        controller_password: "{{ _controller_username }}"
+        controller_host: "{{ _controller_url }}"
       register: setupcontroljob
 
-    - name: "Check API until SETUP / Controller job is successful"
+    - name: "Check API until Z / CaC / Controller job is successful"
       ansible.builtin.uri:
         url: "{{ _controller_url }}/api/v2/jobs/{{ setupcontroljob.id }}/?format=json"
         user: "{{ _controller_username }}"
-        password: "{{ _controller_password }}"
+        password: "{{ _controller_username }}"
         force_basic_auth: true
         method: GET
         return_content: true
         status_code: 200
-        validate_certs: false
+        validate_certs: "{{ controller_validate_certs }}"
       register: workshop_job_templates01
       until: workshop_job_templates01.json.status == "successful"
-      delay: 15
-      retries: 16
+      delay: 15  # Every 15 seconds
+      retries: 24  # 6 minutes 6*60/15
 
-    - name: Run Update inventories via dynamic sources job template - RHEL7
-      awx.awx.job_launch:
-        job_template: "UTILITY / Update inventories via dynamic sources"
-        extra_vars:
-          rhel_inventory_group: rhel7
-      register: update_inventories_rhel7
-
-    - name: "Check API until Update inventories via dynamic sources RHEL7 job is successful"
-      ansible.builtin.uri:
-        url: "{{ _controller_url }}/api/v2/jobs/{{ update_inventories_rhel7.id }}/?format=json"
-        user: "{{ _controller_username }}"
-        password: "{{ _controller_password }}"
-        force_basic_auth: true
-        method: GET
-        return_content: true
-        status_code: 200
-        validate_certs: false
-      register: workshop_job_template02
-      until: workshop_job_template02.json.status == "successful"
-      delay: 15
-      retries: 10
-
-    - name: Run Update inventories via dynamic sources job template - RHEL8
-      awx.awx.job_launch:
-        job_template: "UTILITY / Update inventories via dynamic sources"
-        extra_vars:
-          rhel_inventory_group: rhel8
-      register: update_inventories_rhel8
-
-    - name: "Check API until Update inventories via dynamic sources RHEL8 job is successful"
-      ansible.builtin.uri:
-        url: "{{ _controller_url }}/api/v2/jobs/{{ update_inventories_rhel8.id }}/?format=json"
-        user: "{{ _controller_username }}"
-        password: "{{ _controller_password }}"
-        force_basic_auth: true
-        method: GET
-        return_content: true
-        status_code: 200
-        validate_certs: false
-      register: workshop_job_template03
-      until: workshop_job_template03.json.status == "successful"
-      delay: 15
-      retries: 10
-
-    - name: Run Update inventories via dynamic sources job template - ALL_rhel
-      awx.awx.job_launch:
-        job_template: "UTILITY / Update inventories via dynamic sources"
-        extra_vars:
-          rhel_inventory_group: ALL_rhel
-      register: update_inventories_ALL_rhel
-
-    - name: "Check API until Update inventories via dynamic sources ALL_rhel job is successful"
-      ansible.builtin.uri:
-        url: "{{ _controller_url }}/api/v2/jobs/{{ update_inventories_ALL_rhel.id }}/?format=json"
-        user: "{{ _controller_username }}"
-        password: "{{ _controller_password }}"
-        force_basic_auth: true
-        method: GET
-        return_content: true
-        status_code: 200
-        validate_certs: false
-      register: workshop_job_template04
-      until: workshop_job_template04.json.status == "successful"
-      delay: 15
-      retries: 10
-
-    - name: Run OS / Patch OS to latest job template - RHEL7
-      awx.awx.job_launch:
-        job_template: "OS / Patch OS to latest"
-        extra_vars:
-          rhel_inventory_group: rhel7
-      register: osupdatejob
-
-    - name: "Check API until OS / Patch OS to latest job is successful"
-      ansible.builtin.uri:
-        url: "{{ _controller_url }}/api/v2/jobs/{{ osupdatejob.id }}/?format=json"
-        user: "{{ _controller_username }}"
-        password: "{{ _controller_password }}"
-        force_basic_auth: true
-        method: GET
-        return_content: true
-        status_code: 200
-        validate_certs: false
-      register: workshop_job_template05
-      until: workshop_job_template05.json.status == "successful"
-      delay: 20
-      retries: 45
+    - name: Run Z / SETUP / Workshop deployment workflow template
+      awx.awx.workflow_launch:
+        workflow_template: "Z / SETUP / Workshop deployment"
+        controller_username: "{{ _controller_username }}"
+        controller_password: "{{ _controller_username }}"
+        controller_host: "{{ _controller_url }}"
+        timeout: 900
+...


### PR DESCRIPTION
##### SUMMARY
ansible/workshops automation for RIPU deployment was modified to utilize an updated method for workshop Config as Code and deployment tasks: https://github.com/ansible/workshops/blob/02cd4f44f552af13503d0177e0575ab23dc5f90e/provisioner/workshop_specific/ripu.yml#L14-L132
This PR implements the majority of these changes into the AgD ansible/roles/ansible_bu_setup_workshop role for the Ansible RIPU workshop deploy scenario.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Update to ansible/roles/ansible_bu_setup_workshop role

##### ADDITIONAL INFORMATION
Additionally, a role/task retry automation strategy is included in the common folder of the ansible_bu_setup_workshop role, in this case to be utilized against the infra.controller_configuration.* Config as Code roles, however, this role retry strategy can be utilized for any idempotent role(s).

The following vars:
`ripu_project_scm_url`
`ripu_project_scm_branch`
...will need to be included in the associated RIPU AgnosticV dev/prod vars files and defined to utilize the appropriate RIPU AAP2 project and branch, for example:
`ripu_project_scm_url: 'https://github.com/redhat-partner-tech/leapp-project'`
`ripu_project_scm_branch: 'dev01'`

