### PR TITLE
Update user attribute in asset_injector task

### DIFF
--- a/ansible/roles/asset_injector/tasks/main.yml
+++ b/ansible/roles/asset_injector/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Simple user management
   when: _asset.type == 'user'
   ansible.builtin.user:
-    user: "{{ _asset.user }}"
+    name: "{{ _asset.name }}"
     state: "{{ _asset.state }}"
     password: "{{ _asset.password | default(omit) }}"
   loop: "{{ asset_injector_assets }}"


### PR DESCRIPTION

##### SUMMARY

Fix simple type on asset_injector, used `user` instead of `name`

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

roles/asset_injector

##### ADDITIONAL INFORMATION
