### PR TITLE
Config base-infra Add role to reset system repositories after deployment

### DIFF
--- a/ansible/configs/base-infra/default_vars.yml
+++ b/ansible/configs/base-infra/default_vars.yml
@@ -28,6 +28,9 @@ software_to_deploy: none
 # load-balancers, app_servers, database_servers may be discarded
 # in future iterations (update default_vars_<CLOUD_PROVIDER> as well
 
+# Option to reset the rhsm.conf file to default after deployment
+reset_rhsm_conf: false
+
 ### Common Host settings
 
 # FTL Settings

--- a/ansible/configs/base-infra/post_software.yml
+++ b/ansible/configs/base-infra/post_software.yml
@@ -106,6 +106,18 @@
         name: nookbag
 
 - name: PostSoftware flight-check
+  hosts: bastions[0]
+  gather_facts: true
+  become: true
+  tags:
+    - reset-repositories
+  tasks:
+    - name: Reset RHSM Repositories to Original State
+      when: reset_rhsm_conf | default(false) | bool
+      ansible.builtin.include_role:
+        name: reset-repositories
+
+- name: PostSoftware flight-check
   hosts: localhost
   connection: local
   gather_facts: false


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
Adds bool role to post_software to reset the rhsm.conf file after deployment. This is needed for a Red Hat Insights summit lab.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
configs/base-infra
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
