### PR TITLE
Add workload to install and use cert manager operator

### DIFF
--- a/ansible/roles/install_operator/tasks/install.yml
+++ b/ansible/roles/install_operator/tasks/install.yml
@@ -1,37 +1,37 @@
 ---
 - name: Check that operator name has been provided
-  assert:
+  ansible.builtin.assert:
     that:
     - install_operator_name | default("") | length > 0
     fail_msg: install_operator_name must be set.
 
-- name: "{{ install_operator_name }} - Set up for Namespace other than 'openshift-operators'"
+- name: "Set up for Namespace other than 'openshift-operators' ({{ install_operator_name }})"
   when: install_operator_namespace != "openshift-operators"
   block:
-  - name: "{{ install_operator_name }} - Ensure Namespace exists"
+  - name: "Ensure Namespace exists ({{ install_operator_name }})"
     kubernetes.core.k8s:
       state: present
       api_version: v1
       kind: Namespace
       name: "{{ install_operator_namespace }}"
 
-  - name: "{{ install_operator_name }} - Ensure OperatorGroup exists"
+  - name: "Ensure OperatorGroup exists ({{ install_operator_name }})"
     kubernetes.core.k8s:
       state: present
-      definition: "{{ lookup('template', 'operatorgroup.yaml.j2' ) | from_yaml }}"
+      definition: "{{ lookup('template', 'operatorgroup.yaml.j2') | from_yaml }}"
 
-- name: "{{ install_operator_name }} - Create CatalogSource for use with catalog snapshot"
+- name: "Create CatalogSource for use with catalog snapshot ({{ install_operator_name }})"
   when: install_operator_catalogsource_setup | bool
   kubernetes.core.k8s:
     state: present
-    definition: "{{ lookup('template', 'catalogsource.yaml.j2' ) | from_yaml }}"
+    definition: "{{ lookup('template', 'catalogsource.yaml.j2') | from_yaml }}"
 
-- name: "{{ install_operator_name }} - Set subscription channel to provided channel"
+- name: "Set subscription channel to provided channel ({{ install_operator_name }})"
   when: install_operator_channel | default("") | length > 0
-  set_fact:
+  ansible.builtin.set_fact:
     __install_operator_channel: "{{ install_operator_channel }}"
 
-- name: "{{ install_operator_name }} - Determine channel for the operator if no channel specified"
+- name: "Determine channel for the operator if no channel specified ({{ install_operator_name }})"
   when: install_operator_channel | default("") | length == 0
   block:
   - name: Get cluster version
@@ -41,7 +41,7 @@
       name: version
     register: r_cluster_version
 
-  - name: "{{ install_operator_name }} - Get PackageManifest for the operator"
+  - name: "Get PackageManifest for the operator ({{ install_operator_name }})"
     kubernetes.core.k8s_info:
       api_version: packages.operators.coreos.com/v1
       kind: PackageManifest
@@ -51,8 +51,8 @@
 
   # Set channel to the one matching the deployed cluster version.
   # If no matching channel available set to defaultChannel from the package manifest.
-  - name: "{{ install_operator_name }} - Set operator channel"
-    set_fact:
+  - name: "Set operator channel ({{ install_operator_name }})"
+    ansible.builtin.set_fact:
       __install_operator_channel: "{{ t_channel | regex_replace(' ') }}"
     vars:
       t_cluster_version: >-
@@ -63,16 +63,16 @@
       t_channel: >-
         {{ t_version_match_channel | default(r_packagemanifest.resources[0].status.defaultChannel, true) }}
 
-- name: "{{ install_operator_name }} - Print operator channel to be installed"
-  debug:
+- name: "Print operator channel to be installed ({{ install_operator_name }})"
+  ansible.builtin.debug:
     msg: "Operator channel to be installed: {{ __install_operator_channel }}"
 
-- name: "{{ install_operator_name }} - Create operator subscription"
+- name: "Create operator subscription ({{ install_operator_name }})"
   kubernetes.core.k8s:
     state: present
