### PR TITLE
improve experience-ocpvirt to expose routes

### DIFF
--- a/ansible/configs/experience-ocpvirt/post_software.yml
+++ b/ansible/configs/experience-ocpvirt/post_software.yml
@@ -119,6 +119,17 @@
     - name: Execute importVMs.sh
       ansible.builtin.shell: /root/importVMs.sh
 
+    - name: Copy exposeVMs.sh
+      when: ocp4_aio_expose_vms | default(false) | bool
+      ansible.builtin.template:
+        src: exposeVMs.sh.j2
+        dest: /root/exposeVMs.sh
+        mode: "0755"
+
+    - name: Execute exposeVMs.sh
+      when: ocp4_aio_expose_vms | default(false) | bool
+      ansible.builtin.shell: /root/exposeVMs.sh
+
   - name: Set agnosticd user info data for bastion
     agnosticd_user_info:
       data:

--- a/ansible/configs/experience-ocpvirt/templates/exposeVMs.sh.j2
+++ b/ansible/configs/experience-ocpvirt/templates/exposeVMs.sh.j2
@@ -12,7 +12,7 @@ spec:
     - protocol: TCP
       port: 80
       targetPort: 80
-
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -25,8 +25,7 @@ spec:
     - protocol: TCP
       port: 3306
       targetPort: 3306
-
-
+---
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:

--- a/ansible/configs/experience-ocpvirt/templates/exposeVMs.sh.j2
+++ b/ansible/configs/experience-ocpvirt/templates/exposeVMs.sh.j2
@@ -1,4 +1,5 @@
-
+cat <<EOF | oc apply -f -
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -40,3 +41,4 @@ spec:
   tls:
     termination: edge
     insecureEdgeTerminationPolicy: Allow
+EOF

--- a/ansible/configs/experience-ocpvirt/templates/exposeVMs.sh.j2
+++ b/ansible/configs/experience-ocpvirt/templates/exposeVMs.sh.j2
@@ -39,5 +39,5 @@ spec:
     targetPort: 80
   tls:
     termination: edge
-    insecureEdgeTerminationPolicy: Allow
+    insecureEdgeTerminationPolicy: Redirect
 EOF

--- a/ansible/configs/experience-ocpvirt/templates/exposeVMs.sh.j2
+++ b/ansible/configs/experience-ocpvirt/templates/exposeVMs.sh.j2
@@ -1,0 +1,42 @@
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: webapp
+  namespace: vmimported
+spec:
+  selector:
+    env: webapp
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: database
+  namespace: vmimported
+spec:
+  selector:
+    vm.kubevirt.io/name: database
+  ports:
+    - protocol: TCP
+      port: 3306
+      targetPort: 3306
+
+
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: route-webapp
+  namespace: vmimported
+spec:
+  to:
+    kind: Service
+    name: webapp
+  port:
+    targetPort: 80
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Allow

--- a/ansible/configs/experience-ocpvirt/templates/importVMs.sh.j2
+++ b/ansible/configs/experience-ocpvirt/templates/importVMs.sh.j2
@@ -97,6 +97,9 @@ spec:
             storage: 90Gi
   running: false
   template:
+    metadata:
+      labels:
+        env: webapp
     spec:
       domain:
         clock:
@@ -162,6 +165,7 @@ spec:
       - dataVolume:
           name: ${vm}
         name: rootdisk
+
 EOF
 
 done


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

This updates the experience-ocpvirt config to support exposing the imported VMs application.

. adds labels to the VM resources
. creates Services and Routes to expose the applicaiton
. creates a switch to turn the feature on, it's off by default.
.. ocp4_aio_expose_vms: true


<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
