### PR TITLE
Fix lightspeed conditional so it defaults to false

### DIFF
--- a/ansible/configs/ansible-lightspeed/software.yml
+++ b/ansible/configs/ansible-lightspeed/software.yml
@@ -28,7 +28,7 @@
 
     # Ansible Lightspeed Workshop
     - name: Setup ansible lightspeed demo block
-      when: ansible_lightspeed_setup_demo_repo | bool
+      when: ansible_lightspeed_setup_demo_repo | default(false)| bool
       block:
         - name: Git clone ansible lightspeed repo
           become_user: "{{ student_name }}"


### PR DESCRIPTION
##### SUMMARY

Config fails if `git push --set-upstream origin ansible-lightspeed-fix-conditional-01` not set

Defaults it to false to allow block not to be executed

##### ISSUE TYPE

- Bug Fix

##### COMPONENT NAME

configs/ansible-lightspeed

##### ADDITIONAL INFORMATION

