### PR TITLE
Host ocp4 set facts

### DIFF
--- a/ansible/configs/ocp-workloads/post_software.yml
+++ b/ansible/configs/ocp-workloads/post_software.yml
@@ -54,6 +54,10 @@
     set_fact:
       ansible_python_interpreter: "{{ config_ocp_workloads.virtualenv_path }}/bin/python"
 
+  - name: Set common facts OpenShift cluster
+    include_role:
+      name: host-ocp4-set-facts
+
   - name: Install infra_workloads
     tags:
     - infra_workloads

--- a/ansible/roles/host-ocp4-set-facts/.yamllint
+++ b/ansible/roles/host-ocp4-set-facts/.yamllint
@@ -1,0 +1,2 @@
+---
+extends: ../../../tests/static/.yamllint

--- a/ansible/roles/host-ocp4-set-facts/README.adoc
+++ b/ansible/roles/host-ocp4-set-facts/README.adoc
@@ -1,0 +1,23 @@
+:role: host-ocp4-set-facts
+
+
+Role: {role}
+============
+
+The role {role} sets common useful facts for OpenShift clusters:
+
+* `openshift_api_url` - The URL for the API of the cluster
+* `openshift_console_url` - The URL the OpenShift console
+* `openshift_cluster_ingress_domain` - The default domain for routes used by the ingress controller.
+
+Requirements
+------------
+
+This role must be run on a host with an environment pre-authenticated for cluster access.
+This could be because the ansible user has a functional kubeconfig or because suitable
+environment variables were passed when the role was included.
+
+Change Log
+----------
+- 2024-04-18 Johnathan Kupferer <jkupfere@redhat.com>
+  * Created

--- a/ansible/roles/host-ocp4-set-facts/defaults/main.yml
+++ b/ansible/roles/host-ocp4-set-facts/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+host_ocp4_set_facts_set_user_data: false

--- a/ansible/roles/host-ocp4-set-facts/tasks/main.yml
+++ b/ansible/roles/host-ocp4-set-facts/tasks/main.yml
@@ -1,0 +1,43 @@
+---
+- name: Get openshift-console console route
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: ConfigMap
+    name: console-public
+    namespace: openshift-config-managed
+  register: r_openshift_console_config
+
+- name: Set facts openshift_cluster_ingress_domain and openshift_console_url
+  ansible.builtin.set_fact:
+    openshift_cluster_ingress_domain: >-
+      {{ __console_url | regex_replace('^https://console-openshift-console\.') }}
+    openshift_console_url: "{{ __console_url }}"
+  vars:
+    __console_url: >-
+      {{ r_openshift_console_config.resources[0].data.consoleURL }}
+
+- name: Try to get api URL with oc command
+  command: oc whoami --show-server
+  changed_when: false
+  ignore_errors: true
+  register: r_oc_show_server
+
+- name: Set openshift_api_url if oc command succeeded
+  when: r_oc_show_server is successful
+  ansible.builtin.set_fact:
+    openshift_api_url: >-
+      {{ r_oc_show_server.stdout | trim }}
+
+- name: Fallback to best guess for openshift_api_url
+  when: r_oc_show_server is failed
+  ansible.builtin.set_fact:
+    openshift_api_url: >-
+      https://api.{{ openshift_cluster_ingress_domain | regex_replace('^apps\.') }}:6443
+
+- name: Set user data for OpenShift cluster
+  when: host_ocp4_set_facts_set_user_data | bool
+  agnosticd_user_info:
+    data:
+      openshift_api_url: "{{ openshift_api_url }}"
+      openshift_console_url: "{{ openshift_console_url }}"
+      openshift_cluster_ingress_domain: "{{ openshift_cluster_ingress_domain }}"

--- a/ansible/roles/host-ocp4-set-facts/tasks/main.yml
+++ b/ansible/roles/host-ocp4-set-facts/tasks/main.yml
@@ -7,17 +7,37 @@
     namespace: openshift-config-managed
   register: r_openshift_console_config
 
-- name: Set facts openshift_cluster_ingress_domain and openshift_console_url
+- name: Set fact for openshift_console_url
   ansible.builtin.set_fact:
-    openshift_cluster_ingress_domain: >-
-      {{ __console_url | regex_replace('^https://console-openshift-console\.') }}
-    openshift_console_url: "{{ __console_url }}"
-  vars:
-    __console_url: >-
+    openshift_console_url: >-
       {{ r_openshift_console_config.resources[0].data.consoleURL }}
 
+- name: Try to get the cluster ingress config
+  kubernetes.core.k8s_info:
+    api_version: config.openshift.io/v1
+    kind: Ingress
+    name: cluster
+  register: r_cluster_ingress_config
+  failed_when: false
+
+- name: Set facts from cluster ingress config
+  when: r_cluster_ingress_config.resources | default([]) | length > 0
+  vars:
+    __cluster_ingress_config: "{{ r_cluster_ingress_config.resources[0] }}"
+  ansible.builtin.set_fact:
+    openshift_cluster_ingress_domain: >-
+      {{ __cluster_ingress_config.spec.domain }}
+    openshift_cluster_ingress_apps_domain: >-
+      {{ __cluster_ingress_config.spec.appsDomain | default(omit) }}
+
+- name: Fallback to best guess for openshift_cluster_ingress_domain
+  when: r_cluster_ingress_config.resources | default([]) | length == 0
+  ansible.builtin.set_fact:
+    openshift_cluster_ingress_domain: >-
+      {{ openshift_console_url | regex_replace('^https://console-openshift-console\.') }}
+
 - name: Try to get api URL with oc command
-  command: oc whoami --show-server
+  ansible.builtin.command: oc whoami --show-server
   changed_when: false
   ignore_errors: true
   register: r_oc_show_server


### PR DESCRIPTION
##### SUMMARY

Add role to set common OpenShift facts and call from ocp-workloads config.

- `openshift_api_url`
- `openshift_console_url`
- `openshift_cluster_ingress_domain`

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

New role: host-ocp4-set-facts
Config update: ocp-workloads