### PR TITLE
DevOps Roadshow: Add test/retry for oc in case API endpoint is still working on cert

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_devops_roadshow/files/appprojects/users.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_devops_roadshow/files/appprojects/users.yaml
@@ -13,7 +13,7 @@ spec:
       server: 'https://kubernetes.default.svc'
   sourceRepos:
     - 'https://github.com/redhat-cop/gitops-catalog'
-    - 'https://github.com/AdvancedDevSecOpsWorkshop/workshop'
+    - 'https://github.com/AdvancedDevSecOpsWorkshop/bootstrap'
   roles:
     - description: developers
       name: developer

--- a/ansible/roles_ocp_workloads/ocp4_workload_devops_roadshow/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_devops_roadshow/tasks/workload.yml
@@ -76,6 +76,14 @@
     - openshift-gitops-repo-server
     - openshift-gitops-redis
 
+# Test that oc is working and if not wait until it does (600s total, 10 minutes)
+- name: Wait for OpenShift API to be up and working
+  command: "oc status"
+  retries: 20
+  delay: 30
+  register: result
+  until: result.rc == 0
+
 - name: Check that all deployments are up and running
   command: "oc rollout status deployment {{ item }} -n openshift-gitops"
   with_items:


### PR DESCRIPTION
##### SUMMARY

The workshop fails every so often with cert issues when attempting to use the `oc` command in some of the plays. This PR adds a task to test and retry oc until it works for up to 10 minutes.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
DEVOPS_ROADSHOW
