### PR TITLE
Updated Minio Workload to support modern (2024) Minio. Added bucket creation and multi-user deploy

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_minio/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_minio/defaults/main.yml
@@ -10,7 +10,14 @@ ocp4_workload_minio_project_display: Minio Object Storage
 ocp4_workload_minio_port: 9000
 ocp4_workload_minio_storage_size: "25Gi"
 
-# Access Credentials for Minio Service
+# Create Route objects for the Minio Services
+ocp4_workload_minio_expose_route: true
+
+# Use a modern Minio Image. Requires different parameters etc. See current image below.
+# Setting to false to maintain default compability with old 2020 image
+ocp4_workload_minio_modern_deployment: false
+
+# Access credentials. Not necessary when doing a modern image (set root vars below instead)
 # Should be overwritten via Global Variables !!!
 ocp4_workload_minio_access_key: "minio_access_key"
 ocp4_workload_minio_secret_key: "minio_secret_key"
@@ -19,3 +26,26 @@ ocp4_workload_minio_secret_key: "minio_secret_key"
 ocp4_workload_minio_image: docker.io/minio/minio
 # Minio Container Image tag
 ocp4_workload_minio_image_tag: RELEASE.2020-10-28T08-16-50Z
+
+# Use current (2024) Minio image:
+#   Setting up Minio is only supported for the new image
+# ocp4_workload_minio_modern_deployment: true
+# ocp4_workload_minio_image: quay.io/minio/minio
+# ocp4_workload_minio_image_tag: RELEASE.2024-05-28T17-19-04Z
+# ocp4_workload_minio_modern_deployment: true
+# Access Credentials for new Minio image
+# Should be overwritten via Global Variables !!!
+ocp4_workload_minio_root_user: "root_user"
+ocp4_workload_minio_root_password: "root_password"
+
+# Create minio Bucket after installation
+ocp4_workload_minio_bucket_setup: false
+# Set up one bucket for each user
+ocp4_workload_minio_bucket_multi_user: false
+# Single-user Bucket Name
+ocp4_workload_minio_bucket_name: s3-storage
+
+# Multi-User:
+ocp4_workload_minio_bucket_base: s3-
+ocp4_workload_minio_bucket_num_users: 1
+ocp4_workload_minio_bucket_userbase: user

--- a/ansible/roles_ocp_workloads/ocp4_workload_minio/meta/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_minio/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   role_name: ocp4_workload_minio
-  author: Red Hat GPTE, Wolfgang Kulhanek (wkulhane@redhat.com)
+  author: Red Hat, Wolfgang Kulhanek (wkulhane@redhat.com)
   description: |
     Set up Minio (S3 Storage) on an OpenShift Cluster
   license: MIT

--- a/ansible/roles_ocp_workloads/ocp4_workload_minio/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_minio/readme.adoc
@@ -2,38 +2,13 @@
 
 == Role overview
 
-* This role installs Minio Object Storage into an OpenShift Cluster. It consists of the following tasks files:
-** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
- environment for the workload deployment.
-*** Debug task will print out: `pre_workload Tasks completed successfully.`
-
-** Tasks: link:./tasks/workload.yml[workload.yml] - Used to deploy Minio Object Storage
-*** This role creates a namespace (project), creates a PVC, Deployment and Service for Minio
-*** Debug task will print out: `workload Tasks completed successfully.`
-
-** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
- configure the workload after deployment
-*** This role doesn't do anything here
-*** Debug task will print out: `post_workload Tasks completed successfully.`
-
-** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
- delete the workload
-*** This role removes the Minio Object Storage project (and therefore Minio Object Storage)
-*** Debug task will print out: `remove_workload Tasks completed successfully.`
+* This role installs Minio Object Storage into an OpenShift Cluster.
 
 == Review the defaults variable file
 
 * This file link:./defaults/main.yml[./defaults/main.yml] contains all the variables you need to define to control the deployment of your workload.
 * The variable *ocp_username* is mandatory to assign the workload to the correct OpenShift user.
 * A variable *silent=True* can be passed to suppress debug messages.
