### PR TITLE
Fix route creation

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/defaults/main.yml
@@ -33,13 +33,12 @@ ocp4_workload_openshift_gitops_install_cli: true
 # Enable with care
 ocp4_workload_openshift_gitops_setup_cluster_admin: false
 
+# Enable the route for the default ArgoCD instance.
+ocp4_workload_openshift_gitops_enable_route: true
+
 # Set the openshift-gitops route to use re-encrypt in order for the OpenShift Gitops ArgoCD
 # installation to not throw connection warnings. Default is false for default behavior
-# Use with ocp4_workload_openshift_gitops_update_resources: true
 ocp4_workload_openshift_gitops_update_route_tls: false
-
-# Update requests, limits and other properties for ArgoCD (openshift-gitops) components
-ocp4_workload_openshift_gitops_update_resources: false
 
 # When the previous setting is true use the following requests/limits
 # What is written below are the defaults as of GitOps 1.6.1
@@ -91,7 +90,6 @@ ocp4_workload_openshift_gitops_server_limits_cpu: 500m
 ocp4_workload_openshift_gitops_server_limits_memory: 256Mi
 
 # RBAC
-# Use with ocp4_workload_openshift_gitops_update_resources: true
 ocp4_workload_openshift_gitops_rbac_update: false
 ocp4_workload_openshift_gitops_rbac_policy: |
   g, admin, role:admin

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/main.yml
@@ -1,28 +1,28 @@
 ---
 - name: Running Pre Workload Tasks
+  when: ACTION == "create" or ACTION == "provision"
   ansible.builtin.include_tasks:
     file: ./pre_workload.yml
     apply:
       become: "{{ become_override | bool }}"
-  when: ACTION == "create" or ACTION == "provision"
 
 - name: Running Workload Tasks
+  when: ACTION == "create" or ACTION == "provision"
   ansible.builtin.include_tasks:
     file: ./workload.yml
     apply:
       become: "{{ become_override | bool }}"
-  when: ACTION == "create" or ACTION == "provision"
 
 - name: Running Post Workload Tasks
+  when: ACTION == "create" or ACTION == "provision"
   ansible.builtin.include_tasks:
     file: ./post_workload.yml
     apply:
       become: "{{ become_override | bool }}"
-  when: ACTION == "create" or ACTION == "provision"
 
 - name: Running Workload removal Tasks
+  when: ACTION == "destroy" or ACTION == "remove"
   ansible.builtin.include_tasks:
     file: ./remove_workload.yml
     apply:
       become: "{{ become_override | bool }}"
-  when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/post_workload.yml
@@ -1,14 +1,8 @@
 ---
-# yamllint disable rule:line-length
-- name: project information
-  block:
-  - name: output project information
-    agnosticd_user_info:
-      msg: "{{ item }}"
-    loop:
-    - "OpenShift GitOps ArgoCD: https://openshift-gitops-server-openshift-gitops.{{ _ocp4_workload_openshift_gitops_domain }}"
-  - name: save project information
-    agnosticd_user_info:
-      data:
-        openshift_gitops_server: "https://openshift-gitops-server-openshift-gitops.{{ _ocp4_workload_openshift_gitops_domain }}"
-# yamllint enable rule:line-length
+# Implement your Post Workload deployment tasks here
+
+# Leave this as the last task in the playbook.
+- name: Post_workload tasks complete
+  when: not silent|bool
+  ansible.builtin.debug:
+    msg: "Post-Workload Tasks completed successfully."

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/pre_workload.yml
@@ -1,11 +1,8 @@
 ---
-- name: get IngressController
-  kubernetes.core.k8s_info:
-    kind: IngressController
-    name: default
-    namespace: openshift-ingress-operator
-  register: r_ingress_controller
+# Implement your Pre Workload deployment tasks here
 
-- name: set _ocp4_workload_openshift_gitops_domain
-  ansible.builtin.set_fact:
-    _ocp4_workload_openshift_gitops_domain: "{{ r_ingress_controller.resources[0].status.domain }}"
+# Leave this as the last task in the playbook.
+- name: Pre_workload tasks complete
+  when: not silent|bool
+  ansible.builtin.debug:
+    msg: "Pre-Workload tasks completed successfully."

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/remove_workload.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install OpenShift GitOps operator
-  include_role:
+  ansible.builtin.include_role:
     name: install_operator
   vars:
     install_operator_action: remove

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/workload.yml
@@ -1,4 +1,15 @@
 ---
+- name: Get IngressController
+  kubernetes.core.k8s_info:
+    kind: IngressController
+    name: default
+    namespace: openshift-ingress-operator
+  register: r_ingress_controller
+
+- name: Set _ocp4_workload_openshift_gitops_domain
+  ansible.builtin.set_fact:
+    _ocp4_workload_openshift_gitops_domain: "{{ r_ingress_controller.resources[0].status.domain }}"
+
 - name: Install OpenShift GitOps operator
   ansible.builtin.include_role:
     name: install_operator
@@ -22,25 +33,31 @@
     state: present
     definition: "{{ lookup('file', 'clusterrolebinding.yaml') | from_yaml }}"
 
