### PR TITLE
Skip infra nodes

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/tasks/workload.yml
@@ -9,6 +9,7 @@
     kind: Node
     label_selectors:
     - node-role.kubernetes.io/worker
+    - "!node-role.kubernetes.io/infra"
   register: r_worker_nodes
 
 - name: Fail for less than 3 worker nodes


### PR DESCRIPTION

##### SUMMARY

For running ODF on ROSA. We need to skip labeling infra nodes. 

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/tasks/workload.yml

