### PR TITLE
Make subscription names customizable

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_voteapp/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_voteapp/defaults/main.yml
@@ -1,3 +1,9 @@
 ---
 become_override: false
 silent: false
+
+# For custom Catalogsource (default to not break things)
+ocp4_workload_voteapp_devspace_subscription_name: devworkspace-operator-fast-devspaces-catalogsource-openshift-devspaces
+# For default Catalogsource
+# ocp4_workload_voteapp_devspace_subscription_name: devworkspace-operator-fast-redhat-operators-openshift-marketplace
+ocp4_workload_voteapp_devspace_subscription_namespace: openshift-devspaces

--- a/ansible/roles_ocp_workloads/ocp4_workload_voteapp/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_voteapp/defaults/main.yml
@@ -4,6 +4,7 @@ silent: false
 
 # For custom Catalogsource (default to not break things)
 ocp4_workload_voteapp_devspace_subscription_name: devworkspace-operator-fast-devspaces-catalogsource-openshift-devspaces
+ocp4_workload_voteapp_devspace_subscription_namespace: openshift-devspaces
 # For default Catalogsource
 # ocp4_workload_voteapp_devspace_subscription_name: devworkspace-operator-fast-redhat-operators-openshift-marketplace
-ocp4_workload_voteapp_devspace_subscription_namespace: openshift-devspaces
+# ocp4_workload_voteapp_devspace_subscription_namespace: openshift-operators

--- a/ansible/roles_ocp_workloads/ocp4_workload_voteapp/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_voteapp/tasks/workload.yml
@@ -1,27 +1,27 @@
 ---
-- name: "DevWorkspace operator - Get Installed CSV"
+- name: DevWorkspace operator - Get Installed CSV
   kubernetes.core.k8s_info:
     api_version: operators.coreos.com/v1alpha1
     kind: Subscription
-    name: devworkspace-operator-fast-devspaces-catalogsource-openshift-devspaces
-    namespace: openshift-devspaces
+    name: "{{ ocp4_workload_voteapp_devspace_subscription_name }}"
+    namespace: "{{ ocp4_workload_voteapp_devspace_subscription_namespace }}"
   register: r_devworkspace_subscription
   retries: 30
   delay: 10
   until:
-    - r_devworkspace_subscription.resources[0].status.currentCSV is defined
-    - r_devworkspace_subscription.resources[0].status.currentCSV | length > 0
+  - r_devworkspace_subscription.resources[0].status.currentCSV is defined
+  - r_devworkspace_subscription.resources[0].status.currentCSV | length > 0
 
-- name: "DevWorkspace operator - Wait until CSV is installed"
+- name: DevWorkspace operator - Wait until CSV is installed
   kubernetes.core.k8s_info:
     api_version: operators.coreos.com/v1alpha1
     kind: ClusterServiceVersion
     name: "{{ r_devworkspace_subscription.resources[0].status.currentCSV }}"
-    namespace: openshift-devspaces
+    namespace: "{{ ocp4_workload_voteapp_devspace_subscription_namespace }}"
   register: r_devworkspace_csv
   retries: 40
   delay: 30
   until:
-    - r_devworkspace_csv.resources[0].status.phase is defined
-    - r_devworkspace_csv.resources[0].status.phase | length > 0
-    - r_devworkspace_csv.resources[0].status.phase == "Succeeded"
+  - r_devworkspace_csv.resources[0].status.phase is defined
+  - r_devworkspace_csv.resources[0].status.phase | length > 0
+  - r_devworkspace_csv.resources[0].status.phase == "Succeeded"


### PR DESCRIPTION
##### SUMMARY

voteapp workload had hardcoded subscription names. This fails when using default catalog sources.

Adding vars to make the setting customizable.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_voteapp