### PR TITLE
Extend just a bunch config and add noVNC service template

### DIFF
--- a/ansible/configs/just-a-bunch-of-nodes/software.yml
+++ b/ansible/configs/just-a-bunch-of-nodes/software.yml
@@ -22,7 +22,7 @@
         - infra_workloads | default("") | length > 0
       block:
         - name: Apply role "{{ workload_loop_var }}" on nodes
-          include_role:
+          ansible.builtin.include_role:
             name: "{{ workload_loop_var }}"
           vars:
             ACTION: "provision"
@@ -30,6 +30,22 @@
           loop_control:
             loop_var: workload_loop_var
 
+- name: Configuring Bastion Hosts
+  hosts: bastions
+  become: true
+  tags:
+    - step004
+    - bastion_tasks
+
+  tasks:
+
+    - name: Deploy Software workloads
+      when: software_workloads_for_bastion | default("") | length > 0
+      ansible.builtin.include_role:
+        name: "{{ _software_bastion }}"
+      loop: "{{ software_workloads_for_bastion }}"
+      loop_control:
+        loop_var: _software_bastion
 
 - name: Software flight-check
   hosts: localhost

--- a/ansible/configs/just-a-bunch-of-nodes/templates/novnc.service
+++ b/ansible/configs/just-a-bunch-of-nodes/templates/novnc.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=noVNC service
+After=syslog.target network.target
+
+[Service]
+ExecStart=/usr/local/src/noVNC-{{ novnc_version }}/utils/novnc_proxy --vnc localhost:5901 --cert /etc/letsencrypt/live/{{ groups['bastions'][0].split('.')[0] }}.{{ subdomain_base }}/fullchain.pem --key /etc/letsencrypt/live/{{ groups['bastions'][0].split('.')[0] }}.{{ subdomain_base }}/privkey.pem
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION

##### SUMMARY

- Extend software.yml in just-a-bunch-of-nodes to support `software_workloads_for_bastion`
- Add noVNC service template to ansible config
- 

Allows roles to be listed and configured in AgV

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

configs/just-a-bunch-of-nodes

##### ADDITIONAL INFORMATION
