### PR TITLE
Add retries to Minio Setup to catch instabilities

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_minio/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_minio/tasks/workload.yml
@@ -55,6 +55,10 @@
         mc alias set --insecure
           localminio http://localhost:9000
           {{ ocp4_workload_minio_root_user }} {{ ocp4_workload_minio_root_password }}
+    register: r_minio_setup
+    retries: 3
+    delay: 5
+    until: r_minio_setup.rc == 0
 
   - name: Set up Minio bucket (Single-User)
     when: not ocp4_workload_minio_bucket_multi_user | bool
@@ -63,6 +67,10 @@
       pod: "{{ r_minio_pod.resources[0].metadata.name }}"
       command: |
         mc mb localminio/{{ ocp4_workload_minio_bucket_name }}
+    register: r_minio_bucket
+    retries: 3
+    delay: 5
+    until: r_minio_bucket.rc == 0
 
   - name: Set up Minio bucket (Multi-User)
     when: ocp4_workload_minio_bucket_multi_user | bool
@@ -71,6 +79,10 @@
       pod: "{{ r_minio_pod.resources[0].metadata.name }}"
       command: |
         mc mb localminio/{{ ocp4_workload_minio_bucket_base }}{{ ocp4_workload_minio_bucket_userbase }}{{ user_number }}
+    register: r_minio_bucket_mu
+    retries: 3
+    delay: 5
+    until: r_minio_bucket_mu.rc == 0
     loop: "{{ range(1, ocp4_workload_minio_bucket_num_users | int + 1) | list }}"
     loop_control:
       loop_var: user_number


### PR DESCRIPTION
##### SUMMARY

Once in a while creating the minio buckets fails with a connection error. Adding a few retries to catch those.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_minio