### PR TITLE
Add support for newer Quay releases. Streamlining. Fix Ansible lint warnings.

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/defaults/main.yml
@@ -11,7 +11,7 @@ silent: false
 ocp4_workload_quay_operator_install_operator: true
 
 # Operator channel to subscribe to
-ocp4_workload_quay_operator_channel: "stable-3.6"
+ocp4_workload_quay_operator_channel: stable-3.6
 
 # Operator namespace
 ocp4_workload_quay_operator_namespace: openshift-operators
@@ -28,7 +28,7 @@ ocp4_workload_quay_operator_automatic_install_plan_approval: true
 # empty to get the latest available in the channel at the time when
 # the catalog snapshot got created.
 ocp4_workload_quay_operator_starting_csv: ""
-#ocp4_workload_quay_operator_starting_csv: "quay-operator.v3.6.2"
+# ocp4_workload_quay_operator_starting_csv: "quay-operator.v3.6.2"
 
 # --------------------------------
 # Operator Catalog Snapshot Settings
@@ -69,7 +69,7 @@ ocp4_workload_quay_operator_registry_name: quay
 # When empty the route will be quay-{{guid}}.basedomain
 ocp4_workload_quay_operator_registry_route: ""
 
-ocp4_workload_quay_operator_registry_display_name: "Red Hat Product Demo System Quay"
+ocp4_workload_quay_operator_registry_display_name: "Red Hat Demo Platform Quay"
 
 # Quay Admin User
 ocp4_workload_quay_operator_registry_configure_admin: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/tasks/main.yml
@@ -2,29 +2,29 @@
 # Do not modify this file
 
 - name: Running Pre Workload Tasks
-  include_tasks:
+  when: ACTION == "create" or ACTION == "provision"
+  ansible.builtin.include_tasks:
     file: ./pre_workload.yml
     apply:
       become: "{{ become_override | bool }}"
-  when: ACTION == "create" or ACTION == "provision"
 
 - name: Running Workload Tasks
-  include_tasks:
+  when: ACTION == "create" or ACTION == "provision"
+  ansible.builtin.include_tasks:
     file: ./workload.yml
     apply:
       become: "{{ become_override | bool }}"
-  when: ACTION == "create" or ACTION == "provision"
 
 - name: Running Post Workload Tasks
-  include_tasks:
+  when: ACTION == "create" or ACTION == "provision"
+  ansible.builtin.include_tasks:
     file: ./post_workload.yml
     apply:
       become: "{{ become_override | bool }}"
-  when: ACTION == "create" or ACTION == "provision"
 
 - name: Running Workload removal Tasks
-  include_tasks:
+  when: ACTION == "destroy" or ACTION == "remove"
+  ansible.builtin.include_tasks:
     file: ./remove_workload.yml
     apply:
       become: "{{ become_override | bool }}"
-  when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/tasks/post_workload.yml
@@ -6,19 +6,19 @@
 # For deployment onto a dedicated cluster (as part of the
 # cluster deployment) set workload_shared_deployment to False
 # This is the default so it does not have to be set explicitely
-- name: pre_workload tasks complete
-  debug:
-    msg: "Post-Workload tasks completed successfully."
+- name: Pre_workload tasks complete
   when:
   - not silent|bool
   - not workload_shared_deployment|default(False)
+  ansible.builtin.debug:
+    msg: "Post-Workload tasks completed successfully."
 
 # For RHPDS deployment (onto a shared cluster) set
 # workload_shared_deployment to True
 # (in the deploy script or AgnosticV configuration)
-- name: pre_workload tasks complete
-  debug:
-    msg: "Post-Software checks completed successfully"
+- name: Pre_workload tasks complete
   when:
   - not silent|bool
   - workload_shared_deployment|default(False)
+  ansible.builtin.debug:
+    msg: "Post-Software checks completed successfully"

--- a/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/tasks/pre_workload.yml
@@ -6,19 +6,19 @@
 # For deployment onto a dedicated cluster (as part of the
 # cluster deployment) set workload_shared_deployment to False
 # This is the default so it does not have to be set explicitely
-- name: pre_workload tasks complete
-  debug:
-    msg: "Pre-Workload tasks completed successfully."
+- name: Pre_workload tasks complete
   when:
   - not silent|bool
   - not workload_shared_deployment|default(False)
