### PR TITLE
asset-injector role, update blockinfile vars

### DIFF
--- a/ansible/roles/asset_injector/tasks/main.yml
+++ b/ansible/roles/asset_injector/tasks/main.yml
@@ -91,6 +91,8 @@
     block: "{{ _asset.block }}"
     marker: "{{ _asset.marker | default('# ANSIBLE MANAGED BLOCK') }}"
     create: "{{ _asset.create | default(omit) }}"
+    mode: "{{ _asset.mode | default(omit) }}"
+    owner: "{{ _asset.owner | default(omit) }}"
     backup: "{{ _asset.backup | default(omit) }}"
     unsafe_writes: "{{ _asset.unsafe_writes | default(omit) }}"
     blockquote: "{{ _asset.blockquote | default(omit) }}"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
This update adds variables to control the file mode and owner for injecting assets with blockinfile.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
