### PR TITLE
disabling facility parameter

### DIFF
--- a/ansible/roles-infra/infra-equinix-metal-resources/tasks/create_instances.yaml
+++ b/ansible/roles-infra/infra-equinix-metal-resources/tasks/create_instances.yaml
@@ -23,7 +23,7 @@
     count: "{{ _instance.count }}"
     operating_system: "{{ _instance.os | default(equinix_metal_default_os) }}"
     plan: "{{ _instance.type }}"
-    facility: "{{ _instance.facility }}"
+#    facility: "{{ _instance.facility }}"
     tags: >-
       {{ cloud_tags_final
       | combine(_instance.tags | ec2_tags_to_dict)

--- a/ansible/roles-infra/infra-equinix-metal-resources/tasks/create_instances.yaml
+++ b/ansible/roles-infra/infra-equinix-metal-resources/tasks/create_instances.yaml
@@ -23,7 +23,7 @@
     count: "{{ _instance.count }}"
     operating_system: "{{ _instance.os | default(equinix_metal_default_os) }}"
     plan: "{{ _instance.type }}"
-#    facility: "{{ _instance.facility }}"
+    metro: "any"
     tags: >-
       {{ cloud_tags_final
       | combine(_instance.tags | ec2_tags_to_dict)


### PR DESCRIPTION
  "msg": "failed to set device state present, error: Error 422: The 'facility' parameter is not supported for organization 367d5f94-cc39-4623-966a-fce18b63e2b2. For more details, see https://feedback.equinixmetal.com/changelog/bye-facilities-hello-again-metros",

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
