### PR TITLE
fixing catalogsource namespace issue for ocp4_workload_performance_monitoring

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/tasks/install_crunchy_postgres.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/tasks/install_crunchy_postgres.yml
@@ -8,11 +8,11 @@
     install_operator_csv_nameprefix: postgresoperator
     # install_operator_channel: ""
     # install_operator_starting_csv: ""
-    install_operator_catalog: certified-operators
+    # install_operator_catalog: certified-operators
     install_operator_automatic_install_plan_approval: "{{ ocp4_workload_performance_monitoring_automatic_install_plan_approval }}"
     install_operator_catalogsource_setup: "{{ ocp4_workload_performance_monitoring_catalogsource_setup }}"
     install_operator_catalogsource_name: "{{ ocp4_workload_performance_monitoring_certified_catalogsource_name }}"
-    install_operator_catalogsource_namespace: "{{ ocp4_workload_performance_monitoring_catalogsource_namespace }}"
+    # install_operator_catalogsource_namespace: "{{ ocp4_workload_performance_monitoring_catalogsource_namespace }}"
     install_operator_catalogsource_image: "{{ ocp4_workload_performance_monitoring_certified_catalogsource_image }}"
     install_operator_catalogsource_image_tag: "{{ ocp4_workload_performance_monitoring_catalogsource_image_tag }}"
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/tasks/install_devspaces.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/tasks/install_devspaces.yml
@@ -7,11 +7,11 @@
     install_operator_namespace: openshift-operators
     # install_operator_channel: ""
     # install_operator_starting_csv: ""
-    install_operator_catalog: redhat-operators
+    # install_operator_catalog: redhat-operators
     install_operator_automatic_install_plan_approval: "{{ ocp4_workload_performance_monitoring_automatic_install_plan_approval }}"
     install_operator_catalogsource_setup: "{{ ocp4_workload_performance_monitoring_catalogsource_setup }}"
     install_operator_catalogsource_name: "{{ ocp4_workload_performance_monitoring_redhat_catalogsource_name }}"
-    install_operator_catalogsource_namespace: "{{ ocp4_workload_performance_monitoring_catalogsource_namespace }}"
+    # install_operator_catalogsource_namespace: "{{ ocp4_workload_performance_monitoring_catalogsource_namespace }}"
     install_operator_catalogsource_image: "{{ ocp4_workload_performance_monitoring_redhat_catalogsource_image }}"
     install_operator_catalogsource_image_tag: "{{ ocp4_workload_performance_monitoring_catalogsource_image_tag }}"
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/tasks/install_grafana.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/tasks/install_grafana.yml
@@ -25,11 +25,11 @@
     # install_operator_manage_namespaces: ["{{ grafana_project }}"]
     # install_operator_channel: ""
     # install_operator_starting_csv: ""
-    install_operator_catalog: community-operators
+    # install_operator_catalog: community-operators
     install_operator_automatic_install_plan_approval: "{{ ocp4_workload_performance_monitoring_automatic_install_plan_approval }}"
     install_operator_catalogsource_setup: "{{ ocp4_workload_performance_monitoring_catalogsource_setup }}"
     install_operator_catalogsource_name: "{{ ocp4_workload_performance_monitoring_community_catalogsource_name }}"
-    install_operator_catalogsource_namespace: "{{ ocp4_workload_performance_monitoring_catalogsource_namespace }}"
+    # install_operator_catalogsource_namespace: "{{ ocp4_workload_performance_monitoring_catalogsource_namespace }}"
     install_operator_catalogsource_image: "{{ ocp4_workload_performance_monitoring_community_catalogsource_image }}"
     install_operator_catalogsource_image_tag: "{{ ocp4_workload_performance_monitoring_catalogsource_image_tag }}"
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/tasks/install_hyperfoil.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/tasks/install_hyperfoil.yml
@@ -9,11 +9,11 @@
     # install_operator_manage_namespaces: ["openshift-operators"]
     # install_operator_channel: ""
     # install_operator_starting_csv: ""
