### PR TITLE
Add Showroom setup to post_software.yml in ocp4-cluster

### DIFF
--- a/ansible/configs/ocp4-cluster/destroy_env.yml
+++ b/ansible/configs/ocp4-cluster/destroy_env.yml
@@ -1,3 +1,17 @@
 ---
 - name: Import cloud provider specific destroy playbook
   import_playbook: "./destroy_env_{{ cloud_provider }}.yml"
+
+- name: Delete Showroom
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  become: false
+  tasks:
+
+    - name: Remove Showroom
+      when: showroom_deploy_shared_cluster_enable | default(false) | bool
+      vars:
+        ACTION: "destroy"
+      ansible.builtin.include_role:
+        name: ocp4_workload_showroom

--- a/ansible/configs/ocp4-cluster/post_software.yml
+++ b/ansible/configs/ocp4-cluster/post_software.yml
@@ -273,6 +273,19 @@
 
         Enter ssh password when prompted: {{ hostvars[groups['bastions'][0]]['student_password'] }}
 
+- name: Showroom setup
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  become: false
+  tags:
+  - post_software
+  tasks:
+
+  - name: Deploy Showroom on shared cluster
+    when: showroom_deploy_shared_cluster_enable | default(false) | bool
+    include_role:
+      name: ocp4_workload_showroom
 
 - name: Step 005.7 Clean up
   hosts: localhost


### PR DESCRIPTION
##### SUMMARY

Adds the capability to `ocp4-cluster` to deploy shared showroom at end of post_software

i.e. use only has to supply vars and it will deploy **after** all user-data is set

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME

configs/ocp4-cluster

##### ADDITIONAL INFORMATION
