### PR TITLE
Add extra checks to Quay install. Fix a bunch of Ansible-lint warnings.

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_redhat_developer_hub_bootstrap/tasks/setup_external_secrets.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_redhat_developer_hub_bootstrap/tasks/setup_external_secrets.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install external secrets helm chart
-  shell: |
+  ansible.builtin.shell: |
     helm repo add external-secrets https://charts.external-secrets.io
     helm install external-secrets external-secrets/external-secrets \
     -n external-secrets --create-namespace --set installCRDs=true \
@@ -16,7 +16,7 @@
 - name: Create cluster secret store of vault
   kubernetes.core.k8s:
     state: present
-    definition: "{{ lookup('template', 'cluster-secret-storage-vault.yml.j2' ) | from_yaml }}"
+    definition: "{{ lookup('template', 'cluster-secret-storage-vault.yml.j2') | from_yaml }}"
   retries: 60
   delay: 10
   register: r_cluster_secret_store

--- a/ansible/roles_ocp_workloads/ocp4_workload_redhat_developer_hub_bootstrap/tasks/setup_janus_argocd.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_redhat_developer_hub_bootstrap/tasks/setup_janus_argocd.yml
@@ -20,7 +20,7 @@
   delay: 10
 
 - name: Set common password for ArgoCD
-  k8s:
+  kubernetes.core.k8s:
     validate_certs: false
     state: present
     definition:
@@ -36,7 +36,7 @@
     - janus-argocd
 
 - name: Wait until default project is ready
-  k8s_info:
+  kubernetes.core.k8s_info:
     api_version: argoproj.io/v1alpha1
     kind: AppProject
     name: default

--- a/ansible/roles_ocp_workloads/ocp4_workload_redhat_developer_hub_bootstrap/tasks/setup_quay.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_redhat_developer_hub_bootstrap/tasks/setup_quay.yml
@@ -1,45 +1,100 @@
 ---
 - name: Wait until ODF is ready
-  k8s_info:
+  kubernetes.core.k8s_info:
     api_version: ocs.openshift.io/v1
     kind: StorageCluster
     name: ocs-storagecluster
     namespace: openshift-storage
   register: r_storagecluster
-  until:
-    - r_storagecluster.resources.0.status.phase == "Ready"
+  until: r_storagecluster.resources.0.status.phase == "Ready"
   retries: 120
   delay: 10
 
 - name: Wait until NooBaa is ready
-  k8s_info:
+  kubernetes.core.k8s_info:
     api_version: noobaa.io/v1alpha1
     kind: NooBaa
     name: noobaa
     namespace: openshift-storage
   register: r_noobaa
-  until:
-    - r_noobaa.resources.0.status.phase == "Ready"
+  until: r_noobaa.resources.0.status.phase == "Ready"
   retries: 120
   delay: 10
 
 - name: Install quay
-  include_role:
+  ansible.builtin.include_role:
     name: ocp4_workload_quay_operator
 
-- name: Extend Quay token expiry
-  shell: |
+# Ignore errors for potentially earlier releases of Quay than 3.10
+- name: Wait until Quay database has been redeployed
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: quay-quay-database
+    namespace: quay-enterprise
+  register: r_quay_database_deployment
+  retries: 10
+  delay: 5
+  ignore_errors: true
+  until:
+  - r_quay_database_deployment.resources is defined
+  - r_quay_database_deployment.resources | length == 1
+  - r_quay_database_deployment.resources[0].status is defined
+  - r_quay_database_deployment.resources[0].status.observedGeneration is defined
+  - r_quay_database_deployment.resources[0].status.observedGeneration | int == 2
+
+- name: Get Quay database pod and ensure it's running
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Pod
+    namespace: quay-enterprise
+    label_selectors:
+    - quay-component = postgres
+  register: r_quay_database_pod
+  retries: 40
+  delay: 5
+  until:
+  - r_quay_database_pod.resources is defined
+  - r_quay_database_pod.resources | length == 1
+  - r_quay_database_pod.resources[0].status is defined
+  - r_quay_database_pod.resources[0].status.phase is defined
+  - r_quay_database_pod.resources[0].status.phase == "Running"
+
+- name: Debug database pod name
+  ansible.builtin.debug:
+    msg: "Found Quay database pod: {{ r_quay_database_pod.resources[0].metadata.name }}"
+
+# Ignore errors in case it found the wrong pod name. Next task will remain as failsafe
+- name: Extend Quay token expiration
+  kubernetes.core.k8s_exec:
+    namespace: quay-enterprise
+    pod: "{{ r_quay_database_pod.resources[0].metadata.name }}"
+    command: >-
+      psql -d quay-quay-database -c "update public.oauthaccesstoken set expires_at = '2300-12-31 00:00:00' where id = 1;"
+  register: r_extend_token
+  retries: 2
+  delay: 5
+  ignore_errors: true
+  until:
+  - r_extend_token.rc is defined
+  - r_extend_token.rc == 0
+
+# Failsafe in case the previous step failed
+- name: Extend Quay token expiration (using shell)
+  when: r_extend_token.failed
+  ansible.builtin.shell: |
     oc exec $(oc get pod -n quay-enterprise | grep quay-quay-database | awk '{print $1}') \
     -n quay-enterprise -- psql -d quay-quay-database -c \
     "update public.oauthaccesstoken set expires_at = '2300-12-31 00:00:00' where id = 1;"
 
