### PR TITLE
Switch default OCP Networking Type to OVNKubernetes

### DIFF
--- a/ansible/configs/archive/ocs4-external-implementation/default_vars.yml
+++ b/ansible/configs/archive/ocs4-external-implementation/default_vars.yml
@@ -119,10 +119,9 @@ ocp4_installer_root_url: http://d3s3zqyaz8cp2d.cloudfront.net/pub/openshift-v4/c
 ocp4_base_domain: "example.opentlc.com"
 
 # Network Plugin for OpenShift:
-# - OpenshiftSDN
 # - OVNKubernetes
-# OVNKubernetes requires OCP 4.6 and newer
-ocp4_network_type: OpenshiftSDN
+# - OpenshiftSDN (no longer supported as of 4.15)
+ocp4_network_type: OVNKubernetes
 
 # Install the workaround for OVN deployments. Only for 4.6+
 # This is *only* necessary when the cluster will contain

--- a/ansible/configs/ocp4-cluster/default_vars.yml
+++ b/ansible/configs/ocp4-cluster/default_vars.yml
@@ -118,13 +118,13 @@ ocp4_enable_cluster_shutdown: false
 ocp4_base_domain: "example.opentlc.com"
 
 # Red Hat Network Plugins for OpenShift:
-# - OpenshiftSDN
 # - OVNKubernetes (requires OCP 4.6 and newer)
+# - OpenshiftSDN (no longer supported as of 4.15)
 #
 # Third Party Network Plugins for OpenShift
 # - Calico (tested on OCP 4.7)
 #
-ocp4_network_type: OpenshiftSDN
+ocp4_network_type: OVNKubernetes
 
 # Install the workaround for OVN deployments. Only for 4.6+
 # This is *only* necessary when the cluster will contain

--- a/ansible/configs/ocp4-workshop/files/install-config.yaml.j2
+++ b/ansible/configs/ocp4-workshop/files/install-config.yaml.j2
@@ -28,7 +28,7 @@ networking:
   machineCIDR: 10.0.0.0/16
   serviceNetwork:
   - 172.30.0.0/16
-  networkType: OpenshiftSDN
+  networkType: OVNKubernetes
 platform:
   aws:
     region: {{ aws_region_final | default(aws_region) | to_json }}

--- a/ansible/configs/sap-integration/default_vars.yml
+++ b/ansible/configs/sap-integration/default_vars.yml
@@ -101,9 +101,8 @@ ocp4_enable_cluster_shutdown: false
 
 ocp4_base_domain: "example.opentlc.com"
 
-# Network Plugin for OpenShift: OpenshiftSDN (Default) or OVNKubernetes
-# OVNKubernetes requires OCP 4.6 and newer
-ocp4_network_type: OpenshiftSDN
+# Network Plugin for OpenShift: OVNKubernetes (default) or OpenshiftSDN (up to 4.14)
+ocp4_network_type: OVNKubernetes
 
 # Run fio performance tests at the end
 test_deploy_enable: false

--- a/ansible/roles/host-ocp4-installer/create-manifests.yml
+++ b/ansible/roles/host-ocp4-installer/create-manifests.yml
@@ -30,7 +30,6 @@
 # This downloads all the extra manifests which are maintained by Tigera
 # Can't use unarchive module as it does not handle .gz files that do not contain a .tar archive.
 - block:
-  when: ocp4_network_type|default("OVNKubernetes") == "Calico"
     - name: make sure manifests dir exists
       file:
         path: "/home/{{ ansible_user }}/{{ cluster_name }}/manifests/"
@@ -62,3 +61,4 @@
     - name: remove downloaded file
       ansible.builtin.file:
         path: "/home/{{ ansible_user }}/ocp.tgz"
+  when: ocp4_network_type|default("OVNKubernetes") == "Calico"

--- a/ansible/roles/host-ocp4-installer/create-manifests.yml
+++ b/ansible/roles/host-ocp4-installer/create-manifests.yml
@@ -30,6 +30,7 @@
 # This downloads all the extra manifests which are maintained by Tigera
 # Can't use unarchive module as it does not handle .gz files that do not contain a .tar archive.
 - block:
+  when: ocp4_network_type|default("OVNKubernetes") == "Calico"
     - name: make sure manifests dir exists
       file:
         path: "/home/{{ ansible_user }}/{{ cluster_name }}/manifests/"
@@ -61,4 +62,3 @@
     - name: remove downloaded file
       ansible.builtin.file:
         path: "/home/{{ ansible_user }}/ocp.tgz"
-  when: ocp4_network_type|default("OpenshiftSDN") == "Calico"

--- a/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
+++ b/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
@@ -102,12 +102,12 @@ networking:
   machineCIDR: {{ ocp4_machine_cidr | default('10.0.0.0/16') | to_json }}
   serviceNetwork:
   - {{ ocp_service_network | default('172.30.0.0/16') }}
-{% if ocp4_network_type | default("OpenshiftSDN") is match("OVNKubernetes") %}
-  networkType: OVNKubernetes
-{% elif ocp4_network_type | default("OpenshiftSDN") is match("Calico") %}
+{% if ocp4_network_type | default("OVNKubernetes") is match("OpenshiftSDN") %}
+  networkType: OpenshiftSDN
+{% elif ocp4_network_type | default("OVNKubernetes") is match("Calico") %}
   networkType: Calico
 {% else %}
-  networkType: OpenshiftSDN
+  networkType: OVNKubernetes
 {% endif %}
 platform:
 {% if cloud_provider == 'ec2' %}


### PR DESCRIPTION
##### SUMMARY

As of OpenShift 4.15 OpenShiftSDN is no longer a supported networking type and installations fail. Instead of mandating all configs to set the networking to OVNKubernetes change the defaults where applicable.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-cluster
ocp4-workshop
sap-integration
host-ocp4-installer
ocs-external-implementation (archived)