### PR TITLE
infra-windows-connection-facts remove extra dashes at top of yaml

### DIFF
--- a/ansible/roles-infra/infra-windows-connection-facts/defaults/main.yml
+++ b/ansible/roles-infra/infra-windows-connection-facts/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
----
 ### Type can be winrm, ssh, or custom values.
 ### The loop from the task will assign values depending on the type as below in "infra_windows_connection_facts"
 infra_windows_connection_facts_type: "{{ infra_windows_connection_facts_type | default('winrm') }}"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
infra-windows-connection-facts fails, due to a typo of extra dashes. Removing the resolve.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
infra-windows-connection-facts
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