-    definition: "{{ lookup('template', 'subscription.yaml.j2' ) | from_yaml }}"
+    definition: "{{ lookup('template', 'subscription.yaml.j2') | from_yaml }}"
 
-- name: "{{ install_operator_name }} - Wait until InstallPlan is created"
+- name: "Wait until InstallPlan is created ({{ install_operator_name }})"
   kubernetes.core.k8s_info:
     api_version: operators.coreos.com/v1alpha1
     kind: InstallPlan
@@ -87,18 +87,18 @@
   - r_install_plans.resources | default([]) | length > 0
   - r_install_plans.resources | to_json | from_json | json_query(_query)
 
-- name: "{{ install_operator_name }} - Set InstallPlan name"
-  set_fact:
+- name: "Set InstallPlan name ({{ install_operator_name }})"
+  ansible.builtin.set_fact:
     install_operator_install_plan_name: "{{ r_install_plans.resources | to_json | from_json | json_query(query) }}"
   vars:
     query: >-
       [?contains(spec.clusterServiceVersionNames[] | join(',', @), '{{ install_operator_csv_nameprefix }}')].metadata.name|[0]
 
-- name: "{{ install_operator_name }} - Print InstallPlan"
-  debug:
+- name: "Print InstallPlan ({{ install_operator_name }})"
+  ansible.builtin.debug:
     msg: "InstallPlan: {{ install_operator_install_plan_name }}"
 
-- name: "{{ install_operator_name }} - Get InstallPlan"
+- name: "Get InstallPlan ({{ install_operator_name }})"
   kubernetes.core.k8s_info:
     api_version: operators.coreos.com/v1alpha1
     kind: InstallPlan
@@ -106,13 +106,13 @@
     namespace: "{{ install_operator_namespace }}"
   register: r_install_plan
 
-- name: "{{ install_operator_name }} - Approve InstallPlan if necessary"
+- name: "Approve InstallPlan if necessary ({{ install_operator_name }})"
   when: r_install_plan.resources[0].status.phase is match("RequiresApproval")
   kubernetes.core.k8s:
     state: present
-    definition: "{{ lookup( 'template', 'installplan.yaml.j2' ) }}"
+    definition: "{{ lookup('template', 'installplan.yaml.j2') }}"
 
-- name: "{{ install_operator_name }} - Get Installed CSV"
+- name: "Get Installed CSV ({{ install_operator_name }})"
   kubernetes.core.k8s_info:
     api_version: operators.coreos.com/v1alpha1
     kind: Subscription
@@ -125,12 +125,12 @@
   - r_subscription.resources[0].status.currentCSV is defined
   - r_subscription.resources[0].status.currentCSV | length > 0
 
-- name: "{{ install_operator_name }} - Print CSV version to be installed"
+- name: "Print CSV version to be installed ({{ install_operator_name }})"
   when: install_operator_starting_csv is defined
-  debug:
+  ansible.builtin.debug:
     msg: "Starting CSV: {{ install_operator_starting_csv }}"
 
