### PR TITLE
host-ocp4-assisted-installer : Wait till VM is running retries

### DIFF
--- a/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_masters_etcd.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_masters_etcd.yaml
@@ -122,5 +122,5 @@
     namespace: "{{ namespace }}"
   register: r_vm_status
   until: r_vm_status.resources[0].status.printableStatus|default('') == "Running"
-  retries: 60
+  retries: 120
   delay: 10


### PR DESCRIPTION
Increasing the retries to 120 to fix the following fatal error.

TASK [host-ocp4-assisted-installer : Wait till VM is running] ******************
FAILED - RETRYING: [bastion]: Wait till VM is running (60 retries left).

