### PR TITLE
Miscellaneous fixes of ansible-automation-platform

### DIFF
--- a/ansible/configs/ansible-automation-platform/env_vars.yml
+++ b/ansible/configs/ansible-automation-platform/env_vars.yml
@@ -35,6 +35,10 @@ gitea_vm_repos:  # list of Git repos to migrate/copy into Gitea
     url: https://gitlab.com/ansible-labs-crew/playbooks-adv-controller.git
   - name: shared-apache-role
     url: https://gitlab.com/ansible-labs-crew/shared-apache-role.git
+  - name: playbooks-dev
+    url: https://gitlab.com/ansible-labs-crew/playbooks-dev.git
+  - name: playbooks-ops
+    url: https://gitlab.com/ansible-labs-crew/playbooks-ops.git
 gitea_vm_https_port: 488
 
 ## guid is the deployment unique identifier, it will be appended to all tags,

--- a/ansible/configs/ansible-automation-platform/post_software.yml
+++ b/ansible/configs/ansible-automation-platform/post_software.yml
@@ -83,7 +83,7 @@
           bastion_host_name: "bastion.{{ agnosticd_domain_name }}"
           vscode_web_ui_url: "https://bastion.{{ agnosticd_domain_name }}:{{ vscode_server_nginx_https_port }}"
           vscode_web_ui_password: "{{ hostvars[groups['bastions'][0]]['tower_admin_password'] }}"
-          gitea_web_ui_url: "https://bastion.{{ agnosticd_domain_name }}:{{ vscode_server_nginx_https_port }}"
+          gitea_web_ui_url: "https://bastion.{{ agnosticd_domain_name }}:{{ gitea_vm_https_port }}"
           gitea_web_ui_username: "{{ student_name }}"
           gitea_web_ui_password: "{{ hostvars[groups['bastions'][0]]['tower_admin_password'] }}"
 

--- a/ansible/roles/aap_controller_cert_issue/tasks/main.yml
+++ b/ansible/roles/aap_controller_cert_issue/tasks/main.yml
@@ -55,7 +55,7 @@
       block:
 
         - &tower-baseurl-task
-          awx.awx.tower_settings:
+          awx.awx.settings:
             name: TOWER_URL_BASE
             value: "https://{{ ansible_host.split('.')[0] | lower }}.{{ subdomain_base }}"
             tower_verify_ssl: false

--- a/ansible/roles/aap_controller_manifest_load/tasks/manifest.yml
+++ b/ansible/roles/aap_controller_manifest_load/tasks/manifest.yml
@@ -4,8 +4,8 @@
   include_tasks:
     file: "man_{{ tower_license_manifest.type }}.yml"
 
-- name: manifest | inject tower license manifest
-  awx.awx.tower_license:
+- name: manifest | inject controller license manifest
+  awx.awx.license:
     manifest: "{{ __tower_license_path }}"
     #eula_accepted: true  # works only for Tower 3.8 / awx.awx 19.1.0
     tower_host: "https://localhost/"

--- a/ansible/roles/aap_devel_tools/templates/ansible-navigator.yml.j2
+++ b/ansible/roles/aap_devel_tools/templates/ansible-navigator.yml.j2
@@ -8,7 +8,7 @@ ansible-navigator:
       policy: missing
     volume-mounts:
 {% for volume in aap_devel_tools_volumes %}
-       - {{ volume | to_yaml }}
+      - {{ volume | to_yaml }}
 {%- endfor %}
 {% if aap_devel_tools_env_pass is defined or aap_devel_tools_env_set is defined %}
     environment-variables:


### PR DESCRIPTION


<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

- Fix wrong port of gitea_web_ui_url
- Remove superfluous indentation from ansible-navigator.yml
- Add https://gitlab.com/ansible-labs-crew/playbooks-dev.git and https://gitlab.com/ansible-labs-crew/playbooks-ops.git to Gitea
- Remove warnings about use of awx.awx.tower_license/settings
- 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ansible-automation-platform

##### ADDITIONAL INFORMATION
LB1750