### PR TITLE
Add argocd CLI download

### DIFF
--- a/ansible/configs/rosa-consolidated/default_vars.yml
+++ b/ansible/configs/rosa-consolidated/default_vars.yml
@@ -130,9 +130,11 @@ rosa_terraform_repo_branch: main
 # ssh only from itself (showroom)
 rosa_lock_bastion_security_group: false
 
-# Extra software packages to install
+# Extra software tools to install on the bastion
 install_tektoncd_cli: false
 install_github_cli: false
+install_argocd_cli: false
+argocd_cli_version: v2.10.4
 
 # YAML List of Infrastructure Workloads.
 # REQUIRES Ansible 2.7+ on the deployer host

--- a/ansible/configs/rosa-consolidated/install_additional_tools.yml
+++ b/ansible/configs/rosa-consolidated/install_additional_tools.yml
@@ -4,14 +4,45 @@
   when: install_tektoncd_cli | default(false) | bool
   become: true
   block:
-  - name: Enable dnf copr chmouel/tektoncd-cli repository
-    ansible.builtin.command: >-
-      dnf copr enable chmouel/tektoncd-cli -y
+  - name: Download the Tekton CLI
+    ansible.builtin.get_url:
+      url: https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/latest/tkn-linux-amd64.tar.gz
+      validate_certs: false
+      dest: /tmp/tkn-linux-amd64.tar.gz
+      mode: "0660"
+    register: r_tkn
+    until: r_tkn is success
+    retries: 10
+    delay: 10
 
-  - name: Install tektoncd-cli
-    ansible.builtin.package:
-      name: tektoncd-cli
-      state: present
+  - name: Install tkn CLI on bastion
+    ansible.builtin.unarchive:
+      src: /tmp/tkn-linux-amd64.tar.gz
+      remote_src: true
+      dest: /usr/bin
+      mode: "0775"
+      owner: root
+      group: root
+    args:
+      creates: /usr/bin/tkn
+
+  - name: Remove downloaded file
+    ansible.builtin.file:
+      state: absent
+      path: /tmp/tkn-linux-amd64.tar.gz
+
+  # command: does not work here - somehow the parameters don't get passed properly
+  - name: Setup tkn bash completion
+    ansible.builtin.shell: "/usr/bin/tkn completion bash >/etc/bash_completion.d/tkn"
+    args:
+      creates: /etc/bash_completion.d/tkn
+
+  - name: Setup tkn-pac bash completion
+    ansible.builtin.shell: "/usr/bin/tkn-pac completion bash >/etc/bash_completion.d/tkn-pac"
+    args:
+      creates: /etc/bash_completion.d/tkn-pac
+    # Ignore errors for older pipelines versions
+    ignore_errors: true
 
 # According to Mitesh special request from Grant Shipley
 - name: Install GitHub CLI
@@ -32,3 +63,19 @@
     ansible.builtin.package:
       name: gh
       state: present
+
+# Special request for Chuck Svoboda
+- name: Install ArgoCD CLI
+  when: install_argocd_cli | default(false) | bool
+  become: true
+  block:
+  - name: Download the ArgoCD CLI
+    ansible.builtin.get_url:
+      url: "https://github.com/argoproj/argo-cd/releases/download/{{ argocd_cli_version }}/argocd-linux-amd64"
+      validate_certs: false
+      dest: /usr/bin/argocd
+      mode: "0660"
+    register: r_argocd
+    until: r_argocd is success
+    retries: 10
+    delay: 10


### PR DESCRIPTION
##### SUMMARY

Apparently the MOBB Team needs ArgoCD on the bastion. Adding that capability while cleaning up TKN CLI download code. Fixing Ansible-lint errors.

Enable via config vars:

- install_tektoncd_cli: false
- install_github_cli: false
- install_argocd_cli: false
- argocd_cli_version: v2.10.4

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
rosa-consolidated