### PR TITLE
Add workload to configure permissions for multi-user virt roadshow

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+become_override: false
+ocp_username: opentlc-mgr
+silent: false
+
+ocp4_workload_virt_roadshow_num_users: 1
+
+# Single user (num users == 1)
+# It is assumed that for a single user the workshop is run using a user with cluster-admin privileges
+
+# Multi-user (num users > 1)
+ocp4_workload_virt_roadshow_userbase: user

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow/meta/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  role_name: ocp4_workload_virt_roadshow
+  author: Red Hat, Wolfgang Kulhanek (wkulhane@redhat.com)
+  description: |
+    Set up permissions for OCP Virt Roadshow
+  license: MIT
+  min_ansible_version: 2.9
+  platforms: []
+  galaxy_tags:
+  - ocp
+  - openshift
+  - cnv
+  - kubevirt
+  - roadshow
+dependencies: []

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow/readme.adoc
@@ -1,0 +1,44 @@
+= ocp4_workload_virt_roadshow - Set up permissions for Virt Roadshow
+
+== Review the defaults variable file
+
+* This file link:./defaults/main.yml[./defaults/main.yml] contains all the variables you need to define to control the deployment of your workload.
+* The variable *ocp_username* is mandatory to assign the workload to the correct OpenShift user.
+* A variable *silent=True* can be passed to suppress debug messages.
+
+=== Deploy a Workload with the `ocp-workload` playbook [Mostly for testing]
+
+----
+TARGET_HOST="bastion.ocp43.openshift.opentlc.com"
+OCP_USERNAME="varodrig-redhat.com"
+WORKLOAD="ocp4_workload_virt_roadshow"
+GUID=1001
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=ec2-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"silent=False" \
+    -e"guid=${GUID}" \
+    -e"ACTION=create"
+----
+
+=== To Delete an environment
+
+----
+TARGET_HOST="bastion.ocp43.openshift.opentlc.com"
+OCP_USERNAME="varodrig-redhat.com"
+WORKLOAD="ocp4_workload_virt_roadshow"
+GUID=1002
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=ec2-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"guid=${GUID}" \
+    -e"ACTION=remove"
+----

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+# Do not modify this file
+- name: Running Pre Workload Tasks
+  when: ACTION == "create" or ACTION == "provision"
+  ansible.builtin.include_tasks:
+    file: ./pre_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+
+- name: Running Workload Tasks
+  when: ACTION == "create" or ACTION == "provision"
+  ansible.builtin.include_tasks:
+    file: ./workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+
+- name: Running Post Workload Tasks
+  when: ACTION == "create" or ACTION == "provision"
+  ansible.builtin.include_tasks:
+    file: ./post_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+
+- name: Running Workload removal Tasks
+  when: ACTION == "destroy" or ACTION == "remove"
+  ansible.builtin.include_tasks:
+    file: ./remove_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow/tasks/post_workload.yml
@@ -1,0 +1,27 @@
+---
+# Implement your Post Workload deployment tasks here
+# --------------------------------------------------
+
+
+# Leave these as the last tasks in the playbook
+# ---------------------------------------------
+
+# For deployment onto a dedicated cluster (as part of the
+# cluster deployment) set workload_shared_deployment to False
+# This is the default so it does not have to be set explicitely
+- name: Post_workload tasks complete
+  when:
+  - not silent | bool
+  - not workload_shared_deployment | default(false) | bool
+  ansible.builtin.debug:
+    msg: "Post-Workload tasks completed successfully."
+
+# For RHPDS deployment (onto a shared cluster) set
+# workload_shared_deployment to True
+# (in the deploy script or AgnosticV configuration)
+- name: Post_workload tasks complete
+  when:
+  - not silent | bool
+  - workload_shared_deployment | default(false) | bool
+  ansible.builtin.debug:
+    msg: "Post-Software checks completed successfully"

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow/tasks/pre_workload.yml
@@ -1,0 +1,26 @@
+---
+# Implement your Pre Workload deployment tasks here
+# -------------------------------------------------
+
+# Leave these as the last tasks in the playbook
+# ---------------------------------------------
+
+# For deployment onto a dedicated cluster (as part of the
+# cluster deployment) set workload_shared_deployment to False
+# This is the default so it does not have to be set explicitely
+- name: Pre_workload tasks complete
+  when:
+  - not silent | bool
+  - not workload_shared_deployment | default(false) | bool
+  ansible.builtin.debug:
+    msg: "Pre-Workload tasks completed successfully."
+
+# For RHPDS deployment (onto a shared cluster) set
+# workload_shared_deployment to True
+# (in the deploy script or AgnosticV configuration)
+- name: Pre_workload tasks complete
+  when:
+  - not silent | bool
+  - workload_shared_deployment | default(false) | bool
+  ansible.builtin.debug:
+    msg: "Pre-Software checks completed successfully"

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow/tasks/remove_workload.yml
@@ -1,0 +1,16 @@
+---
+- name: Delete VM Namespaces
+  kubernetes.core.k8s:
+    state: absent
+    api_version: v1
+    kind: Namespace
+    name: "{{ ocp4_workload_virt_roadshow_vms_base_namespace }}{{ ocp4_workload_virt_roadshow_vms_userbase }}{{ user_number }}"
+  loop: "{{ range(1, ocp4_workload_virt_roadshow_vms_num_users | int + 1) | list }}"
+  loop_control:
+    loop_var: user_number
+
+# Leave this as the last task in the playbook.
+- name: Remove_workload tasks complete
+  when: not silent|bool
+  ansible.builtin.debug:
+    msg: "Remove Workload tasks completed successfully."

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow/tasks/workload.yml
@@ -1,0 +1,17 @@
+---
+- name: Set up user permissions
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('template', resource | from_yaml) }}"
+  loop:
+  - clusterrole-operator-viewer.yaml.j2
+  - clusterrolebinding-operator-view.yaml.yaml.j2
+  - rolebinding-openshift-view.yaml.yaml.j2
+  loop_control:
+    loop_var: resource
+
+# Leave this as the last task in the playbook.
+- name: Workload tasks complete
+  when: not silent|bool
+  ansible.builtin.debug:
+    msg: "Workload Tasks completed successfully."

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow/templates/clusterrole-operator-viewer.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow/templates/clusterrole-operator-viewer.yaml.j2
@@ -1,0 +1,15 @@
+{% if ocp4_workload_virt_roadshow_num_users | int > 1 %}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: operator-viewer-role
+rules:
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - clusterserviceversions
+  verbs:
+  - get
+  - list
+{% endif %}

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow/templates/clusterrolebinding-operator-view.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow/templates/clusterrolebinding-operator-view.yaml.j2
@@ -1,0 +1,17 @@
+{% if ocp4_workload_virt_roadshow_num_users | int > 1 %}
+{%   for user_number in range(1, ocp4_workload_virt_roadshow_num_users | int + 1) %}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: operator-view-{{ ocp4_workload_virt_roadshow_userbase }}{{ user_number }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operator-viewer-role
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: {{ ocp4_workload_virt_roadshow_userbase }}{{ user_number }}
+{%   endfor %}
+{% endif %}

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow/templates/rolebinding-openshift-view.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow/templates/rolebinding-openshift-view.yaml.j2
@@ -1,0 +1,18 @@
+{% if ocp4_workload_virt_roadshow_num_users | int > 1 %}
+{%   for user_number in range(1, ocp4_workload_virt_roadshow_num_users | int + 1) %}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: view-{{ ocp4_workload_virt_roadshow_userbase }}{{ user_number }}
+  namespace: openshift
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: {{ ocp4_workload_virt_roadshow_userbase }}{{ user_number }}
+{%   endfor %}
+{% endif %}


### PR DESCRIPTION
##### SUMMARY

For multi-user Virt Roadshow it's necessary to set up some permissions for regular users. Rather than adding those to random workloads adding a new workload to set up these permissions.

##### ISSUE TYPE
- New role Pull Request

##### COMPONENT NAME
ocp4_workload_virt_roadshow