### PR TITLE
ocp4_workload_..vmware: retry get folder ID in vmware workload

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/tasks/vcenter_setup_create_folder_and_vms.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/tasks/vcenter_setup_create_folder_and_vms.yml
@@ -23,6 +23,9 @@
       {{ lookup('vmware.vmware_rest.folder_moid',
       '/' + vcenter_datacenter + '/vm/Workloads/' + _ocp4_workload_virt_roadshow_vmware_vcenter_folder,
       **_ocp4_workload_virt_roadshow_vmware_connection_args) }}
+  retries: 10
+  delay: 5
+  until: _ocp4_workload_virt_roadshow_vmware_vcenter_folder_id | length > 0
 
 - name: Create VMs
   environment:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
