### PR TITLE
Add logic to use pvcs instead of snapshots for os images, add support to pre-delete VMs on CNV to ocp4-cluster

### DIFF
--- a/ansible/configs/ocp4-cluster/default_vars_openshift_cnv.yml
+++ b/ansible/configs/ocp4-cluster/default_vars_openshift_cnv.yml
@@ -25,6 +25,11 @@ ocp4_base_domain: "{{ osp_cluster_dns_zone }}"
 # Container image to use in Ceph cleanup job
 ceph_cleanup_job_image: registry.redhat.io/odf4/rook-ceph-rhel9-operator:v4.15
 
+# Flag to delete all VMs on the cluster before destroying the cluster
+# This should help clean up any VolumeSnapshots that have been created for VMs
+# Only necessary if OpenShift Virtualization has been deployed
+delete_vms_on_destroy: false
+
 # User info settings
 ocp4_cluster_show_default_user_info: true
 ocp4_cluster_show_flight_check_user_info: "{{ ocp4_cluster_show_default_user_info }}"

--- a/ansible/configs/ocp4-cluster/destroy_env_openshift_cnv.yml
+++ b/ansible/configs/ocp4-cluster/destroy_env_openshift_cnv.yml
@@ -26,7 +26,7 @@
         kind: CustomResourceDefinition
         name: "virtualmachines.kubevirt.io"
       register: r_vm_crd
-    
+
     - name: Only delete VMs if OpenShift Virtualization is installed
       when:
       - r_vm_crd.resources is defined
@@ -37,9 +37,9 @@
           api_version: kubevirt.io/v1
           kind: VirtualMachine
         register: r_vms
-      
+
       - name: Delete all VMs on the cluster
-        when: 
+        when:
         - r_vms.resources is defined
         - r_vms.resources | length > 0
         kubernetes.core.k8s:

--- a/ansible/configs/ocp4-cluster/destroy_env_openshift_cnv.yml
+++ b/ansible/configs/ocp4-cluster/destroy_env_openshift_cnv.yml
@@ -3,13 +3,8 @@
   hosts: localhost
   gather_facts: false
   tasks:
-  - name: Run host-ocp4-assisted-destroy role
-    ansible.builtin.include_role:
-      name: host-ocp4-assisted-destroy
-
   - name: Remove ocp workloads
-    when:
-    - remove_workloads | default("") | length > 0
+    when: remove_workloads | default("") | length > 0
     block:
     - name: Invoke roles to remove ocp workloads
       ansible.builtin.include_role:
@@ -21,6 +16,45 @@
       loop: "{{ remove_workloads }}"
       loop_control:
         loop_var: workload_loop_var
+
+  - name: Find and delete all VMs on the cluster
+    when: delete_vms_on_destroy | default(false) | bool
+    block:
+    - name: Sanity Check that OpenShift Virtualization is deployed on the cluster
+      kubernetes.core.k8s_info:
+        api_version: apiextensions.k8s.io/v1
+        kind: CustomResourceDefinition
+        name: "virtualmachines.kubevirt.io"
+      register: r_vm_crd
+    
+    - name: Only delete VMs if OpenShift Virtualization is installed
+      when:
+      - r_vm_crd.resources is defined
+      - r_vm_crd.resources | length == 1
+      block:
+      - name: Find all VMs on the cluster
+        kubernetes.core.k8s_info:
+          api_version: kubevirt.io/v1
+          kind: VirtualMachine
+        register: r_vms
+      
+      - name: Delete all VMs on the cluster
+        when: 
+        - r_vms.resources is defined
+        - r_vms.resources | length > 0
+        kubernetes.core.k8s:
+          state: absent
+          api_version: kubevirt.io/v1
+          kind: VirtualMachine
+          name: "{{ vm.metadata.name }}"
+          namespace: "{{ vm.metadata.name }}"
+        loop: "{{ r_vms.resources }}"
+        loop_control:
+          loop_var: vm
+
+  - name: Run host-ocp4-assisted-destroy role
+    ansible.builtin.include_role:
+      name: host-ocp4-assisted-destroy
 
 - name: Import default cloud provider destroy playbook
   import_playbook: "../../cloud_providers/{{ cloud_provider }}_destroy_env.yml"

