### PR TITLE
Add OADP Operator (both single and multi-user)

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_oadp/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_oadp/defaults/main.yml
@@ -1,0 +1,83 @@
+---
+become_override: false
+ocp_username: opentlc-mgr
+silent: false
+
+# Channel to use for the Kubernetes OADP Operator subscription
+# When not set (or set to "") use the default channel for the
+# OpenShift version this operator is installed on. If there is
+# no matching version use the `defaultChannel`
+ocp4_workload_oadp_channel: stable-1.3
+
+# Set automatic InstallPlan approval. If set to false it is
+# also suggested to set the starting_csv to pin a specific
+# version. This variable has no effect when using a catalog
+# snapshot (always true)
+ocp4_workload_oadp_automatic_install_plan_approval: true
+
+# Set a starting ClusterServiceVersion.
+# Recommended to leave empty to get latest in the channel when not
+# using a catalog snapshot.
+# Highly recommended to be set when using a catalog snapshot but can be
+# empty to get the latest available in the channel at the time when
+# the catalog snapshot got created.
+ocp4_workload_oadp_starting_csv: ""
+# ocp4_workload_oadp_starting_csv: "4.15.0-202405150336"
+
+# OADP 1.3 does not support monitoring multiple namespaces. OADP 1.5 is supposed to have that capability.
+# In the meantime for multi-user clusters set up and configure one copy of the operator for each user on the cluster.
+# This is only supported with Minio storage by this workload
+# Minio must have been configured to have one bucket per user available
+# See workload: ocp4_workload_minio
+
+# Set up for multiple users. If false the workload will install the operator into openshift-adp.
+# When true it will install (and configure) one copy of the operator in a separate namespace for each user
+ocp4_workload_oadp_multi_user: false
+
+# Multi-user mode:
+# ocp4_workload_oadp_num_users: 1
+# ocp4_workload_oadp_userbase: user
+
+# Set up a DataProtectionApplication
+ocp4_workload_oadp_configure_dpa: false
+
+# Storage to use for S3 type storage for DPA
+# - ocs: OpenShift Data Foundations with ObjectBucketClaim CR available
+#        All other options are implicit via ODF
+ocp4_workload_oadp_storage: ocs
+# - minio: A locally deploy Minio instance
+# ocp4_workload_oadp_storage: minio
+#   Access to Minio
+# ocp4_workload_oadp_storage_minio_user: minio-admin
+# ocp4_workload_oadp_storage_minio_password: minio-password
+# ocp4_workload_oadp_storage_minio_name: minio
+# ocp4_workload_oadp_storage_minio_namespace: minio
+# ocp4_workload_oadp_storage_minio_bucket_name: s3-storage
+
+# For Multi-user only Minio is supported as storage:
+# Storage for DataProtectionApplications
+# - Bucket name will be {{ ocp4_workload_oadp_storage_minio_bucket_name_base }}{{ ocp4_workload_oadp_storage_minio_bucket_userbase }}{{ user_number }}
+# ocp4_workload_oadp_storage_minio_bucket_name_base: s3-storage-
+# ocp4_workload_oadp_storage_minio_user: minio-admin
+# ocp4_workload_oadp_storage_minio_password: minio-password
+# ocp4_workload_oadp_storage_minio_name: minio
+# ocp4_workload_oadp_storage_minio_namespace: minio
+
+# --------------------------------
+# Operator Catalog Snapshot Settings
+# --------------------------------
+# See https://github.com/redhat-cop/agnosticd/blob/development/docs/Operator_Catalog_Snapshots.adoc
+# for instructions on how to set up catalog snapshot images
+
+# Use a catalog snapshot
+ocp4_workload_oadp_use_catalog_snapshot: false
+
+# Catalog Source Name when using a catalog snapshot. This should be unique
+# in the cluster to avoid clashes
+ocp4_workload_oadp_catalogsource_name: redhat-operators-snapshot-nmstate
+
+# Catalog snapshot image
+ocp4_workload_oadp_catalog_snapshot_image: quay.io/gpte-devops-automation/olm_snapshot_redhat_catalog
+
+# Catalog snapshot image tag
+ocp4_workload_oadp_catalog_snapshot_image_tag: "v4.15_2024_05_27"

--- a/ansible/roles_ocp_workloads/ocp4_workload_oadp/files/objectbucketclaim.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_oadp/files/objectbucketclaim.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: obc-backups
+  namespace: openshift-storage
+spec:
+  storageClassName: openshift-storage.noobaa.io
+  generateBucketName: backups

