### PR TITLE
aap2-ansible-workshops include pet-name option

### DIFF
--- a/ansible/configs/aap2-ansible-workshops/pre_infra.yml
+++ b/ansible/configs/aap2-ansible-workshops/pre_infra.yml
@@ -32,6 +32,11 @@
         creates: "{{ ANSIBLE_REPO_PATH }}/workdir/{{ env_authorized_key }}.pub"
     when: set_env_authorized_key | bool
 
+  - name: Generate Petname Hostnames for Systems
+    when: pet_name_generator_enable | default(false) | bool
+    ansible.builtin.include_role:
+      name: pet_name_generator
+
 - name: PreSoftware flight-check
   hosts: localhost
   connection: local


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
Adds pet_name_generator role to pre_infra.yml with default false bool
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
