### PR TITLE
Rename openshift_cnv_project_name to openshift_cnv_namespace and use as default sandbox_openshift_namespace

### DIFF
--- a/ansible/configs/ansible-lightspeed/default_vars_openshift_cnv.yml
+++ b/ansible/configs/ansible-lightspeed/default_vars_openshift_cnv.yml
@@ -14,9 +14,6 @@ subdomain_base: "{{ subdomain_base_short }}.{{ subdomain_base_suffix }}"
 ansible_user: cloud-user
 remote_user: cloud-user
 
-# OpenShift CNV project name
-openshift_cnv_project_name: "{{ env_type }}-{{ guid }}"
-
 # Use Dynamic DNS. Always true
 use_dynamic_dns: true
 

--- a/ansible/configs/base-infra/default_vars_openshift_cnv.yaml
+++ b/ansible/configs/base-infra/default_vars_openshift_cnv.yaml
@@ -7,9 +7,6 @@ cloud_provider: openshift_cnv
 ansible_user: cloud-user
 remote_user: cloud-user
 
-# OpenShift CNV project name
-openshift_cnv_project_name: "{{ env_type }}-{{ guid }}"
-
 
 ### Networking and DNS (CNV)
 subdomain_base_short: "{{ guid }}"

--- a/ansible/configs/ocp4-cluster/default_vars_openshift_cnv.yml
+++ b/ansible/configs/ocp4-cluster/default_vars_openshift_cnv.yml
@@ -11,8 +11,6 @@ cloud_provider: openshift_cnv
 ansible_user: cloud-user
 remote_user: cloud-user
 
-# OpenShift CNV project name
-openshift_cnv_project_name: "{{ env_type }}-{{ guid }}"
 
 # Use Dynamic DNS. Always true
 use_dynamic_dns: true

--- a/ansible/configs/zero-touch-base-rhel/default_vars_openshift_cnv.yaml
+++ b/ansible/configs/zero-touch-base-rhel/default_vars_openshift_cnv.yaml
@@ -7,8 +7,6 @@ cloud_provider: openshift_cnv
 ansible_user: cloud-user
 remote_user: cloud-user
 
-# OpenShift CNV project name
-openshift_cnv_project_name: "{{ env_type }}-{{ guid }}"
 
 
 ### Networking and DNS (CNV)

--- a/ansible/configs/zero-touch-base-rhel/default_vars_openshift_cnv.yaml
+++ b/ansible/configs/zero-touch-base-rhel/default_vars_openshift_cnv.yaml
@@ -7,8 +7,6 @@ cloud_provider: openshift_cnv
 ansible_user: cloud-user
 remote_user: cloud-user
 
-
-
 ### Networking and DNS (CNV)
 subdomain_base_short: "{{ guid }}"
 subdomain_base_suffix: ".{{ sandbox_openshift_apps_domain }}"

--- a/ansible/roles-infra/infra-openshift-cnv-create-inventory/defaults/main.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-create-inventory/defaults/main.yaml
@@ -1,6 +1,5 @@
 ---
-openshift_cnv_project_name: "{{ env_type }}-{{ guid }}"
-
+openshift_cnv_namespace: "{{ sandbox_openshift_namespace | default(env_type + '-' + guid) }}"
 # Naming of instances
 openshift_cnv_instance_numeration: '%d'
 

--- a/ansible/roles-infra/infra-openshift-cnv-create-inventory/tasks/create_inventory.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-create-inventory/tasks/create_inventory.yaml
@@ -2,7 +2,7 @@
 - name: Search for all running pods
   kubernetes.core.k8s_info:
     kind: VirtualMachine
-    namespace: "{{ openshift_cnv_project_name }}"
+    namespace: "{{ openshift_cnv_namespace }}"
   register: r_openshift_cnv_instances
   
     
@@ -30,7 +30,7 @@
       kind: Service
       metadata:
         name: "{{ local_bastion }}-ssh"
