### PR TITLE
ec2_add_subnet_and_nic, comment out non role vars in default

### DIFF
--- a/ansible/roles/ec2_add_subnet_and_nic/defaults/main.yaml
+++ b/ansible/roles/ec2_add_subnet_and_nic/defaults/main.yaml
@@ -1,9 +1,9 @@
 ---
 ## From other roles...
-guid: "{{ guid }}"
-aws_region: "{{ aws_region }}"
-aws_access_key: "{{ aws_access_key }}"
-aws_secret_key: "{{ aws_secret_key }}"
+# guid:
+# aws_region:
+# aws_access_key:
+# aws_secret_key:
 
 ## Role Specific Vars
 ## Subnet cidr for created subnet


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ec2_add_subnet_and_nic
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
