### PR TITLE
Fix set-repositories to not report error on unregister

### DIFF
--- a/ansible/roles/set-repositories/tasks/unregister.yml
+++ b/ansible/roles/set-repositories/tasks/unregister.yml
@@ -1,4 +1,8 @@
 ---
 - name: unreg | Unregister From Subscription Manager
   ansible.builtin.command: subscription-manager unregister
+  register: r_unregister
+  failed_when: >-
+    r_unregister is failed and
+    r_unregister.stderr | default('') != 'This system is currently not registered.'
   ignore_errors: true


### PR DESCRIPTION
##### SUMMARY

Fix set-repositories to not report it an error when it attempts to unregister a system that has not been registered.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role set-repositories