### PR TITLE
Fix logic to get correct API and Console URLs

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_authentication_rosa/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_authentication_rosa/tasks/workload.yml
@@ -1,27 +1,20 @@
 ---
-- name: Get the OpenShift console route
-  kubernetes.core.k8s_info:
-    api_version: route.openshift.io/v1
-    kind: Route
-    namespace: openshift-console
-    field_selectors:
-    - spec.to.name=console
-  register: r_dc
-  until:
-  - r_dc is defined
-  - r_dc.resources is defined
-  - r_dc.resources | list | length > 0
-  retries: 60
-  delay: 15
+- name: Get OpenShift Console URL
+  ansible.builtin.shell: |-
+    set -o pipefail && rosa describe cluster --cluster rosa-{{ guid }} -o json | jq -r .console.url
+  register: r_ocp_console_url
+  changed_when: r_ocp_console_url.stdout != ""
 
-- name: Save OpenShift access facts
-  vars:
-    _apps_domain: "{{ r_dc.resources[0].spec.host | regex_search('(?<=\\.).*') }}"
-    _api_domain: "{{ r_dc.resources[0].spec.host | regex_search('(?<=\\.apps).*') }}"
+- name: Get OpenShift API URL
+  ansible.builtin.shell: |-
+    set -o pipefail && rosa describe cluster --cluster rosa-{{ guid }} -o json | jq -r .api.url
+  register: r_ocp_api_url
+  changed_when: r_ocp_api_url.stdout != ""
+
+- name: Set URL facts
   ansible.builtin.set_fact:
-    _ocp4_workload_authentication_rosa_cluster_ingress_domain: "{{ _apps_domain }}"
-    _ocp4_workload_authentication_rosa_console_route: "https://console-openshift-console.{{ _apps_domain }}"
-    _ocp4_workload_authentication_rosa_api_server: "https://api{{ _api_domain }}:6443"
+    _ocp4_workload_authentication_rosa_console_route: "{{ r_ocp_console_url.stdout }}"
+    _ocp4_workload_authentication_rosa_api_server: "{{ r_ocp_api_url.stdout }}"
 
 - name: Use provided admin password
   when: ocp4_workload_authentication_rosa_admin_password | default('') | length > 0
@@ -329,7 +322,6 @@
       password: "{{ _ocp4_workload_authentication_rosa_user_passwords[n] }}"
       console_url: "{{ _ocp4_workload_authentication_rosa_console_route }}"
       openshift_console_url: "{{ _ocp4_workload_authentication_rosa_console_route }}"
-      openshift_cluster_ingress_domain: "{{ _ocp4_workload_authentication_rosa_cluster_ingress_domain }}"
   loop: "{{ range(0, ocp4_workload_authentication_rosa_user_count | int) | list }}"
   loop_control:
     loop_var: n

--- a/ansible/roles_ocp_workloads/ocp4_workload_authentication_rosa/vars/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_authentication_rosa/vars/main.yaml
@@ -1,5 +1,4 @@
 ---
-_ocp4_workload_authentication_rosa_cluster_ingress_domain: ""
 _ocp4_workload_authentication_rosa_console_route: ""
 _ocp4_workload_authentication_rosa_api_server: ""
 


### PR DESCRIPTION
##### SUMMARY

The logic to determine Console and API URL in the workload was not correct - and partially hardcoded.

Fixing to use the rosa cluster properties instead.
Also remove base domain variable that is never used.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_authentication_rosa