### PR TITLE
Fix typos in filenames

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow/tasks/workload.yml
@@ -5,8 +5,8 @@
     definition: "{{ lookup('template', resource | from_yaml) }}"
   loop:
   - clusterrole-operator-viewer.yaml.j2
-  - clusterrolebinding-operator-view.yaml.yaml.j2
-  - rolebinding-openshift-view.yaml.yaml.j2
+  - clusterrolebinding-operator-view.yaml.j2
+  - rolebinding-openshift-view.yaml.j2
   loop_control:
     loop_var: resource
 


### PR DESCRIPTION
##### SUMMARY

Fixing a duplicate `.yaml` in two templates that resulted in failures.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_virt_roadshow