### PR TITLE
ansible_idm_setup_lab fix role installation paths

### DIFF
--- a/ansible/roles/ansible_idm_setup_lab/tasks/ansible-setup.yml
+++ b/ansible/roles/ansible_idm_setup_lab/tasks/ansible-setup.yml
@@ -29,7 +29,7 @@
 
   - name: Create the required directory structure
     ansible.builtin.file:
-      path: /home/lab-user/.ansible/collections/ansible_collections/redhat/
+      path: /home/lab-user/.ansible/roles/redhat/
       state: directory
       mode: '0755'
       owner: lab-user
@@ -37,7 +37,7 @@
 
   - name: Create the required directory structure
     ansible.builtin.file:
-      path: "/home/lab-user/.ansible/collections/ansible_collections/redhat/{{ item.collection_path }}"
+      path: "/home/lab-user/.ansible/roles/redhat/{{ item.collection_path }}"
       state: directory
       mode: '0755'
       owner: lab-user
@@ -54,7 +54,7 @@
   - name: Extract collection
     ansible.builtin.unarchive:
       src: "/home/lab-user/{{ item.name }}"
-      dest: "/home/lab-user/.ansible/collections/ansible_collections/redhat/{{ item.collection_path }}"
+      dest: "/home/lab-user/.ansible/roles/redhat/{{ item.collection_path }}"
       remote_src: yes
       extra_opts: ["--strip-components=2"]
       keep_newer: yes


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
Fix installation location of custom roles
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ansible_idm_setup_lab
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