-    install_operator_catalog: community-operators
+    # install_operator_catalog: community-operators
     install_operator_automatic_install_plan_approval: "{{ ocp4_workload_performance_monitoring_automatic_install_plan_approval }}"
     install_operator_catalogsource_setup: "{{ ocp4_workload_performance_monitoring_catalogsource_setup }}"
     install_operator_catalogsource_name: "{{ ocp4_workload_performance_monitoring_community_catalogsource_name }}"
-    install_operator_catalogsource_namespace: "{{ ocp4_workload_performance_monitoring_catalogsource_namespace }}"
+    # install_operator_catalogsource_namespace: "{{ ocp4_workload_performance_monitoring_catalogsource_namespace }}"
     install_operator_catalogsource_image: "{{ ocp4_workload_performance_monitoring_community_catalogsource_image }}"
     install_operator_catalogsource_image_tag: "{{ ocp4_workload_performance_monitoring_catalogsource_image_tag }}"
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/tasks/install_image_puller.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/tasks/install_image_puller.yml
@@ -8,11 +8,11 @@
     # install_operator_manage_namespaces: ["openshift-operators"]
     # install_operator_channel: ""
     # install_operator_starting_csv: ""
-    install_operator_catalog: community-operators
+    # install_operator_catalog: community-operators
     install_operator_automatic_install_plan_approval: "{{ ocp4_workload_performance_monitoring_automatic_install_plan_approval }}"
     install_operator_catalogsource_setup: "{{ ocp4_workload_performance_monitoring_catalogsource_setup }}"
     install_operator_catalogsource_name: "{{ ocp4_workload_performance_monitoring_community_catalogsource_name }}"
-    install_operator_catalogsource_namespace: "{{ ocp4_workload_performance_monitoring_catalogsource_namespace }}"
+    # install_operator_catalogsource_namespace: "{{ ocp4_workload_performance_monitoring_catalogsource_namespace }}"
     install_operator_catalogsource_image: "{{ ocp4_workload_performance_monitoring_community_catalogsource_image }}"
     install_operator_catalogsource_image_tag: "{{ ocp4_workload_performance_monitoring_catalogsource_image_tag }}"
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/tasks/install_logging_loki.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/tasks/install_logging_loki.yml
@@ -8,13 +8,13 @@
     install_operator_action: install
     install_operator_name: loki-operator
     install_operator_namespace: openshift-operators-redhat
-    install_operator_channel: "stable"
-    install_operator_catalog: redhat-operators
+    # install_operator_channel: "stable"
+    # install_operator_catalog: redhat-operators
     # install_operator_starting_csv: ""
     install_operator_automatic_install_plan_approval: "{{ ocp4_workload_performance_monitoring_automatic_install_plan_approval }}"
     install_operator_catalogsource_setup: "{{ ocp4_workload_performance_monitoring_catalogsource_setup }}"
     install_operator_catalogsource_name: "{{ ocp4_workload_performance_monitoring_redhat_catalogsource_name }}"
-    install_operator_catalogsource_namespace: "{{ ocp4_workload_performance_monitoring_catalogsource_namespace }}"
+    # install_operator_catalogsource_namespace: "{{ ocp4_workload_performance_monitoring_catalogsource_namespace }}"
     install_operator_catalogsource_image: "{{ ocp4_workload_performance_monitoring_redhat_catalogsource_image }}"
     install_operator_catalogsource_image_tag: "{{ ocp4_workload_performance_monitoring_catalogsource_image_tag }}"
 
@@ -26,13 +26,13 @@
     install_operator_name: cluster-logging
     install_operator_namespace: openshift-logging
     install_operator_manage_namespaces: ["openshift-logging"]
-    install_operator_channel: "stable"
+    # install_operator_channel: "stable"
     # install_operator_starting_csv: ""
