### PR TITLE
Update requirements_k8s.txt

### DIFF
--- a/ansible/configs/ocp4-cluster/files/requirements_k8s.txt
+++ b/ansible/configs/ocp4-cluster/files/requirements_k8s.txt
@@ -19,11 +19,11 @@ google-auth==2.3.3
 idna==3.3
 Jinja2==3.0.3
 jmespath==0.10.0
-kubernetes==29.0.0
+kubernetes==23.3.0
 lxml==4.6.3
 MarkupSafe==2.0.1
 oauthlib==3.1.1
-openshift==0.13.2
+openshift==0.13.1
 paramiko==2.7.1
 passlib==1.7.4
 pyasn1==0.4.8
@@ -47,5 +47,3 @@ selinux==0.2.1
 six==1.16.0
 urllib3==1.26.7
 websocket-client==1.2.1
-pyVim==3.0.3
-pyvmomi==8.0.2.0.1


### PR DESCRIPTION
reverting changes on rhel8 because CI's using 
bastion_instance_image: RHEL84GOLD-latest are failing

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

reverting changes on rhel8 because CI's using 
bastion_instance_image: RHEL84GOLD-latest are failing

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Bugfix Pull Request



