### PR TITLE
reset-repositories Enable RHSM repos after reset

### DIFF
--- a/ansible/roles/reset-repositories/tasks/main.yml
+++ b/ansible/roles/reset-repositories/tasks/main.yml
@@ -20,3 +20,9 @@
     src: /etc/rhsm/rhsm.conf.kat-backup
     dest: /etc/rhsm/rhsm.conf
     remote_src: yes
+
+- name: Set RHSM to Manage Repos
+  ansible.builtin.lineinfile:
+    path: /etc/rhsm/rhsm.conf
+    regexp: '^manage_repos'
+    line: "manage_repos = 1"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
Enable rhsm to manage repos after resetting satellite configuration. 

This change is for Summit lab LB1222. This is an insights lab that needs to be reset to system defaults after our satellite configuration.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
reset-repositories
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
