### PR TITLE
Update Public EE for python petname library

### DIFF
--- a/tools/execution_environments/ee-multicloud-public/requirements.txt
+++ b/tools/execution_environments/ee-multicloud-public/requirements.txt
@@ -14,6 +14,7 @@ packet-python>=1.43.1
 passlib
 paramiko
 pexpect>=4.5
+petname
 pyOpenSSL
 pypsrp[kerberos,credssp]
 python-daemon


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
This python library is required for the community. general.random_pet lookup plugin for unique hostnames.

We have a request to use pet names for a Red Hat Insights lab for Summit. The lab owner will be using an internal account to showcase insights which if each system was named [node1.example.com](http://node1.example.com/) will cause the user to experience grief attempting to identify which system of the ~30 is their actual system in the insights console.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
tools/execution_environments/ee-multicloud-public/requirements.txt

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
