### PR TITLE
RIPU workshop - Increase timeout for final workshop deployment workflow template.

### DIFF
--- a/ansible/roles/ansible_bu_setup_workshop/tasks/ripu.yml
+++ b/ansible/roles/ansible_bu_setup_workshop/tasks/ripu.yml
@@ -111,5 +111,5 @@
     - name: Run Z / SETUP / Workshop deployment workflow template
       awx.awx.workflow_launch:
         workflow_template: "Z / SETUP / Workshop deployment"
-        timeout: 900
+        timeout: 1300
 ...


### PR DESCRIPTION
##### SUMMARY
For RIPU workshop deploy, increase timeout for final workshop deployment workflow template from 900 seconds to 1300 seconds.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
roles/ansible_bu_setup_workshop
