### PR TITLE
Fix ocp4-cluster k8s venv setup for RHEL 8

### DIFF
--- a/ansible/configs/ocp4-cluster/pre_software.yml
+++ b/ansible/configs/ocp4-cluster/pre_software.yml
@@ -92,7 +92,7 @@
       - requirements_{{ cloud_provider }}_el9.txt
 
   - name: Setup k8s virtualenv (EL8)
-    when: ansible_distribution != "RedHat" or ansible_distribution_major_version != "8"
+    when: ansible_distribution != "RedHat" or ansible_distribution_major_version != "9"
     ansible.builtin.include_role:
       name: host_virtualenv
     vars:


### PR DESCRIPTION
##### SUMMARY

Correct logic error introduced during reformatting which causes RHEL8 hosts to skip virtualenv setup.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Config ocp4-cluster