### PR TITLE
Add FQCN to agnosticd_save_output_dir role and minor cleanup

### DIFF
--- a/ansible/roles/agnosticd_save_output_dir/tasks/create-output-dir-archive.yml
+++ b/ansible/roles/agnosticd_save_output_dir/tasks/create-output-dir-archive.yml
@@ -1,24 +1,24 @@
 ---
 - name: Create tempfile for archive
-  tempfile:
+  ansible.builtin.tempfile:
     state: file
     prefix: "{{ guid }}-output_dir-"
     suffix: .tar.gz
   register: r_output_dir_archive_tempfile
 
 - name: Set agnosticd_save_output_dir_archive_tempfile
-  set_fact:
+  ansible.builtin.set_fact:
     agnosticd_save_output_dir_archive_tempfile: "{{ r_output_dir_archive_tempfile.path }}"
 
 - name: Create output_dir archive
-  command: >-
+  ansible.builtin.command: >-
     tar -czf {{ agnosticd_save_output_dir_archive_tempfile }} --exclude "google-cloud-sdk" .
   args:
     chdir: "{{ output_dir }}"
 
-- when: agnosticd_save_output_dir_archive_password is defined
-  name: Encrypt tarball using password
-  command: >-
+- name: Encrypt tarball using password
+  when: agnosticd_save_output_dir_archive_password is defined
+  ansible.builtin.command: >-
     gpg --symmetric --batch --yes --passphrase-fd 0
     --output {{ (agnosticd_save_output_dir_archive_tempfile ~ '.gpg') | quote }}
     {{ agnosticd_save_output_dir_archive_tempfile | quote }}

--- a/ansible/roles/agnosticd_save_output_dir/tasks/main.yml
+++ b/ansible/roles/agnosticd_save_output_dir/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Save output dir if archive file is defined
   when: agnosticd_save_output_dir_archive is defined
-  include_tasks:
+  ansible.builtin.include_tasks:
     file: save-output-dir.yml
     apply:
       delegate_to: localhost

--- a/ansible/roles/agnosticd_save_output_dir/tasks/save-output-dir.yml
+++ b/ansible/roles/agnosticd_save_output_dir/tasks/save-output-dir.yml
@@ -1,24 +1,24 @@
 ---
 - block:
   - name: Create output_dir archive
-    include_tasks:
+    ansible.builtin.include_tasks:
       file: create-output-dir-archive.yml
 
   - name: Upload output_dir archive to S3
     when: agnosticd_save_output_dir_s3_bucket is defined
-    include_tasks:
+    ansible.builtin.include_tasks:
       file: upload-archive-s3.yml
 
   always:
   - name: Remove output_dir archive tempfile
     when: agnosticd_save_output_dir_archive_tempfile is defined
-    file:
+    ansible.builtin.file:
       path: "{{ agnosticd_save_output_dir_archive_tempfile }}"
       state: absent
 
   - name: Remove output_dir encrypted archive tempfile
     when: agnosticd_save_output_dir_archive_password is defined
-    file:
+    ansible.builtin.file:
       path: "{{ agnosticd_save_output_dir_archive_tempfile }}.gpg"
       state: absent
 ...

--- a/ansible/roles/agnosticd_save_output_dir/tasks/upload-archive-s3.yml
+++ b/ansible/roles/agnosticd_save_output_dir/tasks/upload-archive-s3.yml
@@ -1,5 +1,5 @@
 ---
-- name: Run infra-cloud-tags role 
+- name: Run infra-cloud-tags role
   when: cloud_tags_final is not defined
   ansible.builtin.include_role:
     name: infra-cloud-tags

--- a/ansible/roles/agnosticd_save_output_dir/tasks/upload-archive-s3.yml
+++ b/ansible/roles/agnosticd_save_output_dir/tasks/upload-archive-s3.yml
@@ -1,13 +1,14 @@
 ---
-- include_role:
-    name: infra-cloud-tags
+- name: Run infra-cloud-tags role 
   when: cloud_tags_final is not defined
+  ansible.builtin.include_role:
+    name: infra-cloud-tags
 
 - name: Save output_dir archive to AWS S3
   vars:
     __amazon_aws_version: >-
       {{ lookup('community.general.collection_version', 'amazon.aws') }}
-  include_tasks:
+  ansible.builtin.include_tasks:
     file: >-
       {{
         __amazon_aws_version is ansible.builtin.version('4.0.0', '>=') |


### PR DESCRIPTION
##### SUMMARY

At least one CI was failing due to this role invoking `ansible.legacy.command`. This PR explicitly makes the role use FQCNs and does some minor cleanup (add a name: use top when consistently)

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME

roles/agnosticd_save_output_dir

##### ADDITIONAL INFORMATION
