### PR TITLE
Install vSphere Automation SDK in k8s virtualenv

### DIFF
--- a/ansible/configs/ocp4-cluster/files/requirements_k8s_el9.txt
+++ b/ansible/configs/ocp4-cluster/files/requirements_k8s_el9.txt
@@ -39,19 +39,4 @@ boto3==1.34.64
 botocore==1.34.64
 s3transfer==0.10.1
 pyVim==3.0.3
-pyvmomi==8.0.2.0.1
-
-vmware-vapi-common-client==2.52.0
-vmware-vapi-runtime==2.52.0
-vmware_vcenter==8.0.3.0
-vmwarecloud-aws==0.1
-vmwarecloud-draas==0.1
-# vsphere-automation-sdk==1.87.0
-
-# nsx_policy_python_sdk==4.2.0
-# nsx_python_sdk==4.2.0
-# nsx-vmc-aws-integration-python-sdk==4.1.2.0.1
-# nsx-vmc-policy-python-sdk==4.1.2.0.1
-
-# future==1.0.0
-# pysphere==0.1.7
+pyvmomi==8.0.3.0.1

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/defaults/main.yml
@@ -6,6 +6,12 @@ silent: false
 # Enable/disable certificate validation on vCenter API
 ocp4_workload_virt_roadshow_vmware_enable_cert_validation: true
 
+# Location to install the vSphere Automation SDK from
+ocp4_workload_virt_roadshow_vsphere_automation_sdk: >-
+  git+https://github.com/vmware/vsphere-automation-sdk-python.git
+
+ocp4_workload_virt_roadshow_virtualenv_location: /opt/virtualenvs/k8s
+
 # Network to use in vCenter
 ocp4_workload_virt_roadshow_vmware_vcenter_network: segment-migrating-to-ocpvirt
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/tasks/vcenter_setup_prerequisites.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/tasks/vcenter_setup_prerequisites.yml
@@ -45,6 +45,16 @@
 - name: Set up provisioning facts
   when: ACTION == "create" or ACTION == "provision"
   block:
+  - name: Ensure that k8s virtualenv contains vSphere Automation SDK
+    become: true
+    ansible.builtin.pip:
+      name: "{{ ocp4_workload_virt_roadshow_vsphere_automation_sdk }}"
+      state: latest
+      virtualenv: "{{ ocp4_workload_virt_roadshow_virtualenv_location }}"
+    # Retry in case of pip communication issues
+    retries: 10
+    delay: 30
+
   - name: Get list of datastores
     ansible.builtin.uri:
       validate_certs: "{{ ocp4_workload_virt_roadshow_vmware_enable_cert_validation | bool }}"


### PR DESCRIPTION
##### SUMMARY

New vmware logic needs the vSphere Automation SDK installed in the k8s virtualenv.

Installing the SDK only for the workload.
Update ocp4-cluster k8s requirements to eliminate a version mismatch.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_virt_roadshow_vmware
ocp4-cluster