### PR TITLE
Add support in ocp-workloads for cluster workload vars

### DIFF
--- a/ansible/configs/ocp-workloads/readme.adoc
+++ b/ansible/configs/ocp-workloads/readme.adoc
@@ -54,11 +54,16 @@ openshift_app:
   api_ca_cert: ...
   api_key: ...
   api_url: ...
+  ocp4_workload_authentication_htpasswd_user_name: app-user
 
 openshift_db:
   api_ca_cert: ...
   api_key: ...
   api_url: ...
+  ocp4_workload_authentication_htpasswd_user_name: db-user
+
+ocp4_workload_authentication_idm_type: htpasswd
+ocp4_workload_authentication_htpasswd_user_count: 1
 ----
 
 
@@ -95,6 +100,11 @@ This feature is currently only supported with direct connection from localhost.
 
 The `cluster_workloads` array must specify target `clusters` whose names correspond to variables than hold connection configuration for the cluster as shown in the example above.
 
+Cluster specific workload variables may be passed within the cluster variables.
+Variables must follow the convention of beginning with the workload name
+followed by an underscore and not be set at the top-level as the `set_fact` call
+used to pass the variable to the workload cannot override a variable passed with
+Ansible extra vars.
 
 == `target_host` variable
 

--- a/ansible/configs/ocp-workloads/run_workload.yml
+++ b/ansible/configs/ocp-workloads/run_workload.yml
@@ -1,5 +1,5 @@
 ---
-- name: Set facts for {{ __cluster_name }}
+- name: Set cluster facts for {{ __cluster_name }}
   vars:
     __cluster_facts: >-
       {{ openshift_cluster_facts[__cluster_name] }}
@@ -8,6 +8,18 @@
     openshift_api_url: "{{ __cluster_facts.api_url }}"
     openshift_cluster_ingress_domain: "{{ __cluster_facts.cluster_ingress_domain }}"
     openshift_console_url: "{{ __cluster_facts.console_url }}"
+
+- name: Set {{ __workload.name }} facts for {{ __cluster_name }}
+  when: __cluster_name in vars
+  loop: >-
+    {{ lookup('vars', __cluster_name) | default({}) | dict2items
+     | json_query("[?starts_with(key, '" ~ __workload.name ~ "_')]")
+    }}
+  loop_control:
+    loop_var: __var
+    label: "{{ __var.key }}"
+  ansible.builtin.set_fact:
+    "{{ __var.key }}": "{{ __var.value }}"
 
 - name: Run Workload {{ __workload.name }} on {{ __cluster_name }}
   ansible.builtin.include_role:


### PR DESCRIPTION
##### SUMMARY

Add the ability for `ocp-workloads` config to pass cluster specific variables to workloads.

Example:

```
cluster_workloads:
- name: ocp4_workload_authentication
  clusters:
  - openshift_app
  - openshift_db

openshift_app:
  api_ca_cert: ...
  api_key: ...
  api_url: ...
  ocp4_workload_authentication_htpasswd_user_name: app-user

openshift_db:
  api_ca_cert: ...
  api_key: ...
  api_url: ...
  ocp4_workload_authentication_htpasswd_user_name: db-user

ocp4_workload_authentication_idm_type: htpasswd
ocp4_workload_authentication_htpasswd_user_count: 1
```

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Config ocp-workloads