### PR TITLE
Switch to new LetsEncrypt R11 intermediate cert.

### DIFF
--- a/ansible/roles/ansible_bu_satellite/tasks/main.yml
+++ b/ansible/roles/ansible_bu_satellite/tasks/main.yml
@@ -69,14 +69,14 @@
     group: root
     owner: root
   loop:
-    - url: https://letsencrypt.org/certs/lets-encrypt-r3.pem
-      checksum: sha256:177e1b8fc43b722b393f4200ff4d92e32deeffbb76fef5ee68d8f49c88cf9d32
+    - url: https://letsencrypt.org/certs/2024/r11.pem
+      checksum: sha256:6c06a45850f93aa6e31f9388f956379d8b4fb7ffca5211b9bab4ad159bdfb7b9
     - url: https://letsencrypt.org/certs/isrgrootx1.pem
       checksum: sha256:22b557a27055b33606b6559f37703928d3e4ad79f110b407d04986e1843543d1
 
-- name: Retrieve LetsEncrypt R3 cert
+- name: Retrieve LetsEncrypt R11 cert
   slurp:
-    src: "/etc/letsencrypt/live/{{ ansible_bu_satellite_external_fqdn }}/lets-encrypt-r3.pem"
+    src: "/etc/letsencrypt/live/{{ ansible_bu_satellite_external_fqdn }}/r11.pem"
   register: intermediate_cert
 
 - name: Retrieve LetsEncrypt root X1 cert
@@ -84,7 +84,7 @@
     src: "/etc/letsencrypt/live/{{ ansible_bu_satellite_external_fqdn }}/isrgrootx1.pem"
   register: root_cert
 
-- name: Combine R3 and root X1 certs to create Letsencrypt CA bundle
+- name: Combine R11 and root X1 certs to create Letsencrypt CA bundle
   copy:
     content: |
       {{ root_cert.content|b64decode }}


### PR DESCRIPTION
##### SUMMARY

Earlier this year, Let’s Encrypt generated new intermediate keys and certificates. On Thursday, June 6th, 2024, Let's Encrypt switched issuance to use the new intermediate certificates. As a result, the CA bundle built for the Satellite was incorrect and any certificate validation would fail.

This PR switches from the old R3 intermediate cert to the new R11 cert.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible/roles/ansible_bu_satellite
