### PR TITLE
Add configmaps to cluster

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow/defaults/main.yml
@@ -10,3 +10,7 @@ ocp4_workload_virt_roadshow_num_users: 1
 
 # Multi-user (num users > 1)
 ocp4_workload_virt_roadshow_userbase: user
+
+# In the future once bug https://issues.redhat.com/browse/CNV-38284 is in the product
+# the namespace will need to change to openshift-cnv
+ocp4_workload_virt_roadshow_configmap_namespace: default

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow/tasks/workload.yml
@@ -7,6 +7,8 @@
   - clusterrole-operator-viewer.yaml.j2
   - clusterrolebinding-operator-view.yaml.j2
   - rolebinding-openshift-view.yaml.j2
+  - configmap-ui-settings.yaml.j2
+  - configmap-user-settings.yaml.j2
   loop_control:
     loop_var: resource
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow/templates/configmap-ui-settings.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow/templates/configmap-ui-settings.yaml.j2
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubevirt-ui-features
+  namespace: {{ ocp4_workload_virt_roadshow_configmap_namespace }}
+data:
+  autocomputeCPULimitsEnabled: "false"
+  autocomputeCPULimitsPreviewEnabled: "false"
+  automaticSubscriptionActivationKey: ""
+  automaticSubscriptionOrganizationId: ""
+  disabledGuestSystemLogsAccess: "false"
+  kubevirtApiserverProxy: "true"
+  loadBalancerEnabled: "false"
+  nodePortAddress: ""
+  nodePortEnabled: "false"

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow/templates/configmap-user-settings.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow/templates/configmap-user-settings.yaml.j2
@@ -5,5 +5,3 @@ metadata:
   name: kubevirt-user-settings
   namespace: {{ ocp4_workload_virt_roadshow_configmap_namespace }}
 data:
-  2f29e2b5-4abb-44ad-bea4-02a4a8ddfa44: '{"cards":{},"columns":{"cdi.kubevirt.io~v1beta1~DataSource":["favorites","name","operating-system","storage-class","size","description"]},"favoriteBootableVolumes":[],"quickStart":{},"ssh":{}}'
-  3a9a2493-c63d-4822-bee2-b8057416032a: '{"columns":{"cdi.kubevirt.io~v1beta1~DataSource":["favorites","name","operating-system","storage-class","size","description"]},"quickStart":{"dontShowWelcomeModal":true}}'

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow/templates/configmap-user-settings.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow/templates/configmap-user-settings.yaml.j2
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubevirt-user-settings
+  namespace: {{ ocp4_workload_virt_roadshow_configmap_namespace }}
+data:
+  2f29e2b5-4abb-44ad-bea4-02a4a8ddfa44: '{"cards":{},"columns":{"cdi.kubevirt.io~v1beta1~DataSource":["favorites","name","operating-system","storage-class","size","description"]},"favoriteBootableVolumes":[],"quickStart":{},"ssh":{}}'
+  3a9a2493-c63d-4822-bee2-b8057416032a: '{"columns":{"cdi.kubevirt.io~v1beta1~DataSource":["favorites","name","operating-system","storage-class","size","description"]},"quickStart":{"dontShowWelcomeModal":true}}'


### PR DESCRIPTION
##### SUMMARY

OCP Virt requires an Admin to log into the console and go to all pages for settings config maps to be written.

Attempt to pre-create config maps with settings.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_virt_roadshow