-    install_operator_catalog: redhat-operators
+    # install_operator_catalog: redhat-operators
     install_operator_automatic_install_plan_approval: "{{ ocp4_workload_performance_monitoring_automatic_install_plan_approval }}"
     install_operator_catalogsource_setup: "{{ ocp4_workload_performance_monitoring_catalogsource_setup }}"
     install_operator_catalogsource_name: "{{ ocp4_workload_performance_monitoring_redhat_catalogsource_name }}"
-    install_operator_catalogsource_namespace: "{{ ocp4_workload_performance_monitoring_catalogsource_namespace }}"
+    # install_operator_catalogsource_namespace: "{{ ocp4_workload_performance_monitoring_catalogsource_namespace }}"
     install_operator_catalogsource_image: "{{ ocp4_workload_performance_monitoring_redhat_catalogsource_image }}"
     install_operator_catalogsource_image_tag: "{{ ocp4_workload_performance_monitoring_catalogsource_image_tag }}"
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/tasks/install_noobaa.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/tasks/install_noobaa.yml
@@ -8,11 +8,11 @@
     install_operator_manage_namespaces: ["openshift-storage"]
     # install_operator_channel: ""
     # install_operator_starting_csv: ""
-    install_operator_catalog: redhat-operators
+    # install_operator_catalog: redhat-operators
     install_operator_automatic_install_plan_approval: "{{ ocp4_workload_performance_monitoring_automatic_install_plan_approval }}"
     install_operator_catalogsource_setup: "{{ ocp4_workload_performance_monitoring_catalogsource_setup }}"
     install_operator_catalogsource_name: "{{ ocp4_workload_performance_monitoring_redhat_catalogsource_name }}"
-    install_operator_catalogsource_namespace: "{{ ocp4_workload_performance_monitoring_catalogsource_namespace }}"
+    # install_operator_catalogsource_namespace: "{{ ocp4_workload_performance_monitoring_catalogsource_namespace }}"
     install_operator_catalogsource_image: "{{ ocp4_workload_performance_monitoring_redhat_catalogsource_image }}"
     install_operator_catalogsource_image_tag: "{{ ocp4_workload_performance_monitoring_catalogsource_image_tag }}"
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/tasks/install_serverless.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/tasks/install_serverless.yml
@@ -8,11 +8,11 @@
     # install_operator_manage_namespaces: ["openshift-operators"]
     # install_operator_channel: ""
     # install_operator_starting_csv: ""
-    install_operator_catalog: redhat-operators
+    # install_operator_catalog: redhat-operators
     install_operator_automatic_install_plan_approval: "{{ ocp4_workload_performance_monitoring_automatic_install_plan_approval }}"
     install_operator_catalogsource_setup: "{{ ocp4_workload_performance_monitoring_catalogsource_setup }}"
     install_operator_catalogsource_name: "{{ ocp4_workload_performance_monitoring_redhat_catalogsource_name }}"
-    install_operator_catalogsource_namespace: "{{ ocp4_workload_performance_monitoring_catalogsource_namespace }}"
+    # install_operator_catalogsource_namespace: "{{ ocp4_workload_performance_monitoring_catalogsource_namespace }}"
     install_operator_catalogsource_image: "{{ ocp4_workload_performance_monitoring_redhat_catalogsource_image }}"
     install_operator_catalogsource_image_tag: "{{ ocp4_workload_performance_monitoring_catalogsource_image_tag }}"
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/tasks/install_sonatype_nexus.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/tasks/install_sonatype_nexus.yml
@@ -21,11 +21,11 @@
     # install_operator_manage_namespaces: ["openshift-operators"]
     # install_operator_channel: ""
     # install_operator_starting_csv: "nxrm-operator-certified.v3.58.1-2"
-    install_operator_catalog: certified-operators
+    # install_operator_catalog: certified-operators
     install_operator_automatic_install_plan_approval: "{{ ocp4_workload_performance_monitoring_automatic_install_plan_approval }}"
     install_operator_catalogsource_setup: "{{ ocp4_workload_performance_monitoring_catalogsource_setup }}"
     install_operator_catalogsource_name: "{{ ocp4_workload_performance_monitoring_certified_catalogsource_name }}"
