### PR TITLE
Fix ceph cleanup on CNV in Sandboxes. Make cleanup image configurable

### DIFF
--- a/ansible/configs/ocp4-cluster/default_vars_openshift_cnv.yml
+++ b/ansible/configs/ocp4-cluster/default_vars_openshift_cnv.yml
@@ -11,7 +11,6 @@ cloud_provider: openshift_cnv
 ansible_user: cloud-user
 remote_user: cloud-user
 
-
 # Use Dynamic DNS. Always true
 use_dynamic_dns: true
 
@@ -22,6 +21,9 @@ wait_for_dns: true
 # osp_cluster_dns_zone needs to come from secrets
 # subdomain_base_suffix: "{{ osp_cluster_dns_zone }}"
 ocp4_base_domain: "{{ osp_cluster_dns_zone }}"
+
+# Container image to use in Ceph cleanup job
+ceph_cleanup_job_image: registry.redhat.io/odf4/rook-ceph-rhel9-operator:v4.15
 
 # User info settings
 ocp4_cluster_show_default_user_info: true
@@ -35,27 +37,27 @@ bastion_memory: 2G
 bastion_rootfs_size: 30Gi
 
 instances:
-  - name: bastion
-    count: 1
-    unique: true
-    alt_name: bastion
-    memory: "{{ bastion_memory }}"
-    cores: "{{ bastion_cores }}"
-    image_size: "{{ bastion_rootfs_size }}"
-    image: "{{ bastion_instance_image }}"
-    metadata:
-      - AnsibleGroup: "bastions"
-      - function: bastion
-      - user: "{{ student_name }}"
-      - project: "{{ project_tag }}"
-      - ostype: linux
-      - Purpose: "{{ purpose }}"
-    tags:
-      - key: "AnsibleGroup"
-        value: "bastions"
-      - key: "ostype"
-        value: "linux"
-      - key: "instance_filter"
-        value: "{{ env_type }}-{{ guid }}"
-    networks:
-      - default
+- name: bastion
+  count: 1
+  unique: true
+  alt_name: bastion
+  memory: "{{ bastion_memory }}"
+  cores: "{{ bastion_cores }}"
+  image_size: "{{ bastion_rootfs_size }}"
+  image: "{{ bastion_instance_image }}"
+  metadata:
+  - AnsibleGroup: "bastions"
+  - function: bastion
+  - user: "{{ student_name }}"
+  - project: "{{ project_tag }}"
+  - ostype: linux
+  - Purpose: "{{ purpose }}"
+  tags:
+  - key: "AnsibleGroup"
+    value: "bastions"
+  - key: "ostype"
+    value: "linux"
+  - key: "instance_filter"
+    value: "{{ env_type }}-{{ guid }}"
+  networks:
+  - default

--- a/ansible/roles/host-ocp4-assisted-destroy/templates/cleanup-ceph.yaml.j2
+++ b/ansible/roles/host-ocp4-assisted-destroy/templates/cleanup-ceph.yaml.j2
@@ -3,11 +3,7 @@ kind: Job
 apiVersion: batch/v1
 metadata:
   name: cleanup-ceph-{{ ai_ocp_namespace }}
-{% if sandbox_openshift_namespace | default("") | length > 0 %}
-  namespace: {{ sandbox_openshift_namespace }}
-{% else %}
   namespace: cleanup
-{% endif %}
 spec:
   replicas: 1
   selector:

--- a/ansible/roles/host-ocp4-assisted-destroy/templates/cleanup-ceph.yaml.j2
+++ b/ansible/roles/host-ocp4-assisted-destroy/templates/cleanup-ceph.yaml.j2
@@ -1,8 +1,13 @@
+---
 kind: Job
 apiVersion: batch/v1
 metadata:
   name: cleanup-ceph-{{ ai_ocp_namespace }}
+{% if sandbox_openshift_namespace | default("") | length > 0 %}
+  namespace: {{ sandbox_openshift_namespace }}
+{% else %}
   namespace: cleanup
+{% endif %}
 spec:
   replicas: 1
   selector:
@@ -13,20 +18,19 @@ spec:
         name: cleanup-ceph
     spec:
       containers:
-      - image: registry.redhat.io/odf4/rook-ceph-rhel9-operator:v4.13
+      - image: {{ ceph_cleanup_job_image }}
         name: cleanup-job
         command:
-          - "/bin/sh"
-          - "/etc/ceph/cleanup-script.sh"
+        - "/bin/sh"
+        - "/etc/ceph/cleanup-script.sh"
         env:
-          - name: LAB
-            value: {{ ai_ocp_namespace }}
+        - name: LAB
+          value: {{ ai_ocp_namespace }}
         volumeMounts:
-          - name: keyring-volume
-            mountPath: /etc/ceph
+        - name: keyring-volume
+          mountPath: /etc/ceph
       restartPolicy: Never
       volumes:
       - name: keyring-volume
         secret:
           secretName: ceph-tenant-config
-


### PR DESCRIPTION
##### SUMMARY

This PR adds a variable to customize the cleanup job image (default now 4.15 instead of the outdated 4.13) enabling easier updates to future releases.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-cluster
host-ocp4-assisted-destroy