### PR TITLE
SonarQube patch for critical CVE

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_sonarqube/templates/cicd/sonarqube-persistent-deploy.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_sonarqube/templates/cicd/sonarqube-persistent-deploy.yaml.j2
@@ -167,6 +167,16 @@ items:
               secretKeyRef:
                 key: database-password
                 name: sonardb
+          - name: SONAR_JDBC_USERNAME
+            valueFrom:
+              secretKeyRef:
+                key: database-user
+                name: sonardb
+          - name: SONAR_JDBC_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: database-password
+                name: sonardb
           - name: FORCE_AUTHENTICATION
             value: "false"
           - name: PROXY_HOST

--- a/ansible/roles_ocp_workloads/ocp4_workload_sonarqube/templates/cicd/sonarqube-persistent-deploy.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_sonarqube/templates/cicd/sonarqube-persistent-deploy.yaml.j2
@@ -189,7 +189,7 @@ items:
             value: "true"
           - name: LDAP_BINDDN
           - name: LDAP_BINDPASSWD
-          image: docker.io/kenmoini/openshift-sonarqube
+          image: quay.io/kenmoini/sonarqube:34b8fd8
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 3

--- a/ansible/roles_ocp_workloads/ocp4_workload_sonarqube/templates/cicd/sonarqube-persistent-deploy.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_sonarqube/templates/cicd/sonarqube-persistent-deploy.yaml.j2
@@ -155,6 +155,8 @@ items:
         - env:
           - name: JDBC_URL
             value: jdbc:postgresql://sonardb:5432/sonar
+          - name: SONAR_JDBC_URL
+            value: jdbc:postgresql://sonardb:5432/sonar
           - name: JDBC_USERNAME
             valueFrom:
               secretKeyRef:
@@ -171,39 +173,22 @@ items:
           - name: PROXY_PORT
           - name: PROXY_USER
           - name: PROXY_PASSWORD
+          - name: SONAR_SECURITY_REALM
           - name: LDAP_URL
-            value: ldaps://idm.example.com:636
           - name: LDAP_REALM
           - name: LDAP_AUTHENTICATION
-            value: simple
           - name: LDAP_USER_BASEDN
-            value: cn=accounts,dc=example,dc=com
           - name: LDAP_USER_REAL_NAME_ATTR
-            value: displayname
           - name: LDAP_USER_EMAIL_ATTR
-            value: mail
           - name: LDAP_USER_REQUEST
-            value: (&(objectClass=inetOrgPerson)(uid={login}))
           - name: LDAP_GROUP_BASEDN
-            value: cn=groups,cn=accounts,dc=example,dc=com
           - name: LDAP_GROUP_REQUEST
-            value: (&(objectClass=groupOfUniqueNames)(uniqueMember={dn}))
           - name: LDAP_GROUP_ID_ATTR
-            value: cn
           - name: LDAP_CONTEXTFACTORY
-            value: com.sun.jndi.ldap.LdapCtxFactory
           - name: SONAR_AUTOCREATE_USERS
             value: "true"
           - name: LDAP_BINDDN
-            valueFrom:
-              secretKeyRef:
-                key: username
-                name: sonar-ldap-bind-dn
           - name: LDAP_BINDPASSWD
-            valueFrom:
-              secretKeyRef:
-                key: password
-                name: sonar-ldap-bind-dn
           image: docker.io/kenmoini/openshift-sonarqube
           imagePullPolicy: Always
           livenessProbe:


### PR DESCRIPTION
##### SUMMARY

The previous configuration of this template in `ansible/roles_ocp_workloads/ocp4_workload_sonarqube/templates/cicd/sonarqube-persistent-deploy.yaml.j2` was using a Sonarqube container image hosted on Docker Hub.  This has been moved to the Quay mirror.

In addition, the previous Sonarqube image was over 4 years old, 3 major releases behind, and also ranked with a startling 10.0 CVE score due to dozens of legacy issues and vulnerabilities, one of which was the Log4j exploit - somewhat of a bad look in the context of the RHTAP demo/workshop.  The image has been updated to SonarQube v10 and tied to a specific tag that's more up to date.

In newer versions of Sonarqube the JDBC_URL was changed to use the SONAR_JDBC_URL which is also reflected in the changed Deployment template.

The LDAP configuration has also been removed - in previous versions it was largely ignored on start up, however in the newer Sonarqube version if the LDAP connection was not made the Sonarqube application would exit and the container would crash, failing to enter a Ready state.  The previous LDAP configuration was also pointing to an IDM server that did not exist.  The environmental variable placeholders have been kept in case this template is used in an environment where an operational LDAP server exists.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible/roles_ocp_workloads/ocp4_workload_sonarqube/
