### PR TITLE
Update to add more retries for linux hosts ssh

### DIFF
--- a/ansible/roles-infra/infra-generic-wait_for_linux_hosts/defaults/main.yaml
+++ b/ansible/roles-infra/infra-generic-wait_for_linux_hosts/defaults/main.yaml
@@ -1,6 +1,6 @@
 ---
 infra_generic_wait_for_linux_hosts_delay: 30
 infra_generic_wait_for_linux_hosts_sleep: 1
-infra_generic_wait_for_linux_hosts_connect_timeout: 10
+infra_generic_wait_for_linux_hosts_connect_timeout: 60
 infra_generic_wait_for_linux_hosts_timeout: 300
 infra_generic_wait_for_linux_hosts_retries: 3


### PR DESCRIPTION
##### SUMMARY
Update to add more retries for linux hosts ssh

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible/roles-infra/infra-generic-wait_for_linux_hosts/defaults/main.yaml

##### ADDITIONAL INFORMATION
Adding more duration for waiting linux host ssh. 
Migrating to OpenShift Virtualization is failing due to this. Job no: 360033, 359791, 355465 
