### PR TITLE
New wrapper role for EDA Config collection

### DIFF
--- a/ansible/roles/ansible-eda-config/README.adoc
+++ b/ansible/roles/ansible-eda-config/README.adoc
@@ -1,0 +1,70 @@
+
+ansible-eda-config
+
+Simply wraps the `infra.eda_configuration` Collection
+
+== Requirements
+
+This role requires the `infra.eda_configuration` Collection to be installed.
+
+== Role Variables
+
+[source,yaml]
+----
+eda_hostname # EDA Controller hostname
+eda_username # EDA Controller username
+eda_password # EDA Controller password
+eda_validate_certs # boolean, defaulted to false 
+
+eda_configuration_dispatcher_roles:
+
+  - {role: user, var: eda_users, tags: user}
+----
+
+== Dependencies
+
+== Collections
+
+`awx.awx`
+
+== Example Playbook
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+[source,yaml]
+----
+---
+---
+- name: Test EDA dispatcher
+  hosts: localhost
+  gather_facts: false
+  become: false
+  vars:
+    eda_hostname: https://eda-controller-aap.apps.example.com
+    eda_username: admin
+    eda_password: MzU0ODUz
+    eda_validate_certs: false
+
+    eda_configuration_dispatcher_roles:
+
+      - {role: user, var: eda_users, tags: user}
+
+    eda_users:
+
+      - username: user1
+        first_name: Jane
+        last_name: Doe
+        email: jdoe@example.com
+        password: my_password1
+        update_secrets: false
+        roles:
+          - Viewer
+
+  roles:
+    - aap2-eda-config
+----
+
+
+== Author Information
+
+Tony Kay (tok@redhat.com) 2024-04-25

--- a/ansible/roles/ansible-eda-config/defaults/main.yml
+++ b/ansible/roles/ansible-eda-config/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+eda_configuration_dispatcher_roles: []

--- a/ansible/roles/ansible-eda-config/tasks/main.yml
+++ b/ansible/roles/ansible-eda-config/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+
+- name: "Setup AAP2 EDA with the infra.eda_configuration collection"
+  when: eda_configuration_dispatcher_roles is defined
+  ansible.builtin.import_role:
+    name: infra.eda_configuration.dispatch


### PR DESCRIPTION
##### SUMMARY

Wraps the Ansible EDA infra.eda_configuration collection

Allows it to be called as an infra_worklaod

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME
roles/ansible-eda-config

##### ADDITIONAL INFORMATION
