### PR TITLE
ansible-bu-workshops move showroom to OCP cluster

### DIFF
--- a/ansible/configs/ansible-bu-workshop/destroy_env.yml
+++ b/ansible/configs/ansible-bu-workshop/destroy_env.yml
@@ -16,3 +16,17 @@
       name: bookbag
     vars:
       ACTION: destroy
+
+- name: Delete Showroom
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  become: false
+  tasks:
+
+    - name: Remove Showroom
+      when: showroom_deploy_shared_cluster_enable | default(false) | bool
+      vars:
+        ACTION: "destroy"
+      ansible.builtin.include_role:
+        name: ocp4_workload_showroom

--- a/ansible/configs/ansible-bu-workshop/post_software.yml
+++ b/ansible/configs/ansible-bu-workshop/post_software.yml
@@ -45,20 +45,28 @@
           hostname: "{{ groups['bastions'][0].split('.')[0] }}.{{ subdomain_base }}"
           subdomain_base: "{{ subdomain_base }}"
           subdomain_internal: "{{ aws_dns_zone_private_chomped | default('') }}"
-
+          bastion_ssh_command: "ssh {{ student_name }}@{{ bastion_public_hostname }}"
+          bastion_public_hostname: "{{ bastion_prefix }}.{{ guid }}{{ subdomain_base_suffix }}"
+          bastion_ssh_user_name: "{{ student_name }}"
+          bastion_ssh_password: "{{ common_password }}"
+        vars:
+          student_name: "{{ ansible_service_account_user_name }}"
+          bastion_prefix: "{{ groups['bastions'][0] | regex_replace('\\..*$') }}"
+        register: r_user_data
 
 - name: PostSoftware flight-check
-  hosts: bastions[0]
-  gather_facts: true
-  become: true
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  become: false
   tags:
-    - showroom
+    - post_flight_check
   tasks:
 
-    - name: Deploy Showroom Web Interface
-      when: showroom_git_repo is defined
-      ansible.builtin.include_role:
-        name: showroom
+    - name: Deploy Showroom on shared cluster
+      when: showroom_deploy_shared_cluster_enable | default(false) | bool
+      include_role:
+        name: ocp4_workload_showroom
 
     - debug:
         msg: "Post-Software checks completed successfully"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
The showroom needs to run on the ocp cluster instead of bastion. The bastion system is also an AAP2 Controller and takes 443.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ansible-bu-workshops
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
