### PR TITLE
Add a few retries to extend the Quay token

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_redhat_developer_hub_bootstrap/tasks/setup_quay.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_redhat_developer_hub_bootstrap/tasks/setup_quay.yml
@@ -86,6 +86,8 @@
     oc exec $(oc get pod -n quay-enterprise | grep quay-quay-database | awk '{print $1}') \
     -n quay-enterprise -- psql -d quay-quay-database -c \
     "update public.oauthaccesstoken set expires_at = '2300-12-31 00:00:00' where id = 1;"
+  retries: 5
+  delay: 5
 
 - name: Create vault secrets for Quay access
   vars:


### PR DESCRIPTION
##### SUMMARY

Annoyingly on controler deploy still failed with a pod not found - even on the shell task. Adding a few retries to get the correct pod name.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_redhat_developer_hub_bootstrap