### PR TITLE
Update reset-repositories role to properly reset rhsm.conf

### DIFF
--- a/ansible/roles/reset-repositories/tasks/main.yml
+++ b/ansible/roles/reset-repositories/tasks/main.yml
@@ -15,7 +15,8 @@
     path: /etc/rhsm/rhsm.conf
     state: absent
 
-- name: Reinstall subscription-manager package
-  ansible.builtin.yum:
-    name: subscription-manager
-    state: latest
+- name: Restore rhsm.conf.kat-backup to rhsm.conf
+  ansible.builtin.copy:
+    src: /etc/rhsm/rhsm.conf.kat-backup
+    dest: /etc/rhsm/rhsm.conf
+    remote_src: yes


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
The rhsm.conf file was not being regenerated. Changing this to restore the original from the backup created.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
reset-repositories
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
