### PR TITLE
Remove EBS Throughput config from ansible/configs/ansible-bu-workshop.

### DIFF
--- a/ansible/configs/ansible-bu-workshop/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/ansible-bu-workshop/files/cloud_providers/ec2_cloud_template.j2
@@ -263,11 +263,9 @@ Resources:
             VolumeSize: "{{ instance['rootfs_size'] | default(aws_default_rootfs_size) }}"
             VolumeType: "{{ aws_default_volume_type }}"
 {%     if aws_ebs_volume_iops is defined
-       and aws_ebs_volume_throughput is defined
        and instance['name'] == "satellite"
 %}
             Iops: "{{ aws_ebs_volume_iops }}"
-            Throughput: "{{ aws_ebs_volume_throughput }}"
 {%     endif %}
 {%     endif %}
 {%     for vol in instance.volumes|default([]) if vol.enable|d(true) %}


### PR DESCRIPTION
##### SUMMARY
While Throughput is a valid config option via the EC2 EBS API, CloudFormation AWS::EC2::Instance Ebs does not currently handle this config option: https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/824

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible/configs/ansible-bu-workshop

