### PR TITLE
ec2_infra_deployment.yml include role to define ansible connection to…

### DIFF
--- a/ansible/cloud_providers/ec2_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/ec2_infrastructure_deployment.yml
@@ -160,6 +160,11 @@
     - step001
     - step001.4
   tasks:
+    - name: Set facts for Windows remote access
+      ansible.builtin.include_role:
+        name: infra-windows-connection-facts
+      when: infra_windows_connection_facts_type is defined
+
     - name: set facts for remote access
       tags:
         - create_inventory
@@ -172,6 +177,7 @@
         ansible_user: Administrator
         ansible_winrm_server_cert_validation: ignore
         aws_region_final: "{{hostvars['localhost'].aws_region_final}}"
+      when: infra_windows_connection_facts_type is not defined
 
     - name: Run infra-ec2-wait_for_linux_hosts Role
       include_role:


### PR DESCRIPTION
… windows

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
This PR adds the option to define facts of how we connect to Windows systems. This role can define Winrm, SSH, or all custom configurations.

This change is to help alleviate issues with windows connection issues after deployment.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ec2_infrastructure_deployment.yml

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
