### PR TITLE
Enable registration and template modules for foreman-proxy.

### DIFF
--- a/ansible/roles/ansible_bu_satellite/tasks/main.yml
+++ b/ansible/roles/ansible_bu_satellite/tasks/main.yml
@@ -118,13 +118,15 @@
   register: satellite_change_hostname
   failed_when: '"Success!" not in satellite_change_hostname.stdout'
 
-- name: Update satellite with LetsEncrypt cert
+- name: Update satellite with LetsEncrypt cert and enable registration and template modules
   shell: >-
     satellite-installer --scenario satellite
     --certs-server-cert "/etc/letsencrypt/live/{{ ansible_bu_satellite_external_fqdn }}/fullchain.pem"
     --certs-server-key "/etc/letsencrypt/live/{{ ansible_bu_satellite_external_fqdn }}/privkey.pem"
     --certs-server-ca-cert "/etc/letsencrypt/live/{{ ansible_bu_satellite_external_fqdn }}/letsencrypt-ca-bundle.pem"
     --certs-update-server --certs-update-server-ca
+    --foreman-proxy-registration true
+    --foreman-proxy-templates true
   register: satellite_update_cert
   failed_when: '"Success!" not in satellite_update_cert.stdout'
 


### PR DESCRIPTION
##### SUMMARY
For Satellite 6.15, the katello-agent has been deprecated, requiring the utilization of the Satellite API and curl-bash method for registration of Content Hosts. Utilization of this registration method requires that the Registration and Template modules be enabled on any Satellite/Capsule systems utilized for Content Host registration.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
roles/ansible_bu_satellite