### PR TITLE
Wrong user base variable used. Fixed

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/templates/secret_vmware_credentials.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/templates/secret_vmware_credentials.yaml.j2
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ ocp4_workload_virt_roadshow_vmware_mtv_namespace_base }}{{ user_number}}
 type: Opaque
 stringData:
-  user: "{{ ocp4_workload_virt_roadshow_auth_user_base }}{{ user_number }}@{{ vcenter_domain }}"
+  user: "{{ ocp4_workload_virt_roadshow_vmware_vcenter_user_base }}{{ user_number }}@{{ vcenter_domain }}"
   password: "{{ _ocp4_workload_virt_roadshow_vmware_vcenter_user_password }}"
   thumbprint: "{{ _ocp4_workload_virt_roadshow_vmware_vcenter_sha1 }}"
   insecureSkipVerify: "true"


### PR DESCRIPTION
##### SUMMARY

For multi-user CNV Roadshow the secret to connect MTV to vCenter was using the wrong user base variable.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_virt_roadshow_vmware