-    install_operator_catalogsource_namespace: "{{ ocp4_workload_performance_monitoring_catalogsource_namespace }}"
+    # install_operator_catalogsource_namespace: "{{ ocp4_workload_performance_monitoring_catalogsource_namespace }}"
     install_operator_catalogsource_image: "{{ ocp4_workload_performance_monitoring_certified_catalogsource_image }}"
     install_operator_catalogsource_image_tag: "{{ ocp4_workload_performance_monitoring_catalogsource_image_tag }}"
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/tasks/install_tekton.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/tasks/install_tekton.yml
@@ -9,11 +9,11 @@
     # install_operator_manage_namespaces: ["shared-maven-mirror"]
     # install_operator_channel: ""
     # install_operator_starting_csv: ""
-    install_operator_catalog: redhat-operators
+    # install_operator_catalog: redhat-operators
     install_operator_automatic_install_plan_approval: "{{ ocp4_workload_performance_monitoring_automatic_install_plan_approval }}"
     install_operator_catalogsource_setup: "{{ ocp4_workload_performance_monitoring_catalogsource_setup }}"
     install_operator_catalogsource_name: "{{ ocp4_workload_performance_monitoring_redhat_catalogsource_name }}"
-    install_operator_catalogsource_namespace: "{{ ocp4_workload_performance_monitoring_catalogsource_namespace }}"
+    # install_operator_catalogsource_namespace: "{{ ocp4_workload_performance_monitoring_catalogsource_namespace }}"
     install_operator_catalogsource_image: "{{ ocp4_workload_performance_monitoring_redhat_catalogsource_image }}"
     install_operator_catalogsource_image_tag: "{{ ocp4_workload_performance_monitoring_catalogsource_image_tag }}"
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_performance_monitoring/tasks/workload.yml
@@ -10,7 +10,7 @@
     users: "{{ users | default([]) + [ocp4_workload_authentication_htpasswd_user_base + item | string] }}"
   loop: "{{ range(1, ((ocp4_workload_authentication_htpasswd_user_count | int) + 1)) | list }}"
 
-- name: Install Tekton
+- name: Install Openshift Pipelines (Tekton)
   ansible.builtin.include_tasks: install_tekton.yml
 
 - name: Install Sonatype Nexus
@@ -19,7 +19,7 @@
 - name: Install Kubernetes Image Puller
   ansible.builtin.include_tasks: install_image_puller.yml
 
-- name: Install Loki
+- name: Install Openshift Logging (Loki)
   ansible.builtin.include_tasks: install_logging_loki.yml
   when: enable_loki | default(true)
 
@@ -50,7 +50,7 @@
 - name: Install Hyperfoil
   ansible.builtin.include_tasks: install_hyperfoil.yml
 
-- name: Setup User's Pipelines
+- name: Setup User's Tekton Pipelines
   ansible.builtin.include_tasks: setup_pipelines.yml
 
 # - name: Warmup Devspaces


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

Fixes CatalogSource namespace issue when installing Workload Operators.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
Workload Role `ocp4_workload_performance_monitoring`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```bash
ansible [core 2.16.5]
  config file = /Users/rsoares/dev/github/redhat-na-ssa/agnosticd/ansible.cfg
  configured module search path = ['/Users/rsoares/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /opt/homebrew/Cellar/ansible/9.4.0/libexec/lib/python3.12/site-packages/ansible
  ansible collection location = /Users/rsoares/.ansible/collections:/usr/share/ansible/collections
  executable location = /opt/homebrew/bin/ansible
  python version = 3.12.3 (main, Apr  9 2024, 08:09:14) [Clang 15.0.0 (clang-1500.3.9.4)] (/opt/homebrew/Cellar/ansible/9.4.0/libexec/bin/python)
  jinja version = 3.1.3
  libyaml = True
```
