### PR TITLE
[CNV] Allow authentication with token (from SA)

### DIFF
--- a/ansible/roles-infra/infra-openshift-cnv-create-inventory/tasks/create_inventory.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-create-inventory/tasks/create_inventory.yaml
@@ -23,7 +23,7 @@
 - name: Expose bastion externally
   kubernetes.core.k8s:
     host: "{{ openshift_cnv_api_uri }}"
-    api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
+    api_key: "{{ k8s_auth_results.k8s_auth.api_key|default(openshift_cnv_sa_token) }}"
     validate_certs: false
     definition:
       apiVersion: v1

--- a/ansible/roles-infra/infra-openshift-cnv-create-inventory/tasks/main.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-create-inventory/tasks/main.yaml
@@ -1,9 +1,11 @@
 ---
 - include_tasks: authentication.yaml
+  when: openshift_cnv_username | default(false)
+
 - block:
     - ansible.builtin.include_tasks: create_inventory.yaml
   module_defaults:
     group/k8s:
       host: "{{ openshift_cnv_api_uri }}"
-      api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
+      api_key: "{{ k8s_auth_results.k8s_auth.api_key|default(openshift_cnv_sa_token) }}"
       validate_certs: false

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/main.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/main.yaml
@@ -1,5 +1,6 @@
 ---
 - ansible.builtin.include_tasks: authentication.yaml
+  when: openshift_cnv_username | default(false)
 
 - when: ACTION == 'provision'
   block:
@@ -9,7 +10,7 @@
   module_defaults:
     group/k8s:
       host: "{{ openshift_cnv_api_uri }}"
-      api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
+      api_key: "{{ k8s_auth_results.k8s_auth.api_key|default(openshift_cnv_sa_token) }}"
       validate_certs: false
 
 
@@ -22,7 +23,7 @@
   module_defaults:
     group/k8s:
       host: "{{ openshift_cnv_api_uri }}"
-      api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
+      api_key: "{{ k8s_auth_results.k8s_auth.api_key|default(openshift_cnv_sa_token) }}"
       validate_certs: false
 
 
@@ -32,5 +33,5 @@
   module_defaults:
     group/k8s:
       host: "{{ openshift_cnv_api_uri }}"
-      api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
+      api_key: "{{ k8s_auth_results.k8s_auth.api_key|default(openshift_cnv_sa_token) }}"
       validate_certs: false

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/start_instances.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/start_instances.yaml
@@ -14,7 +14,7 @@
     loop_var: _instance
   kubevirt.core.kubevirt_vm:
     host: "{{ openshift_cnv_api_uri }}"
-    api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
+    api_key: "{{ k8s_auth_results.k8s_auth.api_key|default(openshift_cnv_sa_token) }}"
     validate_certs: false
     running: true
     name: "{{ _instance.metadata.name }}"

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/stop_instances.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/stop_instances.yaml
@@ -15,7 +15,7 @@
     loop_var: _instance
   kubevirt.core.kubevirt_vm:
     host: "{{ openshift_cnv_api_uri }}"
-    api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
+    api_key: "{{ k8s_auth_results.k8s_auth.api_key|default(openshift_cnv_sa_token) }}"
     validate_certs: false
     running: false
     name: "{{ _instance.metadata.name }}"

--- a/ansible/roles/host-ocp4-assisted-destroy/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-destroy/tasks/main.yaml
@@ -5,12 +5,13 @@
     password: "{{ openshift_cnv_password }}"
     host: "{{ openshift_cnv_api_uri }}"
   register: k8s_auth_results
+  when: openshift_cnv_username | default(false)
 
 - name: Destroy OCP using Assisted Installed
   module_defaults:
     group/k8s:
       host: "{{ openshift_cnv_api_uri }}"
-      api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
+      api_key: "{{ k8s_auth_results.k8s_auth.api_key|default(openshift_cnv_sa_token) }}"
       validate_certs: false
 
   block:

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_masters_etcd.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_masters_etcd.yaml
@@ -2,7 +2,7 @@
 - name: Create Master virtual machine
   kubevirt.core.kubevirt_vm:
     host: "{{ openshift_cnv_api_uri }}"
-    api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
+    api_key: "{{ k8s_auth_results.k8s_auth.api_key|default(openshift_cnv_sa_token) }}"
     validate_certs: false
     name: "{{ vmname }}"
     namespace: "{{ namespace }}"
@@ -115,7 +115,7 @@
 - name: Wait till VM is running
   kubernetes.core.k8s_info:
     host: "{{ openshift_cnv_api_uri }}"
-    api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
+    api_key: "{{ k8s_auth_results.k8s_auth.api_key|default(openshift_cnv_sa_token) }}"
     validate_certs: false
     kind: VirtualMachine
     name: "{{ vmname }}"

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_workers.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_workers.yaml
@@ -2,7 +2,7 @@
 - name: Create Worker virtual machine
   kubevirt.core.kubevirt_vm:
     host: "{{ openshift_cnv_api_uri }}"
-    api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
+    api_key: "{{ k8s_auth_results.k8s_auth.api_key|default(openshift_cnv_sa_token) }}"
     validate_certs: false
     name: "{{ vmname }}"
     namespace: "{{ namespace }}"
@@ -93,7 +93,7 @@
 - name: Wait till VM is running
   kubernetes.core.k8s_info:
     host: "{{ openshift_cnv_api_uri }}"
-    api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
+    api_key: "{{ k8s_auth_results.k8s_auth.api_key|default(openshift_cnv_sa_token) }}"
     validate_certs: false
     kind: VirtualMachine
     name: "{{ vmname }}"

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
@@ -44,13 +44,14 @@
     password: "{{ openshift_cnv_password }}"
     host: "{{ openshift_cnv_api_uri }}"
   register: k8s_auth_results
+  when: openshift_cnv_username | default(false)
 
 
 - name: Install OCP using Assisted Installed
   module_defaults:
     group/k8s:
       host: "{{ openshift_cnv_api_uri }}"
-      api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
+      api_key: "{{ k8s_auth_results.k8s_auth.api_key|default(openshift_cnv_sa_token) }}"
       validate_certs: false
 
   block:


### PR DESCRIPTION
##### SUMMARY

Currently we are using openshift_cnv_username and openshift_cnv_password for authentication to obtain the token (key)

This PR allows to have a variable openshift_cnv_sa_token with the authentication token instead

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME
infra-openshift-cnv-create-inventory and infra-openshift-cnv-resources roles