-- name: "{{ install_operator_name }} - Wait until CSV is installed"
+- name: "Wait until CSV is installed ({{ install_operator_name }})"
   kubernetes.core.k8s_info:
     api_version: operators.coreos.com/v1alpha1
     kind: ClusterServiceVersion

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/defaults/main.yml
@@ -1,0 +1,57 @@
+---
+become_override: false
+ocp_username: opentlc-mgr
+silent: false
+
+# Install certificates for Ingress Controllers
+ocp4_workload_cert_manager_install_ingress_certificates: true
+
+# Install certificates for API Endpoint
+ocp4_workload_cert_manager_install_api_certificates: false
+
+# It takes about 4 minutes per API Server to
+# restart with certificates (due to AWS
+# Load Balancer). Therefore sleep
+# 12 minutes by default to give the kube-apiserver
+# cluster operator enough time to progress.
+# Wait time may be extended if it's needed
+ocp4_workload_cert_manager_wait_after_api_cert_setup: 12
+
+# In the future change to check the cluster operators instead of just pausing
+ocp4_workload_cert_manager_wait_for_rollout: false
+
+# Set to the cloud provider to be used:
+# Valid values are: ec2, azure, gcp, osp, vmc
+# NOTE: Right now only ec2 is implemented
+ocp4_workload_cert_manager_cloud_provider: ec2
+
+# ---------------------------------------------------------------
+# Settings for EC2
+# ---------------------------------------------------------------
+# Set from AgnosticV to the actual AWS credentials
+# region this is being deployed to. E.g.
+# ocp4_workload_cert_manager_cloud_provider: "{{ cloud_provider }}"
+# ocp4_workload_cert_manager_ec2_region: "{{ aws_region }}"
+# ocp4_workload_cert_manager_ec2_access_key_id: "{{ hostvars.localhost.route53user_access_key }}"
+# ocp4_workload_cert_manager_ec2_secret_access_key: "{{ hostvars.localhost.route53user_secret_access_key }}"
+
+ocp4_workload_cert_manager_ec2_region: us-east-2
+ocp4_workload_cert_manager_ec2_access_key_id: ""
+ocp4_workload_cert_manager_ec2_secret_access_key: ""
+
+ocp4_workload_cert_manager_channel: stable-v1
+
+ocp4_workload_cert_manager_starting_csv: ""
+# ocp4_workload_cert_manager_starting_csv: cert-manager-operator.v1.13.0
+
+ocp4_workload_cert_manager_automatic_install_plan_approval: true
+
+ocp4_workload_cert_manager_use_catalog_snapshot: false
+ocp4_workload_cert_manager_catalogsource_name: ""
+ocp4_workload_cert_manager_catalog_snapshot_image: ""
+ocp4_workload_cert_manager_catalog_snapshot_image_tag: ""
+
+# Internal vars. Don't set
+_ocp4_workload_cert_manager_api_hostname: ""
+_ocp4_workload_cert_manager_wildcard_domain: ""
+_ocp4_workload_cert_manager_hostedzoneid: ""

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/meta/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/meta/main.yml
@@ -1,0 +1,15 @@
+---
+galaxy_info:
+  role_name: ocp4_workload_cert_manager
+  author: Red Hat GPTE, Wolfgang Kulhanek (wkulhane@redhat.com)
+  description: |
+    This workload requests and installs Let's Encrypt certificates onto an OpenShift 4 Cluster using the
+    Red Hat Cert Manager operator.
+    It can deploy wildcard certificates to the ingress controllers and a certificate to the API endcpoint.
+  license: MIT
+  min_ansible_version: 2.9
+  platforms: []
+  galaxy_tags:
+  - ocp
+  - openshift
+dependencies: []

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/readme.adoc
@@ -1,0 +1,65 @@
+= ocp4_workload_cert_manager - Install Red Hat Cert Manager Operator and Request and install certificates from Let's Encrypt
+
+== Role overview
+
+* This role requests and installs certificates from Let's Encrypt for an OpenShift 4 Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+ environment for the workload deployment.
+*** Debug task will print out: `pre_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to create the certificates
+*** Debug task will print out: `workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+ configure the workload after deployment
+*** This role doesn't do anything here
+*** Debug task will print out: `post_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+ delete the workload
+*** This role removes the certificates from OCP 4
+*** Debug task will print out: `remove_workload Tasks completed successfully.`
+
+== Review the defaults variable file
+
+* This file link:./defaults/main.yml[./defaults/main.yml] contains all the variables you need to define to control the deployment of your workload.
+* The variable *ocp_username* is mandatory to assign the workload to the correct OpenShift user.
+* A variable *silent=True* can be passed to suppress debug messages.
+* You can modify any of these default values by adding `-e "variable_name=variable_value"` to the command line
+
+=== Deploy a Workload with the `ocp-workload` playbook [Mostly for testing]
+
+----
+TARGET_HOST="bastion.na4.openshift.opentlc.com"
+OCP_USERNAME="wkulhane-redhat.com"
+WORKLOAD="ocp4_workload_cert_manager"
+GUID=1001
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=ec2-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"silent=False" \
+    -e"guid=${GUID}" \
+    -e"ACTION=create"
+----
+
+=== To Delete an environment
+
+----
+TARGET_HOST="bastion.na4.openshift.opentlc.com"
+OCP_USERNAME="wkulhane-redhat.com"
+WORKLOAD="ocp4_workload_cert_manager"
+GUID=1002
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=ec2-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"guid=${GUID}" \
+    -e"ACTION=remove"
+----

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/cert_manager_ec2.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/cert_manager_ec2.yml
@@ -1,0 +1,22 @@
+---
+- name: Get HostedZoneID
+  kubernetes.core.k8s_info:
+    api_version: config.openshift.io/v1
+    kind: DNS
+    name: cluster
+  register: r_hostedzoneid
+
+- name: Set HostedZoneID fact
+  ansible.builtin.set_fact:
+    _ocp4_workload_cert_manager_hostedzoneid: >-
+      {{ r_hostedzoneid.resources[0].spec.publicZone.id }}
+
+- name: Print HostedZoneID
+  ansible.builtin.debug:
+    msg: >-
+      HostedZoneID: {{ _ocp4_workload_cert_manager_hostedzoneid }}
+
+- name: Create AWS credentials secret for cert manager
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('template', 'secret-aws-credentials.yaml.j2') }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+# Do not modify this file
+
+- name: Running Pre Workload Tasks
+  when: ACTION == "create" or ACTION == "provision"
+  ansible.builtin.include_tasks:
+    file: ./pre_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+
+- name: Running Workload Tasks
+  when: ACTION == "create" or ACTION == "provision"
+  ansible.builtin.include_tasks:
+    file: ./workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+
+- name: Running Post Workload Tasks
+  when: ACTION == "create" or ACTION == "provision"
+  ansible.builtin.include_tasks:
+    file: ./post_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+
+- name: Running Workload removal Tasks
+  when: ACTION == "destroy" or ACTION == "remove"
+  ansible.builtin.include_tasks:
+    file: ./remove_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/post_workload.yml
@@ -1,0 +1,9 @@
+---
+# Implement your Post Workload deployment tasks here
+
+
+# Leave this as the last task in the playbook.
+- name: Post_workload tasks complete
+  when: not silent | bool
+  ansible.builtin.debug:
+    msg: "Post-Workload Tasks completed successfully."

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/pre_workload.yml
@@ -1,0 +1,9 @@
+---
+# Implement your Pre Workload deployment tasks here
+
+
+# Leave this as the last task in the playbook.
+- name: Pre_workload tasks complete
+  when: not silent | bool
+  ansible.builtin.debug:
+    msg: "Pre-Workload tasks completed successfully."

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/remove_workload.yml
@@ -1,0 +1,12 @@
+---
+# Implement your Workload removal tasks here
+
+- name: Print unsupported message
+  ansible.builtin.debug:
+    msg: "Removing cert manager is not implemented."
+
+# Leave this as the last task in the playbook.
+- name: Remove_workload tasks complete
+  when: not silent | bool
+  ansible.builtin.debug:
+    msg: "Remove Workload tasks completed successfully."

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/workload.yml
@@ -1,0 +1,193 @@
+---
+# Implement your Workload deployment tasks here
+
+- name: Setting up workload for user
+  ansible.builtin.debug:
+    msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
+
+- name: Install Red Hat Cert Manager Operator
+  ansible.builtin.include_role:
+    name: install_operator
+  vars:
+    install_operator_action: install
+    install_operator_namespace: cert-manager-operator
+    install_operator_name: openshift-cert-manager-operator
+    install_operator_csv_nameprefix: cert-manager-operator
+    install_operator_manage_namespaces:
+    - cert-manager-operator
+    install_operator_channel: "{{ ocp4_workload_cert_manager_channel }}"
+    install_operator_catalog: redhat-operators
+    install_operator_automatic_install_plan_approval: "{{ ocp4_workload_cert_manager_automatic_install_plan_approval | default(true) }}"
+    install_operator_starting_csv: "{{ ocp4_workload_cert_manager_starting_csv }}"
+    install_operator_catalogsource_setup: "{{ ocp4_workload_cert_manager_use_catalog_snapshot | default(false) }}"
+    install_operator_catalogsource_name: "{{ ocp4_workload_cert_manager_catalogsource_name | default('') }}"
+    install_operator_catalogsource_namespace: cert-manager-operator
+    install_operator_catalogsource_image: "{{ ocp4_workload_cert_manager_catalog_snapshot_image | default('') }}"
+    install_operator_catalogsource_image_tag: "{{ ocp4_workload_cert_manager_catalog_snapshot_image_tag | default('') }}"
+
+- name: Create CertManager
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('template', 'certmanager.yaml.j2') }}"
+
+- name: Determine API server URL
+  kubernetes.core.k8s_info:
+    api_version: config.openshift.io/v1
+    kind: Infrastructure
+    name: cluster
+  register: r_api_url
+
+- name: Determine cluster wildcard domain
+  kubernetes.core.k8s_info:
+    api_version: operator.openshift.io/v1
+    kind: IngressController
+    name: default
+    namespace: openshift-ingress-operator
+  register: r_ingress_controller
+
+- name: Set DNS facts
+  ansible.builtin.set_fact:
+    _ocp4_workload_cert_manager_api_hostname: >-
+      {{ r_api_url.resources[0].status.apiServerURL | urlsplit('hostname') }}
+    _ocp4_workload_cert_manager_wildcard_domain: >-
+      {{ r_ingress_controller.resources[0].status.domain }}
+
+- name: Print API and Wildcard Domain
+  ansible.builtin.debug:
+    msg: >-
+      API: {{ _ocp4_workload_cert_manager_api_hostname }},
+      Wildcard Domain: {{ _ocp4_workload_cert_manager_wildcard_domain }}
+
+- name: Wait until Cert Manager is ready
+  kubernetes.core.k8s_info:
+    api_version: operator.openshift.io/v1alpha1
+    kind: CertManager
+    name: cluster
+    wait: true
+    wait_sleep: 5
+    wait_timeout: 120
+    wait_condition:
+      type: "cert-manager-controller-deploymentAvailable"
+      status: "True"
+  register: r_cert_manager
+
+- name: Set up cert manager prerequisites for EC2
+  when: ocp4_workload_cert_manager_cloud_provider == "ec2"
+  ansible.builtin.include_tasks: cert_manager_ec2.yml
+
+- name: Set up cert manager prerequisites for Azure
+  when: ocp4_workload_cert_manager_cloud_provider == "azure"
+  ansible.builtin.fail:
+    msg: "Azure is not yet implemented for Cert Manager Operator"
+
+- name: Set up cert manager prerequisites for GCP
+  when: ocp4_workload_cert_manager_cloud_provider == "gcp"
+  ansible.builtin.fail:
+    msg: "GCP is not yet implemented for Cert Manager Operator"
+
+- name: Set up cert manager prerequisites for OpenStack
+  when: ocp4_workload_cert_manager_cloud_provider == "osp"
+  ansible.builtin.fail:
+    msg: "OpenStack is not yet implemented for Cert Manager Operator"
+
+- name: Set up cert manager prerequisites for VMC
+  when: ocp4_workload_cert_manager_cloud_provider == "vmc"
+  ansible.builtin.fail:
+    msg: "VMC is not yet implemented for Cert Manager Operator"
+
+- name: Set up ClusterIssuer and request certificates
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('template', item) }}"
+  loop:
+  - clusterissuer.yaml.j2
+  - certificate-ingress.yaml.j2
+  - certificate-api.yaml.j2
+
+- name: Install Ingress controller certificate
+  when: ocp4_workload_cert_manager_install_ingress_certificates | bool
+  block:
+  - name: Wait until Ingress Certificate is ready
+    kubernetes.core.k8s_info:
+      api_version: certmanager.k8s.io/v1alpha1
+      kind: Certificate
+      name: cert-manager-ingress-cert
+      namespace: openshift-ingress
+      wait: true
+      wait_sleep: 5
+      wait_timeout: 120
+      wait_condition:
+        type: "Ready"
+        status: "True"
+    register: r_certificate_ingress
+
+  - name: Update Ingress controller to use certificate
+    kubernetes.core.k8s:
+      state: present
+      definition: "{{ lookup('template', 'default-ingress-controller.yaml.j2') }}"
+
+- name: Install API Server certificate
+  when: ocp4_workload_cert_manager_install_api_certificates | bool
+  block:
+  - name: Wait until API Certificate is ready
+    kubernetes.core.k8s_info:
+      api_version: certmanager.k8s.io/v1alpha1
+      kind: Certificate
+      name: cert-manager-api-cert
+      namespace: openshift-config
+      wait: true
+      wait_sleep: 5
+      wait_timeout: 120
+      wait_condition:
+        type: "Ready"
+        status: "True"
+    register: r_certificate_api
+
+  - name: Update API server to use certificate
+    kubernetes.core.k8s:
+      state: present
+      definition: "{{ lookup('template', 'api-server.yaml.j2') }}"
+
+  # It takes about 4 minutes per API Server to
+  # restart with certificates (due to AWS
+  # Load Balancer). Can't really check the cluster operator because once the updates have rolled out
+  # subsequent checks will fail. :-(. Need to just sleep.
+  - name: Wait for Cluster Operator kube-apiserver to finish rolling out
+    ansible.builtin.pause:
+      minutes: "{{ ocp4_workload_cert_manager_wait_after_api_cert_setup | int }}"
+
+  - name: Find all Kube Configs
+    become: true
+    ansible.builtin.find:
+      file_type: file
+      hidden: true
+      paths:
+      - /root
+      - /home
+      contains: "^ +certificate-authority-data:"
+      patterns: "*config*"
+      recurse: true
+    register: r_config_files
+
+  - name: Fix Kube Configs
+    become: true
+    ansible.builtin.replace:
+      path: "{{ item.path }}"
+      regexp: "^ +certificate-authority-data:.*"
+    loop: "{{ r_config_files.files }}"
+
+  - name: Make sure API calls succeed
+    kubernetes.core.k8s_info:
+      api_version: config.openshift.io/v1
+      kind: Ingress
+      name: cluster
+    register: r_ingress_config
+    retries: 30
+    delay: 10
+    until: not r_ingress_config.failed
+
+# Leave this as the last task in the playbook.
+- name: Workload tasks complete
+  when: not silent | bool
+  ansible.builtin.debug:
+    msg: "Workload Tasks completed successfully."

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/api-server.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/api-server.yaml.j2
@@ -1,0 +1,12 @@
+---
+apiVersion: config.openshift.io/v1
+kind: APIServer
+metadata:
+  name: cluster
+spec:
+  servingCerts:
+    namedCertificates:
+    - names:
+      - {{ _ocp4_workload_cert_manager_api_hostname }}
+      servingCertificate:
+        name: cert-manager-api-cert

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/certificate-api.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/certificate-api.yaml.j2
@@ -1,0 +1,21 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cert-manager-api-cert
+  namespace: openshift-config
+spec:
+  isCa: false
+  commonName: "{{ _ocp4_workload_cert_manager_api_hostname }}"
+  secretName: cert-manager-api-cert
+  duration: 2160h
+  renewBefore: 360h
+  usages:
+  - server auth
+  - client auth
+  dnsNames:
+  - "{{ _ocp4_workload_cert_manager_api_hostname }}"
+  issuerRef:
+    kind: ClusterIssuer
+    name: letsencrypt-production-{{ ocp4_workload_cert_manager_cloud_provider }}
+    group: cert-manager.io

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/certificate-ingress.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/certificate-ingress.yaml.j2
@@ -1,0 +1,22 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cert-manager-ingress-cert
+  namespace: openshift-ingress
+spec:
+  isCa: false
+  commonName: "{{ _ocp4_workload_cert_manager_wildcard_domain }}"
+  secretName: cert-manager-ingress-cert
+  duration: 2160h
+  renewBefore: 360h
+  usages:
+  - server auth
+  - client auth
+  dnsNames:
+  - "{{ _ocp4_workload_cert_manager_wildcard_domain }}"
+  - "*.{{ _ocp4_workload_cert_manager_wildcard_domain }}"
+  issuerRef:
+    kind: ClusterIssuer
+    name: letsencrypt-production-{{ ocp4_workload_cert_manager_cloud_provider }}
+    group: cert-manager.io

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/certmanager.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/certmanager.yaml.j2
@@ -1,0 +1,17 @@
+---
+apiVersion: operator.openshift.io/v1alpha1
+kind: CertManager
+metadata:
+    name: cluster
+spec:
+  logLevel: Normal
+  managementState: Managed
+  observedConfig: null
+  operatorLogLevel: Normal
+{% if ocp4_workload_cert_manager_cloud_provider == "ec2" %}
+  unsupportedConfigOverrides:
+    controller:
+      args:
+      - "--dns01-recursive-nameservers=1.1.1.1:53"
+      - "--dns01-recursive-nameservers-only"
+{% endif %}

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/clusterissuer.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/clusterissuer.yaml.j2
@@ -1,0 +1,26 @@
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-production-{{ ocp4_workload_cert_manager_cloud_provider }}
+spec:
+  acme:
+    email: rhpds-admins@redhat.com
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: cluster-issuer-le-production
+    solvers:
+    - selector:
+        dnsZones:
+        - {{ _ocp4_workload_cert_manager_api_hostname }}
+        - {{ _ocp4_workload_cert_manager_wildcard_domain }}
+      dns01:
+{% if ocp4_workload_cert_manager_cloud_provider == "ec2" %}      
+        route53:
+          region: {{ ocp4_workload_cert_manager_ec2_region }}
+          hostedZoneID: {{ _ocp4_workload_cert_manager_hostedzoneid }}
+          accessKeyID: {{ ocp4_workload_cert_manager_ec2_access_key_id }}
+          secretAccessKeySecretRef:
+            name: cert-manager-aws-creds
+            key: aws_secret_access_key
+{% endif %}

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/default-ingress-controller.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/default-ingress-controller.yaml.j2
@@ -1,0 +1,9 @@
+---
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: default
+  namespace: openshift-ingress-operator
+spec:
+  defaultCertificate:
+    name: cert-manager-ingress-cert

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/secret-aws-credentials.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/secret-aws-credentials.yaml.j2
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cert-manager-aws-creds
+  namespace: cert-manager
+type: Opaque
+data:
+  aws_access_key_id: {{ ocp4_workload_cert_manager_ec2_access_key_id | b64encode }}
+  aws_secret_access_key: {{ ocp4_workload_cert_manager_ec2_secret_access_key | b64encode }}


### PR DESCRIPTION
##### SUMMARY

Add a workload to use the Red Hat cert manager operator to request and install Let's Encrypt certificates for OCP 4 clusters.

Initial support for AWS EC2.

##### ISSUE TYPE
- New role Pull Request

##### COMPONENT NAME
ocp4_workload_cert_manager