### PR TITLE
Move VScode server to port 8443

### DIFF
--- a/ansible/configs/ansible-automation-platform/env_vars.yml
+++ b/ansible/configs/ansible-automation-platform/env_vars.yml
@@ -25,6 +25,7 @@
 # Version of the VSCode server as available at
 # https://github.com/coder/code-server/releases
 # vscode_server_version: 4.5.2  # use default version from role vscode-server
+vscode_server_nginx_https_port: 8443
 
 ## guid is the deployment unique identifier, it will be appended to all tags,
 ## files and anything that identifies this environment from another "just like it"
@@ -136,6 +137,20 @@ security_groups:
     description: "HTTPS public"
     from_port: 443
     to_port: 443
+    protocol: tcp
+    cidr: "0.0.0.0/0"
+    rule_type: Ingress
+  - name: BasHTTPS8Public
+    description: "HTTPS public"
+    from_port: 8443
+    to_port: 8443
+    protocol: tcp
+    cidr: "0.0.0.0/0"
+    rule_type: Ingress
+  - name: BasHTTPS3Public
+    description: "HTTPS public"
+    from_port: 3443
+    to_port: 3443
     protocol: tcp
     cidr: "0.0.0.0/0"
     rule_type: Ingress

--- a/ansible/configs/ansible-automation-platform/post_software.yml
+++ b/ansible/configs/ansible-automation-platform/post_software.yml
@@ -53,7 +53,7 @@
       agnosticd_user_info:
         msg: |
             To Access VScode UI via browser:
-            URL: https://bastion.{{ agnosticd_domain_name }}
+            URL: https://bastion.{{ agnosticd_domain_name }}:{{ vscode_server_nginx_https_port }}
             Password: {{ hostvars[groups['bastions'][0]]['tower_admin_password'] }}
 
             To Access Lab Instructions:
@@ -82,7 +82,7 @@
           private_automation_hub_admin_password: "{{ hostvars[groups['bastions'][0]]['tower_admin_password'] }}"
           bastion_student_name: "{{ student_name }}"
           bastion_host_name: "bastion.{{ agnosticd_domain_name }}"
-          vscode_web_ui_url: "https://bastion.{{ agnosticd_domain_name }}"
+          vscode_web_ui_url: "https://bastion.{{ agnosticd_domain_name }}:{{ vscode_server_nginx_https_port }}"
           vscode_web_ui_password: "{{ hostvars[groups['bastions'][0]]['tower_admin_password'] }}"
 
     - name: Deploy Bookbag

--- a/ansible/roles/vscode-server/README.adoc
+++ b/ansible/roles/vscode-server/README.adoc
@@ -35,7 +35,7 @@ vscode-server/
 ├── defaults
 │   └── main.yml
 ├── files
-│   └── nginx.conf
+│   └── automationcontroller_nginx.conf
 ├── README.adoc
 ├── tasks
 │   ├── main.yml
@@ -47,6 +47,7 @@ vscode-server/
 │   └── vscode-server.yml
 ├── templates
 │   ├── config.yaml.j2
+│   ├── nginx.conf.j2
 │   └── settings.json
 └── vars
     └── main.yml
@@ -69,7 +70,7 @@ Role Variables
 | vscode_server_install_nginx | Bool | Yes | True | To install custom nginx server to provide vscode server over http/https
 | vscode_server_install_vscode | Bool | Yes | True | To install / setup vscode-server
 | vscode_server_default_extensions | List | Yes | Yes | List of extension available on https://gpte-public.s3.amazonaws.com/vscode-plugins/
-| vscode_server_nginx_conf | String | Yes | Yes | nginx configuration file 
+| vscode_server_nginx_conf | String | Yes | Yes | nginx configuration file (as template) 
 | vscode_server_extension_urls | List | no| - | List of additional vscode extension extenal urls 
 |===
  

--- a/ansible/roles/vscode-server/defaults/main.yml
+++ b/ansible/roles/vscode-server/defaults/main.yml
@@ -3,6 +3,8 @@
 vscode_server_hostname: "{{ inventory_hostname }}"
 vscode_user_name: "{{ ansible_user }}"
 #vscode_user_password:
+vscode_server_nginx_https_port: 443
+vscode_server_nginx_conf: "nginx.conf.j2"
 
 # Enable become when run as ocp workload
 # default is true

--- a/ansible/roles/vscode-server/tasks/nginx-server.yml
+++ b/ansible/roles/vscode-server/tasks/nginx-server.yml
@@ -40,8 +40,8 @@
     mode: 0644
 
 - name: nginx | copy custom vscode nginx configuration file
-  copy:
-    src: "{{ vscode_server_nginx_conf | default('nginx.conf') }}"
+  ansible.builtin.template:
+    src: "{{ vscode_server_nginx_conf }}"
     dest: /etc/nginx/nginx.conf
 
 - name: nginx | enable selinux boolean to connect with vscode-server

--- a/ansible/roles/vscode-server/templates/nginx.conf.j2
+++ b/ansible/roles/vscode-server/templates/nginx.conf.j2
@@ -30,12 +30,12 @@ http {
     server {
         listen       80 default_server;
         listen       [::]:80 default_server;
-        listen       443 ssl http2 default_server;
-        listen       [::]:443 ssl http2 default_server;
+        listen       {{ vscode_server_nginx_https_port }} ssl http2 default_server;
+        listen       [::]:{{ vscode_server_nginx_https_port }} ssl http2 default_server;
         server_name  _;
         location / {
           proxy_pass http://127.0.0.1:8080;
-          proxy_set_header Host $host;
+          proxy_set_header Host $http_host;
           proxy_set_header Upgrade $http_upgrade;
           proxy_set_header Connection upgrade;
           proxy_set_header Accept-Encoding gzip;


### PR DESCRIPTION


<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

Make the vscode-server able to have a different HTTPS port Open the ports 8443 (and 3443 as preparation for Gitea)
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### COMPONENT NAME

ansible-automation-platform

##### ADDITIONAL INFORMATION

LB1750