### PR TITLE
OCP4_workload_minio: don't fail on existing minio buckets during install

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_minio/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_minio/tasks/workload.yml
@@ -66,7 +66,7 @@
       namespace: "{{ ocp4_workload_minio_project }}"
       pod: "{{ r_minio_pod.resources[0].metadata.name }}"
       command: |
-        mc mb localminio/{{ ocp4_workload_minio_bucket_name }}
+        mc mb localminio/{{ ocp4_workload_minio_bucket_name }} --ignore-existing
     register: r_minio_bucket
     retries: 3
     delay: 5
@@ -78,7 +78,7 @@
       namespace: "{{ ocp4_workload_minio_project }}"
       pod: "{{ r_minio_pod.resources[0].metadata.name }}"
       command: |
-        mc mb localminio/{{ ocp4_workload_minio_bucket_base }}{{ ocp4_workload_minio_bucket_userbase }}{{ user_number }}
+        mc mb localminio/{{ ocp4_workload_minio_bucket_base }}{{ ocp4_workload_minio_bucket_userbase }}{{ user_number }} --ignore-existing
     register: r_minio_bucket_mu
     retries: 3
     delay: 5


### PR DESCRIPTION
Make bucket creation not fail if bucket already exists.

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
