### PR TITLE
Replace query and fileglob with hard coded list of files in DevOps Roadshow workshop

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_devops_roadshow/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_devops_roadshow/tasks/workload.yml
@@ -45,8 +45,12 @@
 - name: deploy-gitops-operator
   kubernetes.core.k8s:
     state: present
-    src: "{{ item }}"
-  loop: "{{ query('fileglob', 'files/gitops-operator/*.yaml') }}"
+    src: files/gitops-operator/{{ item }}
+  with_items:
+    - application-controller-rolebinding.yaml
+    - controller-managedby-rbac.yaml
+    - server-managedby-rbac.yaml
+    - subscription.yaml
 
 - name: Wait until the openshift-gitops namespace is created
   kubernetes.core.k8s_info:
@@ -127,14 +131,17 @@
 - name: Deploy appprojects
   kubernetes.core.k8s:
     state: present
-    src: "{{ item }}"
-  loop: "{{ query('fileglob', 'files/appprojects/*.yaml') }}"
+    src: files/appprojects/{{ item }}
+  with_items:
+    - cluster-config.yaml
+    - users.yaml
 
 - name: Deploy infra applications
   kubernetes.core.k8s:
     state: present
-    src: "{{ item }}"
-  loop: "{{ query('fileglob', 'files/applications/*.yaml') }}"
+    src: files/applications/{{ item }}
+  with_items:
+    - app-of-app.yaml
 
 # Todo: Check health of apps
 - name: Wait 30 seconds for deployment


### PR DESCRIPTION
##### SUMMARY

Fixes problems in this workshop with using query and fileglob in AgnosticD by replacing them with a hard coded list of files. Less maintainable but at least it works.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_devops_roadshow

##### ADDITIONAL INFORMATION

None