### PR TITLE
Re-arrange delete of user to fix (?) error?

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/tasks/vcenter_remove_user.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/tasks/vcenter_remove_user.yml
@@ -25,6 +25,7 @@
   ansible.builtin.command: |
     ansible-playbook
     /home/{{ vmware_ibm_ldap_jumphost_user }}/sandbox_ad_user.yaml
-    -e '{"vmware_add_create_user":{"name":"{{ ocp4_workload_virt_roadshow_vmware_vcenter_user }}","firstname":"{{ ocp4_workload_virt_roadshow_vmware_vcenter_user }}","surname":"{{ ocp4_workload_virt_roadshow_vmware_vcenter_user }}","password":"","group":"{{ ocp4_workload_virt_roadshow_vmware_vcenter_group }}"}}' -e state=absent
+    -e state=absent
+    -e '{"vmware_add_create_user":{"name":"{{ ocp4_workload_virt_roadshow_vmware_vcenter_user }}","firstname":"{{ ocp4_workload_virt_roadshow_vmware_vcenter_user }}","surname":"{{ ocp4_workload_virt_roadshow_vmware_vcenter_user }}","password":"","group":"{{ ocp4_workload_virt_roadshow_vmware_vcenter_group }}"}}'
   ignore_errors: true
 # yamllint enable rule:line-length


### PR DESCRIPTION
##### SUMMARY

Oddly deleting the user in vCenter failed with an error that the playbook couldn't be found. Re-arranging the command a bit.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_virt_roadshow_vmware