### PR TITLE
Add asset injection to ansible-lightspeed config

### DIFF
--- a/ansible/configs/ansible-lightspeed/software.yml
+++ b/ansible/configs/ansible-lightspeed/software.yml
@@ -67,6 +67,13 @@
         - name: Update dconfig
           ansible.builtin.command: dconf update
 
+    - name: Inject assets onto host(s)
+      when:
+        - asset_injector_assets is defined
+        - asset_injector_assets | length > 0
+      ansible.builtin.include_role:
+        name: asset_injector
+
 
 - name: Software flight-check
   hosts: localhost


### PR DESCRIPTION
##### SUMMARY

Add, boolean protected, asset-injector to the ansible-lightspeed config for additional customization

##### ISSUE TYPE
 
- Feature Pull Request


##### COMPONENT NAME

configs/ansible-lightspeed

##### ADDITIONAL INFORMATION
