### PR TITLE
[RHEL-security] Add dependency packages for gpg lab

### DIFF
--- a/ansible/configs/rhel-security/gpg.yml
+++ b/ansible/configs/rhel-security/gpg.yml
@@ -3,4 +3,6 @@
   package:
     name:
       - gnupg2
+      - pinentry
+      - pinentry-tty
     state: present

--- a/ansible/roles/rhel-security-verification/tasks/gpg-verify.yml
+++ b/ansible/roles/rhel-security-verification/tasks/gpg-verify.yml
@@ -5,6 +5,8 @@
       package:
         name:
           - gnupg2
+          - pinentry
+          - pinentry-tty
         state: present
       check_mode: true
       register: packages_installed


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

in RHEL-security workshop we migrated RHEL-8 systems to RHEL-9, gpg lab is not working because of this change and missing pinentry-tty package. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

Fixes the RHEL-security workshop and it's simple fix just to add more packages and verify it's present on the lab. 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
