### PR TITLE
Fix ocp workload defaults

### DIFF
--- a/ansible/configs/ocp-workloads/default_vars.yml
+++ b/ansible/configs/ocp-workloads/default_vars.yml
@@ -39,7 +39,7 @@ ocp_workloads_virtualenv_path: /opt/virtualenvs/k8s
 #   api_key: ...
 #   api_url: ...
 cluster_workloads: >-
-  {{ infra_workloads | json_query("[].{name: @, clusters: ['default']}") }}
+  {{ ocp_workloads | json_query("[].{name: @, clusters: ['default']}") }}
 
 # Simple list of workloads roles to apply to all clusters
 ocp_workloads: >-


### PR DESCRIPTION
##### SUMMARY

Fix `cluster_workloads` to be default to `ocp_workloads`, which defaults to `infra_workloads` for compatibility.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Config ocp-workloads