### PR TITLE
ZT RHEL update to allow outbound with var

### DIFF
--- a/ansible/configs/zero-touch-base-rhel/lock_bastion_security_group.yml
+++ b/ansible/configs/zero-touch-base-rhel/lock_bastion_security_group.yml
@@ -32,7 +32,7 @@
     - ports: "{{ zero_touch_ports }}"
       proto: tcp
       cidr_ip: "0.0.0.0/0"
-    rules_egress: []
+    rules_egress: "{{ zero_touch_egress_rules | default('[]') }}"
   register: r_sg
 
 - name: Disable/Enable DNS support for EC2 instance


### PR DESCRIPTION
Zero Touch RHEL, This PR is to allow outbound traffic to the satellite. This is required by multiple labs to install packages.