### PR TITLE
Add user info to agnosticd_user_data if only one user was created

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/tasks/workload.yml
@@ -186,6 +186,9 @@
     - name: Print the user details if a single user was created
       when: ocp4_workload_gitea_operator_user_number | int == 1
       agnosticd_user_info:
+        data:
+          gitea_user: "{{ ocp4_workload_gitea_operator_generate_user_format }}"
+          gitea_password: "{{ r_gitea_user_setup_complete.resources[0].status.userPassword }}"
         msg: >-
           A Gitea user '{{ ocp4_workload_gitea_operator_generate_user_format }}' was created, with the password
           '{{ r_gitea_user_setup_complete.resources[0].status.userPassword }}'


### PR DESCRIPTION
##### SUMMARY

If only one user was created in Gitea no user information was saved to agnosticd_user_data (only printed).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_gitea_operator