### PR TITLE
Add `rhc-worker-playbook` to enable Ansible

### DIFF
--- a/ansible/roles/rhel-security-verification/tasks/openscap-verify.yml
+++ b/ansible/roles/rhel-security-verification/tasks/openscap-verify.yml
@@ -7,6 +7,7 @@
           - scap-security-guide
           - openscap-scanner
           - scap-workbench
+          - rhc-worker-playbook
         state: present
       check_mode: true
       register: packages_installed


### PR DESCRIPTION
##### SUMMARY
Since switch from `ansible` to `ansible-core` we need additional modules for our playbooks to execute properly.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

##### ADDITIONAL INFORMATION
