### PR TITLE
adding dns_search 

### DIFF
--- a/ansible/roles/showroom/templates/ansible_runner_api_service/ansible_runner_api_service.j2
+++ b/ansible/roles/showroom/templates/ansible_runner_api_service/ansible_runner_api_service.j2
@@ -4,6 +4,7 @@ ansible-runner-api:
   hostname: ansible-runner-api
   ports:
     - "{{ showroom_ansible_runner_api_port | default(8501) }}:80"
+  dns_search: {{ guid }}.internal
   volumes:
     - "{{ showroom_user_content_dir }}/runtime-automation/:/app/runtime-automation:ro"
     - "{{ showroom_user_home_dir }}/.ssh:/app/.ssh"


### PR DESCRIPTION
##### SUMMARY

Add dns_search Parameter in Ansible Runner API Showroom Service Template.

Problem:
In RHEL 9, pods are unable to connect using short names due to the missing search entry in the /etc/resolv.conf file.

Solution:
To address this issue and ensure compatibility across both RHEL 8 and RHEL 9, the dns_search parameter in the container compose file within the Ansible Runner API showroom service template.

This adjustment will allow pods to resolve short names correctly by specifying the appropriate search domains in the DNS resolution process.


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Role: showroom