### PR TITLE
Fix rosa-consolidated user data

### DIFF
--- a/ansible/configs/rosa-consolidated/default_vars.yml
+++ b/ansible/configs/rosa-consolidated/default_vars.yml
@@ -26,7 +26,6 @@ cloud_tags:
 # Bastion user
 bastion_user_name: rosa
 bastion_user_enable_sudo: false
-bastion_user_password: ""
 bastion_user_password_length: 12
 
 # Remove motd (register for insights) prompt from bastion

--- a/ansible/configs/rosa-consolidated/install_rosa_common_post.yml
+++ b/ansible/configs/rosa-consolidated/install_rosa_common_post.yml
@@ -1,11 +1,11 @@
 ---
 - name: Get ROSA API URL
   ansible.builtin.set_fact:
-    rosa_api_url: "{{ (r_rosa_installer_status.stdout | from_json).api.url }}"
+    rosa_openshift_api_url: "{{ (r_rosa_installer_status.stdout | from_json).api.url }}"
 
 - name: Get ROSA console URL
   ansible.builtin.set_fact:
-    rosa_console_url: "{{ (r_rosa_installer_status.stdout | from_json).console.url }}"
+    rosa_openshift_console_url: "{{ (r_rosa_installer_status.stdout | from_json).console.url }}"
 
 - name: Create ROSA admin user
   when: rosa_setup_cluster_admin | default(false) | bool

--- a/ansible/configs/rosa-consolidated/pre_software.yml
+++ b/ansible/configs/rosa-consolidated/pre_software.yml
@@ -23,7 +23,7 @@
       regexp: "^export GUID"
       line: "export GUID={{ guid }}"
 
-  - name: Generate user password if not defined
+  - name: Generate user password
     ansible.builtin.set_fact:
       bastion_user_password: >-
         {{ lookup('password', '/dev/null length={{ bastion_user_password_length }} chars=ascii_letters,digits') }}

--- a/ansible/configs/rosa-consolidated/pre_software.yml
+++ b/ansible/configs/rosa-consolidated/pre_software.yml
@@ -25,14 +25,14 @@
 
   - name: Generate user password if not defined
     ansible.builtin.set_fact:
-      rosa_user_password: >-
+      bastion_user_password: >-
         {{ lookup('password', '/dev/null length={{ bastion_user_password_length }} chars=ascii_letters,digits') }}
 
   - name: Create user with password
     ansible.builtin.user:
       state: present
       name: "{{ bastion_user_name }}"
-      password: "{{ rosa_user_password | password_hash('sha512') }}"
+      password: "{{ bastion_user_password | password_hash('sha512') }}"
       password_lock: false
       comment: ROSA User
       group: users

--- a/ansible/configs/rosa-consolidated/software.yml
+++ b/ansible/configs/rosa-consolidated/software.yml
@@ -112,6 +112,7 @@
     agnosticd_user_info:
       data:
         rosa_token_warning: "{{ rosa_token_warning }}"
+        rosa_subdomain_base: "{{ subdomain_base }}"
         ssh_command: "ssh {{ bastion_user_name }}@bastion.{{ subdomain_base }}"
         ssh_password: "{{ bastion_user_password }}"
         ssh_username: "{{ bastion_user_name }}"

--- a/ansible/configs/rosa-consolidated/software.yml
+++ b/ansible/configs/rosa-consolidated/software.yml
@@ -108,25 +108,27 @@
     ansible.builtin.set_fact:
       rosa_token_warning: false
 
+  - name: Save ROSA user data
+    agnosticd_user_info:
+      data:
+        rosa_token_warning: "{{ rosa_token_warning }}"
+        ssh_command: "ssh {{ bastion_user_name }}@bastion.{{ subdomain_base }}"
+        ssh_password: "{{ bastion_user_password }}"
+        ssh_username: "{{ bastion_user_name }}"
+        targethost: "bastion.{{ subdomain_base }}"
+        guid: "{{ guid }}"
+
   - name: Save ROSA user data when ROSA has been installed
     when: rosa_deploy | default(true) | bool
     block:
     - name: Save ROSA user data when ROSA has been installed
       agnosticd_user_info:
         data:
