### PR TITLE
Mods to reflect updated Config as Code workshop deploy strategy for Ansible RIPU workshop.

### DIFF
--- a/ansible/roles/ansible_bu_setup_workshop/tasks/ripu.yml
+++ b/ansible/roles/ansible_bu_setup_workshop/tasks/ripu.yml
@@ -78,12 +78,22 @@
     _controller_username: "{{ aap_auth.controller_username | default(aap_controller_admin_user) | default('admin') }}"
     _controller_password: "{{ aap_auth.controller_password | default(aap_controller_admin_password) }}"
   block:
-    - name: Run SETUP / Controller job template
+    # Allow projects to pull collections via collections/requirements.yml
+    - name: Turn on AWX_COLLECTIONS_ENABLED on controller
+      awx.awx.settings:
+        name: AWX_COLLECTIONS_ENABLED
+        value: true
+        controller_username: "{{ _controller_username }}"
+        controller_password: "{{ _controller_password }}"
+        controller_host: "{{ _controller_url }}"
+        validate_certs: false
+
+    - name: Run Z / CaC / Controller job template
       awx.awx.job_launch:
-        job_template: "SETUP / Controller"
+        job_template: "Z / CaC / Controller"
       register: setupcontroljob
 
-    - name: "Check API until SETUP / Controller job is successful"
+    - name: "Check API until Z / CaC / Controller job is successful"
       ansible.builtin.uri:
         url: "{{ _controller_url }}/api/v2/jobs/{{ setupcontroljob.id }}/?format=json"
         user: "{{ _controller_username }}"
@@ -95,93 +105,11 @@
         validate_certs: false
       register: workshop_job_templates01
       until: workshop_job_templates01.json.status == "successful"
-      delay: 15
-      retries: 16
+      delay: 15  # Every 15 seconds
+      retries: 24  # 6 minutes 6*60/15
 
-    - name: Run Update inventories via dynamic sources job template - RHEL7
-      awx.awx.job_launch:
-        job_template: "UTILITY / Update inventories via dynamic sources"
-        extra_vars:
-          rhel_inventory_group: rhel7
-      register: update_inventories_rhel7
-
-    - name: "Check API until Update inventories via dynamic sources RHEL7 job is successful"
-      ansible.builtin.uri:
-        url: "{{ _controller_url }}/api/v2/jobs/{{ update_inventories_rhel7.id }}/?format=json"
-        user: "{{ _controller_username }}"
-        password: "{{ _controller_password }}"
-        force_basic_auth: true
-        method: GET
-        return_content: true
-        status_code: 200
-        validate_certs: false
-      register: workshop_job_template02
-      until: workshop_job_template02.json.status == "successful"
-      delay: 15
-      retries: 10
-
-    - name: Run Update inventories via dynamic sources job template - RHEL8
-      awx.awx.job_launch:
-        job_template: "UTILITY / Update inventories via dynamic sources"
-        extra_vars:
-          rhel_inventory_group: rhel8
-      register: update_inventories_rhel8
-
-    - name: "Check API until Update inventories via dynamic sources RHEL8 job is successful"
-      ansible.builtin.uri:
-        url: "{{ _controller_url }}/api/v2/jobs/{{ update_inventories_rhel8.id }}/?format=json"
-        user: "{{ _controller_username }}"
-        password: "{{ _controller_password }}"
-        force_basic_auth: true
-        method: GET
-        return_content: true
-        status_code: 200
-        validate_certs: false
-      register: workshop_job_template03
-      until: workshop_job_template03.json.status == "successful"
-      delay: 15
-      retries: 10
-
-    - name: Run Update inventories via dynamic sources job template - ALL_rhel
-      awx.awx.job_launch:
-        job_template: "UTILITY / Update inventories via dynamic sources"
-        extra_vars:
-          rhel_inventory_group: ALL_rhel
-      register: update_inventories_ALL_rhel
-
-    - name: "Check API until Update inventories via dynamic sources ALL_rhel job is successful"
-      ansible.builtin.uri:
-        url: "{{ _controller_url }}/api/v2/jobs/{{ update_inventories_ALL_rhel.id }}/?format=json"
-        user: "{{ _controller_username }}"
-        password: "{{ _controller_password }}"
-        force_basic_auth: true
-        method: GET
-        return_content: true
-        status_code: 200
-        validate_certs: false
-      register: workshop_job_template04
-      until: workshop_job_template04.json.status == "successful"
-      delay: 15
-      retries: 10
-
-    - name: Run OS / Patch OS to latest job template - RHEL7
-      awx.awx.job_launch:
-        job_template: "OS / Patch OS to latest"
-        extra_vars:
-          rhel_inventory_group: rhel7
-      register: osupdatejob
-
-    - name: "Check API until OS / Patch OS to latest job is successful"
-      ansible.builtin.uri:
-        url: "{{ _controller_url }}/api/v2/jobs/{{ osupdatejob.id }}/?format=json"
-        user: "{{ _controller_username }}"
-        password: "{{ _controller_password }}"
-        force_basic_auth: true
-        method: GET
-        return_content: true
-        status_code: 200
-        validate_certs: false
-      register: workshop_job_template05
-      until: workshop_job_template05.json.status == "successful"
-      delay: 20
-      retries: 45
+    - name: Run Z / SETUP / Workshop deployment workflow template
+      awx.awx.workflow_launch:
+        workflow_template: "Z / SETUP / Workshop deployment"
+        timeout: 900
+...


### PR DESCRIPTION
##### SUMMARY
Updates Config as Code job templates that are executed towards the end of the workshop deploy automation for Ansible RIPU workshop.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible/roles/ansible_bu_setup_workshop role

##### ADDITIONAL INFORMATION
The initial Config as Code job template "Z / CaC / Controller" is configured in AgnosticV [here](https://github.com/rhpds/agnosticv/blob/cb64480cd8c2c2a9f9eb0e363a12eba96547e578/sandboxes-gpte/ANS_BU_WKSP_RIPU/common.yaml#L443-L452).
