### PR TITLE
ansible-bu-workshop: use on-demand capacity reservations

### DIFF
--- a/ansible/configs/ansible-bu-workshop/default_vars_ec2.yml
+++ b/ansible/configs/ansible-bu-workshop/default_vars_ec2.yml
@@ -128,3 +128,6 @@ instances:
 # -------------------------------------------------
 inventory_groups:
   - nodes
+
+agnosticd_aws_capacity_reservations:
+  az1: "{{ instances | agnosticd_instances_to_odcr(agnosticd_images) }}"

--- a/ansible/configs/ansible-bu-workshop/default_vars_ec2.yml
+++ b/ansible/configs/ansible-bu-workshop/default_vars_ec2.yml
@@ -131,3 +131,5 @@ inventory_groups:
 
 agnosticd_aws_capacity_reservations:
   az1: "{{ instances | agnosticd_instances_to_odcr(agnosticd_images) }}"
+
+agnosticd_aws_capacity_reservations_enable: true

--- a/ansible/configs/ansible-bu-workshop/default_vars_ec2.yml
+++ b/ansible/configs/ansible-bu-workshop/default_vars_ec2.yml
@@ -132,4 +132,4 @@ inventory_groups:
 agnosticd_aws_capacity_reservations:
   az1: "{{ instances | agnosticd_instances_to_odcr(agnosticd_images) }}"
 
-agnosticd_aws_capacity_reservations_enable: true
+agnosticd_aws_capacity_reservations_enable: false

--- a/ansible/filter_plugins/core.py
+++ b/ansible/filter_plugins/core.py
@@ -329,19 +329,17 @@ def agnosticd_filter_out_installed_collections(requirements, installed_collectio
 
 
 def agnosticd_instances_to_odcr(instances, agnosticd_images):
-    '''Convert agnosticd instances list to on demande capacity reservations'''
+    '''Convert agnosticd instances list to on demand capacity reservations'''
 
     result = []
 
     for instance in instances:
 
-        instance_type = instance.get('instance_type', None)
+        instance_type = instance.get('flavor', {}).get('ec2', None)
         if not instance_type:
-            instance_type = instance.get('flavor', {}).get('ec2', None)
-            if not instance_type:
-                raise AnsibleFilterError(
-                    'instance_type or flavor.ec2 is required in instance definition'
-                )
+            raise AnsibleFilterError(
+                'instance_type or flavor.ec2 is required in instance definition'
+            )
 
         if instance['name'] in agnosticd_images:
             instance['instance_platform'] = instance.get(
@@ -352,7 +350,7 @@ def agnosticd_instances_to_odcr(instances, agnosticd_images):
                 instance['instance_platform'] = 'Linux/UNIX'
 
         result.append({
-            'instance_count': instance.get('instance_count', 1),
+            'instance_count': instance.get('count', 1),
             'instance_type': instance_type,
             'instance_platform': instance.get('instance_platform', 'Linux/UNIX'),
         })

--- a/ansible/filter_plugins/core.py
+++ b/ansible/filter_plugins/core.py
@@ -328,6 +328,37 @@ def agnosticd_filter_out_installed_collections(requirements, installed_collectio
     return requirements
 
 
+def agnosticd_instances_to_odcr(instances, agnosticd_images):
+    '''Convert agnosticd instances list to on demande capacity reservations'''
+
+    result = []
+
+    for instance in instances:
+
+        instance_type = instance.get('instance_type', None)
+        if not instance_type:
+            instance_type = instance.get('flavor', {}).get('ec2', None)
+            if not instance_type:
+                raise AnsibleFilterError(
+                    'instance_type or flavor.ec2 is required in instance definition'
+                )
+
+        if instance['name'] in agnosticd_images:
+            instance['instance_platform'] = instance.get(
+                'instance_platform',
+                agnosticd_images.get(instance['name'], {}).get('platform_details', 'Linux/UNIX'))
+            if instance['instance_platform'] == 'Red Hat BYOL Linux':
+                # Red Hat BYOL Linux is not supported by ODCR, use Linux/UNIX
+                instance['instance_platform'] = 'Linux/UNIX'
+
+        result.append({
+            'instance_count': instance.get('instance_count', 1),
+            'instance_type': instance_type,
+            'instance_platform': instance.get('instance_platform', 'Linux/UNIX'),
+        })
+
+    return result
+
 class FilterModule(object):
     ''' AgnosticD core jinja2 filters '''
 
@@ -340,4 +371,5 @@ class FilterModule(object):
             'image_to_ec2_filters': image_to_ec2_filters,
             'agnosticd_get_all_images': agnosticd_get_all_images,
             'agnosticd_filter_out_installed_collections': agnosticd_filter_out_installed_collections,
+            'agnosticd_instances_to_odcr': agnosticd_instances_to_odcr,
         }


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->

Enable on-demand capacity reservations for ansible-bu-workshop config.
The flag `agnosticd_aws_capacity_reservations_enable` is false by default, so it'll have to be explicitely enabled in agnosticV.

This change also introduce a new jinja2 filter to facilitate the creation of the reservation by using what's defined in the `instances` variable.


##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

