### PR TITLE
Update workload.yml to increase retry for getting ready RHODS dashboard route

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhods_self_managed/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhods_self_managed/tasks/workload.yml
@@ -44,7 +44,7 @@
     - r_odh_dashboard_route.resources | length > 0
     - r_odh_dashboard_route.resources.0.status.ingress.0.host is defined
     - r_odh_dashboard_route.resources.0.status.ingress.0.host | length > 0
-  retries: 30
+  retries: 60
   delay: 30
 
 - debug: var=r_odh_dashboard_route.resources.0.status.ingress.0.host


### PR DESCRIPTION
##### SUMMARY
Sometimes RHODS dashboard route is taking more time to get ready to serve.
Controller Job No: 688862, 691261

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ansible/roles_ocp_workloads/ocp4_workload_rhods_self_managed/tasks/workload.yml

