### PR TITLE
Update equinix_metal_infrastructure_deployment.yml

### DIFF
--- a/ansible/cloud_providers/equinix_metal_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/equinix_metal_infrastructure_deployment.yml
@@ -78,7 +78,7 @@
       vars:
         infra_generic_wait_for_linux_hosts_delay: 30
         infra_generic_wait_for_linux_hosts_sleep: 10
-        infra_generic_wait_for_linux_hosts_connect_timeout: 20
+        infra_generic_wait_for_linux_hosts_connect_timeout: 60
         infra_generic_wait_for_linux_hosts_timeout: 1200
         infra_generic_wait_for_linux_hosts_retries: 10
 


### PR DESCRIPTION
updated 
infra_generic_wait_for_linux_hosts_connect_timeout: 60 from 20  because most of the deployment are failing with error  "TASK [infra-generic-wait_for_linux_hosts : wait for linux host to be available] *** fatal: [hypervisor]: FAILED! => {"changed": false, "elapsed": 1269, "msg": "timed out waiting for ping module test: Failed to connect to the host via ssh: ssh: connect to host hypervisor.tffnz.dynamic.redhatworkshops.io port 22: Connection timed out"}

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
updated 
infra_generic_wait_for_linux_hosts_connect_timeout: 60 from 20  because most of the deployment are failing with error  "TASK [infra-generic-wait_for_linux_hosts : wait for linux host to be available] *** fatal: [hypervisor]: FAILED! => {"changed": false, "elapsed": 1269, "msg": "timed out waiting for ping module test: Failed to connect to the host via ssh: ssh: connect to host hypervisor.tffnz.dynamic.redhatworkshops.io port 22: Connection timed out"}



##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME

updating the variables Step 001.3 Configure Linux Hosts and Wait for Connection 


