### PR TITLE
Update Showroom role ssh_config.j2 template for loglevel error

### DIFF
--- a/ansible/roles/showroom/templates/ssh_config.j2
+++ b/ansible/roles/showroom/templates/ssh_config.j2
@@ -7,5 +7,6 @@ Host {{ user }}
   Port 22
   UserKnownHostsFile /dev/null
   StrictHostKeyChecking no
+  LogLevel ERROR
 
 {% endfor %}


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
This update is to remove starting line warning errors for the zero touch rhel showroom terminal.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ansible/roles/showroom/

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
