### PR TITLE
Move showroom to OCP shared, including destroy for cleanup

### DIFF
--- a/ansible/configs/ansible-automation-platform/destroy_env.yml
+++ b/ansible/configs/ansible-automation-platform/destroy_env.yml
@@ -7,6 +7,7 @@
   gather_facts: false
   become: false
   tasks:
+
     - name: Run infra-ec2-template-destroy
       include_role:
         name: "infra-{{cloud_provider}}-template-destroy"
@@ -16,3 +17,10 @@
       include_role:
         name: "infra-{{cloud_provider}}-template-destroy"
       when: cloud_provider == 'azure'
+
+    - name: Remove Showroom
+      when: showroom_deploy_shared_cluster_enable | default(false) | bool
+      vars:
+        ACTION: "destroy"
+      ansible.builtin.include_role:
+        name: ocp4_workload_showroom

--- a/ansible/configs/ansible-automation-platform/post_software.yml
+++ b/ansible/configs/ansible-automation-platform/post_software.yml
@@ -99,23 +99,18 @@
       vars:
         ACTION: create
 
-- name: Deploy Showroom or Nookbag
-  hosts: bastions[0]
-  gather_facts: true
-  become: true
-  tags:
-    - showroom
-
+- name: Step 00xxxxx post software
+  hosts: localhost
+  become: false
+  gather_facts: false
   tasks:
+    - debug:
+        msg: "Post-Software Steps starting"
 
-    - name: Deploy Showroom Web Interface
-      when:
-        - showroom_git_repo is defined
-      ansible.builtin.include_role:
-        name: showroom
+    - name: Deploy Showroom on shared cluster
+      when: showroom_deploy_shared_cluster_enable | default(false) | bool
+      include_role:
+        name: ocp4_workload_showroom
 
-    - name: Deploy nookbag Web Interface
-      when:
-        - nookbag_git_repo is defined
-      ansible.builtin.include_role:
-        name: nookbag
+    - debug:
+        msg: "Post-Software checks completed successfully"


### PR DESCRIPTION
##### SUMMARY

Use showroom on OCP Shared v locally on VM

Simplifies and avoids LE Cert clash with Nginx, VSCode wanting the same port, and a host of other stuff.

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME

configs/ansible-automation-platform


##### ADDITIONAL INFORMATION

Local showroom had never deployed successfully here and needed excessive work due to a non standard AgD config