### PR TITLE
Add AWS requirements to RHEL 9 k8s environment

### DIFF
--- a/ansible/configs/ocp4-cluster/files/requirements_k8s_el9.txt
+++ b/ansible/configs/ocp4-cluster/files/requirements_k8s_el9.txt
@@ -35,3 +35,6 @@ selinux==0.3.0
 six==1.16.0
 urllib3==1.26.18
 websocket-client==1.7.0
+boto3==1.34.64
+botocore==1.34.64
+s3transfer==0.10.1


### PR DESCRIPTION
##### SUMMARY

For CNV environments the DNS entries are created in Route53.

Requirements were there for RHEL 8 but not for RHEL 9.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-cluster