-* Other variables:
-** *ocp4_workload_minio_project*: The name of the project to create and install Minio Object Storage to. Default: `gpte-minio`
-** *ocp4_workload_minio_project_display*: The display name of the project. Default: `Minio Object Storage`
-** *ocp4_workload_minio_port*: The Port for the LoadBalancer Service to listen on. Default: 9000
-** *ocp4_workload_minio_storage_size*: The Size of the PVC for Minio. Default: 25Gi
-** *ocp4_workload_minio_access_key*: The Access Key for Minio. *Should be overwritten via Global Variable!!*
-** *ocp4_workload_minio_secret_key*: The Secret Key for Minio. *Should be overwritten via Global Variable!!*
-* You can modify any of these default values by adding `-e "variable_name=variable_value"` to the command line
 
 === Deploy a Workload with the `ocp-workload` playbook [Mostly for testing]
 
@@ -74,54 +49,4 @@ ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
     -e"ocp_workload=${WORKLOAD}" \
     -e"guid=${GUID}" \
     -e"ACTION=remove"
-----
-
-
-== Other related information:
-
-=== Deploy Workload on OpenShift Cluster from an existing playbook:
-
-[source,yaml]
-----
-- name: Deploy a workload role on a master host
-  hosts: all
-  become: true
-  gather_facts: False
-  tags:
-    - step007
-  roles:
-    - { role: "{{ocp_workload}}", when: 'ocp_workload is defined' }
-----
-NOTE: You might want to change `hosts: all` to fit your requirements
-
-
-=== Set up your Ansible inventory file
-
-* You can create an Ansible inventory file to define your connection method to your host (Master/Bastion with `oc` command)
-* You can also use the command line to define the hosts directly if your `ssh` configuration is set to connect to the host correctly
-* You can also use the command line to use localhost or if your cluster is already authenticated and configured in your `oc` configuration
-
-.Example inventory file
-[source, ini]
-----
-[gptehosts:vars]
-ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem
-ansible_user=ec2-user
-
-[gptehosts:children]
-openshift
-
-[openshift]
-bastion.cluster1.openshift.opentlc.com
-bastion.cluster2.openshift.opentlc.com
-bastion.cluster3.openshift.opentlc.com
-bastion.cluster4.openshift.opentlc.com
-
-[dev]
-bastion.cluster1.openshift.opentlc.com
-bastion.cluster2.openshift.opentlc.com
-
-[prod]
-bastion.cluster3.openshift.opentlc.com
-bastion.cluster4.openshift.opentlc.com
 ----

--- a/ansible/roles_ocp_workloads/ocp4_workload_minio/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_minio/tasks/main.yml
@@ -1,31 +1,20 @@
 ---
-
-# Do not modify this file
-
 - name: Running Pre Workload Tasks
-  include_tasks:
-    file: ./pre_workload.yml
-    apply:
-      become: "{{ become_override | bool }}"
   when: ACTION == "create" or ACTION == "provision"
+  ansible.builtin.include_tasks:
+    file: ./pre_workload.yml
 
 - name: Running Workload Tasks
-  include_tasks:
-    file: ./workload.yml
-    apply:
-      become: "{{ become_override | bool }}"
   when: ACTION == "create" or ACTION == "provision"
+  ansible.builtin.include_tasks:
+    file: ./workload.yml
 
 - name: Running Post Workload Tasks
-  include_tasks:
-    file: ./post_workload.yml
-    apply:
-      become: "{{ become_override | bool }}"
   when: ACTION == "create" or ACTION == "provision"
+  ansible.builtin.include_tasks:
+    file: ./post_workload.yml
 
 - name: Running Workload removal Tasks
