### PR TITLE
ansible_bu_setup_workshop include registered var into another task list

### DIFF
--- a/ansible/roles/ansible_bu_setup_workshop/tasks/ripu.yml
+++ b/ansible/roles/ansible_bu_setup_workshop/tasks/ripu.yml
@@ -10,6 +10,8 @@
 - name: Include ansible-navigator tasks
   ansible.builtin.include_tasks:
     file: ./common/ansible-navigator.yml
+  vars:
+  r_instances_info: "{{ hostvars['localhost'].r_instances_info }}"
 
 - name: Include code-server tasks
   ansible.builtin.include_tasks:
@@ -34,8 +36,8 @@
     src: ./files/setup.yml
     dest: "/home/{{ student_name }}/setup.yml"
     owner: "{{ student_name }}"
-    group: "{{ student_name }}" 
-    
+    group: "{{ student_name }}"
+
 - name: Clone rhel-workshop
   ansible.builtin.git:
     repo: https://github.com/ansible/workshops.git


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
The template within this role needs access to the localhost registered variable "r_instances_info"
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ansible_bu_setup_workshop
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
