### PR TITLE
Fix handling of gcp_credentials if value is mapping

### DIFF
--- a/ansible/roles-infra/infra-gcp-credentials-file/tasks/main.yml
+++ b/ansible/roles-infra/infra-gcp-credentials-file/tasks/main.yml
@@ -12,4 +12,5 @@
       copy:
         dest: "{{ gcp_credentials_file }}"
         mode: 0644
-        content: "{{ gcp_credentials }}\n"
+        content: |
+          {{ gcp_credentials | to_json if gcp_credentials is mapping else gcp_credentials }}

--- a/ansible/roles/gcp-get-token/tasks/main.yml
+++ b/ansible/roles/gcp-get-token/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Load GCP credentials into string
   set_fact:
-    gcp_creds: "{{ gcp_credentials | from_json }}"
+    gcp_creds: "{{ gcp_credentials if gcp_credentials is mapping else gcp_credentials | from_json }}"
 
 - name: Set JWT header as string
   set_fact:

--- a/ansible/roles/open-env-gcp-add-user-to-project/tasks/main.yml
+++ b/ansible/roles/open-env-gcp-add-user-to-project/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Load GCP credentials into string
   set_fact:
-    gcp_creds: "{{ gcp_credentials | from_json }}"
+    gcp_creds: "{{ gcp_credentials if gcp_credentials is mapping else gcp_credentials | from_json }}"
 
 - name: Check if email is Red Hat associate
   set_fact:

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/secret-gcp-credentials.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/secret-gcp-credentials.yaml.j2
@@ -6,5 +6,6 @@ metadata:
   namespace: cert-manager
 type: Opaque
 stringData:
-  key.json: >-
-    {{ ocp4_workload_cert_manager_gcp_credentials }}
+  # FIXME - this gives full access credentials to cert-manager.
+  # Should use a service account with limited access.
+  key.json: {{ ocp4_workload_cert_manager_gcp_credentials | to_json | to_json if ocp4_workload_cert_manager_gcp_credentials is mapping else ocp4_workload_cert_manager_gcp_credentials | to_json }}


### PR DESCRIPTION
##### SUMMARY

When the `gcp_credentials` value is supplied as a vaulted string then Ansible automatically handles the json string by loading it as a dictionary. This PR includes fixes to handle this format.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

GCP cloud provider