### PR TITLE
Rename tools to cicd ns in DevOps Roadshow

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_devops_roadshow/templates/user-appset.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_devops_roadshow/templates/user-appset.yaml.j2
@@ -17,12 +17,10 @@ spec:
       namespace: openshift-gitops
     spec:
       destination:
-        namespace: "user{% raw %}{{ user }}{% endraw %}-tools"
+        namespace: "user{% raw %}{{ user }}{% endraw %}-cicd"
         server: 'https://kubernetes.default.svc'
       project: default
       syncPolicy:
-        syncOptions:
-        - CreateNamespace=true
         automated:
           prune: false
           selfHeal: false


### PR DESCRIPTION
##### SUMMARY

We renamed the userX-tools namespace to userX-cicd and I forgot to change it in the user generating appset which results in a redundant namespace being created. I also removed the createNamespace flag from the Argo CD application since the users helm chart will do this anyway.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_devops_roadshow
