### PR TITLE
Fix showroom_primary_port typo in showroom traefik orchestration

### DIFF
--- a/ansible/roles/showroom/templates/base_service_traefik_httpd/base_service_traefik_httpd.j2
+++ b/ansible/roles/showroom/templates/base_service_traefik_httpd/base_service_traefik_httpd.j2
@@ -12,7 +12,7 @@ reverse-proxy:
     - "/run/user/{{ showroom_user_uid }}/podman/podman.sock:/var/run/docker.sock:z"
     - "{{ showroom_user_orchestration_dir }}/acme.json:/acme.json:z"
   ports:
-    - "{{ showroom_port | default(443) }}:443"
+    - "{{ showroom_primary_port | default(443) }}:443"
   labels:
     - traefik.enable=false
 


### PR DESCRIPTION
##### SUMMARY

Orchestration template for showroom's traefik reverse proxy had a port typo in it

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

roles/showroom

##### ADDITIONAL INFORMATION
