### PR TITLE
[prepuser] Use new hostvars.localhost.ssh_provision_key_path

### DIFF
--- a/ansible/roles/bastion/tasks/prepuser.yml
+++ b/ansible/roles/bastion/tasks/prepuser.yml
@@ -15,7 +15,7 @@
 - name: prepuser | copy the environment .pem key
   become: true
   copy:
-    src: "{{ hostvars.localhost.env_authorized_key_path }}"
+    src: "{{ hostvars.localhost.ssh_provision_key_path | default (hostvars.localhost.env_authorized_key_path) }}"
     dest: "~{{ bastion_prepared_user }}/.ssh/{{env_authorized_key}}.pem"
     owner: "{{ bastion_prepared_user }}"
     group: "{{ bastion_prepared_group }}"


### PR DESCRIPTION
##### SUMMARY

hostvars.localhost.ssh_provision_key_path it is the recommended variable, if doesnt exist it will use hostvars.localhost.env_authorized_key_path

##### ISSUE TYPE
- New config Pull Request

##### COMPONENT NAME
prepuser role

