### PR TITLE
Fix order of installs to make sure epel is there before certbot. Update and cleanup requirements.

### DIFF
--- a/ansible/configs/experience-ocpvirt/pre_software.yml
+++ b/ansible/configs/experience-ocpvirt/pre_software.yml
@@ -31,6 +31,12 @@
     ansible.builtin.command: ip link set dev bond0 mtu 9000
     when: cloud_provider == "equinix_metal"
 
+  - name: Install epel-release
+    ansible.builtin.yum:
+      name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
+      disable_gpg_check: true
+    retries: 5
+
   - name: Install required software
     ansible.builtin.yum:
       name: "{{ item }}"
@@ -47,12 +53,6 @@
     - vim
     - bind-utils
     - certbot
-
-  - name: Install epel-release
-    ansible.builtin.yum:
-      name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
-      disable_gpg_check: true
-    retries: 5
 
   - name: Write Route53 credentials into /root/.aws/credentials
     ansible.builtin.blockinfile:

--- a/ansible/configs/experience-ocpvirt/requirements.yml
+++ b/ansible/configs/experience-ocpvirt/requirements.yml
@@ -1,39 +1,39 @@
 ---
 roles:
-  - src: https://github.com/rhpds/ocp4_aio_infra_role_base_software.git
-    scm: git
-    name: ocp4_aio_base_software
-    version: development
+- name: ocp4_aio_base_software
+  scm: git
+  src: https://github.com/rhpds/ocp4_aio_infra_role_base_software.git
+  version: development
 
-  - name: ocp4_aio_base_virt
-    src: https://github.com/rhpds/ocp4_aio_infra_role_base_virt.git
-    scm: git
-    version: development
+- name: ocp4_aio_base_virt
+  scm: git
+  src: https://github.com/rhpds/ocp4_aio_infra_role_base_virt.git
+  version: development
 
-  - name: ocp4_aio_prepare_bastion
-    src: https://github.com/rhpds/ocp4_aio_infra_role_prepare_bastion.git
-    scm: git
-    version: development
+- name: ocp4_aio_prepare_bastion
+  scm: git
+  src: https://github.com/rhpds/ocp4_aio_infra_role_prepare_bastion.git
+  version: development
 
-  - name: ocp4_aio_deploy_bastion
-    src: https://github.com/rhpds/ocp4_aio_infra_role_deploy_bastion.git
-    scm: git
-    version: development
+- name: ocp4_aio_deploy_bastion
+  scm: git
+  src: https://github.com/rhpds/ocp4_aio_infra_role_deploy_bastion.git
+  version: development
 
-  - name: ocp4_aio_deploy_ocp
-    src: https://github.com/rhpds/ocp4_aio_infra_role_deploy_ocp.git
-    scm: git
-    version: development
+- name: ocp4_aio_deploy_ocp
+  scm: git
+  src: https://github.com/rhpds/ocp4_aio_infra_role_deploy_ocp.git
+  version: development
 
-  - name: ocp4_aio_role_ocs
-    src: https://github.com/rhpds/ocp4_aio_role_ocs.git
-    scm: git
-    version: development
+- name: ocp4_aio_role_ocs
+  scm: git
+  src: https://github.com/rhpds/ocp4_aio_role_ocs.git
+  version: development
 
 collections:
-  - name: community.general
-    version: 7.4.0
-  - name: equinix.cloud
-    version: 0.6.0
-  - name: community.vmware
-    version: 3.9.0
+- name: community.general
+  version: 8.5.0
+- name: equinix.cloud
+  version: 0.6.0
+- name: community.vmware
+  version: 4.2.0


### PR DESCRIPTION
##### SUMMARY

certbot is in epel - therefore change order of tasks to install epel first.
Cleanup requirements (latest collections, unified structure)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
experience-ocpvirt