### PR TITLE
EE doc: rename `alpha` to `rc` (Release Candidate)

### DIFF
--- a/tools/execution_environments/ee-multicloud-public/release_cycle.adoc
+++ b/tools/execution_environments/ee-multicloud-public/release_cycle.adoc
@@ -20,11 +20,11 @@ The release cycle for execution environments is designed to go through several s
 . *Expiration*: These execution environments are ephemeral and will expire after 7 days.
 . *Purpose*: These execution environments are solely for testing and should not be used in any production-like environment.
 
-=== 3. Merging and RC Release Preparation
+=== 3. Merging and Release Candidate Preparation
 
 . *Merging*: Once testing is completed in the DEV and TEST environments, PRs are merged into the `development` branch.
   - Note: Several PRs can be merged before proceeding to the next step.
-. *Release Candidate*: Once enough PRs are merged and it's deemed necessary, a new RC is cut with a version tag in the form `vX.Y.Z-rc`.
+. *Release Candidate*: Once enough PRs are merged and it's deemed necessary, a new RC image is cut with a version tag in the form `vX.Y.Z-rc`.
 . *Testing Period*: The RC execution environment undergoes thorough testing with several core catalog items.
 
 === 4. Bug Fixes and Iterative Release Candidates
@@ -45,7 +45,7 @@ The release cycle for execution environments is designed to go through several s
 
 == Notes
 
-- All RC releases are immutable; changes result in a new incremented RC release.
-- Stable releases are tag aliases of the corresponding RC releases, ensuring that both images are identical.
-- RC releases and stable releases should both be tested in environments that are as close to the production environment as possible.
+- All release candidates are immutable; changes result in a new incremented RC tag.
+- Stable releases are tag aliases of the corresponding release candidate, ensuring that both images are identical.
+- Release candidates and stable releases should both be tested in environments that are as close to the production environment as possible.
 - Strict versioning is followed for traceability and to ensure reproducibility.

--- a/tools/execution_environments/ee-multicloud-public/release_cycle.adoc
+++ b/tools/execution_environments/ee-multicloud-public/release_cycle.adoc
@@ -2,7 +2,9 @@
 
 == Overview
 
-The release cycle for execution environments is designed to go through several stages to ensure quality and stability. These stages include development, automated builds for Pull Requests, alpha releases, and stable releases.
+The release cycle for execution environments is designed to go through several stages to ensure quality and stability. These stages include development, automated builds for Pull Requests, alpha release, release candidate (RC), and stable releases.
+
+*UPDATE 2024-03*:  Rename `alpha` to `rc` (Release Candidate) for clarity.
 
 == Release Phases
 
@@ -18,32 +20,32 @@ The release cycle for execution environments is designed to go through several s
 . *Expiration*: These execution environments are ephemeral and will expire after 7 days.
 . *Purpose*: These execution environments are solely for testing and should not be used in any production-like environment.
 
-=== 3. Merging and Alpha Release Preparation
+=== 3. Merging and RC Release Preparation
 
 . *Merging*: Once testing is completed in the DEV and TEST environments, PRs are merged into the `development` branch.
   - Note: Several PRs can be merged before proceeding to the next step.
-. *Alpha Release*: Once enough PRs are merged and it's deemed necessary, a new alpha release is cut with a version tag in the form `vX.Y.Z-alpha`.
-. *Testing Period*: The alpha execution environment undergoes thorough testing with several core catalog items.
+. *Release Candidate*: Once enough PRs are merged and it's deemed necessary, a new RC is cut with a version tag in the form `vX.Y.Z-rc`.
+. *Testing Period*: The RC execution environment undergoes thorough testing with several core catalog items.
 
-=== 4. Bug Fixes and Iterative Alpha Releases
+=== 4. Bug Fixes and Iterative Release Candidates
 
 . *Bug Identification*: If any bugs are found, they are fixed in a new feature or bug-fix branch.
 . *New PR*: A new PR is created, tested, and merged as per phases 1 and 2.
-. *Iterative Alpha Release*: A new alpha release is cut, incremented to the next alpha version, e.g., `vX.Y.Z-alpha.2`.
+. *Iterative Release Candidate*: A new release candidate is cut, incremented to the next rc version, e.g., `vX.Y.Z-rc.2`.
 
 === 5. Stable Release
 
-. *Final Testing*: The last alpha release is subjected to final testing and validation.
-. *Stable Release*: If all tests pass, a stable tag alias is created for the last alpha execution environment, effectively releasing it as a stable version with a new tag in the form `vX.Y.Z`.
-  - Note: The stable release is not a new build but an alias to the last alpha release, ensuring that the images are identical.
+. *Final Testing*: The last release candidate is subjected to final testing and validation.
+. *Stable Release*: If all tests pass, a stable tag alias is created for the last Release Candidate execution environment, effectively releasing it as a stable version with a new tag in the form `vX.Y.Z`.
+  - Note: The stable release is not a new build but an alias to the last release candidate, ensuring that the images are identical.
 
-=== 6. Alpha Environment Retention
+=== 6. Release Candidate Environment Retention
 
-- Alpha execution environments are never deleted and remain accessible for reference or rollback scenarios.
+- Release candidate (`vx.y.z-rc*` tag) execution environments are never deleted and remain accessible for reference or rollback scenarios.
 
 == Notes
 
-- All alpha releases are immutable; changes result in a new incremented alpha release.
-- Stable releases are tag aliases of the corresponding alpha releases, ensuring that both images are identical.
-- Alpha releases and stable releases should both be tested in environments that are as close to the production environment as possible.
+- All RC releases are immutable; changes result in a new incremented RC release.
+- Stable releases are tag aliases of the corresponding RC releases, ensuring that both images are identical.
+- RC releases and stable releases should both be tested in environments that are as close to the production environment as possible.
 - Strict versioning is followed for traceability and to ensure reproducibility.


### PR DESCRIPTION
For clarity rename Alpha releases to Candidate Releases. It's also shorter.

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request


