### PR TITLE
[WIP] object convert to template

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacs/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacs/defaults/main.yml
@@ -9,3 +9,4 @@ ocp4_workload_rhacs_install_operator_use_catalog_snapshot: true
 ocp4_workload_rhacs_install_operator_catalog_source_tag: "v4.0.0-18"
 
 ocp4_workload_rhacs_central_namespace: stackrox
+ocp4_workload_rhacs_central_scanner_v4: disabled

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacs/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacs/tasks/workload.yml
@@ -50,35 +50,7 @@
 - name: Create Central via CR
   k8s:
     state: present
-    definition:
-      apiVersion: platform.stackrox.io/v1alpha1
-      kind: Central
-      metadata:
-        namespace: stackrox
-        name: stackrox-central-services
-      spec:
-        central:
-          adminPasswordSecret:
-            name: acs-password
-          exposure:
-            loadBalancer:
-              enabled: false
-              port: 443
-            nodePort:
-              enabled: false
-            route:
-              enabled: true
-          persistence:
-            persistentVolumeClaim:
-              claimName: stackrox-db
-        egress:
-          connectivityPolicy: Online
-        scanner:
-          analyzer:
-            scaling:
-              autoScaling: Disabled
-              replicas: 1
-          scannerComponent: Enabled
+    definition: "{{ lookup('template', 'central.yaml.j2' ) | from_yaml }}"
 
 - name: Get Central route
   k8s_info:

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacs/templates/central.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacs/templates/central.yaml.j2
@@ -1,0 +1,32 @@
+apiVersion: platform.stackrox.io/v1alpha1
+kind: Central
+metadata:
+  name: stackrox-central-services
+  namespace: stackrox
+spec:
+  central:
+    adminPasswordSecret:
+      name: acs-password
+    exposure:
+      loadBalancer:
+        enabled: false
+        port: 443
+      nodePort:
+        enabled: false
+      route:
+        enabled: true
+    persistence:
+      persistentVolumeClaim:
+        claimName: stackrox-db
+  egress:
+    connectivityPolicy: Online
+  scanner:
+    analyzer:
+      scaling:
+        autoScaling: Disabled
+        replicas: 1
+    scannerComponent: Enabled
+{%if ocp4_workload_rhacs_install_operator_channel.split('-')[1] | float >= 4.4 %}
+  scannerV4:
+    scannerComponent: Enabled
+{%endif%}

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacs/templates/central.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacs/templates/central.yaml.j2
@@ -26,7 +26,9 @@ spec:
         autoScaling: Disabled
         replicas: 1
     scannerComponent: Enabled
+{%if ocp4_workload_rhacs_central_scanner_v4 == 'enabled' %}
 {%if ocp4_workload_rhacs_install_operator_channel.split('-')[1] | float >= 4.4 %}
   scannerV4:
     scannerComponent: Enabled
+{%endif%}
 {%endif%}


### PR DESCRIPTION

##### SUMMARY
RHACS Certral custom resource task converted to template

Reason: In RHACS 4.4 there is new feature  scannerV4 is available and it is disabled by default. So to enable it we have to add option with condition which doesn't effect existing or old CIs.


##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
Role: ocp4_workload_rhacs