### PR TITLE
Fix workload ocp4_workload_summit_2024_cloud_native_camel devspaces bug.

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_summit_2024_cloud_native_camel/tasks/install_devspaces.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_summit_2024_cloud_native_camel/tasks/install_devspaces.yml
@@ -74,7 +74,7 @@
 - name: Check DevSpaces plugin-registry devfile endpoint readiness
   ansible.builtin.uri:
     validate_certs: '{{ verify_tls }}'
-    url: https://devspaces.{{ route_subdomain }}/plugin-registry/v3/plugins/che-incubator/che-code/insiders/devfile.yaml
+    url: https://devspaces.{{ route_subdomain }}/plugin-registry/v3/plugins/che-incubator/che-code/latest/devfile.yaml
     method: GET
     return_content: false
     status_code: 200


### PR DESCRIPTION
…spaces operator

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Ansible task (Check DevSpaces plugin-registry devfile endpoint readiness)  was failing for checking plugin registry endpoint uri, Updated plugin registry URI to match the latest version of dev spaces



<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
Install_devspaces.yaml , Task : Check DevSpaces plugin-registry devfile endpoint readiness


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
