### PR TITLE
ansible_bu_setup_workshop role - raise oracle scenario deploy timeout to 5 hours.

### DIFF
--- a/ansible/roles/ansible_bu_setup_workshop/tasks/auto_satellite.yml
+++ b/ansible/roles/ansible_bu_setup_workshop/tasks/auto_satellite.yml
@@ -131,5 +131,5 @@
       when: el_rebuild_distribution == 'oracle'
       awx.awx.workflow_launch:
         workflow_template: "Z / SETUP / Workshop - OL7"
-        timeout: 3900 # 63 minutes
+        timeout: 18000 # 5 hours
 ...


### PR DESCRIPTION
##### SUMMARY
Raise oracle scenario deploy timeout to 5 hours. ~ 4 hours is required to sync Oracle repos on Satellite.

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
ansible_bu_setup_workshop role