+  ansible.builtin.debug:
+    msg: "Pre-Workload tasks completed successfully."
 
 # For RHPDS deployment (onto a shared cluster) set
 # workload_shared_deployment to True
 # (in the deploy script or AgnosticV configuration)
-- name: pre_workload tasks complete
-  debug:
-    msg: "Pre-Software checks completed successfully"
+- name: Pre_workload tasks complete
   when:
   - not silent|bool
   - workload_shared_deployment|default(False)
+  ansible.builtin.debug:
+    msg: "Pre-Software checks completed successfully"

--- a/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/tasks/remove_workload.yml
@@ -3,7 +3,7 @@
   when: ocp4_workload_quay_operator_registry_install | bool
   block:
   - name: Remove Quay Registry
-    k8s:
+    kubernetes.core.k8s:
       state: absent
       api_version: quay.redhat.com/v1
       kind: QuayRegistry
@@ -11,7 +11,7 @@
       namespace: "{{ ocp4_workload_quay_operator_registry_namespace }}"
 
   - name: Wait for all Quay Pods to be terminated
-    k8s_info:
+    kubernetes.core.k8s_info:
       api_version: v1
       kind: Pod
       namespace: "{{ ocp4_workload_quay_operator_registry_namespace }}"
@@ -24,7 +24,7 @@
     delay: 10
 
   - name: Remove Quay Registry Namespace
-    k8s:
+    kubernetes.core.k8s:
       state: absent
       api_version: v1
       kind: Namespace
@@ -34,7 +34,7 @@
   when: ocp4_workload_quay_operator_install_operator | bool
   block:
   - name: Remove Quay Operator
-    include_role:
+    ansible.builtin.include_role:
       name: install_operator
     vars:
       install_operator_action: remove
@@ -52,9 +52,8 @@
       install_operator_catalogsource_image: "{{ ocp4_workload_quay_operator_catalog_snapshot_image | default('') }}"
       install_operator_catalogsource_image_tag: "{{ ocp4_workload_pipelines_catalog_snapshot_image_tag }}"
 
-
 # Leave this as the last task in the playbook.
-- name: remove_workload tasks complete
-  debug:
-    msg: "Remove Workload tasks completed successfully."
+- name: Remove_workload tasks complete
   when: not silent|bool
+  ansible.builtin.debug:
+    msg: "Remove Workload tasks completed successfully."

--- a/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/tasks/workload.yml
@@ -1,19 +1,19 @@
 ---
 - name: Setting up workload for user {{ ocp_username }}
-  debug:
+  ansible.builtin.debug:
     msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
 
 # Quay needs OpenShift Container Storage (Noobaa in particular)
 # Check that the correct storage class exists on the cluster
 - name: Retrieve Bucket Class
-  k8s_info:
+  kubernetes.core.k8s_info:
     api_version: noobaa.io/v1alpha1
     kind: BucketClass
     namespace: openshift-storage
   register: r_bucket_class
 
 - name: Assert that there is a Bucket Storage Class
-  assert:
+  ansible.builtin.assert:
     that:
     - r_bucket_class.resources | length == 1
     fail_msg: Quay must be installed on a cluster with OpenShift Container Storage configured - and a Bucket Class deployed.
@@ -22,7 +22,7 @@
   when: ocp4_workload_quay_operator_install_operator | bool
   block:
   - name: Install Quay Operator
-    include_role:
+    ansible.builtin.include_role:
       name: install_operator
     vars:
       install_operator_action: install
@@ -45,7 +45,7 @@
   block:
 
   - name: Determine Cluster Base Domain for Quay Route
-    k8s_info:
+    kubernetes.core.k8s_info:
       api_version: config.openshift.io/v1
       kind: Ingress
       name: cluster
@@ -54,16 +54,16 @@
 
   - name: Use Provided Quay route hostname
     when: ocp4_workload_quay_operator_registry_route | default("") | length > 0
-    set_fact:
+    ansible.builtin.set_fact:
       _ocp4_workload_quay_operator_registry_route: "{{ ocp4_workload_quay_operator_registry_route }}"
 
   - name: Otherwise use quay-{{guid}}.basedomain for the Quay route hostname
     when: ocp4_workload_quay_operator_registry_route | default("") | length == 0
