### PR TITLE
infra-ec2-wait_for_windows_hosts localhost to poll windows instead of…

### DIFF
--- a/ansible/roles-infra/infra-ec2-wait_for_windows_hosts/tasks/main.yml
+++ b/ansible/roles-infra/infra-ec2-wait_for_windows_hosts/tasks/main.yml
@@ -6,6 +6,7 @@
     delay: 120
   register: rwait
   ignore_errors: true
+  delegate_to: localhost
 
 - name: restart instance if wait_for_connection failed
   become: false
@@ -23,3 +24,4 @@
     connect_timeout: 60
     delay: 120
   when: rwait is failed
+  delegate_to: localhost


### PR DESCRIPTION
… itself

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
This role errors Windows deployments as it calls win_ping from the windows host itself which is not available. The EE should be able to use this module to complete the checks.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
infra-ec2-wait_for_windows_hosts
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

PLAY [Step 001.4 Configure Windows Hosts and Wait for Connection] **************

TASK [set facts for remote access] *********************************************
ok: [windows.lfkh5.internal]

TASK [Run infra-ec2-wait_for_linux_hosts Role] *********************************

TASK [infra-ec2-wait_for_windows_hosts : wait for windows host to be available] ***
fatal: [windows.lfkh5.internal]: FAILED! => {"changed": false, "elapsed": 1020, "msg": "timed out waiting for ping module test: The module ansible.windows.win_ping was not found in configured module paths"}
...ignoring

TASK [infra-ec2-wait_for_windows_hosts : restart instance if wait_for_connection failed] ***
changed: [windows.lfkh5.internal -> localhost]

TASK [infra-ec2-wait_for_windows_hosts : wait for windows host to be available (retry)] ***
fatal: [windows.lfkh5.internal]: FAILED! => {"changed": false, "elapsed": 1020, "msg": "timed out waiting for ping module test: The module ansible.windows.win_ping was not found in configured module paths"}

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