-        namespace: "{{ openshift_cnv_project_name }}"
+        namespace: "{{ openshift_cnv_namespace }}"
       spec:
         ports:
           - port: 22

--- a/ansible/roles-infra/infra-openshift-cnv-resources/defaults/main.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/defaults/main.yaml
@@ -1,5 +1,5 @@
 ---
-openshift_cnv_project_name: "{{ env_type }}-{{ guid }}"
+openshift_cnv_namespace: "{{ sandbox_openshift_namespace | default(env_type + '-' + guid) }}"
 
 # Naming of instances
 openshift_cnv_instance_numeration: '%d'

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/check_network.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/check_network.yaml
@@ -2,7 +2,7 @@
 - name: Get Network if exists
   kubernetes.core.k8s_info:
     kind: NetworkAttachmentDefinition
-    namespace: "{{ openshift_cnv_project_name }}"
+    namespace: "{{ openshift_cnv_namespace }}"
     name: "{{ _network.name }}"
   register: r_networkinfo
   until: r_networkinfo is success

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
@@ -142,7 +142,7 @@
       kind: VirtualMachine
       metadata:
         name: "{{ _instance_name }}"
-        namespace: "{{ openshift_cnv_project_name }}"
+        namespace: "{{ openshift_cnv_namespace }}"
         annotations: >-
           {{ cloud_tags_final
           | combine(_instance.metadata|default({})) | combine(_instance.tags|default({}) | ec2_tags_to_dict) }}

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
@@ -6,11 +6,11 @@
       kind: NetworkAttachmentDefinition
       metadata:
         name: "{{ _network.name }}{{ guid }}"
-        namespace: "{{ openshift_cnv_project_name }}"
+        namespace: "{{ openshift_cnv_namespace }}"
       spec:
         config: "{{ config | to_json }}"
   vars:
-    config: "{'cniVersion':'0.3.1','type':'ovn-k8s-cni-overlay','topology':'layer2','name': '{{ _network.name }}{{ guid }}', 'netAttachDefName': '{{ openshift_cnv_project_name }}/{{ _network.name }}{{ guid }}', 'mtu': 9000}"
+    config: "{'cniVersion':'0.3.1','type':'ovn-k8s-cni-overlay','topology':'layer2','name': '{{ _network.name }}{{ guid }}', 'netAttachDefName': '{{ openshift_cnv_namespace }}/{{ _network.name }}{{ guid }}', 'mtu': 9000}"
   register: r_createnetwork
   until: r_createnetwork is success
   retries: "{{ openshift_cnv_retries }}"

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_project.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_project.yaml
@@ -4,7 +4,7 @@
     api_version: v1
     kind: Namespace
     state: present
-    name: "{{ openshift_cnv_project_name }}"
+    name: "{{ openshift_cnv_namespace }}"
     definition:
       metadata:
         labels:
@@ -22,12 +22,12 @@
       apiVersion: rbac.authorization.k8s.io/v1
       kind: RoleBinding
       metadata:
-        name: "allow-clone-{{ openshift_cnv_project_name }}"
+        name: "allow-clone-{{ openshift_cnv_namespace }}"
         namespace: cnv-images
       subjects:
         - kind: ServiceAccount
           name: default
-          namespace: "{{ openshift_cnv_project_name }}"
+          namespace: "{{ openshift_cnv_namespace }}"
       roleRef:
         kind: ClusterRole
         name: datavolume-cloner
@@ -40,4 +40,4 @@
 - name: Save Project in user_info
   agnosticd_user_info:
     data:
-      openshift_cnv_project_name: "{{ openshift_cnv_project_name }}"
+      openshift_cnv_namespace: "{{ openshift_cnv_namespace }}"

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_routes.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_routes.yaml
@@ -6,7 +6,7 @@
       kind: Route
       metadata:
         name: "{{ route.name }}"