-  include_tasks:
-    file: ./remove_workload.yml
-    apply:
-      become: "{{ become_override | bool }}"
   when: ACTION == "destroy" or ACTION == "remove"
+  ansible.builtin.include_tasks:
+    file: ./remove_workload.yml

--- a/ansible/roles_ocp_workloads/ocp4_workload_minio/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_minio/tasks/post_workload.yml
@@ -1,9 +1,8 @@
 ---
 # Implement your Post Workload deployment tasks here
 
-
 # Leave this as the last task in the playbook.
-- name: post_workload tasks complete
-  debug:
-    msg: "Post-Workload Tasks completed successfully."
+- name: Post_workload tasks complete
   when: not silent | bool
+  ansible.builtin.debug:
+    msg: "Post-Workload Tasks completed successfully."

--- a/ansible/roles_ocp_workloads/ocp4_workload_minio/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_minio/tasks/pre_workload.yml
@@ -3,6 +3,6 @@
 
 # Leave this as the last task in the playbook.
 - name: pre_workload tasks complete
-  debug:
-    msg: "Pre-Workload tasks completed successfully."
   when: not silent | bool
+  ansible.builtin.debug:
+    msg: "Pre-Workload tasks completed successfully."

--- a/ansible/roles_ocp_workloads/ocp4_workload_minio/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_minio/tasks/remove_workload.yml
@@ -1,15 +1,14 @@
 ---
 # Implement your Workload removal tasks here
-
 - name: Remove Minio Object Storage Project
-  k8s:
+  kubernetes.core.k8s:
     name: "{{ ocp4_workload_minio_project }}"
     api_version: v1
     kind: Namespace
     state: absent
 
 # Leave this as the last task in the playbook.
-- name: remove_workload tasks complete
-  debug:
-    msg: "Remove Workload tasks completed successfully."
+- name: Remove_workload tasks complete
   when: not silent | bool
+  ansible.builtin.debug:
+    msg: "Remove Workload tasks completed successfully."

--- a/ansible/roles_ocp_workloads/ocp4_workload_minio/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_minio/tasks/workload.yml
@@ -1,27 +1,82 @@
 ---
-# Implement your Workload deployment tasks here
-
-- name: Setting up workload for user
-  debug:
-    msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
-
 - name: Create OpenShift Objects for Minio Object Storage
-  k8s:
+  kubernetes.core.k8s:
     state: present
-    merge_type:
-    - strategic-merge
-    - merge
-    definition: "{{ lookup('template', item ) | from_yaml }}"
+    definition: "{{ lookup('template', item) | from_yaml }}"
   loop:
-  - ./templates/project.yaml.j2
+  - ./templates/namespace.yaml.j2
   - ./templates/secret.yaml.j2
   - ./templates/persistentvolumeclaim.yaml.j2
   - ./templates/deployment.yaml.j2
   - ./templates/service.yaml.j2
