### PR TITLE
Remove outdated lab URL replaced by Showroom

### DIFF
--- a/ansible/configs/ansible-automation-platform/post_software.yml
+++ b/ansible/configs/ansible-automation-platform/post_software.yml
@@ -55,10 +55,6 @@
             To Access VScode UI via browser:
             URL: https://bastion.{{ agnosticd_domain_name }}:{{ vscode_server_nginx_https_port }}
             Password: {{ hostvars[groups['bastions'][0]]['tower_admin_password'] }}
-
-            To Access Lab Instructions:
-            URL: {{ lab_ui_url }}
-
             To Access Ansible controller UI via browser:
             URL: https://{{ tower_instance_name }}1.{{ agnosticd_domain_name }}
             Username: {{ automationcontroller_admin_user | default('admin') }}
@@ -77,7 +73,6 @@
             Username: {{ student_name }}
             Password: {{ hostvars[groups['bastions'][0]]['tower_admin_password'] }}
         data:
-          lab_instructions_url: "{{ lab_ui_url }}"
           ansible_controller_web_ui_url: "https://{{ tower_instance_name }}1.{{ agnosticd_domain_name }}"
           ansible_controller_username: "{{ automationcontroller_admin_user | default('admin') }}"
           ansible_controller_admin_password: "{{ hostvars[groups['bastions'][0]]['tower_admin_password'] }}"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

As the title says, simply removing outdated links and variables replaced by Showroom.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
ansible-automation-platform

##### ADDITIONAL INFORMATION
LB1750