-    set_fact:
+    ansible.builtin.set_fact:
       _ocp4_workload_quay_operator_registry_route: "quay-{{ guid }}.{{ r_ingress_config.resources[0].spec.domain }}"
 
   - name: Create Quay Registry Resources
-    k8s:
+    kubernetes.core.k8s:
       state: present
       definition: "{{ lookup('template', item ) | from_yaml }}"
     loop:
@@ -72,7 +72,7 @@
     - quay_registry.yaml.j2
 
   - name: Wait for Quay Registry to be available
-    k8s_info:
+    kubernetes.core.k8s_info:
       api_version: quay.redhat.com/v1
       kind: QuayRegistry
       name: "{{ ocp4_workload_quay_operator_registry_name }}"
@@ -88,7 +88,7 @@
     when: ocp4_workload_quay_operator_registry_configure_admin | bool
     block:
     - name: Wait for Quay API to be available
-      uri:
+      ansible.builtin.uri:
         url: "{{ r_quay_registry.resources[0].status.registryEndpoint }}/api/v1/discovery"
         method: GET
         validate_certs: false
@@ -99,26 +99,26 @@
 
     - name: Set provided admin password
       when: ocp4_workload_quay_operator_registry_admin_password | default("") | length > 0
-      set_fact:
+      ansible.builtin.set_fact:
         _ocp4_workload_quay_operator_registry_admin_password: >-
           {{ ocp4_workload_quay_operator_registry_admin_password }}
 
     - name: Generate quayadmin password
       when: ocp4_workload_quay_operator_registry_admin_password | default("") | length == 0
