### PR TITLE
[RHEL-security] Fix new path for audit sample rules

### DIFF
--- a/ansible/roles/rhel-security-verification/tasks/audit-verify.yml
+++ b/ansible/roles/rhel-security-verification/tasks/audit-verify.yml
@@ -33,9 +33,9 @@
 - name: Run "augenrules --check"
   command: augenrules --check
 
-- name: Gather state of "/usr/share/doc/audit/rules" for Lab 6.2.2.1 Pre-Configured Rules
+- name: Gather state of "/usr/share/audit/sample-rules" for Lab 6.2.2.1 Pre-Configured Rules
   file:
-    path: /usr/share/doc/audit/rules
+    path: /usr/share/audit/sample-rules
     state: directory
   check_mode: true
   register: rules_directory


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Easy fix to ensure the verification test for audit lab the directory exists, however in RHEL-9 we changed the path for directory in audit package. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