--- a/ansible/roles_ocp_workloads/ocp4_workload_oadp/meta/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_oadp/meta/main.yml
@@ -1,0 +1,15 @@
+---
+galaxy_info:
+  role_name: ocp4_workload_oadp
+  author:
+  - Wolfgang Kulhanek <wkulhane@redhat.com>
+  description: |
+    Deploys OADP Operator to an OCP4 cluster
+  platforms: []
+  license: GNU General Public License v3.0
+  galaxy_tags:
+  - ocp4
+  - openshift
+  - nmstate
+  - cnv
+dependencies: []

--- a/ansible/roles_ocp_workloads/ocp4_workload_oadp/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_oadp/readme.adoc
@@ -1,0 +1,48 @@
+= ocp4_workload_oadp - Deploy OADP Operator to an OpenShift Cluster
+
+== Role overview
+
+== The defaults variable file
+
+* This file ./defaults/main.yml contains all the variables you need to define to control the deployment of your workload.
+* The variable ocp_username is mandatory to assign the workload to the correct OpenShift user.
+* A variable silent=True can be passed to suppress debug messages.
+* You can modify any of these default values by adding -e "variable_name=variable_value" to the command line
+
+== Deploy a Workload with the `ocp-workload` playbook [Mostly for testing]
+
+----
+TARGET_HOST="bastion.na4.openshift.opentlc.com"
+OCP_USERNAME="wkulhane-redhat.com"
+WORKLOAD="ocp4_workload_oadp"
+GUID=1001
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=ec2-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"silent=False" \
+    -e"guid=${GUID}" \
+    -e"_quay_dockerconfigjson=${QUAY_DOCKERCONFIGJSON}" \
+    -e"ACTION=create"
+----
+
+=== To Delete an environment
+
+----
+TARGET_HOST="bastion.na4.openshift.opentlc.com"
+OCP_USERNAME="wkulhane-redhat.com"
+WORKLOAD="ocp4_workload_oadp"
+GUID=1002
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=ec2-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"guid=${GUID}" \
+    -e"ACTION=remove"
+----

--- a/ansible/roles_ocp_workloads/ocp4_workload_oadp/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_oadp/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: Running Pre Workload Tasks
+  when: ACTION == "create" or ACTION == "provision"
+  ansible.builtin.include_tasks:
+    file: ./pre_workload.yml
+
+- name: Running Workload Tasks
+  when: ACTION == "create" or ACTION == "provision"
+  ansible.builtin.include_tasks:
+    file: ./workload.yml
+
+- name: Running Post Workload Tasks
+  when: ACTION == "create" or ACTION == "provision"
+  ansible.builtin.include_tasks:
+    file: ./post_workload.yml
+
+- name: Running Workload removal Tasks
+  when: ACTION == "destroy" or ACTION == "remove"
+  ansible.builtin.include_tasks:
+    file: ./remove_workload.yml

--- a/ansible/roles_ocp_workloads/ocp4_workload_oadp/tasks/oadp_multi_user_install.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_oadp/tasks/oadp_multi_user_install.yml
@@ -1,0 +1,39 @@
+---
+- name: Install OADP Operator
+  ansible.builtin.include_role:
+    name: install_operator
+  vars:
+    install_operator_action: install
+    install_operator_name: redhat-oadp-operator
+    install_operator_namespace: "oadp-{{ ocp4_workload_oadp_userbase }}{{ user_number }}"
+    install_operator_manage_namespaces:
+    - "oadp-{{ ocp4_workload_oadp_userbase }}{{ user_number }}"
+    install_operator_channel: "{{ ocp4_workload_oadp_channel }}"
+    install_operator_catalog: redhat-operators
+    install_operator_csv_nameprefix: oadp-operator
+    install_operator_automatic_install_plan_approval: "{{ ocp4_workload_oadp_automatic_install_plan_approval | default(true) }}"
+    install_operator_starting_csv: "{{ ocp4_workload_oadp_starting_csv }}"
+    install_operator_catalogsource_setup: "{{ ocp4_workload_oadp_use_catalog_snapshot | default(false) }}"
+    install_operator_catalogsource_name: "{{ ocp4_workload_oadp_catalogsource_name | default('') }}"
+    install_operator_catalogsource_namespace: "oadp-{{ ocp4_workload_oadp_userbase }}{{ user_number }}"
+    install_operator_catalogsource_image: "{{ ocp4_workload_oadp_catalog_snapshot_image | default('') }}"
+    install_operator_catalogsource_image_tag: "{{ ocp4_workload_oadp_catalog_snapshot_image_tag | default('') }}"
+  loop: "{{ range(1, ocp4_workload_oadp_num_users | int + 1) | list }}"
+  loop_control:
+    loop_var: user_number
+
+- name: Grant admin permission to users for OADP namespace
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('template', 'rolebinding.yaml.j2') }}"
+
+- name: Set up DataProtectionApplication for users
+  when: ocp4_workload_oadp_configure_dpa | bool
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('template', resource) }}"
+  loop:
+  - secret_cloud_credentials_multi_user.yaml.j2
+  - 'dataprotectionapplication_multi_user.yaml.j2'
+  loop_control:
+    loop_var: resource

