### PR TITLE
migrating2ocpvirt - set version: on requirements.yml where missing

### DIFF
--- a/ansible/configs/migrating-to-ocpvirt/requirements.yml
+++ b/ansible/configs/migrating-to-ocpvirt/requirements.yml
@@ -17,6 +17,7 @@ roles:
   - name: ocp4_aio_deploy_bastion
     src: https://github.com/rhpds/ocp4_aio_infra_role_deploy_bastion.git
     scm: git
+    version: development
 
   - name: ocp4_aio_deploy_ocp
     src: https://github.com/rhpds/ocp4_aio_infra_role_deploy_ocp.git


### PR DESCRIPTION
Didn't have a version for  
  - name: ocp4_aio_deploy_bastion
    src: https://github.com/rhpds/ocp4_aio_infra_role_deploy_bastion.git
    scm: git

so I set it to development