### PR TITLE
Bump terraform to v1.4 for ibm-rhoic

### DIFF
--- a/ansible/configs/ibm-rhoic/default_vars.yml
+++ b/ansible/configs/ibm-rhoic/default_vars.yml
@@ -56,3 +56,4 @@ sandbox_account_name: TBD
 # Terraform Templates to use with IBM Schematics
 terraform_vpc: "https://github.com/redhat-gpst/terraform.ibmcloud.vpc"
 terraform_rhoic: "https://github.com/redhat-gpst/terraform.ibmcloud.rhoic"
+terraform_version: terraform_v1.4

--- a/ansible/configs/ibm-rhoic/infra.yml
+++ b/ansible/configs/ibm-rhoic/infra.yml
@@ -32,7 +32,7 @@
         body:
           name: "rhpds-vpc"
           type:
-            - terraform_v0.14
+            - "{{ terraform_version }}"
           location: "us-east"
           description: "Creating VPC, Subnet, and Public Gateway for RHOIC"
           tags: []
@@ -40,7 +40,7 @@
             url: "{{ terraform_vpc }}"
           template_data:
             - folder: "."
-              type: terraform_v0.14
+              type: "{{ terraform_version }}"
               variablestore:
                 - name: ibmcloud_api_key
                   value: "{{ sandbox_master_api_key }}"

--- a/ansible/configs/ibm-rhoic/software.yml
+++ b/ansible/configs/ibm-rhoic/software.yml
@@ -77,7 +77,7 @@
         body:
           name: "rhpds-rhoic"
           type:
-            - terraform_v0.14
+            - "{{ terraform_version }}"
           location: "us-east"
           description: "Creating Cloud Object Storage and the RHOIC cluster"
           tags: []
@@ -85,7 +85,7 @@
             url: "{{ terraform_rhoic }}"
           template_data:
             - folder: "."
-              type: terraform_v0.14
+              type: "{{ terraform_version }}"
               variablestore:
                 - name: ibmcloud_api_key
                   value: "{{ sandbox_master_api_key }}"


### PR DESCRIPTION
##### SUMMARY

Add variable `terraform_version` and set default to `terraform-v1.4` for ibm-rhoic config.
The old hard-coded version `terraform-v0.14` is no longer available.

https://cloud.ibm.com/docs/schematics?topic=schematics-migrating-terraform-version

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Config ibm-rhoic