### PR TITLE
[Do not merge] Skipping Infra node to be tagged for ODF

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/tasks/workload.yml
@@ -9,6 +9,7 @@
     kind: Node
     label_selectors:
     - node-role.kubernetes.io/worker
+    - "!node-role.kubernetes.io/infra"
   register: r_worker_nodes
 
 - name: Fail for less than 3 worker nodes


### PR DESCRIPTION
##### SUMMARY
To install ODF on ROSA cluster, changing the role so that it does not tag infra nodes with label for ceph.

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
roles_ocp_workloads/ocp4_workload_openshift_data_foundation/tasks/workload.yml

