### PR TITLE
Update configureMTV.sh.j2

### DIFF
--- a/ansible/configs/roadshow-ocpvirt/templates/configureMTV.sh.j2
+++ b/ansible/configs/roadshow-ocpvirt/templates/configureMTV.sh.j2
@@ -1,10 +1,3 @@
-cat << EOF | oc apply -f -
-apiVersion: project.openshift.io/v1
-kind: Project
-metadata:
-  name: openshift-mtv
-EOF
-
 SHA1=$(openssl s_client \
     -connect portal.vc.opentlc.com:443 \
     < /dev/null 2>/dev/null \
@@ -23,6 +16,17 @@ stringData:
   thumbprint: "${SHA1}"
   insecureSkipVerify: "true"
   url: https://portal.vc.opentlc.com/sdk
+EOF
+
+until oc get forkliftcontrollers.forklift.konveyor.io; do sleep 60; done
+cat << EOF | oc apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: ForkliftController
+metadata:
+  name: forklift-controller
+  namespace: openshift-mtv
+spec:
+  olm_managed: true
 EOF
 
 cat << EOF | oc apply -f -

--- a/ansible/configs/roadshow-ocpvirt/templates/configureMTV.sh.j2
+++ b/ansible/configs/roadshow-ocpvirt/templates/configureMTV.sh.j2
@@ -1,3 +1,10 @@
+cat << EOF | oc apply -f -
+apiVersion: project.openshift.io/v1
+kind: Project
+metadata:
+  name: openshift-mtv
+EOF
+
 SHA1=$(openssl s_client \
     -connect portal.vc.opentlc.com:443 \
     < /dev/null 2>/dev/null \


### PR DESCRIPTION
error: resource mapping not found for name: "vmware" namespace: "openshift-mtv" from "STDIN": no matches for kind "Provider" in version "forklift.konveyor.io/v1beta1"

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
