### PR TITLE
ansible_bu_setup_workshop role - introduce centos vs oracle Ansible inventory configuration

### DIFF
--- a/ansible/roles/ansible_bu_setup_workshop/templates/hosts/auto_satellite.j2
+++ b/ansible/roles/ansible_bu_setup_workshop/templates/hosts/auto_satellite.j2
@@ -24,6 +24,7 @@ ansible_user=ec2-user
 [rhel:children]
 rhel7
 
+{% if el_rebuild_distribution == 'centos' -%}
 [centos7]
 {% for host in groups['centos_nodes'] %}
 {{ host.split('.')[0] }} ansible_host={{ host }}
@@ -34,6 +35,20 @@ ansible_user=ec2-user
 
 [centos:children]
 centos7
+{% endif -%}
+
+{% if el_rebuild_distribution == 'oracle' -%}
+[ol7]
+{% for host in groups['oracle_nodes'] %}
+{{ host.split('.')[0] }} ansible_host={{ host }}
+{% endfor %}
+
+[ol7:vars]
+ansible_user=ec2-user
+
+[ol7:children]
+ol7
+{% endif -%}
 
 [control]
 ansible-1 ansible_host={{ groups['bastions'][0] }}


### PR DESCRIPTION
##### SUMMARY
AgV config `sandboxes-gpte/ANS_BU_WKSP_AUTO_SATELLITE` provides means for choosing between CentOS or Oracle Linux instances for deploy, this change provides for centos vs oracle in Ansible inventory configuration.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible/roles/ansible_bu_setup_workshop
