### PR TITLE
ocp4_workload_external_odf modernization (kinda)

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_external_odf/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_external_odf/defaults/main.yml
@@ -1,5 +1,17 @@
 ---
 become_override: false
-odf_channel: "stable-4.13"
+odf_channel: stable-4.13
+ocp4_workload_external_odf_channel: "{{ odf_channel }}"
 
+# enable moving registry storage to external ODF
+ocp4_workload_external_odf_registry_move: true
+
+ocp4_workload_external_odf_registry_move_enable: true
 ocp4_workload_external_odf_registry_size: 100Gi
+
+# secrets from agv
+ocp4_workload_external_odf_external_config: "{{ odf_external_config }}"
+ocp4_workload_external_odf_external_pool: "{{ odf_external_pool }}"
+
+# volume names
+ocp4_workload_external_odf_volume_name_prefix: "{{ env_type }}-{{ guid }}-"

--- a/ansible/roles_ocp_workloads/ocp4_workload_external_odf/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_external_odf/tasks/workload.yml
@@ -1,16 +1,12 @@
+# vim: ft=yaml
 ---
 - name: Install Operator and configure external Ceph
-  environment:
-    KUBECONFIG: /home/{{ ansible_user }}/{{ cluster_name }}/auth/kubeconfig
   block:
     - name: Set up ODF operator
       kubernetes.core.k8s:
         state: present
         definition: "{{ lookup('template',  item ) | from_yaml }}"
-      loop:
-        - odf-ns.yaml
-        - odf-og.yaml
-        - odf-sub.yaml.j2
+      loop: [odf-ns.yaml, odf-og.yaml, odf-sub.yaml.j2]
 
     - name: Set up StorageCluster
       kubernetes.core.k8s:
@@ -20,10 +16,11 @@
       until: r_storagecluster is success
       retries: 30
       delay: 30
-      loop:
-        - secret.yaml.j2
-        - storageclass.yaml.j2
-        - storagecluster.yaml.j2
+      loop: [secret.yaml.j2, storageclass.yaml.j2, storagecluster.yaml.j2]
+
+- name: Deploy Image Regsistry to external ODF
+  when: ocp4_workload_external_odf_registry_move_enable
+  block:
     - name: Create PVC for image registry
       kubernetes.core.k8s:
         state: present
@@ -34,11 +31,28 @@
       delay: 30
 
     - name: Configure registry
-      ansible.builtin.shell: >
-        oc patch configs.imageregistry.operator.openshift.io cluster --type merge --patch
-        '{"spec":{"rolloutStrategy":"Recreate","replicas":1,"storage":{"pvc":{"claim":"pvc-image-registry"}},
-        "managementState": "Managed"}}'
+      kubernetes.core.k8s:
+        state: patched
+        api_version: imageregistry.operator.openshift.io/v1
+        kind: Config
+        name: cluster
+        merge_type: merge
+        definition:
+          spec:
+            rolloutStrategy: Recreate
+            replicas: 1
+            storage:
+              pvc:
+                claim: pvc-image-registry
+            managementState: Managed
 
     - name: Enable ODF UI plugin
-      ansible.builtin.shell: >
-        oc patch console.operator cluster -n openshift-storage --type json -p '[{"op": "add", "path": "/spec/plugins", "value": ["odf-console"]}]'
+      kubernetes.core.k8s_json_patch:
+        api_version: operator.openshift.io/v1
+        kind: Console
+        namespace: openshift-storage
+        name: cluster
+        patch:
+          - op: add
+            path: /spec/plugins
+            value: [odf-console]

--- a/ansible/roles_ocp_workloads/ocp4_workload_external_odf/templates/odf-sub.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_external_odf/templates/odf-sub.yaml.j2
@@ -8,7 +8,7 @@ metadata:
   name: odf-operator
   namespace: openshift-storage
 spec:
-  channel: "{{ odf_channel }}"
+  channel: "{{ ocp4_workload_external_odf_channel }}"
   installPlanApproval: Automatic
   name: odf-operator
   source: redhat-operators

--- a/ansible/roles_ocp_workloads/ocp4_workload_external_odf/templates/secret.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_external_odf/templates/secret.yaml.j2
@@ -5,5 +5,5 @@ metadata:
   name: rook-ceph-external-cluster-details
   namespace: openshift-storage
 data:
-  external_cluster_details: {{ odf_external_config }}
+  external_cluster_details: {{ ocp4_workload_external_odf_external_config }}
 type: Opaque

--- a/ansible/roles_ocp_workloads/ocp4_workload_external_odf/templates/storageclass.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_external_odf/templates/storageclass.yaml.j2
@@ -17,9 +17,8 @@ parameters:
   csi.storage.k8s.io/provisioner-secret-namespace: openshift-storage
   imageFeatures: layering,deep-flatten,exclusive-lock,object-map,fast-diff
   imageFormat: "2"
-  pool: {{ odf_external_pool }}
-  volumeNamePrefix: {{ env_type }}-{{ guid }}-
+  pool: {{ ocp4_workload_external_odf_external_pool }}
+  volumeNamePrefix: "{{ ocp4_workload_external_odf_volume_name_prefix }}"
 provisioner: openshift-storage.rbd.csi.ceph.com
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
-


### PR DESCRIPTION
* don't set environment KUBEADMIN - why did we need it?
* turn ansible.builtin.shell calls to `oc` into proper kubernetes.core tasks

Needs test against equinix and ROSA platforms.


<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
