### PR TITLE
Add showroom destroy and deploy tasks to ansible

### DIFF
--- a/ansible/configs/ansible-lightspeed/destroy_env.yml
+++ b/ansible/configs/ansible-lightspeed/destroy_env.yml
@@ -2,3 +2,16 @@
 - name: Import default destroy playbook
   import_playbook: ../../cloud_providers/{{cloud_provider}}_destroy_env.yml
 
+- name: Delete Showroom
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  become: false
+  tasks:
+
+    - name: Remove Showroom
+      when: showroom_deploy_shared_cluster_enable | default(false) | bool
+      vars:
+        ACTION: "destroy"
+      ansible.builtin.include_role:
+        name: ocp4_workload_showroom

--- a/ansible/configs/ansible-lightspeed/post_software.yml
+++ b/ansible/configs/ansible-lightspeed/post_software.yml
@@ -77,7 +77,6 @@
               subdomain_base: "{{ subdomain_base }}"
               subdomain_internal: "{{ aws_dns_zone_private_chomped | default('') }}"
 
-
 - name: PostSoftware flight-check
   hosts: localhost
   connection: local
@@ -87,6 +86,11 @@
     - step005_03
     - post_software
   tasks:
+
+    - name: Deploy Showroom on shared cluster
+      when: showroom_deploy_shared_cluster_enable | default(false) | bool
+      include_role:
+        name: ocp4_workload_showroom
+
     - debug:
         msg: "Post-Software checks completed successfully"
-


### PR DESCRIPTION
##### SUMMARY

Added the when: protected option to use Shared Showroom OCP in config ansible-lightspeed

- Allows it to be used with Showroom while simplifying port issues around CNV


##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

configs/ansible-lightspeed

##### ADDITIONAL INFORMATION
