### PR TITLE
Set max migrations to 1

### DIFF
--- a/ansible/configs/experience-ocpvirt/files/configure_operators.sh
+++ b/ansible/configs/experience-ocpvirt/files/configure_operators.sh
@@ -91,6 +91,7 @@ metadata:
   namespace: openshift-mtv
 spec:
   olm_managed: true
+  controller_max_vm_in_flight: 1
 EOF
 
 cat << EOF | oc apply -f -


### PR DESCRIPTION
##### SUMMARY

Set maximum parallel migrations to 1 for MTV to reduce load.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
experience-ocpvirt