### PR TITLE
RHTAP timeout patch

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_trusted_application_pipeline/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_trusted_application_pipeline/defaults/main.yml
@@ -14,6 +14,12 @@ ocp4_workload_trusted_application_pipeline_backstage_gitlab_group: janus-idp
 
 ocp4_workload_trusted_application_pipeline_postgresql_password: postgres
 
+# --------------------------------
+# Storage System parameters
+# --------------------------------
+ocp4_workload_openshift_data_foundation_ceph_storage_system_deploy_timeout: 600
+ocp4_workload_openshift_data_foundation_ceph_storage_cluster_deploy_timeout: 600
+
 ocp4_workload_trusted_application_pipeline_gitlab_root_user: root
 ocp4_workload_trusted_application_pipeline_gitlab_root_password: openshift
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_trusted_application_pipeline/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_trusted_application_pipeline/tasks/workload.yml
@@ -10,6 +10,34 @@
     name: cluster
   register: r_ingress_config
 
+- name: Wait for ODF Storage System to finish deploying
+  kubernetes.core.k8s_info:
+    api_version: odf.openshift.io/v1alpha1
+    kind: StorageSystem
+    name: ocs-storagecluster-storagesystem
+    namespace: openshift-storage
+    wait: true
+    wait_condition:
+      reason: ReconcileCompleted
+      status: 'True'
+      type: Available
+    wait_sleep: 10
+    wait_timeout: "{{ ocp4_workload_openshift_data_foundation_ceph_storage_system_deploy_timeout }}"
+
+- name: Wait for ODF Storage Cluster to finish deploying
+  kubernetes.core.k8s_info:
+    api_version: ocs.openshift.io/v1
+    kind: StorageCluster
+    name: ocs-storagecluster
+    namespace: openshift-storage
+    wait: true
+    wait_condition:
+      reason: ReconcileCompleted
+      status: "True"
+      type: ReconcileComplete
+    wait_sleep: 10
+    wait_timeout: "{{ ocp4_workload_openshift_data_foundation_ceph_storage_cluster_deploy_timeout }}"
+
 - name: Get OpenShift Apps Domain
   ansible.builtin.set_fact:
     ocp4_workload_trusted_application_pipeline_apps_domain: "{{ r_ingress_config.resources[0].spec.domain }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_trusted_application_pipeline/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_trusted_application_pipeline/tasks/workload.yml
@@ -22,7 +22,7 @@
       status: 'True'
       type: Available
     wait_sleep: 10
-    wait_timeout: "{{ ocp4_workload_openshift_data_foundation_ceph_storage_system_deploy_timeout }}"
+    wait_timeout: "{{ ocp4_workload_trusted_application_pipeline_ceph_storage_system_deploy_timeout }}"
 
 - name: Wait for ODF Storage Cluster to finish deploying
   kubernetes.core.k8s_info:
@@ -36,7 +36,7 @@
       status: "True"
       type: ReconcileComplete
     wait_sleep: 10
-    wait_timeout: "{{ ocp4_workload_openshift_data_foundation_ceph_storage_cluster_deploy_timeout }}"
+    wait_timeout: "{{ ocp4_workload_trusted_application_pipeline_ceph_storage_cluster_deploy_timeout }}"
 
 - name: Get OpenShift Apps Domain
   ansible.builtin.set_fact:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Adds timeouts for OSD deployment

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
RHTAP timeout patch

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Why trying to deploy CI Red Hat Trusted Application Pipeline, you may encounter this error:
TASK [ocp4_workload_openshift_data_foundation : Wait for ODF Storage Cluster to finish deploying] ***
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible_collections.kubernetes.core.plugins.module_utils.k8s.exceptions.CoreException: Failed to gather information about StorageCluster(s) even after waiting for 600 seconds
fatal: [bastion.tf2q9.internal]: FAILED! => {"changed": false, "msg": "Failed to gather information about StorageCluster(s) even after waiting for 600 seconds"}

Error looks similar to errors fixed by:
https://github.com/rhpds/agnosticv/pull/14743/files
https://github.com/redhat-cop/agnosticd/pull/7977/files

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below
N/A - fix submitted through github.com
```
