### PR TITLE
ocp4_workload_virt_roadshow_vmware: retries for Create VM

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/tasks/vcenter_setup_create_folder_and_vms.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/tasks/vcenter_setup_create_folder_and_vms.yml
@@ -41,6 +41,8 @@
       datastore: "{{ _ocp4_workload_virt_roadshow_vmware_datastore_id }}"
     state: deploy
     powered_on: false
+  retries: 5
+  delay: 10
   loop: "{{ ocp4_workload_virt_roadshow_vmware_vms }}"
   loop_control:
     loop_var: vm


### PR DESCRIPTION
Under load, the VMware cluster sometimes fails, so add retriesZZ

```
"default_message": "The maximum attempts to find unique directory name limit has been reached.",
        "id": "com.vmware.vim.vm.error.AttemptToFindUniqueDirectoryNameLimitReached"
```

##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