-        namespace: "{{ openshift_cnv_project_name }}"
+        namespace: "{{ openshift_cnv_namespace }}"
       spec:
         host: "{{ route.host|default(route.name) }}.{{ guid }}.{{ sandbox_openshift_apps_domain }}"
         port:
@@ -33,7 +33,7 @@
       kind: Route
       metadata:
         name: "{{ route.name }}"
-        namespace: "{{ openshift_cnv_project_name }}"
+        namespace: "{{ openshift_cnv_namespace }}"
       spec:
         host: "{{ route.host|default(route.name) }}.{{ guid }}.{{ sandbox_openshift_apps_domain }}"
         path: "{{ route.path|default('/') }}"

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_service.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_service.yaml
@@ -6,7 +6,7 @@
       kind: Service
       metadata:
         name: "{{ service.name }}"
-        namespace: "{{ openshift_cnv_project_name }}"
+        namespace: "{{ openshift_cnv_namespace }}"
       spec: "{{ spec | from_yaml }}"
   vars:
     _instance_name: "{{ _instance.name }}{{ _index+1 if _instance.count|d(1)|int > 1 }}"

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_services.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_services.yaml
@@ -7,7 +7,7 @@
       kind: Service
       metadata:
         name: "{{ _instance_name }}"
-        namespace: "{{ openshift_cnv_project_name }}"
+        namespace: "{{ openshift_cnv_namespace }}"
       spec:
         clusterIP: None
         ports:

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/delete_networks.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/delete_networks.yaml
@@ -2,7 +2,7 @@
 - name: Get a list of Network
   kubernetes.core.k8s_info:
     kind: NetworkAttachmentDefinition
-    namespace: "{{ openshift_cnv_project_name }}"
+    namespace: "{{ openshift_cnv_namespace }}"
   register: r_network_list
   until: r_network_list is success
   retries: "{{ openshift_cnv_retries }}"

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/delete_project.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/delete_project.yaml
@@ -4,7 +4,7 @@
     api_version: v1
     kind: Namespace
     state: absent
-    name: "{{ openshift_cnv_project_name }}"
+    name: "{{ openshift_cnv_namespace }}"
     wait: true
     wait_timeout: 600
   register: r_project

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/main.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/main.yaml
@@ -5,6 +5,7 @@
 - when: ACTION == 'provision'
   block:
     - ansible.builtin.include_tasks: create_project.yaml
+      when: sandbox_openshift_namespace is not defined
     - ansible.builtin.include_tasks: create_networks.yaml
     - ansible.builtin.include_tasks: create_instances.yaml
   module_defaults:
@@ -20,6 +21,7 @@
     #- ansible.builtin.include_tasks: delete_instances.yaml
     - ansible.builtin.include_tasks: delete_networks.yaml
     - ansible.builtin.include_tasks: delete_project.yaml
+      when: sandbox_openshift_namespace is not defined
   module_defaults:
     group/k8s:
       host: "{{ sandbox_openshift_api_url }}"

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/start_instances.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/start_instances.yaml
@@ -2,7 +2,7 @@
 - name: Get a list of VMs
   kubernetes.core.k8s_info:
     kind: VirtualMachine
-    namespace: "{{ openshift_cnv_project_name }}"
+    namespace: "{{ openshift_cnv_namespace }}"
   register: r_vm_list
   until: r_vm_list is success
   retries: "{{ openshift_cnv_retries }}"
@@ -18,7 +18,7 @@
     validate_certs: false
     running: true
     name: "{{ _instance.metadata.name }}"
-    namespace: "{{ openshift_cnv_project_name }}"
+    namespace: "{{ openshift_cnv_namespace }}"
   register: r_vmstart
   until: r_vmstart is success
   retries: "{{ openshift_cnv_retries }}"

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/status_instances.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/status_instances.yaml
@@ -2,7 +2,7 @@
 - name: Get a list of VMs
   kubernetes.core.k8s_info:
     kind: VirtualMachine
