### PR TITLE
Include Let's Encrypt R10 Intermediate cert in CA bundle.

### DIFF
--- a/ansible/roles/ansible_bu_satellite/tasks/main.yml
+++ b/ansible/roles/ansible_bu_satellite/tasks/main.yml
@@ -69,26 +69,34 @@
     group: root
     owner: root
   loop:
+    - url: https://letsencrypt.org/certs/2024/r10.pem
+      checksum: sha256:29ee679fb573c905bf3538126de6893a9e20ebe1cf400c6df22e5d171c94f543
     - url: https://letsencrypt.org/certs/2024/r11.pem
       checksum: sha256:6c06a45850f93aa6e31f9388f956379d8b4fb7ffca5211b9bab4ad159bdfb7b9
     - url: https://letsencrypt.org/certs/isrgrootx1.pem
       checksum: sha256:22b557a27055b33606b6559f37703928d3e4ad79f110b407d04986e1843543d1
 
+- name: Retrieve LetsEncrypt R10 cert
+  slurp:
+    src: "/etc/letsencrypt/live/{{ ansible_bu_satellite_external_fqdn }}/r10.pem"
+  register: intermediate_cert_r10
+
 - name: Retrieve LetsEncrypt R11 cert
   slurp:
     src: "/etc/letsencrypt/live/{{ ansible_bu_satellite_external_fqdn }}/r11.pem"
-  register: intermediate_cert
+  register: intermediate_cert_r11
 
 - name: Retrieve LetsEncrypt root X1 cert
   slurp:
     src: "/etc/letsencrypt/live/{{ ansible_bu_satellite_external_fqdn }}/isrgrootx1.pem"
   register: root_cert
 
-- name: Combine R11 and root X1 certs to create Letsencrypt CA bundle
+- name: Combine R10, R11 and root X1 certs to create Letsencrypt CA bundle
   copy:
     content: |
       {{ root_cert.content|b64decode }}
-      {{ intermediate_cert.content | b64decode }}
+      {{ intermediate_cert_r10.content | b64decode }}
+      {{ intermediate_cert_r11.content | b64decode }}
     dest: "/etc/letsencrypt/live/{{ ansible_bu_satellite_external_fqdn }}/letsencrypt-ca-bundle.pem" 
 
 - name: Start httpd


### PR DESCRIPTION
##### SUMMARY
In order to properly construct the Let's Encrypt CA bundle certificate, you must also include the R10 Intermediate certificate.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
ansible/roles/ansible_bu_satellite
