### PR TITLE
Fix openshift_cluster_admin_service_account for OpenShift 4.16

### DIFF
--- a/ansible/roles/openshift_cluster_admin_service_account/tasks/main.yml
+++ b/ansible/roles/openshift_cluster_admin_service_account/tasks/main.yml
@@ -30,7 +30,37 @@
         name: "{{ openshift_cluster_admin_service_account_name }}"
         namespace: "{{ openshift_cluster_admin_service_account_namespace }}"
 
+- name: Create cluster-admin service account token
+  command: >-
+    oc -v9 create token --duration=99999h
+    -n {{ openshift_cluster_admin_service_account_namespace | quote }}
+    {{ openshift_cluster_admin_service_account_name | quote }}
+  register: r_create_service_account_token
+  ignore_errors: true
+
+- name: Set openshift_cluster_admin_token
+  when: r_create_service_account_token is successful
+  set_fact:
+    openshift_cluster_admin_token: "{{ r_create_service_account_token.stdout }}"
+
+- name: Get OpenShift API server CA cert
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: ConfigMap
+    name: loadbalancer-serving-ca
+    namespace: openshift-kube-apiserver-operator
+  failed_when: r_get_api_server_ca.resources | length != 1
+  register: r_get_api_server_ca
+  ignore_errors: true
+
+- name: Set openshift_api_ca_cert
+  when: r_get_api_server_ca is successful
+  set_fact:
+    openshift_api_ca_cert: >-
+      {{ r_get_api_server_ca.resources[0].data['ca-bundle.crt'] }}
+
 - name: Get cluster-admin service account token
+  when: openshift_cluster_admin_token is undefined
   vars:
     __token_secret_query: >-
       [?
@@ -52,12 +82,16 @@
     retries: 5
     delay: 1
 
-  - name: Set openshift_api_ca_cert and openshift_cluster_admin_token
+  - name: Set openshift_cluster_admin_token
+    set_fact:
+      openshift_cluster_admin_token: >-
+        {{ __token_secret.data.token | b64decode }}
+
+  - name: Set openshift_api_ca_cert
+    when: openshift_api_ca_cert is undefined
     set_fact:
       openshift_api_ca_cert: >-
         {{ __token_secret.data['ca.crt'] | b64decode }}
-      openshift_cluster_admin_token: >-
-        {{ __token_secret.data.token | b64decode }}
 
 - name: Report openshift_api_ca_cert and openshift_cluster_admin_token as user data
   agnosticd_user_info:


### PR DESCRIPTION
##### SUMMARY

OpenShift service account token handling changed with 4.16 such that it no longer automatically generates a service account access token.

This fixes the role by adding a call to create an access token as well as getting the API CA cert a different way.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role openshift_cluster_admin_service_account