### PR TITLE
go back to string for gcp credentials

### DIFF
--- a/ansible/roles/open-env-gcp-add-user-to-project/tasks/main.yml
+++ b/ansible/roles/open-env-gcp-add-user-to-project/tasks/main.yml
@@ -38,7 +38,7 @@
 - name: Get all service accounts
   google.cloud.gcp_iam_service_account_info:
     auth_kind: serviceaccount
-    service_account_contents: "{{ gcp_creds }}"
+    service_account_contents: "{{ gcp_credentials }}"
     project: "{{ gcp_creds.project_id }}"
   register: service_accounts
 
@@ -49,7 +49,7 @@
 - name: Delete any old OPEN Environment service accounts that might be orphaned
   google.cloud.gcp_iam_service_account:
     auth_kind: serviceaccount
-    service_account_contents: "{{ gcp_creds }}"
+    service_account_contents: "{{ gcp_credentials }}"
     name: "{{ service_account_email }}"
     display_name: "OPEN Environment Service account {{ guid }}"
     project: "{{ gcp_creds.project_id }}"
@@ -59,7 +59,7 @@
 - name: Create a service account for OPEN Environment
   google.cloud.gcp_iam_service_account:
     auth_kind: serviceaccount
-    service_account_contents: "{{ gcp_creds }}"
+    service_account_contents: "{{ gcp_credentials }}"
     name: "{{ service_account_email }}"
     display_name: "OPEN Environment Service account {{ guid }}"
     project: "{{ gcp_creds.project_id }}"
@@ -203,7 +203,7 @@
 - name: Fetch Root DNS zone Info
   google.cloud.gcp_dns_managed_zone_info:
     auth_kind: serviceaccount
-    service_account_contents: "{{ gcp_creds }}"
+    service_account_contents: "{{ gcp_credentials }}"
     project: "{{ gcp_creds.project_id }}"
     dns_name: '{{ gcp_root_dns_zone + "." }}'
   register: gcp_managed_zone
@@ -211,7 +211,7 @@
 - name: Add delegation for NS to the Root DNS Zone
   google.cloud.gcp_dns_resource_record_set:
     auth_kind: serviceaccount
-    service_account_contents: "{{ gcp_creds }}"
+    service_account_contents: "{{ gcp_credentials }}"
     project: "{{ gcp_creds.project_id }}"
     managed_zone: "{{ gcp_managed_zone.resources[0] }}"
     name: '{{ guid + "." + gcp_root_dns_zone + "." }}'

--- a/ansible/roles/open-env-gcp-remove-project/tasks/main.yml
+++ b/ansible/roles/open-env-gcp-remove-project/tasks/main.yml
@@ -25,7 +25,7 @@
 - name: Delete OPEN Environment service account
   google.cloud.gcp_iam_service_account:
     auth_kind: serviceaccount
-    service_account_contents: "{{ gcp_creds }}"
+    service_account_contents: "{{ gcp_credentials }}"
     name: "{{ service_account_email }}"
     display_name: "OPEN Environment Service account {{ guid }}"
     project: "{{ gcp_creds.project_id }}"
@@ -34,7 +34,7 @@
 - name: Fetch Root DNS zone Info
   google.cloud.gcp_dns_managed_zone_info:
     auth_kind: serviceaccount
-    service_account_contents: "{{ gcp_creds }}"
+    service_account_contents: "{{ gcp_credentials }}"
     project: "{{ gcp_creds.project_id }}"
     dns_name: '{{ gcp_root_dns_zone + "." }}'
   register: gcp_managed_zone
@@ -42,7 +42,7 @@
 - name: Remove the DNS delegations
   google.cloud.gcp_dns_resource_record_set:
     auth_kind: serviceaccount
-    service_account_contents: "{{ gcp_creds }}"
+    service_account_contents: "{{ gcp_credentials }}"
     managed_zone:
       name: "{{ gcp_managed_zone.resources[0].name }}"
       dnsName: "{{ gcp_managed_zone.resources[0].dnsName }}"
@@ -111,7 +111,7 @@
   # - name: Delete GCP Project
   #   google.cloud.gcp_resourcemanager_project:
   #     auth_kind: serviceaccount
-  #     service_account_contents: "{{ gcp_creds }}"
+  #     service_account_contents: "{{ gcp_credentials }}"
   #     name: "{{ project_name }}"
   #     id: "{{ project_name }}"
   #     parent:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
go back to string for gcp credentials
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
open-env-gcp

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
