### PR TITLE
🎈pointing to uptaded content for v4.15🎈

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_tl500/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_tl500/tasks/workload.yml
@@ -145,7 +145,6 @@
   loop:
     - "helm dep up"
     - "helm upgrade --install tl500-base . \
-        -f values-v4.11+.yaml \
         --namespace tl500 --create-namespace --timeout=20m"
   register: tl500_base_result
   until: tl500_base_result.rc == 0
@@ -160,7 +159,6 @@
   loop:
     - "helm dep up"
     - "helm upgrade --install tl500-course-content . \
-        -f values-v4.11+.yaml \
         --namespace tl500 --create-namespace --timeout=20m"
   register: tl500_course_content
   until: tl500_course_content.rc == 0


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New config Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
TL500 DevOps Culture and Practice

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->

I'll mark the PR ready when I get okay from @eformat :) so I am tagging him here to check ❤️

Also, is it possible to mark existing prod TL500 catalog item on RHPDS as maintenance or something like that? There are a couple of PRs in different repositories that we need to align to make this change..which might affect the existing TL500 item.

And, since [AgnosticV repository](https://github.com/rhpds/agnosticv/blob/master/sandboxes-gpte/OCP4_WORKSHOP_DEVOPS_TL500/dev.yaml#L7) is already updated by @bbethell-1 with OCP v4.15 (thanks again!✨), there is nothing to do on that side. 

When we are moving these changes to prod, we need to do an update [here](https://github.com/rhpds/agnosticv/blob/master/sandboxes-gpte/OCP4_WORKSHOP_DEVOPS_TL500/common.yaml#L33) I assume though, right?

Thanks!

