### PR TITLE
Revert "Update workload.yml -add retires"

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/workload.yml
@@ -66,7 +66,6 @@
     wait: true
     wait_sleep: 5
     wait_timeout: 600
-    retries: 2
     wait_condition:
       type: "cert-manager-controller-deploymentAvailable"
       status: "True"


### PR DESCRIPTION
Reverts redhat-cop/agnosticd#8305


TASK [ocp4_workload_cert_manager : Wait until Cert Manager is ready] ***********
Monday 15 July 2024  13:53:54 +0000 (0:00:00.063)       0:43:39.417 *********** 
fatal: [bastion.w9v4f.internal]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (kubernetes.core.k8s_info) module: retries. Supported parameters include: api_key, api_version, ca_cert, client_cert, client_key, context, field_selectors, host, impersonate_groups, impersonate_user, kind, kubeconfig, label_selectors, name, namespace, no_proxy, password, persist_config, proxy, proxy_headers, username, validate_certs, wait, wait_condition, wait_sleep, wait_timeout (api, cert_file, key_file, ssl_ca_cert, verify_ssl, version)."}