### PR TITLE
remove unnecessary role permissions in vmware

### DIFF
--- a/ansible/configs/experience-ocpvirt/default_vars_ec2.yml
+++ b/ansible/configs/experience-ocpvirt/default_vars_ec2.yml
@@ -108,8 +108,4 @@ instances:
 
 vcenter_role: "Sandbox User"
 vcenter_permissions:
-  Datacenter: "{{ vcenter_datacenter }}"
-  ClusterComputeResource: "{{ vcenter_cluster }}"
   Folder: "{{ env_type }}-{{ guid }}"
-  Datastore: WorkloadDatastore
-  Network: segment-migrating-to-ocpvirt

--- a/ansible/configs/experience-ocpvirt/default_vars_equinix_metal.yml
+++ b/ansible/configs/experience-ocpvirt/default_vars_equinix_metal.yml
@@ -35,8 +35,4 @@ student_name: lab-user
 vcenter_role: "Sandbox User"
 vcenter_folder: "ocpvirt-{{ guid }}"
 vcenter_permissions:
-  Datacenter: "{{ vcenter_datacenter }}"
-  ClusterComputeResource: "{{ vcenter_cluster }}"
-  Datastore: "{{ vcenter_datastore | default('datastore1') }}"
-  Network: segment-migrating-to-ocpvirt
   Folder: "{{ vcenter_folder }}"

--- a/ansible/configs/roadshow-ocpvirt/default_vars_ec2.yml
+++ b/ansible/configs/roadshow-ocpvirt/default_vars_ec2.yml
@@ -108,8 +108,4 @@ instances:
 
 vcenter_role: "Sandbox User"
 vcenter_permissions:
-  Datacenter: SDDC-Datacenter
-  ClusterComputeResource: Cluster-1
   Folder: "{{ env_type }}-{{ guid }}"
-  Datastore: WorkloadDatastore
-  Network: segment-migrating-to-ocpvirt

--- a/ansible/configs/roadshow-ocpvirt/default_vars_equinix_metal.yml
+++ b/ansible/configs/roadshow-ocpvirt/default_vars_equinix_metal.yml
@@ -35,5 +35,3 @@ student_name: lab-user
 vcenter_role: "Sandbox User"
 vcenter_permissions:
   Folder: "{{ env_type }}-{{ guid }}"
-  Datastore: WorkloadDatastore
-  Network: segment-migrating-to-ocpvirt

--- a/ansible/roles-infra/infra-vmc-sandbox/defaults/main.yml
+++ b/ansible/roles-infra/infra-vmc-sandbox/defaults/main.yml
@@ -11,9 +11,7 @@ vc_ipa_pass: somepassword
 # Role name for the sandbox user
 vcenter_role: "Sandbox User"                                                      
 vcenter_permissions:
-  ClusterComputeResource: Cluster-1
   Folder: "{{ env_type }}-{{ guid }}"
-  Datastore: WorkloadDatastore
   Network: segment-{{ env_type }}-{{ guid }}
 vcenter_permissions_readonly:
   Datacenter: SDDC-Datacenter

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/defaults/main.yml
@@ -40,8 +40,6 @@ ocp4_workload_virt_roadshow_vmware_vcenter_role: "Sandbox User"
 # Permissions for user(s) in vCenter
 ocp4_workload_virt_roadshow_vmware_vcenter_permissions:
   Folder: "{{ _ocp4_workload_virt_roadshow_vmware_vcenter_folder }}"
-  Datastore: "{{ _ocp4_workload_virt_roadshow_vmware_datastore | default('datastore1') }}"
-  Network: "{{ ocp4_workload_virt_roadshow_vmware_vcenter_network }}"
 
 # How many users to configure vCenter for
 # 1: only a single user


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
remove unnecessary role permissions in vmware
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ansible/configs/experience-ocpvirt/default_vars_ec2.yml
ansible/configs/experience-ocpvirt/default_vars_equinix_metal.yml
ansible/configs/roadshow-ocpvirt/default_vars_ec2.yml
ansible/configs/roadshow-ocpvirt/default_vars_equinix_metal.yml
ansible/roles-infra/infra-vmc-sandbox/defaults/main.yml
ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/defaults/main.yml

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
