### PR TITLE
Enable oadp gitops workload for odf

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_oadp_gitops/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_oadp_gitops/defaults/main.yml
@@ -42,6 +42,9 @@ ocp4_workload_oadp_gitops_starting_csv: ""
 # When true it will install (and configure) one copy of the operator in a separate namespace for each user
 ocp4_workload_oadp_gitops_multi_user: false
 
+# Single user
+ocp4_workload_oadp_gitops_user: admin
+
 # Multi-user mode:
 # ocp4_workload_oadp_gitops_num_users: 1
 # ocp4_workload_oadp_gitops_user_base: user
@@ -49,15 +52,18 @@ ocp4_workload_oadp_gitops_multi_user: false
 # Role to grant users for the oadp namespace
 ocp4_workload_oadp_gitops_role: admin
 
+# For ODF set the default volumesnapshotclass
+ocp4_workload_oadp_gitops_set_default_volumesnapshotclass: true
+ocp4_workload_oadp_gitops_volumesnapshotclass: ocs-storagecluster-rbdplugin-snapclass
+
 # Set up a DataProtectionApplication
 ocp4_workload_oadp_gitops_configure_dpa: false
 
 # Storage to use for S3 type storage for DPA
-# - ocs: OpenShift Data Foundations with ObjectBucketClaim CR available
+# - odf: OpenShift Data Foundations with ObjectBucketClaim CR available
 #        All other options are implicit via ODF
-#        ODF is NOT IMPLEMENTED AT THIS POINT
 # - minio: A locally deploy Minio instance
-ocp4_workload_oadp_gitops_storage: minio
+ocp4_workload_oadp_gitops_storage: odf
 # ocp4_workload_oadp_gitops_storage: minio
 # Access to Minio
 # ocp4_workload_oadp_gitops_storage_minio_user: minio-admin
@@ -66,7 +72,6 @@ ocp4_workload_oadp_gitops_storage: minio
 # ocp4_workload_oadp_gitops_storage_minio_namespace: minio
 # ocp4_workload_oadp_gitops_storage_minio_bucket_name: s3-storage
 
-# For Multi-user only Minio is supported as storage:
 # Storage for DataProtectionApplications
 # - Bucket name will be:
 #   {{ ocp4_workload_oadp_gitops_storage_minio_bucket_name_base }}{{ ocp4_workload_oadp_gitops_storage_minio_bucket_userbase }}{{ user_number }}
@@ -79,7 +84,7 @@ ocp4_workload_oadp_gitops_storage: minio
 # --------------------------------
 # Operator Catalog Snapshot Settings
 # --------------------------------
-# See https://github.com/redhat-cop/agnosticd/blob/development/docs/Operator_Catalog_Snapshots.adoc
+# See https://github.com/redhat-cop/agnosticd/blob/development/dodf/Operator_Catalog_Snapshots.adoc
 # for instructions on how to set up catalog snapshot images
 
 # Use a catalog snapshot

--- a/ansible/roles_ocp_workloads/ocp4_workload_oadp_gitops/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_oadp_gitops/tasks/workload.yml
@@ -13,6 +13,22 @@
     success_msg: "OpenShift GitOps installation found."
     fail_msg: "OpenShift GitOps Operator must be installed and configured for OADP to be installed."
 
+- name: Ensure ObjectBucketClaim exists for ODF deployment
+  when: ocp4_workload_oadp_gitops_storage == "odf"
+  block:
+  - name: Get ObjectBucketClaim custom resource for ODF deployment
+    kubernetes.core.k8s_info:
+      api_version: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: objectbucketclaims.objectbucket.io
+    register: r_objectbucketclaim
+
+  - name: Fail when no ObjectBucketClaim is found
+    ansible.builtin.assert:
+      that: r_objectbucketclaim.resources | default ([]) | length > 0
+      success_msg: "ObjectBucketClaim custom resource found."
+      fail_msg: "OpenShift Data Foundations must be installed and configured with ObjectBucketClaims for OADP to be installed with ODF."
+
 - name: Install OADP (single user)
   when: not ocp4_workload_oadp_gitops_multi_user | bool
   kubernetes.core.k8s:
@@ -24,6 +40,18 @@
   kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('template', 'applicationset.yaml.j2') }}"
+
+- name: Set default volumesnapshotclass
+  when: ocp4_workload_oadp_gitops_set_default_volumesnapshotclass | bool
+  kubernetes.core.k8s:
+    state: patched
+    api_version: snapshot.storage.k8s.io/v1
+    kind: VolumeSnapshotClass
+    name: "{{ ocp4_workload_oadp_gitops_volumesnapshotclass }}"
+    definition:
+      metadata:
+        labels:
+          velero.io/csi-volumesnapshot: "true"
 
 # Leave this as the last task in the playbook.
 - name: Workload tasks complete

--- a/ansible/roles_ocp_workloads/ocp4_workload_oadp_gitops/templates/application.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_oadp_gitops/templates/application.yaml.j2
@@ -18,6 +18,12 @@ spec:
     automated:
       prune: false
       selfHeal: false
+  ignoreDifferences:
+  - group: '*'
+    kind: DataProtectionApplication
+    jsonPointers:
+    - /spec/backupLocations/0/velero/config/s3Url
+    - /spec/backupLocations/0/velero/objectStorage/bucket
   source:
     repoURL: {{ ocp4_workload_oadp_gitops_repo }}
     targetRevision: {{ ocp4_workload_oadp_gitops_repo_tag }}
@@ -32,7 +38,7 @@ spec:
         useCatalogSnapshot: {{ ocp4_workload_oadp_gitops_use_catalog_snapshot }}
         catalogSource:
           name: {{ ocp4_workload_oadp_gitops_catalogsource_name }}
-          namespace: {{ ocp4_workload_oadp_gitops_namespace_base }}
+          namespace: openshift-adp
           image: {{ ocp4_workload_oadp_gitops_catalog_snapshot_image }}
           tag: {{ ocp4_workload_oadp_gitops_catalog_snapshot_image_tag }}
 {% if ocp4_workload_oadp_gitops_configure_dpa | bool %}
@@ -49,6 +55,6 @@ spec:
             password: "{{ ocp4_workload_oadp_gitops_storage_minio_password }}"
             storageBucketName: "{{ ocp4_workload_oadp_gitops_storage_minio_bucket_name }}"
 {%   else %}
-          storage: ocs
+          storage: odf
 {%   endif %}
 {% endif %}

--- a/ansible/roles_ocp_workloads/ocp4_workload_oadp_gitops/templates/applicationset.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_oadp_gitops/templates/applicationset.yaml.j2
@@ -29,6 +29,12 @@ spec:
         automated:
           prune: false
           selfHeal: false
+      ignoreDifferences:
+      - group: '*'
+        kind: DataProtectionApplication
+        jsonPointers:
+        - /spec/backupLocations/0/velero/config/s3Url
+        - /spec/backupLocations/0/velero/objectStorage/bucket
       source:
         repoURL: {{ ocp4_workload_oadp_gitops_repo }}
         targetRevision: {{ ocp4_workload_oadp_gitops_repo_tag }}
@@ -61,6 +67,6 @@ spec:
                 password: "{{ ocp4_workload_oadp_gitops_storage_minio_password }}"
                 storageBucketName: "{{ ocp4_workload_oadp_gitops_storage_minio_bucket_name_base }}{% raw %}{{ user }}{% endraw %}"
 {%   else %}
-              storage: ocs
+              storage: odf
 {%   endif %}
 {% endif %}


### PR DESCRIPTION
##### SUMMARY

Enable the OADP Gitops workload to deploy with ODF as storage instead of Minio. Test single and multi-user on GCP.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_oadp_gitops