-- name: Update resources for openshift-gitops ArgoCD instance
-  when: ocp4_workload_openshift_gitops_update_resources | bool
-  block:
-  - name: Wait until openshift-gitops ArgoCD instance has been created
-    kubernetes.core.k8s_info:
-      api_version: argoproj.io/v1alpha1
-      kind: ArgoCD
-      name: openshift-gitops
-      namespace: openshift-gitops
-    register: r_openshift_gitops
-    until:
-    - r_openshift_gitops is defined
-    - r_openshift_gitops.resources is defined
-    - r_openshift_gitops.resources | length == 1
+- name: Set api version to beta for stable channel
+  when: not (ocp4_workload_openshift_gitops_channel == "stable" or ocp4_workload_openshift_gitops_channel is version_compare("gitops-1.13", ">="))
+  ansible.builtin.set_fact:
+    _ocp4_workload_openshift_gitops_api_version: v1alpha1
 
-  - name: Update resources for the openshift-gitops ArgoCD instance
-    kubernetes.core.k8s:
-      state: patched
-      definition: "{{ lookup('template', 'openshift-gitops.yaml.j2') | from_yaml }}"
+- name: Debug version
+  ansible.builtin.debug:
+    msg: "API Version: {{ _ocp4_workload_openshift_gitops_api_version }}"
+
+- name: Wait until openshift-gitops ArgoCD instance has been created
+  kubernetes.core.k8s_info:
+    api_version: "argoproj.io/{{ _ocp4_workload_openshift_gitops_api_version }}"
+    kind: ArgoCD
+    name: openshift-gitops
+    namespace: openshift-gitops
+  register: r_openshift_gitops
+  until:
+  - r_openshift_gitops is defined
+  - r_openshift_gitops.resources is defined
+  - r_openshift_gitops.resources | length == 1
+
+- name: Update the openshift-gitops ArgoCD instance
+  kubernetes.core.k8s:
+    state: patched
+    definition: "{{ lookup('template', 'openshift-gitops.yaml.j2') | from_yaml }}"
 
 - name: Attempt to install the ArgoCD CLI to the bastion
   when: ocp4_workload_openshift_gitops_install_cli | bool
@@ -66,3 +83,17 @@
     retries: 5
     delay: 5
     ignore_errors: true
+
+# yamllint disable rule:line-length
+- name: project information
+  block:
+  - name: Print project information
+    agnosticd_user_info:
+      msg: "{{ item }}"
+    loop:
+    - "OpenShift GitOps ArgoCD: https://openshift-gitops-server-openshift-gitops.{{ _ocp4_workload_openshift_gitops_domain }}"
+  - name: Save project information
+    agnosticd_user_info:
+      data:
+        openshift_gitops_server: "https://openshift-gitops-server-openshift-gitops.{{ _ocp4_workload_openshift_gitops_domain }}"
+# yamllint enable rule:line-length

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/templates/openshift-gitops.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/templates/openshift-gitops.yaml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/{{ _ocp4_workload_openshift_gitops_api_version }}
 kind: ArgoCD
 metadata:
   name: openshift-gitops
@@ -60,8 +60,8 @@ spec:
 {% endif %}
   repo:
     env:
-      - name: SUB_DOMAIN
-        value: {{ _ocp4_workload_openshift_gitops_domain }}
+    - name: SUB_DOMAIN
+      value: {{ _ocp4_workload_openshift_gitops_domain }}
 {% if ocp4_workload_openshift_gitops_repo_update | default(false) | bool %}
     resources:
       limits:
@@ -81,13 +81,15 @@ spec:
         cpu: "{{ ocp4_workload_openshift_gitops_server_requests_cpu }}"
         memory: "{{ ocp4_workload_openshift_gitops_server_requests_memory }}"
 {% endif %}
-{% if ocp4_workload_openshift_gitops_update_route_tls | bool %}
-    insecure: true
+{% if ocp4_workload_openshift_gitops_enable_route | bool %}
     route:
       enabled: true
+{%   if ocp4_workload_openshift_gitops_update_route_tls | bool %}
       tls:
         termination: edge
         insecureEdgeTerminationPolicy: Redirect
+    insecure: true
+{%   endif %}
 {% endif %}
 {% if ocp4_workload_openshift_gitops_resource_customizations | length > 0 %}
   resourceCustomizations: |

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/vars/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/vars/main.yml
@@ -1,0 +1,3 @@
+---
+# Gitops uses v1beta1 starting with 1.13. Before it was v1alpha1
+_ocp4_workload_openshift_gitops_api_version: v1beta1


### PR DESCRIPTION
##### SUMMARY

Starting with Gitops 1.13 the default Route is created using proper TLS encryption on the default ArgoCD instance.

Turning off setting the TLS route resulted in the route not being created at all.

Fix: New variable (set to true by default) to control creating the route. Only update TLS settings when requested.

Also fixed: API version of the ArgoCD instance changed to v1beta1 from v1alpha1. Added code to use the correct API version.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_openshift_gitops