### PR TITLE
fix deletions in VMW if folder is not created

### DIFF
--- a/ansible/configs/experience-ocpvirt/vcenter-remove-access.yml
+++ b/ansible/configs/experience-ocpvirt/vcenter-remove-access.yml
@@ -19,6 +19,7 @@
   retries: 1
   delay: 10
   loop: "{{ vcenter_permissions | dict2items }}"
+  ignore_errors: true
 
 # yamllint disable rule:line-length
 - name: Run playbook in the jumphost to remove the user

--- a/ansible/configs/osp-on-ocp/vcenter-remove-access.yml
+++ b/ansible/configs/osp-on-ocp/vcenter-remove-access.yml
@@ -19,6 +19,7 @@
   retries: 1
   delay: 10
   loop: "{{ vcenter_permissions | dict2items }}"
+  ignore_errors: true
 
 # yamllint disable rule:line-length
 - name: Run playbook in the jumphost to remove the user


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
fix deletions in VMW if folder is not created
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
configs/experience-ocpvirt/vcenter-remove-access.yml
configs/osp-on-ocp/vcenter-remove-access.yml

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