--- a/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/defaults/main.yml
@@ -37,8 +37,11 @@ ocp4_workload_kubevirt_workload_tolerations: []
 # - key: metal
 #   operator: Exists
 
-# Import boot sources on deployment (false for CNV based clusters)
-ocp4_workload_kubevirt_import_boot_sources: true
+# Use Snapshots for boot sources - which is the default
+# For deployments on top of CNV with Ceph set to false
+# When set to false CNV is configured to use PVCs for boot sources
+# which elminiates VolumeSnapshots without associated PVCs
+ocp4_workload_kubevirt_boot_sources_shapshot: true
 
 # --------------------------------
 # Operator Catalog Snapshot Settings

--- a/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/tasks/workload.yml
@@ -47,6 +47,61 @@
     hyperconverged_query: >-
       [?type=='Available'].status[] | [0]
 
+# For deployments on CNV with external Ceph use PVCs for boot image snapshots
+# HyperConverged must have been created with .spec.featureGates.enableCommonBootImageImport: false
+# See template for that logic
+- name: Set boot sources to use PVCs
+  when: not ocp4_workload_kubevirt_boot_sources_shapshot | bool
+  block:
+  - name: Get all available storage classes
+    kubernetes.core.k8s_info:
+      api_version: storage.k8s.io/v1
+      kind: StorageClass
+    register: r_storageclasses
+
+  - name: Abort if no storage classes found
+    when: r_storageclasses.resources | length == 0
+    ansible.builtin.fail:
+      msg: "No storage classes found. Can not continue."
+
+  - name: Find default storage class
+    ansible.builtin.set_fact:
+      _ocp4_workload_kubevirt_default_storage_class: "{{ default_sc[0] }}"
+    vars:
+      default_sc: "{{ r_storageclasses.resources | json_query(query) }}"
+      query: "[?metadata.annotations.\"storageclass.kubernetes.io/is-default-class\" == 'true'].metadata.name"
+
+  - name: Abort if no default storage class found
+    when: _ocp4_workload_kubevirt_default_storage_class | length == 0
+    ansible.builtin.fail:
+      msg: "No default storage class found. Can not continue."
+
+  - name: Print default storage class name
+    ansible.builtin.debug:
+      msg: "Default storage class: {{ _ocp4_workload_kubevirt_default_storage_class }}"
+
+  - name: Patch the storage profile matching the default storage class to use pvc instead of snapshot
+    kubernetes.core.k8s:
+      state: patched
+      api_version: cdi.kubevirt.io/v1beta1
+      kind: StorageProfile
+      name: "{{ _ocp4_workload_kubevirt_default_storage_class }}"
+      definition:
+        spec:
+          dataImportCronSourceFormat: pvc
+
+  - name: Finally patch HyperConverged to import boot sources now using PVCs
+    kubernetes.core.k8s:
+      state: patched
+      api_version: hco.kubevirt.io/v1beta1
+      kind: HyperConverged
+      name: kubevirt-hyperconverged
+      namespace: openshift-cnv
+      definition:
+        spec:
+          featureGates:
+            enableCommonBootImageImport: true
+
 - name: Install virtctl to bastion VM
   when: ocp4_workload_kubevirt_install_virtctl | bool
   block:

--- a/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/templates/hyperconverged.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/templates/hyperconverged.yaml.j2
@@ -11,7 +11,7 @@ spec:
       tolerations:
         {{ ocp4_workload_kubevirt_workload_tolerations | to_yaml }}
 {% endif %}
-{% if ocp4_workload_kubevirt_import_boot_sources | bool %}
+{% if ocp4_workload_kubevirt_boot_sources_shapshot | default(true) | bool %}
   featureGates:
     enableCommonBootImageImport: true
 {% else %}

--- a/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/vars/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/vars/main.yml
@@ -1,0 +1,3 @@
+---
+# Internal Variables
+_ocp4_workload_kubevirt_default_storage_class: ""


### PR DESCRIPTION
##### SUMMARY

To fix the issue with dangling VolumeSnapshots:

- Add logic to ocp4_workload_kubevirt to use pvcs instead of snapshots for OS Disk Images
- Add support to ocp4-cluster for CNV to pre-delete all VMs on the cluster to also clean up snapshots that may have been created by users.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-cluster
ocp4_workload_kubevirt