### PR TITLE
Allow passing of the hostedzoneid (for CNV clusters) instead of determining it

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/defaults/main.yml
@@ -39,6 +39,9 @@ ocp4_workload_cert_manager_ec2_region: us-east-2
 ocp4_workload_cert_manager_ec2_access_key_id: ""
 ocp4_workload_cert_manager_ec2_secret_access_key: ""
 
+# If a HostedZoneID is provided use that one, otherwise determine dynamically
+ocp4_workload_cert_manager_ec2_hostedzoneid: ""
+
 ocp4_workload_cert_manager_channel: stable-v1
 
 ocp4_workload_cert_manager_starting_csv: ""

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/cert_manager_ec2.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/cert_manager_ec2.yml
@@ -1,15 +1,24 @@
 ---
-- name: Get HostedZoneID
-  kubernetes.core.k8s_info:
-    api_version: config.openshift.io/v1
-    kind: DNS
-    name: cluster
-  register: r_hostedzoneid
-
-- name: Set HostedZoneID fact
+- name: Use provided HostedZoneID
+  when: ocp4_workload_cert_manager_ec2_hostedzoneid | default("") | length > 0
   ansible.builtin.set_fact:
     _ocp4_workload_cert_manager_hostedzoneid: >-
-      {{ r_hostedzoneid.resources[0].spec.publicZone.id }}
+      {{ ocp4_workload_cert_manager_ec2_hostedzoneid }}
+
+- name: Determine HostedZoneID
+  when: ocp4_workload_cert_manager_ec2_hostedzoneid | default("") | length == 0
+  block:
+  - name: Get HostedZoneID
+    kubernetes.core.k8s_info:
+      api_version: config.openshift.io/v1
+      kind: DNS
+      name: cluster
+    register: r_hostedzoneid
+
+  - name: Set HostedZoneID fact
+    ansible.builtin.set_fact:
+      _ocp4_workload_cert_manager_hostedzoneid: >-
+        {{ r_hostedzoneid.resources[0].spec.publicZone.id }}
 
 - name: Print HostedZoneID
   ansible.builtin.debug:


### PR DESCRIPTION
##### SUMMARY

For CNV Clusters (which use Route53) allow passing of the HostedZoneID via variable instead of trying to determine it. This way certs can be requested for CNV clusters.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_cert_manager