### PR TITLE
Add post workshop deploy automation from workshop controller.

### DIFF
--- a/ansible/roles/ansible_bu_setup_workshop/tasks/auto_satellite.yml
+++ b/ansible/roles/ansible_bu_setup_workshop/tasks/auto_satellite.yml
@@ -52,3 +52,70 @@
     path: "/tmp/workshops"
     state: absent
 
+# Launch Automation Controller Run Time Job Templates
+- name: Automation Controller Job Launch Block
+  environment:
+    CONTROLLER_HOST: "{{ aap_auth.controller_host | default(aap_controller_web_url) }}"
+    CONTROLLER_USERNAME: "{{ aap_auth.controller_username | default(aap_controller_admin_user) | default('admin') }}"
+    CONTROLLER_PASSWORD: "{{ aap_auth.controller_password | default(aap_controller_admin_password) }}"
+    CONTROLLER_VERIFY_SSL: "{{ aap_auth.controller_verify_ssl | default('true') }}"
+  vars:
+    _controller_url: "https://{{ aap_auth.controller_host | default(aap_controller_web_url) }}"
+    _controller_username: "{{ aap_auth.controller_username | default(aap_controller_admin_user) | default('admin') }}"
+    _controller_password: "{{ aap_auth.controller_password | default(aap_controller_admin_password) }}"
+  block:
+    # Allow projects to pull collections via collections/requirements.yml
+    - name: Turn on AWX_COLLECTIONS_ENABLED on controller
+      awx.awx.settings:
+        name: AWX_COLLECTIONS_ENABLED
+        value: true
+        controller_username: "{{ _controller_username }}"
+        controller_password: "{{ _controller_password }}"
+        controller_host: "{{ _controller_url }}"
+        validate_certs: false
+
+    - name: Run Z / CaC / Satellite job template
+      awx.awx.job_launch:
+        job_template: "Z / CaC / Satellite"
+      register: setupsatellitejob
+
+    - name: "Check API until Z / CaC / Satellite job is successful"
+      ansible.builtin.uri:
+        url: "{{ _controller_url }}/api/v2/jobs/{{ setupsatellitejob.id }}/?format=json"
+        user: "{{ _controller_username }}"
+        password: "{{ _controller_password }}"
+        force_basic_auth: true
+        method: GET
+        return_content: true
+        status_code: 200
+        validate_certs: false
+      register: workshop_job_templates01
+      until: workshop_job_templates01.json.status == "successful"
+      delay: 20  # Every 20 seconds
+      retries: 45  # 15 minutes 15*60/20
+
+    - name: Run Z / CaC / Controller job template
+      awx.awx.job_launch:
+        job_template: "Z / CaC / Controller"
+      register: setupcontroljob
+
+    - name: "Check API until Z / CaC / Controller job is successful"
+      ansible.builtin.uri:
+        url: "{{ _controller_url }}/api/v2/jobs/{{ setupcontroljob.id }}/?format=json"
+        user: "{{ _controller_username }}"
+        password: "{{ _controller_password }}"
+        force_basic_auth: true
+        method: GET
+        return_content: true
+        status_code: 200
+        validate_certs: false
+      register: workshop_job_templates02
+      until: workshop_job_templates02.json.status == "successful"
+      delay: 20  # Every 20 seconds
+      retries: 18  # 5 minutes 6*60/20
+
+    - name: Run Z / SETUP / Workshop - CentOS7 deployment workflow template
+      awx.awx.workflow_launch:
+        workflow_template: "Z / SETUP / Workshop - CentOS7"
+        timeout: 3900 # 63 minutes
+...


### PR DESCRIPTION
##### SUMMARY
Add post workshop deploy automation job template and workflow template execution tasks.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`ansible/roles/ansible_bu_setup_workshop/tasks/auto_satellite.yml`

##### ADDITIONAL INFORMATION
Same method as how [post workshop configuration is performed via ansible/workshops automation code](https://github.com/ansible/workshops/blob/5ffa2037ee0d2898b29c9797e99bbde3e096eeba/provisioner/workshop_specific/auto_satellite.yml#L348-L403) as well as in `ansible/roles/ansible_bu_setup_workshop/tasks/ripu.yml`