-  - ./templates/route.yaml.j2
+
+- name: Create OpenShift routes for Minio Object Storage
+  when: ocp4_workload_minio_expose_route | bool
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('template', item) | from_yaml }}"
+  loop:
+  - ./templates/route_minio.yaml.j2
+  - ./templates/route_console.yaml.j2
+
+- name: Set up a Minio Bucket
+  when: ocp4_workload_minio_bucket_setup | bool
+  block:
+  - name: Wait until Minio Deployment is running
+    kubernetes.core.k8s_info:
+      api_version: "apps/v1"
+      kind: Deployment
+      name: minio
+      namespace: "{{ ocp4_workload_minio_project }}"
+      wait: true
+      wait_sleep: 10
+      wait_timeout: 360
+
+  - name: Get Minio Pod
+    kubernetes.core.k8s_info:
+      api_version: v1
+      kind: Pod
+      namespace: "{{ ocp4_workload_minio_project }}"
+      label_selectors:
+      - app = minio
+    register: r_minio_pod
+
+  # Set up Minio with a bucket
+  # POD=$(oc get pod -n minio -lapp=minio -o jsonpath='{range.items[*]}{.metadata.name}{"\n"}{end}')
+  # oc -n minio rsh ${POD} mc alias set --insecure localminio localhost:9000 root-user root-user-password
+  # oc -n minio rsh ${POD} mc mb localminio/testbucket
+  # Validate the bucket exists:
+  # oc -n minio rsh ${POD} mc ls localminio
+  - name: Set up local Minio in pod
+    kubernetes.core.k8s_exec:
+      namespace: "{{ ocp4_workload_minio_project }}"
+      pod: "{{ r_minio_pod.resources[0].metadata.name }}"
+      command: |
+        mc alias set --insecure
+          localminio http://localhost:9000
+          {{ ocp4_workload_minio_root_user }} {{ ocp4_workload_minio_root_password }}
+
+  - name: Set up Minio bucket (Single-User)
+    when: not ocp4_workload_minio_bucket_multi_user | bool
+    kubernetes.core.k8s_exec:
+      namespace: "{{ ocp4_workload_minio_project }}"
+      pod: "{{ r_minio_pod.resources[0].metadata.name }}"
+      command: |
+        mc mb localminio/{{ ocp4_workload_minio_bucket_name }}
+
+  - name: Set up Minio bucket (Multi-User)
+    when: ocp4_workload_minio_bucket_multi_user | bool
+    kubernetes.core.k8s_exec:
+      namespace: "{{ ocp4_workload_minio_project }}"
+      pod: "{{ r_minio_pod.resources[0].metadata.name }}"
+      command: |
+        mc mb localminio/{{ ocp4_workload_minio_bucket_base }}{{ ocp4_workload_minio_bucket_userbase }}{{ user_number }}
+    loop: "{{ range(1, ocp4_workload_minio_bucket_num_users | int + 1) | list }}"
+    loop_control:
+      loop_var: user_number
 
 # Leave this as the last task in the playbook.
-- name: workload tasks complete
-  debug:
-    msg: "Workload Tasks completed successfully."
+- name: Workload tasks complete
   when: not silent | bool
+  ansible.builtin.debug:
+    msg: "Workload Tasks completed successfully."

--- a/ansible/roles_ocp_workloads/ocp4_workload_minio/templates/deployment.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_minio/templates/deployment.yaml.j2
@@ -1,8 +1,9 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: minio-deployment
-  namespace: "{{ ocp4_workload_minio_project }}"
+  name: minio
+  namespace: {{ ocp4_workload_minio_project }}
 spec:
   strategy:
     type: Recreate
@@ -17,11 +18,26 @@ spec:
     spec:
       containers:
       - name: minio
-        image: "{{ ocp4_workload_minio_image }}:{{ ocp4_workload_minio_image_tag }}"
+        image: {{ ocp4_workload_minio_image }}:{{ ocp4_workload_minio_image_tag }}
         args:
         - server
         - /storage
+{% if ocp4_workload_minio_modern_deployment | bool %}
+        - "--console-address=:9001"
+{% endif %}
         env:
+{% if ocp4_workload_minio_modern_deployment | bool %}
+        - name: MINIO_ROOT_USER
+          valueFrom:
+            secretKeyRef:
+              key: minio_root_user
+              name: minio-keys
+        - name: MINIO_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: minio_root_password
+              name: minio-keys
+{% else %}
         - name: MINIO_ACCESS_KEY
           valueFrom:
             secretKeyRef:
@@ -32,8 +48,14 @@ spec:
             secretKeyRef:
               key: minio_secret_key
               name: minio-keys
+{% endif %}
         ports:
-        - containerPort: 9000
+        - name: minio
+          containerPort: 9000
+{% if ocp4_workload_minio_modern_deployment | bool %}
+        - name: console
+          containerPort: 9001
+{% endif %}
         volumeMounts:
         - name: storage
           mountPath: "/storage"