-      set_fact:
+      ansible.builtin.set_fact:
         _ocp4_workload_quay_operator_registry_admin_password: >-
           {{ lookup('password', '/dev/null length={{
             ocp4_workload_quay_operator_registry_admin_password_length | default(20)
             }} chars=ascii_letters,digits') }}
 
     - name: Create QuayAdmin user
-      uri:
+      ansible.builtin.uri:
         url: "{{ r_quay_registry.resources[0].status.registryEndpoint }}/api/v1/user/initialize"
         method: POST
         body:
           username: "{{ ocp4_workload_quay_operator_registry_admin_user }}"
           password: "{{ _ocp4_workload_quay_operator_registry_admin_password }}"
-          email: "quayadmin@opentlc.com"
+          email: "quayadmin@demo.redhat.com"
           access_token: "true"
         body_format: json
         validate_certs: false
@@ -127,62 +127,57 @@
 
     - name: Save access_token
       when: r_quayadmin.status == 200
-      set_fact:
+      ansible.builtin.set_fact:
         _ocp4_workload_quay_operator_registry_admin_token: "{{ r_quayadmin.json.access_token }}"
 
     - name: Create quay admin token secret
-      k8s:
+      kubernetes.core.k8s:
         state: present
-        definition: "{{ lookup('template', 'quay-admin-token-secret.yml.j2' ) | from_yaml }}"
+        definition: "{{ lookup('template', 'quay-admin-token-secret.yml.j2') | from_yaml }}"
 
-  - name: Get Quay Config Editor credentials secret
-    k8s_info:
-      api_version: v1
-      kind: Secret
-      name: "{{ r_quay_registry.resources[0].status.configEditorCredentialsSecret }}"
-      namespace: "{{ ocp4_workload_quay_operator_registry_namespace }}"
-    register: r_config_editor_secret
-
-  - name: Print student user info
+  - name: Save user data for Quay console URL
     agnosticd_user_info:
-      msg: "{{ item }}"
-    loop:
-    - ""
-    - "Red Hat Quay is available at {{ r_quay_registry.resources[0].status.registryEndpoint }}"
-    - "Red Hat Quay Config is available at {{ r_quay_registry.resources[0].status.configEditorEndpoint }}"
-    - "- Config User: quayconfig"
-    - "- Config Password: {{ r_config_editor_secret.resources[0].data.password | b64decode }}"
-
-  - name: Print student user data
-    agnosticd_user_info:
+      msg: "Red Hat Quay is available at {{ r_quay_registry.resources[0].status.registryEndpoint }}"
       data:
         quay_console_url: "{{ r_quay_registry.resources[0].status.registryEndpoint }}"
-        quay_config_url: "{{ r_quay_registry.resources[0].status.configEditorEndpoint }}"
-        quay_config_username: "quayconfig"
-        quay_config_password: "{{ r_config_editor_secret.resources[0].data.password | b64decode }}"
 
-  - name: Print student admin info
+  - name: Save user data for Quay admin user
     when: ocp4_workload_quay_operator_registry_configure_admin | bool
+    agnosticd_user_info:
+      msg: >-
+        "A Quay Super User '{{ ocp4_workload_quay_operator_registry_admin_user }}' has been created."
+        "The super user password is {{ _ocp4_workload_quay_operator_registry_admin_password }}".
+        "The token for the super user is {{ _ocp4_workload_quay_operator_registry_admin_token }}".
+      data:
+        quay_admin_username: "{{ ocp4_workload_quay_operator_registry_admin_user }}"
+        quay_admin_password: "{{ _ocp4_workload_quay_operator_registry_admin_password }}"
+        quay_admin_token: "{{ _ocp4_workload_quay_operator_registry_admin_token }}"
+
+  # Only for old versions of Quay. Newer versions don't have a config editor anymore
+  - name: Get and save Quay config editor credentials secret
+    when: r_quay_registry.resources[0].status.configEditorCredentialsSecret | default("") | length > 0
     block:
-    - name: Print student admin info
-      agnosticd_user_info:
-        msg: "{{ item }}"
-      loop:
-      - ""
-      - "A Quay Super User '{{ ocp4_workload_quay_operator_registry_admin_user }}' has been created."
-      - "The super user password is {{ _ocp4_workload_quay_operator_registry_admin_password }}"
-      - "The token for the super user is {{ _ocp4_workload_quay_operator_registry_admin_token }}"
+    - name: Get Quay config editor credentials secret
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Secret
+        name: "{{ r_quay_registry.resources[0].status.configEditorCredentialsSecret }}"
+        namespace: "{{ ocp4_workload_quay_operator_registry_namespace }}"
+      register: r_config_editor_secret
 
-    - name: Print student user data
+    - name: Save user data for Quay config editor
       agnosticd_user_info:
+        msg: >-
+          "Red Hat Quay Config is available at {{ r_quay_registry.resources[0].status.configEditorEndpoint }}."
+          "- Config User: quayconfig."
+          "- Config Password: {{ r_config_editor_secret.resources[0].data.password | b64decode }}."
         data:
-          quay_admin_username: "{{ ocp4_workload_quay_operator_registry_admin_user }}"
-          quay_admin_password: "{{ _ocp4_workload_quay_operator_registry_admin_password }}"
-          quay_admin_token: "{{ _ocp4_workload_quay_operator_registry_admin_token }}"
-
+          quay_config_url: "{{ r_quay_registry.resources[0].status.configEditorEndpoint }}"
+          quay_config_username: "quayconfig"
+          quay_config_password: "{{ r_config_editor_secret.resources[0].data.password | b64decode }}"
 
 # Leave this as the last task in the playbook.
-- name: workload tasks complete
-  debug:
+- name: Workload tasks complete
+  ansible.builtin.debug:
     msg: "Workload Tasks completed successfully."
   when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/templates/config_bundle_secret.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/templates/config_bundle_secret.yaml.j2
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Secret
 metadata:

--- a/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/templates/quay-admin-token-secret.yml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/templates/quay-admin-token-secret.yml.j2
@@ -1,3 +1,4 @@
+---
 kind: Secret
 apiVersion: v1
 metadata:

--- a/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/templates/quay_namespace.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/templates/quay_namespace.yaml.j2
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/templates/quay_registry.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/templates/quay_registry.yaml.j2
@@ -1,3 +1,4 @@
+---
 apiVersion: quay.redhat.com/v1
 kind: QuayRegistry
 metadata:


### PR DESCRIPTION
##### SUMMARY

Recent releases of Quay (e.g. 3.10) don't have a config editor anymore - which made this workload fail.

Adding condition to only get config editor credentials if it was created.

Fix Ansible lint errors/warnings
Streamline code.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_quay_operator