### PR TITLE
base-infra config, update pre_software to be windows enabled

### DIFF
--- a/ansible/configs/base-infra/pre_software.yml
+++ b/ansible/configs/base-infra/pre_software.yml
@@ -19,7 +19,7 @@
         name: create_ssh_provision_key
 
 - name: Configure all hosts with Repositories, Common Files and Set environment key
-  hosts: all
+  hosts: all:!windows
   become: true
   gather_facts: false
   tags:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
Updates host identifier for pre_software to be windows enabled.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
base-infra
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