--- a/ansible/roles_ocp_workloads/ocp4_workload_oadp/tasks/oadp_single_user_install.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_oadp/tasks/oadp_single_user_install.yml
@@ -1,0 +1,95 @@
+---
+- name: Install OADP Operator
+  ansible.builtin.include_role:
+    name: install_operator
+  vars:
+    install_operator_action: install
+    install_operator_name: redhat-oadp-operator
+    install_operator_namespace: openshift-adp
+    install_operator_manage_namespaces:
+    - openshift-adp
+    install_operator_channel: "{{ ocp4_workload_oadp_channel }}"
+    install_operator_catalog: redhat-operators
+    install_operator_csv_nameprefix: oadp-operator
+    install_operator_automatic_install_plan_approval: "{{ ocp4_workload_oadp_automatic_install_plan_approval | default(true) }}"
+    install_operator_starting_csv: "{{ ocp4_workload_oadp_starting_csv }}"
+    install_operator_catalogsource_setup: "{{ ocp4_workload_oadp_use_catalog_snapshot | default(false) }}"
+    install_operator_catalogsource_name: "{{ ocp4_workload_oadp_catalogsource_name | default('') }}"
+    install_operator_catalogsource_namespace: openshift-adp
+    install_operator_catalogsource_image: "{{ ocp4_workload_oadp_catalog_snapshot_image | default('') }}"
+    install_operator_catalogsource_image_tag: "{{ ocp4_workload_oadp_catalog_snapshot_image_tag | default('') }}"
+
+- name: Configure OADP
+  when: ocp4_workload_oadp_configure_dpa | bool
+  block:
+  - name: Configure OADP Storage on OCS
+    when: ocp4_workload_oadp_storage == "ocs"
+    block:
+    - name: Create ObjectBucketClaim
+      kubernetes.core.k8s:
+        state: present
+        definition: "{{ lookup('file', 'objectbucketclaim.yaml') }}"
+
+    - name: Wait for Secret with credentials to exist
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Secret
+        name: obc-backups
+        namespace: openshift-storage
+      register: r_obc_backups_secret
+      retries: 40
+      delay: 5
+      until: r_obc_backups_secret.resources | default([]) | length > 0
+
+    - name: Create cloud credentials variable
+      ansible.builtin.set_fact:
+        _ocp4_workload_oadp_storage_user: "{{ r_obc_backups_secret.resources[0].data.AWS_ACCESS_KEY_ID | b64decode }}"
+        _ocp4_workload_oadp_storage_password: "{{ r_obc_backups_secret.resources[0].data.AWS_SECRET_ACCESS_KEY | b64decode }}"
+
+    - name: Create cloud credentials secret for OADP
+      kubernetes.core.k8s:
+        state: present
+        definition: "{{ lookup('template', 'secret_cloud_credentials.yaml.j2') }}"
+
+    - name: Get Bucket ConfigMap
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: ConfigMap
+        name: obc-backups
+        namespace: openshift-storage
+      register: r_obc_backups_configmap
+
+    - name: Set Bucket facts
+      ansible.builtin.set_fact:
+        _ocp4_workload_oadp_bucket_host: "{{ r_obc_backups_configmap.resources[0].data.BUCKET_HOST }}"
+        _ocp4_workload_oadp_bucket_name: "{{ r_obc_backups_configmap.resources[0].data.BUCKET_NAME }}"
+
+    - name: Debug Bucket facts
+      ansible.builtin.debug:
+        msg: "Host: {{ _ocp4_workload_oadp_bucket_host }}, Name: {{ _ocp4_workload_oadp_bucket_name }}"
+
+  - name: Configure OADP Storage on Minio
+    when: ocp4_workload_oadp_storage == "minio"
+    block:
+    - name: Set Storage facts
+      ansible.builtin.set_fact:
+        _ocp4_workload_oadp_bucket_host: "{{ ocp4_workload_oadp_storage_minio_name }}.{{ ocp4_workload_oadp_storage_minio_namespace }}.svc:9000"
+        _ocp4_workload_oadp_bucket_name: "{{ ocp4_workload_oadp_storage_minio_bucket_name }}"
+        _ocp4_workload_oadp_storage_user: "{{ ocp4_workload_oadp_storage_minio_user }}"
+        _ocp4_workload_oadp_storage_password: "{{ ocp4_workload_oadp_storage_minio_password }}"
+
+    - name: Debug Bucket facts
+      ansible.builtin.debug:
+        msg: "Host: {{ _ocp4_workload_oadp_bucket_host }}, Name: {{ _ocp4_workload_oadp_bucket_name }}"
+
+    - name: Create cloud credentials secret for OADP
+      kubernetes.core.k8s:
+        state: present
+        definition: "{{ lookup('template', 'secret_cloud_credentials.yaml.j2') }}"
+
+  - name: Create the DPA instance
+    vars:
+      _ocp4_workload_oadp_namespace: openshift-adp
+    kubernetes.core.k8s:
+      state: present
+      definition: "{{ lookup('template', 'dataprotectionapplication.yaml.j2') }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_oadp/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_oadp/tasks/post_workload.yml
@@ -1,0 +1,8 @@
+---
+# Implement your Post Workload deployment tasks here
+
+# Leave this as the last task in the playbook.
+- name: Post_workload tasks complete
+  when: not silent|bool
+  ansible.builtin.debug:
+    msg: "Post-Workload Tasks completed successfully."

