### PR TITLE
Remove gate for workloads to enable showroom workload on shared clusters

### DIFF
--- a/ansible/configs/rosa-consolidated/post_software.yml
+++ b/ansible/configs/rosa-consolidated/post_software.yml
@@ -8,9 +8,10 @@
     ansible.builtin.debug:
       msg: "Post-Software Steps starting"
 
+# Deploy workloads even for deploy = false to enable showroom.
 - name: Step 005.1 Deploy workloads
   when:
-  - rosa_deploy | default(true) | bool
+  # - rosa_deploy | default(true) | bool
   - infra_workloads | default("") | length > 0
   ansible.builtin.import_playbook: workloads.yml
 


### PR DESCRIPTION
##### SUMMARY

Remove check if Rosa has been deployed before running workloads - this enables the showroom workload on a shared cluster.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rosa-consolidated