### PR TITLE
update kubernetes.core module version

### DIFF
--- a/ansible/configs/rosa-consolidated/requirements.yml
+++ b/ansible/configs/rosa-consolidated/requirements.yml
@@ -1,7 +1,7 @@
 ---
 collections:
 - name: kubernetes.core
-  version: 2.4.0
+  version: 3.0.1
 - name: amazon.aws
   version: 6.4.0
 - name: community.general


### PR DESCRIPTION
##### SUMMARY

Updated kubernetes.core ansible module version. Old version doesn't work with Ansible automation platform role. 
This is the same version used in ocp4-cluster config.

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
Config: rosa-consolidated