### PR TITLE
ansible_bu_setup_workshop role - auto_satellite deploy logic, centos or oracle

### DIFF
--- a/ansible/roles/ansible_bu_setup_workshop/tasks/auto_satellite.yml
+++ b/ansible/roles/ansible_bu_setup_workshop/tasks/auto_satellite.yml
@@ -122,7 +122,14 @@
       retries: 18  # 5 minutes 6*60/20
 
     - name: Run Z / SETUP / Workshop - CentOS7 deployment workflow template
+      when: el_rebuild_distribution == 'centos'
       awx.awx.workflow_launch:
         workflow_template: "Z / SETUP / Workshop - CentOS7"
+        timeout: 3900 # 63 minutes
+
+    - name: Run Z / SETUP / Workshop - OL7 deployment workflow template
+      when: el_rebuild_distribution == 'oracle'
+      awx.awx.workflow_launch:
+        workflow_template: "Z / SETUP / Workshop - OL7"
         timeout: 3900 # 63 minutes
 ...


### PR DESCRIPTION
##### SUMMARY
Include deploy logic for `el_rebuild_distribution` var choice of centos vs oracle.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible/roles/ansible_bu_setup_workshop