### PR TITLE
Update create_instances.yaml

### DIFF
--- a/ansible/roles-infra/infra-equinix-metal-resources/tasks/create_instances.yaml
+++ b/ansible/roles-infra/infra-equinix-metal-resources/tasks/create_instances.yaml
@@ -13,7 +13,7 @@
   vars:
   equinix.metal.device:
     wait_for_public_IPv: 4
-    auth_token: "{{ equinix_metal_api_token }}"
+    api_token: "{{ equinix_metal_api_token }}"
     project_id: "{{ equinix_metal_project_id }}"
     hostnames: >-
       {{ _instance.name }}


### PR DESCRIPTION
updated auth_token to API_token as auth_token parameter is not supported by metro module

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

updating auth_token with API_token parameter as auth_token paarameter is not support by metro module 



##### ISSUE TYPE
=
- Bugfix Pull Request


##### COMPONENT NAME
openshift virt roadshow 