-- name: Create vault secret for quay
-  shell: |
-    oc exec vault-0 -n {{ ocp4_workload_redhat_developer_hub_bootstrap_vault_namespace
-    }} -- vault kv put kv/secrets/janusidp/registry/auth value={{ quay_auth | b64encode }}
-    oc exec vault-0 -n {{ ocp4_workload_redhat_developer_hub_bootstrap_vault_namespace
-    }} -- vault kv put kv/secrets/janusidp/registry/username value=quayadmin
-    oc exec vault-0 -n {{ ocp4_workload_redhat_developer_hub_bootstrap_vault_namespace
-    }} -- vault kv put kv/secrets/janusidp/registry/password value={{ common_password }}
+- name: Create vault secrets for Quay access
   vars:
-    quay_auth: quayadmin:{{ common_password }}
+    quay_auth: "quayadmin:{{ common_password }}"
+  kubernetes.core.k8s_exec:
+    namespace: "{{ ocp4_workload_redhat_developer_hub_bootstrap_vault_namespace }}"
+    pod: vault-0
+    command: "{{ item }}"
+  loop:
+  - "vault kv put kv/secrets/janusidp/registry/auth value={{ quay_auth | b64encode }}"
+  - "vault kv put kv/secrets/janusidp/registry/username value=quayadmin"
+  - "vault kv put kv/secrets/janusidp/registry/password value={{ common_password }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_redhat_developer_hub_bootstrap/tasks/setup_vault.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_redhat_developer_hub_bootstrap/tasks/setup_vault.yml
@@ -2,7 +2,7 @@
 - name: Create Vault application
   kubernetes.core.k8s:
     state: present
-    definition: "{{ lookup('template', 'application-vault.yml.j2' ) | from_yaml }}"
+    definition: "{{ lookup('template', 'application-vault.yml.j2') | from_yaml }}"
 
 - name: Retrieve Vault Pod
   kubernetes.core.k8s_info:
@@ -20,7 +20,7 @@
   - r_vault.resources[0].status.phase == 'Running'
 
 - name: Copy unsealing key
-  shell: |
+  ansible.builtin.shell: |
     oc exec vault-0 -n {{ ocp4_workload_redhat_developer_hub_bootstrap_vault_namespace
     }} --stdin --tty -- cat /vault/data/vault-auto-unseal-keys.txt > /tmp/vault-auto-unseal-keys.txt
   retries: 60
@@ -29,18 +29,18 @@
   until: r_copy is not failed
 
 - name: Get login token
-  shell: >-
+  ansible.builtin.shell: >-
     grep -A 0 root_token /tmp/vault-auto-unseal-keys.txt | sed 's/root_token: //g'
   register: r_token
 
 - name: Set vault token fact
-  set_fact:
+  ansible.builtin.set_fact:
     ocp4_workload_redhat_developer_hub_bootstrap_vault_token: "{{ r_token.stdout }}"
 
 - name: Create vault auth resources
