### PR TITLE
Update users appproject and permissions in DevOps Roadshow

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_devops_roadshow/files/appprojects/users.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_devops_roadshow/files/appprojects/users.yaml
@@ -14,3 +14,11 @@ spec:
   sourceRepos:
     - 'https://github.com/redhat-cop/gitops-catalog'
     - 'https://github.com/AdvancedDevSecOpsWorkshop/workshop'
+  roles:
+    - description: developers
+      name: developer
+      groups:
+        - developers
+      policies:
+        - p, proj:users:developer, applications, get, *, allow
+        - p, proj:users:developer, applications, sync, *, allow

--- a/ansible/roles_ocp_workloads/ocp4_workload_devops_roadshow/templates/user-appset.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_devops_roadshow/templates/user-appset.yaml.j2
@@ -19,7 +19,7 @@ spec:
       destination:
         namespace: "user{% raw %}{{ user }}{% endraw %}-cicd"
         server: 'https://kubernetes.default.svc'
-      project: default
+      project: users
       syncPolicy:
         automated:
           prune: false


### PR DESCRIPTION
##### SUMMARY

This PR changes the users applicationset to use the users appproject as was originally intended. it also updates the permissions on the users appproject so that users can see the user facing applications with limited permissions (get and sync only)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
DEVOPS_ROADSHOW