-          rosa_sandbox_account_id: "{{ hostvars.localhost.sandbox_account_id }}"
-          rosa_console_user_name: "{{ hostvars.localhost.rosa_console_user_name }}"
-          rosa_console_password: "{{ hostvars.localhost.rosa_console_password }}"
-          rosa_bastion_user_name: "{{ bastion_user_name }}"
-          rosa_subdomain_base: "{{ subdomain_base }}"
-          rosa_user_password: "{{ rosa_user_password }}"
-          rosa_console_url: "{{ rosa_console_url }}"
-          rosa_api_url: "{{ rosa_api_url }}"
-          rosa_token_warning: "{{ rosa_token_warning }}"
+          rosa_openshift_console_url: "{{ rosa_openshift_console_url }}"
+          rosa_openshift_api_url: "{{ rosa_openshift_api_url }}"
           rosa_deploy_hcp: "{{ rosa_deploy_hcp }}"
           rosa_version: "{{ _rosa_version_to_install }}"
           rosa_version_next: "{{ _rosa_version_next | default('none') }}"
-          rosa_ocp_cli_version: "{{ _rosa_ocp_cli_version }}"
 
     - name: Save ROSA admin user data when ROSA has been installed with admin user
       when:
@@ -134,27 +136,5 @@
       - not rosa_setup_cluster_admin_delete_after_workloads | default(false) | bool
       agnosticd_user_info:
         data:
-          rosa_admin_user: "cluster-admin"
-          rosa_admin_password: "{{ _rosa_cluster_admin_password }}"
-
-  - name: Save ROSA user data when ROSA has not been installed
-    when: not rosa_deploy | default(true) | bool
-    agnosticd_user_info:
-      data:
-        rosa_sandbox_account_id: "{{ hostvars.localhost.sandbox_account_id }}"
-        rosa_console_user_name: "{{ hostvars.localhost.rosa_console_user_name }}"
-        rosa_console_password: "{{ hostvars.localhost.rosa_console_password }}"
-        rosa_bastion_user_name: "{{ bastion_user_name }}"
-        rosa_subdomain_base: "{{ subdomain_base }}"
-        rosa_user_password: "{{ rosa_user_password }}"
-        rosa_token_warning: "{{ rosa_token_warning }}"
-        rosa_console_url: "none"
-
-  - name: Save SSH data (for Showroom)
-    agnosticd_user_info:
-      data:
-        ssh_command: "ssh {{ bastion_user_name }}@bastion.{{ subdomain_base }}"
-        ssh_password: "{{ rosa_user_password }}"
-        ssh_username: "{{ bastion_user_name }}"
-        targethost: "bastion.{{ subdomain_base }}"
-        guid: "{{ guid }}"
+          rosa_openshift_admin_user: "cluster-admin"
+          rosa_openshift_admin_password: "{{ _rosa_cluster_admin_password }}"


### PR DESCRIPTION
Variables in the agnosticd_user_info data impacted:

- **rosa_sandbox_account_id**: deleted as it can be retrieved by `aws_web_console_url`
- **rosa_console_user_name**: deleted as it can be retrieved by `aws_web_console_user_name`
- **rosa_console_password**: deleted as it can be retrieved by `aws_web_console_password`
- **rosa_console_url**: renamed to `rosa_openshift_console_url`
- **rosa_api_url**: renamed to `rosa_openshift_api_url`
- **rosa_bastion_user_name**: deleted as it can be retrieved by `ssh_username`
- **rosa_user_password**: deleted, use `ssh_password`
- **rosa_ocp_cli_version**: deleted
- **rosa_admin_user**: renamed to `rosa_openshift_admin_user`
- **rosa_admin_password**: renamed to `rosa_openshift_admin_password`

AgnosticV changes to be done after this:

- https://github.com/rhpds/agnosticv/pull/16032

Showrooms affected and respective PR's:

- https://github.com/augustrh/showroom/pull/3
- https://github.com/redhat-gpst/rosa-fsx-lab-guide/pull/9
- https://github.com/rhpds/showroom-rosa-workshop/pull/2
- https://github.com/rh-mad-workshop/mad-cat-rosa/pull/7
- https://github.com/rhpds/showroom-rosa-ops-hoe/pull/6
