### PR TITLE
Fix oc client version

### DIFF
--- a/ansible/roles/host-ocp4-installer/tasks/install_installer.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/install_installer.yml
@@ -1,3 +1,8 @@
+- name: Gather distribution version
+  setup:
+    gather_subset:
+    - distribution_version
+
 # ocp4_installer_version = 4.1.1 .. 4.99.99
 # ocp4_installer_version = 4.x.x-rc.x
 # -> specific installer version
@@ -30,9 +35,11 @@
         ocp4_installer_version
       ) }}
     ocp4_client_url: >-
-      {{ '{0}/ocp/stable-{1}/openshift-client-linux.tar.gz'.format(
+      {{ '{0}/ocp/stable-{1}/openshift-client-linux-{2}-rhel{3}.tar.gz'.format(
         ocp4_installer_root_url | default("https://mirror.openshift.com/pub/openshift-v4/clients"),
-        ocp4_installer_version
+        ocp4_installer_version,
+        'amd64' if ansible_architecture == 'x86_64' else ansible_architecture,
+        ansible_distribution_major_version
       ) }}
 
 - name: Ensure ocp4_installer_url and ocp4_client_url are set


### PR DESCRIPTION
This change try to fix:

```
TASK [host-ocp4-installer : Create OpenShift Bash completion file] *************
Wednesday 03 July 2024  11:30:55 +0000 (0:00:00.542)       1:01:05.004 ********
fatal: [bastion.n5s6l.internal]: FAILED! => {"changed": true, "cmd": "oc completion bash >/etc/bash_completion.d/openshift", "delta": "0:00:00.005362", "end": "2024-07-03 11:30:55.557546", "msg": "non-zero return code", "rc": 1, "start": "2024-07-03 11:30:55.552184", "stderr": "oc: /lib64/libc.so.6: version `GLIBC_2.33' not found (required by oc)\noc: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by oc)\noc: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by oc)", "stderr_lines": ["oc: /lib64/libc.so.6: version `GLIBC_2.33' not found (required by oc)", "oc: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by oc)", "oc: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by oc)"], "stdout": "", "stdout_lines": []}
```

Determine RHEL distribution  and use that to get the proper binary file from  mirror.openshift.com

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
