### PR TITLE
expose extended loop info

### DIFF
--- a/ansible/roles/pet_name_generator/tasks/main.yml
+++ b/ansible/roles/pet_name_generator/tasks/main.yml
@@ -5,6 +5,7 @@
   loop: "{{ pet_name_generator_instances }}"
   loop_control:
     loop_var: instance
+    extended: true
 
 - debug:
     var: "{{ pet_name }}"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Exposing extended loop info (see Ansible docs [here](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_loops.html#extended-loop-variables)) will enable users of the role to make sequentially numbered names and do other clever things. For example, if you wanted two pet hosts using "7" separator and two with "8" separator, that's now possible like this: 

```yaml
pet_name_generator_separator: "{{ '7788'[ansible_loop.index0] }}"
pet_name_generator_lookup: "{{ lookup('community.general.random_pet', separator=pet_name_generator_separator) }}"
pet_name_generator_enable: true
pet_name_generator_instances:
- node1_instance_name
- node2_instance_name
- node3_instance_name
- node4_instance_name
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

role: pet_name_generator

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->

@wilson-walrus, as discussed. 