### PR TITLE
ansible_idm_setup_lab fix file permissions at end

### DIFF
--- a/ansible/roles/ansible_idm_setup_lab/tasks/ansible-setup.yml
+++ b/ansible/roles/ansible_idm_setup_lab/tasks/ansible-setup.yml
@@ -63,10 +63,23 @@
       group: users
     loop: "{{ custom_collections }}"
 
-  - name: Recursively change ownership of all items within the collections directory
+  - name: Set ownership and permissions for lab-user
     ansible.builtin.file:
-      path: /home/lab-user/.ansible/collections/
+      path: "/home/lab-user"
       owner: lab-user
       group: users
-      recurse: yes
       state: directory
+      recurse: true
+
+  - name: Locate all *.tar.gz files in /home/lab-user
+    ansible.builtin.find:
+      paths: "/home/lab-user/"
+      patterns: "*.tar.gz"
+    register: gz_files
+
+  - name: Remove located *.tar.gz files
+    ansible.builtin.file:
+      path: "{{ item.path }}"
+      state: absent
+    loop: "{{ gz_files.files }}"
+    when: gz_files.matched > 0


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
Role needed to update injected file permissions for lab-user.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ansible_idm_setup_lab

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
