### PR TITLE
rhel-security add conditional to stop setup script

### DIFF
--- a/ansible/configs/rhel-security/crypto.yml
+++ b/ansible/configs/rhel-security/crypto.yml
@@ -22,6 +22,7 @@
     mode: +x
 
 - name: Run setup
+  when: crypto_lab_setup | default(true) | bool
   command:
     chdir: /root/crypto-lab
     cmd: /root/crypto-lab/setup


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
This setup script is broken for RHEL 9. Adding conditional until fixed so summit developers can test.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
rhel-security
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
