### PR TITLE
Add openshift_route_default_domain

### DIFF
--- a/ansible/roles/host-ocp4-installer/tasks/print_cluster_info.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/print_cluster_info.yml
@@ -44,6 +44,7 @@
     openshift_console_url: "{{ webconsole_url.stdout | trim }}"
     openshift_client_download_url: "{{ ocp4_client_url }}"
     openshift_cluster_ingress_domain: "{{ r_ingress_domain.stdout | trim }}"
+    openshift_route_default_domain: "{{ r_ingress_domain.stdout | trim }}"
 
 - name: Set user data for OpenShift access
   agnosticd_user_info:

--- a/ansible/roles/host-ocp4-set-facts/README.adoc
+++ b/ansible/roles/host-ocp4-set-facts/README.adoc
@@ -8,7 +8,9 @@ The role {role} sets common useful facts for OpenShift clusters:
 
 * `openshift_api_url` - The URL for the API of the cluster
 * `openshift_console_url` - The URL the OpenShift console
-* `openshift_cluster_ingress_domain` - The default domain for routes used by the ingress controller.
+* `openshift_cluster_ingress_domain` - The `spec.domain` configured the ingress controller.
+* `openshift_cluster_ingress_apps_domain` - The `spec.appsDomain` for routes used by the ingress controller.
+* `openshift_route_default_domain` - The default route used for routes.
 
 Requirements
 ------------

--- a/ansible/roles/host-ocp4-set-facts/tasks/main.yml
+++ b/ansible/roles/host-ocp4-set-facts/tasks/main.yml
@@ -36,6 +36,11 @@
     openshift_cluster_ingress_domain: >-
       {{ openshift_console_url | regex_replace('^https://console-openshift-console\.') }}
 
+- name: Set openshift_route_default_domain
+  ansible.builtin.set_fact:
+    openshift_route_default_domain: >-
+      {{ openshift_cluster_ingress_apps_domain | default(openshift_cluster_ingress_domain) }}
+
 - name: Try to get api URL with oc command
   ansible.builtin.command: oc whoami --show-server
   changed_when: false


### PR DESCRIPTION
##### SUMMARY

Add `openshift_route_default_domain` fact set by `host-ocp4-installer` and `host-ocp4-set-facts` roles. This supplements the `openshift_cluster_ingress_domain` and `openshift_cluster_ingress_apps_domain` variables which related the cluster ingress domains `spec.domain` and `spec.appsDomain`. The variable `openshift_route_default_domain` is the domain used by routes with dynamic `spec.host` and is either equal to `openshift_cluster_ingress_domain` or `openshift_cluster_ingress_apps_domain` depending on which is set.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Roles `host-ocp4-installer` and `host-ocp4-set-facts`.