### PR TITLE
shifting infra workload include task

### DIFF
--- a/ansible/configs/experience-ocpvirt/post_software.yml
+++ b/ansible/configs/experience-ocpvirt/post_software.yml
@@ -142,18 +142,6 @@
         openshift_admin_user: admin
         openshift_admin_password: "{{ hostvars['localhost']['openshift_admin_password'] }}"
 
-  - name: Install OpenShift workloads
-    when: infra_workloads | default("") | length > 0
-    block:
-    - name: Install OpenShift workloads
-      ansible.builtin.include_role:
-        name: "{{ workload_loop_var }}"
-      vars:
-        ocp_username: "system:admin"
-        ACTION: "provision"
-      loop: "{{ infra_workloads }}"
-      loop_control:
-        loop_var: workload_loop_var
 
 - name: Prepare Hypervisor for proxypass
   hosts: hypervisor
@@ -195,6 +183,24 @@
         192.168.123.11 console-openshift-console.apps.ocp.example.com
         192.168.123.11 oauth-openshift.apps.ocp.example.com
         192.168.123.11 zzzzz.apps.ocp.example.com
+
+
+- name: Bastion post install tasks
+  hosts: bastion_vms
+  tasks:
+  - name: Install OpenShift workloads
+    when: infra_workloads | default("") | length > 0
+    block:
+    - name: Install OpenShift workloads
+      ansible.builtin.include_role:
+        name: "{{ workload_loop_var }}"
+      vars:
+        ocp_username: "system:admin"
+        ACTION: "provision"
+      loop: "{{ infra_workloads }}"
+      loop_control:
+        loop_var: workload_loop_var
+
 
 - name: Print informations
   hosts: localhost


### PR DESCRIPTION
##### SUMMARY

Moved infra_workloads task from line no 145 to line no 188.
Reason: Workloads requires public console link which get sets later so I moved workloads task afterwards.   

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Config: experience-ocpvirt