### PR TITLE
Update post_infra.yml rhel8 base indentation fix

### DIFF
--- a/ansible/configs/rhel8-base/post_infra.yml
+++ b/ansible/configs/rhel8-base/post_infra.yml
@@ -9,7 +9,7 @@
     - post_infrastructure
   tasks:
     - debug:
-      msg: "Post-Infrastructure completed successfully"
+        msg: "Post-Infrastructure completed successfully"
 
 
 - name: Step 002 Post Infrastructure regreSSHion Hotfix


### PR DESCRIPTION
deploys are failing with this log https://aap2-prod-us-east-2.aap.infra.demo.redhat.com/#/jobs/playbook/638173/output

-->
##### SUMMARY

the RHEL9 base CI using the RHEL8 base config is failing with syntax error like in this job: https://aap2-prod-us-east-2.aap.infra.demo.redhat.com/#/jobs/playbook/638173/output

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
RHEL8 config post_infra task
