### PR TITLE
Destroy on CNV called setup_runtime twice. Removing the one in the destroy logic to speed things up.

### DIFF
--- a/ansible/configs/ocp4-cluster/destroy_env_openshift_cnv.yml
+++ b/ansible/configs/ocp4-cluster/destroy_env_openshift_cnv.yml
@@ -1,7 +1,4 @@
 ---
-- name: Setup Runtime
-  ansible.builtin.import_playbook: ../../setup_runtime.yml
-
 - name: Destroy environment on OpenShift CNV
   hosts: localhost
   gather_facts: false


### PR DESCRIPTION

##### SUMMARY

Destroy on CNV called setup_runtime twice. Removing the one in the destroy logic to speed things up.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-cluster (on CNV)