-    namespace: "{{ openshift_cnv_project_name }}"
+    namespace: "{{ openshift_cnv_namespace }}"
   register: r_vm_list
   until: r_vm_list is success
   retries: "{{ openshift_cnv_retries }}"

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/stop_instances.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/stop_instances.yaml
@@ -2,7 +2,7 @@
 - name: Get a list of VMIs
   kubernetes.core.k8s_info:
     kind: VirtualMachineInstance
-    namespace: "{{ openshift_cnv_project_name }}"
+    namespace: "{{ openshift_cnv_namespace }}"
   register: r_vmi_list
   until: r_vmi_list is success
   retries: "{{ openshift_cnv_retries }}"
@@ -19,7 +19,7 @@
     validate_certs: false
     running: false
     name: "{{ _instance.metadata.name }}"
-    namespace: "{{ openshift_cnv_project_name }}"
+    namespace: "{{ openshift_cnv_namespace }}"
   register: r_stop_vm
   until: r_stop_vm is success
   retries: "{{ openshift_cnv_retries }}"

--- a/ansible/roles-infra/infra-vmc-resources/tasks/status_instances.yaml
+++ b/ansible/roles-infra/infra-vmc-resources/tasks/status_instances.yaml
@@ -3,7 +3,7 @@
 - name: Get a list of VMs
   k8s_info:
     kind: VirtualMachine
-    namespace: "{{ openshift_cnv_project_name }}"
+    namespace: "{{ openshift_cnv_namespace }}"
   register: r_vm_list
 
 - name: Report status in user info

--- a/ansible/roles-infra/infra_vmware_ibm_resources/tasks/status_instances.yaml
+++ b/ansible/roles-infra/infra_vmware_ibm_resources/tasks/status_instances.yaml
@@ -3,7 +3,7 @@
 - name: Get a list of VMs
   k8s_info:
     kind: VirtualMachine
-    namespace: "{{ openshift_cnv_project_name }}"
+    namespace: "{{ openshift_cnv_namespace }}"
   register: r_vm_list
 
 - name: Report status in user info

--- a/ansible/roles/host-ocp4-assisted-destroy/vars/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-destroy/vars/main.yaml
@@ -2,4 +2,4 @@
 ai_pull_secret: "{{ ocp4_pull_secret | to_json | to_json if ocp4_pull_secret is mapping else ocp4_pull_secret | to_json }}"
 ai_offline_token: "{{ ocp4_ai_offline_token }}"
 ai_cluster_name: "{{ guid }}"
-ai_ocp_namespace: "{{ env_type }}-{{ guid }}"
+ai_ocp_namespace: "{{ sandbox_openshift_namespace | default(env_type + '-' + guid) }}"

--- a/ansible/roles/host-ocp4-assisted-installer/vars/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/vars/main.yaml
@@ -9,7 +9,7 @@ ai_control_plane_cores: 8
 ai_control_plane_memory: 16Gi
 ai_workers_cores: 16
 ai_workers_memory: 64Gi
-ai_ocp_namespace: "{{ env_type }}-{{ guid }}"
+ai_ocp_namespace: "{{ sandbox_openshift_namespace | default(env_type + '-' + guid)}}"
 ai_ocp_vmname_sno: "sno-{{ cluster_name }}"
 ai_ocp_vmname_master_prefix: "control-plane-{{ cluster_name }}"
 ai_ocp_vmname_worker_prefix: "worker-{{ cluster_name }}"


### PR DESCRIPTION
##### SUMMARY

This is another PR for the preparation of using sandbox for OpenShift Virtualization

If the variable **sandbox_openshift_namespace** is defined, then is used as namespace for openshift_cnv

As well, if the variable **sandbox_openshift_namespace** is defined, the project and the rolebinding are not created or deleted, as sandbox will be the responsible for it.

This PR removes as well the variable openshift_cnv_project_name from default_vars.yaml

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
openshit_cnv cloud provider


