### PR TITLE
add folder to add vm to network on ocp4 upi

### DIFF
--- a/ansible/roles-infra/infra_vmware_ibm_resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra_vmware_ibm_resources/tasks/create_instance.yaml
@@ -40,6 +40,7 @@
   vars:
     _instance_name: "{{ _instance.name }}{{ _index+1 if _instance.count|d(1)|int > 1 }}"
   community.vmware.vmware_guest_network:
+    folder: "/Workloads/{{env_type}}-{{ guid }}"
     name: "{{ _instance_name }}"
     network_name: "segment-{{ env_type }}-{{ guid }}"
     start_connected: true


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
add folder to add vm to network on ocp4 upi
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
roles-infra/infra_vmware_ibm_resources

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
