### PR TITLE
New role windows-password-generator

### DIFF
--- a/ansible/roles/windows-password-generator/README.md
+++ b/ansible/roles/windows-password-generator/README.md
@@ -1,0 +1,36 @@
+windows-password-gen
+====================
+
+This role uses ansible.bultin.set_fact to produce a random password that is within the requirements for a windows server.
+
+Passwords must meet at least three of the following four criteria:
+- Include at least one uppercase letter (A-Z).
+- Include at least one lowercase letter (a-z).
+- Include at least one digit (0-9).
+- Include at least one special character (e.g., !@#$%^&*()).
+
+Requirements
+------------
+Ansible Core
+
+ansible.cfg
+-----------
+- Configure ansible.cfg with local parameters for custom lookup plugin locations
+- Point ansible to the vault password file
+
+Variables
+---------
+
+```yaml
+windows_ready_password: >-
+  {{ (lookup('ansible.builtin.password', '/dev/null length=3 chars=ascii_uppercase') +
+      lookup('ansible.builtin.password', '/dev/null length=4 chars=ascii_lowercase') +
+      lookup('ansible.builtin.password', '/dev/null length=1 chars=digits')) | list | shuffle | join('') }}
+```
+
+Author Information
+------------------
+
+Wilson Harris
+Red Hat
+April 23 2024

--- a/ansible/roles/windows-password-generator/tasks/main.yml
+++ b/ansible/roles/windows-password-generator/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Generate Windows regulation common_password
+  ansible.builtin.set_fact:
+    windows_ready_password: >-
+      {{ (lookup('ansible.builtin.password', '/dev/null length=3 chars=ascii_uppercase') +
+          lookup('ansible.builtin.password', '/dev/null length=4 chars=ascii_lowercase') +
+          lookup('ansible.builtin.password', '/dev/null length=1 chars=digits')) | list | shuffle | join('') }}


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
This role generates a password that meets the minimum requirements for Microsoft Windows Server. For summit lab LB1401.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
windows-password-generator
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
