### PR TITLE
Adjust cpu settings for pre-imported VMs to enable CPU hotplug

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/templates/multi_user/vm_database.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/templates/multi_user/vm_database.yaml.j2
@@ -38,6 +38,8 @@ spec:
       domain:
         cpu:
           cores: 1
+          sockets: 1
+          threads: 1
         devices:
           disks:
           - disk:

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/templates/multi_user/vm_winweb01.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/templates/multi_user/vm_winweb01.yaml.j2
@@ -42,8 +42,8 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 2
-          sockets: 1
+          cores: 1
+          sockets: 2
           threads: 1
         devices:
           disks:

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/templates/multi_user/vm_winweb02.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/templates/multi_user/vm_winweb02.yaml.j2
@@ -42,8 +42,8 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 2
-          sockets: 1
+          cores: 1
+          sockets: 2
           threads: 1
         devices:
           disks:

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/templates/single_user/vm_database.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/templates/single_user/vm_database.yaml.j2
@@ -37,6 +37,8 @@ spec:
       domain:
         cpu:
           cores: 1
+          sockets: 1
+          threads: 1
         devices:
           disks:
           - disk:

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/templates/single_user/vm_winweb01.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/templates/single_user/vm_winweb01.yaml.j2
@@ -41,8 +41,8 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 2
-          sockets: 1
+          cores: 1
+          sockets: 2
           threads: 1
         devices:
           disks:

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/templates/single_user/vm_winweb02.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/templates/single_user/vm_winweb02.yaml.j2
@@ -41,8 +41,8 @@ spec:
               tickPolicy: catchup
           utc: {}
         cpu:
-          cores: 2
-          sockets: 1
+          cores: 1
+          sockets: 2
           threads: 1
         devices:
           disks:


### PR DESCRIPTION
##### SUMMARY

As per this thread:
https://redhat-internal.slack.com/archives/C06A9FZL9N1/p1723670395722869

and this thread:
https://redhat-internal.slack.com/archives/C06A9FZL9N1/p1723819765836269?thread_ts=1723670395.722869&cid=C06A9FZL9N1

Change the values for CPUs for the pre-imported VMs to enable CPU hotplug scenarios.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_virt_roadshow_vms