### PR TITLE
Add permissions to see nodes for regular users

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_multi_user/files/clusterrole-node-viewer.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_multi_user/files/clusterrole-node-viewer.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: node-reader
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch"]

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_multi_user/files/clusterrolebinding-node-view.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_multi_user/files/clusterrolebinding-node-view.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: node-view-non-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: node-reader
+subjects:
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: 'system:authenticated'

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_multi_user/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_multi_user/tasks/workload.yml
@@ -9,6 +9,16 @@
   loop_control:
     loop_var: resource
 
+- name: Set up user permissions to see nodes
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('file', resource | from_yaml) }}"
+  loop:
+  - clusterrole-node-viewer.yaml
+  - clusterrolebinding-node-view.yaml
+  loop_control:
+    loop_var: resource
+
 - name: Set up user permissions to see things in system namespaces
   kubernetes.core.k8s:
     state: present


### PR DESCRIPTION
##### SUMMARY

For Multi-User CNV Roadshow add permissions so that regular users can see nodes - important for the live migration part of the lab.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_virt_roadshow_multi_user