### PR TITLE
Remove local connection from destroy

### DIFF
--- a/ansible/configs/ocp4-cluster/destroy_env_openshift_cnv.yml
+++ b/ansible/configs/ocp4-cluster/destroy_env_openshift_cnv.yml
@@ -1,13 +1,13 @@
 ---
-- import_playbook: ../../setup_runtime.yml
+- name: Setup Runtime
+  ansible.builtin.import_playbook: ../../setup_runtime.yml
 
 - name: Destroy environment on OpenShift CNV
   hosts: localhost
-  connection: local
   gather_facts: false
   tasks:
   - name: Run host-ocp4-assisted-destroy role
-    include_role:
+    ansible.builtin.include_role:
       name: host-ocp4-assisted-destroy
 
   - name: Remove ocp workloads
@@ -15,7 +15,7 @@
     - remove_workloads | default("") | length > 0
     block:
     - name: Invoke roles to remove ocp workloads
-      include_role:
+      ansible.builtin.include_role:
         name: "{{ workload_loop_var }}"
       vars:
         ocp_username: "system:admin"


### PR DESCRIPTION
##### SUMMARY

connection:local prevents dynamic additions of hosts. So some destroy tasks fail.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_cluster