### PR TITLE
New Role pet_name_generator

### DIFF
--- a/ansible/roles/pet_name_generator/README.md
+++ b/ansible/roles/pet_name_generator/README.md
@@ -1,0 +1,30 @@
+# pet_name_generator
+
+Generate unique hostnames with the python petname libary.
+
+## Requirements
+Python Libraries:
+  - petname
+
+## Role Variables
+
+`pet_name_generator_lookup`  - Default lookup creates a two word unique system name with a blank separator defined.
+
+`pet_name_generator_instances` - set_fact reads this list and sets a pet_name to each item.
+
+```
+pet_name_generator_instances:
+  - bastion_hostname
+  - node1_hostname
+  - node2_hostname
+```
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+Wilson Harris
+Red Hat, GPTE

--- a/ansible/roles/pet_name_generator/defaults/main.yml
+++ b/ansible/roles/pet_name_generator/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+pet_name_generator_lookup: "{{ lookup('community.general.random_pet', separator='') }}"
+pet_name_generator_instances:
+  - bastion_hostname

--- a/ansible/roles/pet_name_generator/tasks/main.yml
+++ b/ansible/roles/pet_name_generator/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Set petnames for all systems in pet_name_generator_instances
+  ansible.builtin.set_fact:
+    {"{{ instance }}": "{{ pet_name_generator_lookup }}"}
+  loop: "{{ pet_name_generator_instances }}"
+  loop_control:
+    loop_var: instance

--- a/ansible/roles/pet_name_generator/tasks/main.yml
+++ b/ansible/roles/pet_name_generator/tasks/main.yml
@@ -5,3 +5,9 @@
   loop: "{{ pet_name_generator_instances }}"
   loop_control:
     loop_var: instance
+
+- debug:
+    var: "{{ pet_name }}"
+  loop: "{{ pet_name_generator_instances }}"
+  loop_control:
+    loop_var: pet_name


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
This role creates unique hostnames for systems. It uses set_fact to create or override hostname variables and assigns them to a new value using the Python petname generator.

This is useful for deployments of systems mimicking a real-world environment or for Red Hat Insights labs making the systems easier to locate in the web console.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
pet_name_generator
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
