### PR TITLE
zero-touch-base-rhel add functionality for rhel 7 systems

### DIFF
--- a/ansible/configs/zero-touch-base-rhel/pre_software.yml
+++ b/ansible/configs/zero-touch-base-rhel/pre_software.yml
@@ -117,6 +117,18 @@
   tasks:
     - name: Setup ssh for showroom_ssh_host
       block:
+        - name: Configure CentOS7 systems for vault repos
+          when:
+            - "ansible_distribution == 'CentOS'"
+            - "ansible_distribution_major_version | int  == 7"
+          ansible.builtin.import_role:
+            name: centos-eol-repos
+
+        - name: Install common packages from common_packages list
+          when: agd_install_common | default(true) | bool
+          ansible.builtin.import_role:
+            name: common
+
         - name: create /root/.ssh
           ansible.builtin.file:
             dest: /root/.ssh

--- a/ansible/configs/zero-touch-base-rhel/pre_software.yml
+++ b/ansible/configs/zero-touch-base-rhel/pre_software.yml
@@ -110,6 +110,59 @@
       include_role:
         name: asset_injector
 
+- name: Run tasks only on RHEL 8 systems
+  hosts: all
+  become: true
+  when: (ansible_distribution == "CentOS" or ansible_distribution == "RedHat") and ansible_distribution_major_version == "7"
+  tasks:
+    - name: Setup ssh for showroom_ssh_host
+      block:
+        - name: create /root/.ssh
+          ansible.builtin.file:
+            dest: /root/.ssh
+            mode: 0700
+            owner: "root"
+            group: "root"
+            state: directory
+
+        - name: copy the environment .pem key
+          ansible.builtin.copy:
+            src: "{{ hostvars.localhost.env_authorized_key_path }}"
+            dest: "/root/.ssh/{{ env_authorized_key }}.pem"
+            owner: "root"
+            group: "root"
+            mode: 0400
+
+        - name: copy the environment .pub key
+          ansible.builtin.copy:
+            content: "{{ hostvars.localhost.env_authorized_key_content_pub }}"
+            dest: "/root/.ssh/{{ env_authorized_key }}.pub"
+            owner: "root"
+            group: "root"
+            mode: 0400
+
+        - name: copy .ssh/config template
+          ansible.builtin.template:
+            src: ./files/ssh_config.j2
+            dest: /root/.ssh/config
+            owner: "root"
+            group: "root"
+            mode: 0400
+
+        - name: Set authorized key from file
+          authorized_key:
+            user: "root"
+            state: present
+            key: "{{ hostvars.localhost.ssh_provision_pubkey_content
+              | default(hostvars.localhost.env_authorized_key_content_pub) }}"
+
+        - name: Inject assets
+          when:
+            - asset_injector_assets is defined
+            - asset_injector_assets | length > 0
+          include_role:
+            name: asset_injector
+
 - name: PreSoftware flight-check
   hosts: localhost
   connection: local

--- a/ansible/configs/zero-touch-base-rhel/pre_software.yml
+++ b/ansible/configs/zero-touch-base-rhel/pre_software.yml
@@ -110,7 +110,7 @@
       include_role:
         name: asset_injector
 
-- name: Run tasks only on RHEL 8 systems
+- name: Setup legacy systems
   hosts: all
   become: true
   when: (ansible_distribution == "CentOS" or ansible_distribution == "RedHat") and ansible_distribution_major_version == "7"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
This update adds code to configure a second system for the showroom to ssh into. This is due to labs running RHEL 7 that also cannot use OCP4 showroom.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
zero-touch-base-rhel
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