--- a/ansible/roles_ocp_workloads/ocp4_workload_oadp/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_oadp/tasks/pre_workload.yml
@@ -1,0 +1,8 @@
+---
+# Implement your Pre Workload deployment tasks here
+
+# Leave this as the last task in the playbook.
+- name: Pre_workload tasks complete
+  when: not silent|bool
+  ansible.builtin.debug:
+    msg: "Pre-Workload tasks completed successfully."

--- a/ansible/roles_ocp_workloads/ocp4_workload_oadp/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_oadp/tasks/remove_workload.yml
@@ -1,0 +1,24 @@
+---
+# - name: Delete OADP
+#   kubernetes.core.k8s:
+#     state: absent
+#     definition: "{{ lookup('file', 'nmstate.yaml') }}"
+
+- name: Remove OADP Operator
+  ansible.builtin.include_role:
+    name: install_operator
+  vars:
+    install_operator_action: remove
+    install_operator_name: redhat-oadp-operator
+    install_operator_namespace: openshift-adp
+    install_operator_manage_namespaces:
+    - openshift-adp
+    install_operator_channel: "{{ ocp4_workload_oadp_channel }}"
+    install_operator_catalog: redhat-operators
+    install_operator_automatic_install_plan_approval: "{{ ocp4_workload_oadp_automatic_install_plan_approval | default(true) }}"
+    install_operator_starting_csv: "{{ ocp4_workload_oadp_starting_csv }}"
+    install_operator_catalogsource_setup: "{{ ocp4_workload_oadp_use_catalog_snapshot | default(false) }}"
+    install_operator_catalogsource_name: "{{ ocp4_workload_oadp_catalogsource_name | default('') }}"
+    install_operator_catalogsource_namespace: openshift-adp
+    install_operator_catalogsource_image: "{{ ocp4_workload_oadp_catalog_snapshot_image | default('') }}"
+    install_operator_catalogsource_image_tag: "{{ ocp4_workload_oadp_catalog_snapshot_image_tag | default('') }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_oadp/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_oadp/tasks/workload.yml
@@ -1,0 +1,14 @@
+---
+- name: Install OADP Operator for single user
+  when: not ocp4_workload_oadp_multi_user | bool
+  ansible.builtin.include_tasks: oadp_single_user_install.yml
+
+- name: Install OADP Operator for multi-user
+  when: ocp4_workload_oadp_multi_user | bool
+  ansible.builtin.include_tasks: oadp_multi_user_install.yml
+
+# Leave this as the last task in the playbook.
+- name: Workload tasks complete
+  when: not silent|bool
+  ansible.builtin.debug:
+    msg: "Workload Tasks completed successfully."

