### PR TITLE
Add user_info.data to config/exploring-ocpvirt to match config/ocp4-cluster

### DIFF
--- a/ansible/configs/experience-ocpvirt/post_software.yml
+++ b/ansible/configs/experience-ocpvirt/post_software.yml
@@ -135,6 +135,7 @@
       data:
         preinstall_operators: "{{ preinstall_operators }}"
         vcenter_user: "{{ hostvars['localhost']['vcenter_student_username'] }}@{{ vcenter_domain }}"
+        vcenter_domain: "{{ vcenter_domain }}"
         vcenter_full_user: "{{ hostvars['localhost']['vcenter_student_username'] }}@{{ vcenter_domain }}"
         vcenter_password: "{{ hostvars['localhost']['vcenter_student_password'] }}"
         vcenter_console: "{{ hostvars['localhost']['vcenter_hostname'] }}"
@@ -145,15 +146,18 @@
         bastion_host_ssh_user: "{{ student_name }}"
         bastion_host_ssh_password: "{{ hostvars['hypervisor']['student_password'] | default(hostvars[groups.bastions.0]['student_password']) }}"
 
+# added "openshift_cluster_*" variables below to match openshift_cnv config
   - name: Save Kube Configuration for IPI
     when: ocp4_aio_deploy_ipi
     agnosticd_user_info:
       data:
         openshift_api_server: "https://api.{{ guid }}.{{ cluster_dns_zone }}:6443"
         openshift_web_console: "https://console-openshift-console.apps.{{ guid }}.{{ cluster_dns_zone }}"
+        openshift_cluster_console_url: "https://console-openshift-console.apps.{{ guid }}.{{ cluster_dns_zone }}"
         openshift_admin_user: admin
+        openshift_cluster_admin_user: admin
         openshift_admin_password: "{{ hostvars['localhost']['openshift_admin_password'] }}"
-
+        openshift_cluster_admin_password: "{{ hostvars['localhost']['openshift_admin_password'] }}"
 
 - name: Prepare Hypervisor for proxypass
   hosts: hypervisor

--- a/ansible/configs/experience-ocpvirt/post_software.yml
+++ b/ansible/configs/experience-ocpvirt/post_software.yml
@@ -135,6 +135,7 @@
       data:
         preinstall_operators: "{{ preinstall_operators }}"
         vcenter_user: "{{ hostvars['localhost']['vcenter_student_username'] }}@{{ vcenter_domain }}"
+        vcenter_full_user: "{{ hostvars['localhost']['vcenter_student_username'] }}@{{ vcenter_domain }}"
         vcenter_password: "{{ hostvars['localhost']['vcenter_student_password'] }}"
         vcenter_console: "{{ hostvars['localhost']['vcenter_hostname'] }}"
         vcenter_datastore: "{{ hostvars['localhost']['vcenter_datastore'] }}"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

When using the same showroom repo for the same demo from each of the two configs, I discovered that the user_info.data variable names were different in some cases.

Using ocp4-cluster config as (mostly) the guide, I normalized them.

I also did a bit of attribute analysis and discovered some variations we might note and discuss.

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
configs:  experience-ocpvirt

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
