### PR TITLE
Updated k8s requirements to allow vCenter tasks to run

### DIFF
--- a/ansible/configs/ocp4-cluster/files/requirements_k8s.txt
+++ b/ansible/configs/ocp4-cluster/files/requirements_k8s.txt
@@ -19,11 +19,11 @@ google-auth==2.3.3
 idna==3.3
 Jinja2==3.0.3
 jmespath==0.10.0
-kubernetes==23.3.0
+kubernetes==29.0.0
 lxml==4.6.3
 MarkupSafe==2.0.1
 oauthlib==3.1.1
-openshift==0.13.1
+openshift==0.13.2
 paramiko==2.7.1
 passlib==1.7.4
 pyasn1==0.4.8
@@ -47,3 +47,5 @@ selinux==0.2.1
 six==1.16.0
 urllib3==1.26.7
 websocket-client==1.2.1
+pyVim==3.0.3
+pyvmomi==8.0.2.0.1

--- a/ansible/configs/ocp4-cluster/files/requirements_k8s_el9.txt
+++ b/ansible/configs/ocp4-cluster/files/requirements_k8s_el9.txt
@@ -38,3 +38,5 @@ websocket-client==1.7.0
 boto3==1.34.64
 botocore==1.34.64
 s3transfer==0.10.1
+pyVim==3.0.3
+pyvmomi==8.0.2.0.1


### PR DESCRIPTION
##### SUMMARY

In order to run workload ocp4_workload_virt_roadshow_vmware the k8s virtualenv needs two additional python modules installed.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-cluster