### PR TITLE
set-repositories generate unique dmi.system.uuid rhsm facts for bare metal

### DIFF
--- a/ansible/roles/set-repositories/tasks/satellite-repos.yml
+++ b/ansible/roles/set-repositories/tasks/satellite-repos.yml
@@ -97,7 +97,7 @@
 
 - name: Generate UUID for dmi.system.uuid if cloud provider is Equinix Metal
   ansible.builtin.set_fact:
-    dmi_system_uuid: "{{ ' ' | to_uuid }}"
+    dmi_system_uuid: "{{ 999999999 | random | to_uuid }}"
   when: cloud_provider == 'equinix_metal'
 
 - name: sat | Set set_repositories_subscription_hostname with randomization

--- a/ansible/roles/set-repositories/tasks/satellite-repos.yml
+++ b/ansible/roles/set-repositories/tasks/satellite-repos.yml
@@ -95,6 +95,11 @@
     gather_subset: min
   when: ansible_date_time is not defined
 
+- name: Generate UUID for dmi.system.uuid if cloud provider is Equinix Metal
+  ansible.builtin.set_fact:
+    dmi_system_uuid: "{{ ' ' | to_uuid }}"
+  when: cloud_provider == 'equinix_metal'
+
 - name: sat | Set set_repositories_subscription_hostname with randomization
   when: set_repositories_subscription_hostname is not defined
   set_fact:
@@ -110,8 +115,11 @@
     dest: /etc/rhsm/facts/katello.facts
     content: "{{ __content | to_json }}"
   vars:
-    __content:
-      network.fqdn: "{{ set_repositories_subscription_hostname }}"
+    __content: >-
+      {{
+        {"network.fqdn": set_repositories_subscription_hostname}
+        | combine({"dmi.system.uuid": dmi_system_uuid} if cloud_provider == 'equinix_metal' else {})
+      }}
 
 - name: sat | Register with activation-key
   when: set_repositories_satellite_ha is not defined or set_repositories_satellite_ha|bool == False


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
equinix_metal systems were failing registrations due to hardware UUIDs being reported multiple times to the satellite.
This change will generate a random UUID to use in place of the default grabbed from /var/lib/rhsm/facts/
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
set-repositories
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
