### PR TITLE
Add support to overwrite ami architecture (role: ocp4_machineset_config & ocp4_workload_machinesets )

### DIFF
--- a/ansible/roles/ocp4_machineset_config/README.adoc
+++ b/ansible/roles/ocp4_machineset_config/README.adoc
@@ -121,6 +121,10 @@ machineset enables autoscaling.
 | `ocp4_machineset_config_default_aws_instance_type`
 | AWS instance type
 
+| `aws_instance_ami_architecture`
+| Empty, inherited from cluster default machineset
+| AWS AMI architecture, "aarch64","ppc64le","s390x","x86_64"
+
 | `aws_root_volume_size`
 | `ocp4_machineset_config_default_aws_root_volume_size`
 | Root EBS storage disk size

--- a/ansible/roles/ocp4_machineset_config/tasks/machineset-group-aws.yml
+++ b/ansible/roles/ocp4_machineset_config/tasks/machineset-group-aws.yml
@@ -1,4 +1,21 @@
 ---
+
+- name: Block to determine AWS AMI if instance ami_architecture is set
+  when: machineset_group.aws_instance_ami_architecture is defined
+  block:
+
+    - name: Gather coreos stream json
+      ansible.builtin.command: "openshift-install coreos print-stream-json"
+      register: stream_json
+
+    - name: Format output
+      ansible.builtin.set_fact:
+        prepare_stream_json: "{{ stream_json.stdout | to_json | from_json }}"
+
+    - name: Overwrite aws_coreos_ami_id
+      ansible.builtin.set_fact:
+        custom_aws_coreos_ami_id: "{{ prepare_stream_json.architectures[machineset_group.aws_instance_ami_architecture].images.aws.regions[aws_region].image }}"
+
 - name: Define {{ machineset_group.name }} machinesets
   kubernetes.core.k8s:
     state: present
@@ -14,6 +31,7 @@
     availability_zone: "{{ aws_worker_availability_zone.name }}"
     availability_zone_region: "{{ aws_worker_availability_zone.region }}"
     availability_zone_subnet: "{{ aws_worker_availability_zone.subnet }}"
+    aws_instance_ami_id: "{{ custom_aws_coreos_ami_id | default(aws_coreos_ami_id) }}"
     aws_instance_type: >-
       {{ machineset_group.instance_type | default(default_aws_instance_type) }}
     aws_root_volume_size: >-

--- a/ansible/roles/ocp4_machineset_config/tasks/machineset-group-aws.yml
+++ b/ansible/roles/ocp4_machineset_config/tasks/machineset-group-aws.yml
@@ -14,6 +14,7 @@
 
     - name: Overwrite aws_coreos_ami_id
       ansible.builtin.set_fact:
+      # yamllint disable-line rule:line-length
         custom_aws_coreos_ami_id: "{{ prepare_stream_json.architectures[machineset_group.aws_instance_ami_architecture].images.aws.regions[aws_region].image }}"
 
 - name: Define {{ machineset_group.name }} machinesets

--- a/ansible/roles/ocp4_machineset_config/templates/machineset-aws.j2
+++ b/ansible/roles/ocp4_machineset_config/templates/machineset-aws.j2
@@ -37,7 +37,7 @@ spec:
       providerSpec:
         value:
           ami:
-            id: {{ aws_coreos_ami_id }}
+            id: {{ aws_instance_ami_id }}
           apiVersion: {{ cloud_provider_api_version }}
           blockDevices:
           - ebs:
@@ -66,7 +66,7 @@ spec:
           tags: {{ aws_worker_tags | to_json }}
           userDataSecret:
             name: worker-user-data
-{% if machineset_group.taints | d('') | length > 0 %}            
+{% if machineset_group.taints | d('') | length > 0 %}
       taints:
 {% for taint in machineset_group.taints %}
       - key: "{{ taint.key }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_machinesets/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_machinesets/defaults/main.yml
@@ -52,6 +52,11 @@ ocp4_workload_machinesets_machineset_groups:
     value: reserved
     effect: NoExecute
   instance_type: "m5a.2xlarge"
+
+  # Optional to change the architectures of the Ami: ["aarch64","ppc64le","s390x","x86_64"]
+  #   Basicly from : `openshift-install coreos print-stream-json | jq  -r -c '.architectures | keys '`
+  # instance_ami_architecture: "aarch64"
+
 # root_volume_size is only available for AWS it is ignored for OpenStack
 #   root_volume_size: "150"
 # root_volume_iops is only available for AWS it is ignored for OpenStack


### PR DESCRIPTION
##### SUMMARY

Enable the ansible roles ocp4_machineset_config & ocp4_workload_machinesets to create a machineset with a different architecure. 

Example for a multi-arch cluster:

```yaml
ocp4_installer_version: 4.15.14
ocp4_installer_url: https://mirror.openshift.com/pub/openshift-v4/multi/clients/ocp/4.15.14/amd64/openshift-install-linux.tar.gz
ocp4_client_url: https://mirror.openshift.com/pub/openshift-v4/multi/clients/ocp/4.15.14/amd64/openshift-client-linux.tar.gz
ocp4_network_type: OVNKubernetes

infra_workloads:
- ocp4_workload_machinesets

ocp4_workload_machinesets_machineset_groups:
- name: arm 
  role: arm
  instance_type: m7g.2xlarge 
#  openshift-install coreos print-stream-json | jq  -r -c '.architectures | keys ' # ["aarch64","ppc64le","s390x","x86_64"] 
  instance_ami_architecture: aarch64
  autoscale: false 
  total_replicas: "{{ [(num_users | int / 5) | round(0, 'ceil') | int, 3] | max }}" 
  total_replicas_min: "{{ [(num_users | int / 5) | round(0, 'ceil') | int, 3] | max }}" 
  total_replicas_max: "{{ [(num_users | int / 5) | round(0, 'ceil') | int, 3] | max }}"
  taints:
  - key: "kubernetes.io/arch"
    value: "arm"
    effect: NoSchedule
```

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Roles
 * ocp4_machineset_config
 * ocp4_workload_machinesets

##### ADDITIONAL INFORMATION

