### PR TITLE
Update default Python version mapping python3 to 3.11 in ai_setup_ilab role

### DIFF
--- a/ansible/roles/ai_setup_ilab/tasks/main.yml
+++ b/ansible/roles/ai_setup_ilab/tasks/main.yml
@@ -41,7 +41,7 @@
 - name: Set system default Python version, to 3.11
   ansible.builtin.alternatives:
     name: python
-    link: /usr/bin/python
+    link: /usr/bin/python3
     path: /usr/bin/python3.11
 
 # TODO: Extract vars to defaults/main.yml and make more generic


### PR DESCRIPTION

##### SUMMARY

Fix: RHEL 9 wants alternatives to set python3 and not pythons

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

roles/ai_setup_ilab

##### ADDITIONAL INFORMATION