--- a/ansible/roles_ocp_workloads/ocp4_workload_oadp/templates/dataprotectionapplication.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_oadp/templates/dataprotectionapplication.yaml.j2
@@ -1,0 +1,35 @@
+---
+apiVersion: oadp.openshift.io/v1alpha1
+kind: DataProtectionApplication
+metadata:
+  name: oadp-dpa
+  namespace: {{ _ocp4_workload_oadp_namespace }}
+spec:
+  configuration:
+    velero:
+      featureFlags:
+      - EnableCSI
+      defaultPlugins:
+      - csi 
+      - openshift
+      - aws
+      - kubevirt
+  backupLocations:
+  - velero:
+      config:
+        profile: default
+{% if ocp4_workload_oadp_storage == "ocs" %}        
+        region: localstorage
+{% else %}
+        region: minio
+{% endif %}
+        s3Url: http://{{ _ocp4_workload_oadp_bucket_host }}
+        s3ForcePathStyle: "true"
+      provider: aws
+      credential:
+        name: cloud-credentials
+        key: cloud
+      default: true
+      objectStorage:
+        bucket: {{ _ocp4_workload_oadp_bucket_name }}
+        prefix: velero

--- a/ansible/roles_ocp_workloads/ocp4_workload_oadp/templates/dataprotectionapplication_multi_user.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_oadp/templates/dataprotectionapplication_multi_user.yaml.j2
@@ -1,0 +1,33 @@
+{% for user_number in range(1, ocp4_workload_oadp_num_users | int + 1) %}
+---
+apiVersion: oadp.openshift.io/v1alpha1
+kind: DataProtectionApplication
+metadata:
+  name: oadp-dpa
+  namespace: oadp-{{ ocp4_workload_oadp_userbase }}{{ user_number }}
+spec:
+  configuration:
+    velero:
+      featureFlags:
+      - EnableCSI
+      defaultPlugins:
+      - csi 
+      - openshift
+      - aws
+      - kubevirt
+  backupLocations:
+  - velero:
+      config:
+        profile: default
+        region: minio
+        s3Url: http://{{ ocp4_workload_oadp_storage_minio_name }}.{{ ocp4_workload_oadp_storage_minio_namespace }}.svc:9000
+        s3ForcePathStyle: "true"
+      provider: aws
+      credential:
+        name: cloud-credentials
+        key: cloud
+      default: true
+      objectStorage:
+        bucket: {{ ocp4_workload_oadp_storage_minio_bucket_name_base }}{{ ocp4_workload_oadp_userbase }}{{ user_number }}
+        prefix: velero
+{% endfor %}

--- a/ansible/roles_ocp_workloads/ocp4_workload_oadp/templates/rolebinding.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_oadp/templates/rolebinding.yaml.j2
@@ -1,0 +1,16 @@
+{% for user_number in range(1, ocp4_workload_oadp_num_users | int + 1) %}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: admin
+  namespace: oadp-{{ ocp4_workload_oadp_userbase }}{{ user_number }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: {{ ocp4_workload_oadp_userbase }}{{ user_number }}
+{% endfor %}

--- a/ansible/roles_ocp_workloads/ocp4_workload_oadp/templates/secret_cloud_credentials.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_oadp/templates/secret_cloud_credentials.yaml.j2
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloud-credentials
+  namespace: openshift-adp
+stringData:
+  cloud: |
+    [default]
+    aws_access_key_id={{ ocp4_workload_oadp_storage_minio_user }}
+    aws_secret_access_key={{ ocp4_workload_oadp_storage_minio_password }}

--- a/ansible/roles_ocp_workloads/ocp4_workload_oadp/templates/secret_cloud_credentials_multi_user.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_oadp/templates/secret_cloud_credentials_multi_user.yaml.j2
@@ -1,0 +1,13 @@
+{% for user_number in range(1, ocp4_workload_oadp_num_users | int + 1) %}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloud-credentials
+  namespace: oadp-{{ ocp4_workload_oadp_userbase }}{{ user_number }}
+stringData:
+  cloud: |
+    [default]
+    aws_access_key_id={{ ocp4_workload_oadp_storage_minio_user }}
+    aws_secret_access_key={{ ocp4_workload_oadp_storage_minio_password }}
+{% endfor %}


### PR DESCRIPTION
##### SUMMARY

Add workload to deploy the OADP Operator.
Optionally configure a DataProtectionApplication.

Single-user is the default (install for admins only).
Multi-user is available to deploy (and configure) one copy of the operator until the operator supports multi-tenancy (1.5+).

##### ISSUE TYPE
- New role Pull Request

##### COMPONENT NAME
ocp4_workload_oadp