### PR TITLE
Add aio_http module to k8s virtualenv

### DIFF
--- a/ansible/configs/ocp4-cluster/files/requirements_k8s.txt
+++ b/ansible/configs/ocp4-cluster/files/requirements_k8s.txt
@@ -1,3 +1,4 @@
+aiohttp==3.10.2
 adal==1.2.2
 ansible==2.9.27
 asn1crypto==1.3.0

--- a/ansible/configs/ocp4-cluster/files/requirements_k8s_el9.txt
+++ b/ansible/configs/ocp4-cluster/files/requirements_k8s_el9.txt
@@ -5,6 +5,7 @@ ansible==8.7.0
 ansible-core==2.15.9
 importlib-resources==5.0.7
 
+aiohttp==3.10.2
 cachetools==5.3.3
 certifi==2024.2.2
 cffi==1.16.0


### PR DESCRIPTION
##### SUMMARY

New vCenter logic needs the aiohttp module in the k8s virtualenv.

Added.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-cluster