--- a/ansible/roles_ocp_workloads/ocp4_workload_minio/templates/namespace.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_minio/templates/namespace.yaml.j2
@@ -1,10 +1,8 @@
-apiVersion: project.openshift.io/v1
-kind: Project
+---
+apiVersion: v1
+kind: Namespace
 metadata:
   annotations:
     openshift.io/description: ""
     openshift.io/display-name: "{{ ocp4_workload_minio_project_display }}"
-  name: "{{ ocp4_workload_minio_project }}"
-spec:
-  finalizers:
-  - kubernetes
+  name: {{ ocp4_workload_minio_project }}

--- a/ansible/roles_ocp_workloads/ocp4_workload_minio/templates/persistentvolumeclaim.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_minio/templates/persistentvolumeclaim.yaml.j2
@@ -1,9 +1,9 @@
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  # This name uniquely identifies the PVC. Will be used in deployment below.
   name: minio-pv-claim
-  namespace: "{{ ocp4_workload_minio_project }}"
+  namespace: {{ ocp4_workload_minio_project }}
   labels:
     app: minio-storage-claim
 spec:

--- a/ansible/roles_ocp_workloads/ocp4_workload_minio/templates/route_console.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_minio/templates/route_console.yaml.j2
@@ -1,0 +1,19 @@
+{% if ocp4_workload_minio_modern_deployment | bool %}
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: console
+  namespace: {{ ocp4_workload_minio_project }}
+spec:
+  port:
+    targetPort: 9001
+  to:
+    kind: Service
+    name: minio
+    weight: 100
+  wildcardPolicy: None
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+{% endif %}

--- a/ansible/roles_ocp_workloads/ocp4_workload_minio/templates/route_minio.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_minio/templates/route_minio.yaml.j2
@@ -1,8 +1,9 @@
+---
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: minio
-  namespace: "{{ ocp4_workload_minio_project }}"
+  namespace: {{ ocp4_workload_minio_project }}
 spec:
   port:
     targetPort: 9000

--- a/ansible/roles_ocp_workloads/ocp4_workload_minio/templates/secret.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_minio/templates/secret.yaml.j2
@@ -1,9 +1,15 @@
+---
 apiVersion: v1
 kind: Secret
 metadata:
   name: minio-keys
-  namespace: "{{ ocp4_workload_minio_project }}"
+  namespace: {{ ocp4_workload_minio_project }}
 type: Opaque
 stringData:
-  minio_access_key: "{{ ocp4_workload_minio_access_key }}"
-  minio_secret_key: "{{ ocp4_workload_minio_secret_key }}"
+{% if ocp4_workload_minio_modern_deployment | bool %}
+  minio_root_user: {{ ocp4_workload_minio_root_user }}
+  minio_root_password: {{ocp4_workload_minio_root_password }}
+{% else %}
+  minio_access_key: {{ ocp4_workload_minio_access_key }}
+  minio_secret_key: {{ ocp4_workload_minio_secret_key }}
+{% endif %}

--- a/ansible/roles_ocp_workloads/ocp4_workload_minio/templates/service.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_minio/templates/service.yaml.j2
@@ -1,13 +1,21 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
   name: minio
-  namespace: "{{ ocp4_workload_minio_project }}"
+  namespace: {{ ocp4_workload_minio_project }}
 spec:
   ports:
-  - port: 9000
+  - name: minio
+    port: 9000
     protocol: TCP
     targetPort: 9000
+{% if ocp4_workload_minio_modern_deployment | bool %}
+  - name: console
+    port: 9001
+    protocol: TCP
+    targetPort: 9001
+{% endif %}
   selector:
     app: minio
   sessionAffinity: None


### PR DESCRIPTION
##### SUMMARY

Minio Workload hasn't been touched since 2020. Updated to support 2024 Minio deployments (while hopefully not breaking existing users).
Add capability to create a bucket.
Add capability to create buckets for each user
Add capability to not create routes.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_minio