### PR TITLE
Change VCenter Portal Address to be configurable

### DIFF
--- a/ansible/configs/experience-ocpvirt/templates/configureMTV.sh.j2
+++ b/ansible/configs/experience-ocpvirt/templates/configureMTV.sh.j2
@@ -1,5 +1,5 @@
 SHA1=$(openssl s_client \
-    -connect portal.vc.opentlc.com:443 \
+    -connect {{ vcenter_proxy_hostname }}:443 \
     < /dev/null 2>/dev/null \
     | openssl x509 -fingerprint -noout -in /dev/stdin \
     | cut -d '=' -f 2)
@@ -17,7 +17,7 @@ stringData:
   password: {{  hostvars['jumphost']['vcenter_student_password']  }}
   thumbprint: "${SHA1}"
   insecureSkipVerify: "true"
-  url: https://portal.vc.opentlc.com/sdk
+  url: https://{{ vcenter_proxy_hostname }}/sdk
 EOF
 
 cat << EOF | oc apply -f -
@@ -29,7 +29,7 @@ metadata:
   namespace: openshift-mtv
 spec:
   type: vsphere
-  url: "https://portal.vc.opentlc.com/sdk"
+  url: "https://{{ vcenter_proxy_hostname }}/sdk"
   settings:
     vddkInitImage: image-registry.openshift-image-registry.svc:5000/openshift/vddk:latest
   secret:


### PR DESCRIPTION
##### SUMMARY

portal.vc.opentlc.com was hardcoded. Changing to a variable coming from a secret - to be able to change without code changes.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
experience-ocpvirt