### PR TITLE
Add argocd CLI download

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/defaults/main.yml
@@ -4,6 +4,7 @@ ocp_username: opentlc-mgr
 silent: false
 
 # Channel to use for the OpenShift GitOps subscription
+# Pin to a specific version like gitops-1.10 if necessary
 ocp4_workload_openshift_gitops_channel: stable
 
 # Set automatic InstallPlan approval. If set to false it is also suggested
@@ -25,6 +26,9 @@ ocp4_workload_openshift_gitops_starting_csv: ""
 # openshift-pipelines-operator-rh for Pipelines 1.6.0 and later
 ocp4_workload_openshift_gitops_pipelines_csv_prefix: openshift-pipelines-operator-rh
 
+# Install the argocd CLI on the bastion
+ocp4_workload_openshift_gitops_install_cli: true
+
 # Grant cluster-admin permission to the default ArgoCD service account
 # Enable with care
 ocp4_workload_openshift_gitops_setup_cluster_admin: false
@@ -34,7 +38,7 @@ ocp4_workload_openshift_gitops_setup_cluster_admin: false
 # Use with ocp4_workload_openshift_gitops_update_resources: true
 ocp4_workload_openshift_gitops_update_route_tls: false
 
-# Update requests and limits for ArgoCD (openshift-gitops) components
+# Update requests, limits and other properties for ArgoCD (openshift-gitops) components
 ocp4_workload_openshift_gitops_update_resources: false
 
 # When the previous setting is true use the following requests/limits
@@ -126,7 +130,7 @@ ocp4_workload_openshift_gitops_catalogsource_name: redhat-operators-snapshot-git
 ocp4_workload_openshift_gitops_catalog_snapshot_image: quay.io/gpte-devops-automation/olm_snapshot_redhat_catalog
 
 # Catalog snapshot image tag
-ocp4_workload_openshift_gitops_catalog_snapshot_image_tag: v4.10_2022_07_18
+ocp4_workload_openshift_gitops_catalog_snapshot_image_tag: v4.15_2023_03_18
 
 # Ignore differences in ArgoCD applications,
 # so they do not stay OutOfSync.

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/workload.yml
@@ -41,3 +41,28 @@
     kubernetes.core.k8s:
       state: patched
       definition: "{{ lookup('template', 'openshift-gitops.yaml.j2') | from_yaml }}"
+
+- name: Attempt to install the ArgoCD CLI to the bastion
+  when: ocp4_workload_openshift_gitops_install_cli | bool
+  block:
+  - name: Get the OpenShift Gitops ArgoCD server route
+    kubernetes.core.k8s_info:
+      api_version: route.openshift.io/v1
+      kind: Route
+      name: openshift-gitops-server
+      namespace: openshift-gitops
+    register: r_openshift_gitops_server_route
+
+  - name: Try to install the ArgoCD CLI
+    become: true
+    ansible.builtin.get_url:
+      url: >-
+        https://{{ r_openshift_gitops_server_route.resources[0].spec.host }}/download/argocd-linux-amd64
+      dest: /usr/bin/argocd
+      validate_certs: false
+      owner: root
+      group: root
+      mode: "0775"
+    retries: 5
+    delay: 5
+    ignore_errors: true


### PR DESCRIPTION
##### SUMMARY

Add logic to install the argocd CLI on the bastion if the OpenShift Gitops operator is being installed. Works all the way back to ArgoCD 2.6.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_openshift_gitops