### PR TITLE
Add dnf packages management in asset_injector role

### DIFF
--- a/ansible/roles/asset_injector/tasks/main.yml
+++ b/ansible/roles/asset_injector/tasks/main.yml
@@ -88,6 +88,17 @@
   tags:
     - asset_injector_blockinfile
 
+- name: Manage dnf packages
+  when: _asset.type == 'dnf'
+  ansible.builtin.dnf:
+    name: "{{ _asset.name }}"
+    state: "{{ _asset.state | default('present') }}"
+  loop: "{{ asset_injector_assets }}"
+  loop_control:
+    loop_var: _asset
+  tags:
+    - asset_injector_dnf
+
 - name: Manage services
   when: _asset.type == 'service'
   ansible.builtin.service:


### PR DESCRIPTION
##### SUMMARY

Added a capability to do late dnf of packages, rpms etc

Use Case - some CIs over-write existing package installs at the creators request. EG laying a Centos_Stream rpm onto a RHEL system (Summit 2024 Podman Desktop for example)

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

roles/asset_injector

##### ADDITIONAL INFORMATION
