### PR TITLE
pull files from S3 not www

### DIFF
--- a/ansible/configs/roadshow-ocpvirt/pre_software.yml
+++ b/ansible/configs/roadshow-ocpvirt/pre_software.yml
@@ -162,7 +162,7 @@
 
     - name: Download required files for the lab
       get_url:
-        url: "https://www.opentlc.com/download/ocp4_virt_foundations/{{ item }}"
+        url: "https://catalog-item-assets.s3.us-east-2.amazonaws.com/qcow_images/{{ item }}"
         dest: "/var/www/html/{{ item }}"
         owner: apache
         group: apache


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Pull files from S3 instead of legacy WWW host.
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
roadshow-ocpvirt

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
