### PR TITLE
Add fail_on_start and fail_on_start to test-empty-config

### DIFF
--- a/ansible/configs/test-empty-config/default_vars.yml
+++ b/ansible/configs/test-empty-config/default_vars.yml
@@ -7,4 +7,15 @@ bookbag_deploy: false
 # Control whether to simulate multi-user environment by reporting per-user info messages and data
 test_empty_config_multi_user: false
 test_empty_config_user_count: "{{ user_count | default(num_users) | default(10) }}"
+
+# Variables to request the test empty config to fail on specific actions
+fail_infra: false
+fail_on_start: false
+fail_on_stop: false
+fail_post_infra: false
+fail_post_software: false
+fail_pre_infra: false
+fail_pre_software: false
+fail_software: false
+fail_update: false
 ...

--- a/ansible/configs/test-empty-config/infra.yml
+++ b/ansible/configs/test-empty-config/infra.yml
@@ -14,7 +14,7 @@
         msg:
           - Entering the test-empty-config infra.yml
 
-    - when: fail_infra | default(false) | bool
+    - when: fail_infra | bool
       name: Fail the test-empty-config infra.yml if requested
       fail:
         msg: infra.yml failed as requested

--- a/ansible/configs/test-empty-config/lifecycle.yml
+++ b/ansible/configs/test-empty-config/lifecycle.yml
@@ -4,6 +4,20 @@
   become: false
   gather_facts: false
   tasks:
+    - name: Fail on start if requested
+      when:
+        - ACTION == 'start'
+        - fail_on_start | bool
+      fail:
+        msg: fail on lifecycle start as requested
+
+    - name: Fail on stop if requested
+      when:
+        - ACTION == 'stop'
+        - fail_on_stop | bool
+      fail:
+        msg: fail on lifecycle stop as requested
+
     - when: cloud_provider == 'osp'
       name: Include AWS dry-run read-only role
       include_role:

--- a/ansible/configs/test-empty-config/post_infra.yml
+++ b/ansible/configs/test-empty-config/post_infra.yml
@@ -14,7 +14,7 @@
         msg:
           - Entering the test-empty-config post_infra.yml
 
-    - when: fail_post_infra | default(false) | bool
+    - when: fail_post_infra | bool
       name: Fail the test-empty-config post_infra.yml if requested
       fail:
         msg: post_infra.yml failed as requested

--- a/ansible/configs/test-empty-config/post_software.yml
+++ b/ansible/configs/test-empty-config/post_software.yml
@@ -14,7 +14,7 @@
       msg:
       - Entering the test-empty-config post_software.yml
 
-  - when: fail_post_software | default(false) | bool
+  - when: fail_post_software | bool
     name: Fail the test-empty-config post_software.yml if requested
     fail:
       msg: post_software.yml failed as requested

--- a/ansible/configs/test-empty-config/pre_infra.yml
+++ b/ansible/configs/test-empty-config/pre_infra.yml
@@ -16,7 +16,7 @@
         msg:
           - Entering the test-empty-config pre_infra.yml
 
-    - when: fail_pre_infra | default(false) | bool
+    - when: fail_pre_infra | bool
       name: Fail the test-empty-config pre_infra.yml if requested
       fail:
         msg: pre_infra.yml failed as requested

--- a/ansible/configs/test-empty-config/pre_software.yml
+++ b/ansible/configs/test-empty-config/pre_software.yml
@@ -14,7 +14,7 @@
         msg:
           - Entering the test-empty-config pre_software.yml
 
-    - when: fail_pre_software | default(false) | bool
+    - when: fail_pre_software | bool
       name: Fail the test-empty-config pre_software.yml if requested
       fail:
         msg: pre_software.yml failed as requested

--- a/ansible/configs/test-empty-config/software.yml
+++ b/ansible/configs/test-empty-config/software.yml
@@ -14,7 +14,7 @@
         msg:
           - Entering the test-empty-config software.yml
 
-    - when: fail_software | default(false) | bool
+    - when: fail_software | bool
       name: Fail the test-empty-config software.yml if requested
       fail:
         msg: software.yml failed as requested

--- a/ansible/configs/test-empty-config/update.yml
+++ b/ansible/configs/test-empty-config/update.yml
@@ -14,7 +14,7 @@
       debug:
         msg: "random_string: {{ lookup('agnosticd_user_data', 'random_string') }}"
 
-    - when: fail_update | default(false) | bool
+    - when: fail_update | bool
       name: Fail the test-empty-config update.yml if requested
       fail:
         msg: update.yml failed as requested


### PR DESCRIPTION
##### SUMMARY

- Add fail_on_start and fail_on_stop to test-empty-config
- Move defaults for fail_* variables to default_vars.yml

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Config test-empty-config