### PR TITLE
experience-ocpvirt: starting VMs during deployment

### DIFF
--- a/ansible/configs/experience-ocpvirt/templates/importVMs.sh.j2
+++ b/ansible/configs/experience-ocpvirt/templates/importVMs.sh.j2
@@ -25,7 +25,7 @@ spec:
         resources:
           requests:
             storage: 16Gi
-  running: false
+  running: {{ aio_start_imported_vms | default("false") | bool | lower }}
   template:
     metadata:
       annotations:
@@ -95,7 +95,7 @@ spec:
         resources:
           requests:
             storage: 90Gi
-  running: false
+  running: {{ aio_start_imported_vms | default("false") | bool | lower }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
small change to the shell script to parameterize starting newly imported VMs during deployment