### PR TITLE
[infra-openshift-cnv-resources]  enhance CNV cloud provider

### DIFF
--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
@@ -43,7 +43,7 @@
               'pod': {}
           }
       ] }}
-  loop: "{{ _instance.networks | default([]) | list }}"
+  loop: "{{ _instance.networks | default(['default']) | list }}"
   loop_control:
     loop_var: _network
     index_var: _network_idx
@@ -82,7 +82,7 @@
             'name': 'cloudinitdisk',
             'cloudInitNoCloud': {
                 'userDataBase64': _cloud_config | b64encode,
-                'networkData': _instance.networkdata | default('')
+                'networkDataBase64': _instance.networkdata | default('network: 2') | b64encode
             }
         }
     ] }}"
@@ -147,7 +147,8 @@
           {{ cloud_tags_final
           | combine(_instance.metadata|default({})) | combine(_instance.tags|default({}) | ec2_tags_to_dict) }}
       spec:
-        dataVolumeTemplates: "{{ _datavolume + _instance.disks|default([]) }}"
+        dataVolumeTemplates: >-
+         {{ _datavolume + (_instance.disks | default([]) | to_json | replace('INSTANCENAME',_instance_name) | from_json)  }}
         running: true
         template:
           metadata:

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_services.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_services.yaml
@@ -9,6 +9,7 @@
         name: "{{ _instance_name }}"
         namespace: "{{ openshift_cnv_project_name }}"
       spec:
+        clusterIP: None
         ports:
         - port: {{ _instance.servicePort | default(22) |int}}
           protocol: TCP


### PR DESCRIPTION
##### SUMMARY

- With this PR the networkdata for the VMs will be working as expected, as before it was complex to define properly the definition
- VMs with not network definition will be mapped automatically to default network
- dataVolumeTemplates will work for VMs with count different to 1
- connection between VMs will not be limited now to port 22 using service

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
infra-openshift-cnv-resources Role
