### PR TITLE
Revert addition to remove VMs first for CNV

### DIFF
--- a/ansible/configs/ocp4-cluster/default_vars_openshift_cnv.yml
+++ b/ansible/configs/ocp4-cluster/default_vars_openshift_cnv.yml
@@ -25,11 +25,6 @@ ocp4_base_domain: "{{ osp_cluster_dns_zone }}"
 # Container image to use in Ceph cleanup job
 ceph_cleanup_job_image: registry.redhat.io/odf4/rook-ceph-rhel9-operator:v4.15
 
-# Flag to delete all VMs on the cluster before destroying the cluster
-# This should help clean up any VolumeSnapshots that have been created for VMs
-# Only necessary if OpenShift Virtualization has been deployed
-delete_vms_on_destroy: false
-
 # User info settings
 ocp4_cluster_show_default_user_info: true
 ocp4_cluster_show_flight_check_user_info: "{{ ocp4_cluster_show_default_user_info }}"

--- a/ansible/configs/ocp4-cluster/destroy_env_openshift_cnv.yml
+++ b/ansible/configs/ocp4-cluster/destroy_env_openshift_cnv.yml
@@ -17,41 +17,6 @@
       loop_control:
         loop_var: workload_loop_var
 
-  - name: Find and delete all VMs on the cluster
-    when: delete_vms_on_destroy | default(false) | bool
-    block:
-    - name: Sanity Check that OpenShift Virtualization is deployed on the cluster
-      kubernetes.core.k8s_info:
-        api_version: apiextensions.k8s.io/v1
-        kind: CustomResourceDefinition
-        name: "virtualmachines.kubevirt.io"
-      register: r_vm_crd
-
-    - name: Only delete VMs if OpenShift Virtualization is installed
-      when:
-      - r_vm_crd.resources is defined
-      - r_vm_crd.resources | length == 1
-      block:
-      - name: Find all VMs on the cluster
-        kubernetes.core.k8s_info:
-          api_version: kubevirt.io/v1
-          kind: VirtualMachine
-        register: r_vms
-
-      - name: Delete all VMs on the cluster
-        when:
-        - r_vms.resources is defined
-        - r_vms.resources | length > 0
-        kubernetes.core.k8s:
-          state: absent
-          api_version: kubevirt.io/v1
-          kind: VirtualMachine
-          name: "{{ vm.metadata.name }}"
-          namespace: "{{ vm.metadata.name }}"
-        loop: "{{ r_vms.resources }}"
-        loop_control:
-          loop_var: vm
-
   - name: Run host-ocp4-assisted-destroy role
     ansible.builtin.include_role:
       name: host-ocp4-assisted-destroy


### PR DESCRIPTION
##### SUMMARY

Remove added logic to remove VMs from OCP CNV clusters. Wasn't working because no kube context available.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-cluster