### PR TITLE
Asset injector dnf 02

### DIFF
--- a/ansible/roles/asset_injector/README.adoc
+++ b/ansible/roles/asset_injector/README.adoc
@@ -98,6 +98,14 @@ asset_injector_assets:
         PasswordAuthentication yes
         UsePAM yes
 
+    # DNF - good for S3 bucket RPMs etc
+
+    - description: Install upstream podman rpm
+      type:'dnf'
+      name: podman-latest.rpm
+      state: present
+      disable_gpg_check: true
+
     # Service
 
     - description: Restart sshd to pick up new configuration

--- a/ansible/roles/asset_injector/tasks/main.yml
+++ b/ansible/roles/asset_injector/tasks/main.yml
@@ -93,7 +93,7 @@
   ansible.builtin.dnf:
     name: "{{ _asset.name }}"
     state: "{{ _asset.state | default('present') }}"
-    disable_gpg_check: "{{ _asset.disable_gpg_check | default(true) }}"
+    disable_gpg_check: "{{ _asset.disable_gpg_check | default(false) }}"
   loop: "{{ asset_injector_assets }}"
   loop_control:
     loop_var: _asset

--- a/ansible/roles/asset_injector/tasks/main.yml
+++ b/ansible/roles/asset_injector/tasks/main.yml
@@ -93,6 +93,7 @@
   ansible.builtin.dnf:
     name: "{{ _asset.name }}"
     state: "{{ _asset.state | default('present') }}"
+    disable_gpg_check: "{{ _asset.disable_gpg_check | default(true) }}"
   loop: "{{ asset_injector_assets }}"
   loop_control:
     loop_var: _asset


### PR DESCRIPTION

Enable "{{ _asset.disable_gpg_check | default(false) }}" in asset-injector

##### SUMMARY

Add support to easily allow over-rise for example when pulling from an S3 bucket


##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

roles/asset-injector

##### ADDITIONAL INFORMATION