-  k8s:
+  kubernetes.core.k8s:
     state: present
-    definition: "{{ lookup('template',  item ) | from_yaml }}"
+    definition: "{{ lookup('template', item) | from_yaml }}"
   loop:
   - secret-vault-token.yml.j2
   - service-account-vault.yml.j2
@@ -48,7 +48,7 @@
   - secret-vault-auth.yml.j2
 
 - name: Login to vault
-  shell: |
+  ansible.builtin.shell: |
     oc exec vault-0 -n {{ ocp4_workload_redhat_developer_hub_bootstrap_vault_namespace
     }} --stdin --tty -- vault login {{ ocp4_workload_redhat_developer_hub_bootstrap_vault_token }}
   register: r_vault_login
@@ -57,7 +57,7 @@
   delay: 10
 
 - name: Create vault policy
-  shell: |
+  ansible.builtin.shell: |
     oc exec vault-0 -n {{ ocp4_workload_redhat_developer_hub_bootstrap_vault_namespace
     }} -- bash -c 'rm -rf /tmp/rhdh-policy.hcl'
     oc exec vault-0 -n {{ ocp4_workload_redhat_developer_hub_bootstrap_vault_namespace
@@ -70,7 +70,7 @@
     }} -- bash -c 'vault policy write rhdh-policy /tmp/rhdh-policy.hcl'
 
 - name: Enable kubernetes auth
-  shell: |
+  ansible.builtin.shell: |
     export SA_SECRET_NAME=$(oc get secrets -n default --output=json \
     | jq -r '.items[].metadata | select(.name|startswith("vault-auth-secret")).name')
     export SA_JWT_TOKEN=$(oc get secret $SA_SECRET_NAME -n default \
@@ -89,7 +89,7 @@
     issuer="https://kubernetes.default.svc.cluster.local"
 
 - name: Create role and service account authentication
-  shell: |
+  ansible.builtin.shell: |
     oc exec vault-0 -n {{ ocp4_workload_redhat_developer_hub_bootstrap_vault_namespace
     }} -- vault write auth/kubernetes/role/rhdh-role \
     bound_service_account_names=vault-auth \
@@ -103,5 +103,5 @@
     oc exec vault-0 -n vault -- vault write auth/kubernetes/login role=rhdh-role jwt=$SA_JWT_TOKEN
 
 - name: Enable kv version 2
-  shell: |
+  ansible.builtin.shell: |
     oc exec vault-0 -n vault -- vault secrets enable -version=2 kv

--- a/ansible/roles_ocp_workloads/ocp4_workload_redhat_developer_hub_bootstrap/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_redhat_developer_hub_bootstrap/tasks/workload.yml
@@ -1,10 +1,10 @@
 ---
 - name: Setting up workload
-  debug:
+  ansible.builtin.debug:
     msg: "Setting up GitLab"
 
 - name: Install Helm
-  shell: |
+  ansible.builtin.shell: |
     curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
     chmod 700 get_helm.sh
     ./get_helm.sh
@@ -20,24 +20,24 @@
     GIT_SSL_NO_VERIFY: "true"
 
 - name: Setup Gitops
-  include_tasks:
+  ansible.builtin.include_tasks:
     file: ./setup_janus_argocd.yml
 
 - name: Setup Vault
-  include_tasks:
+  ansible.builtin.include_tasks:
     file: ./setup_vault.yml
 
 - name: Setup External Secrets Operator
-  include_tasks:
+  ansible.builtin.include_tasks:
     file: ./setup_external_secrets.yml
 
 - name: Setup Quay
-  include_tasks:
+  ansible.builtin.include_tasks:
     file: ./setup_quay.yml
 
 # Leave this as the last task in the playbook.
 # --------------------------------------------
-- name: workload tasks complete
-  debug:
+- name: Workload tasks complete
+  ansible.builtin.debug:
     msg: "Workload Tasks completed successfully."
   when: not silent|bool


### PR DESCRIPTION
##### SUMMARY

When deploying Quay 3.10 the database config fails. This PR adds logic to fix that while remaining compatible with the old Quay 3.6.

Also fixing a bunch of Ansible Lint warnings.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_redhat_developer_hub_bootstrap