### PR TITLE
account for hosted_control_plane_default

### DIFF
--- a/ansible/configs/rosa-consolidated/install_rosa_common_pre.yml
+++ b/ansible/configs/rosa-consolidated/install_rosa_common_pre.yml
@@ -29,7 +29,7 @@
     _rosa_ocp_cli_version: >-
       {{ (r_rosa_versions.stdout | from_json | json_query(_query)) [0].raw_id }}
   vars:
-    _query: "[?default==`true`]"
+    _query: "[? hosted_control_plane_default==`true` || default==`true` ]"
 
 - name: Set ROSA version to install specific version
   when:


### PR DESCRIPTION
when requesting the default version of the hosted control plane ROSA, the jmespath query did not match the output of `rosa list versions --output json --hosted-cp`
This new code accounts for HCP and non-HCP ROSA versions in the output of `rosa list versions` with or without `--hosted-cp`