### PR TITLE
Update installer logic

### DIFF
--- a/ansible/roles/host-ocp4-installer/tasks/create-manifests.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/create-manifests.yml
@@ -29,14 +29,16 @@
 
 # This downloads all the extra manifests which are maintained by Tigera
 # Can't use unarchive module as it does not handle .gz files that do not contain a .tar archive.
-- block:
-    - name: make sure manifests dir exists
+- name: Set up with Calico
+  when: ocp4_network_type|default("OVNKubernetes") == "Calico"
+  block:
+    - name: Make sure manifests dir exists
       ansible.builtin.file:
         path: "/home/{{ ansible_user }}/{{ cluster_name }}/manifests/"
         state: directory
         mode: "0775"
 
-    - name: Download Project Calico Manifest archive file to {{ ansible_user }} home dir
+    - name: Download Project Calico Manifest archive file to home dir
       ansible.builtin.get_url:
         url: "https://projectcalico.docs.tigera.io/manifests/ocp.tgz"
         dest: "/home/{{ ansible_user }}/"
@@ -51,14 +53,13 @@
         # yamllint disable-line rule:line-length
         cmd: "gtar -x -f /home/{{ ansible_user }}/ocp.tgz --strip-components 1 -C /home/{{ ansible_user }}/{{ cluster_name }}/manifests/"
 
-    - name: verify permissions on Calico manifest files are set to 775
+    - name: Verify permissions on Calico manifest files are set to 775
       ansible.builtin.file:
         path: "/home/{{ ansible_user }}/{{ cluster_name }}/manifests/"
         state: directory
         recurse: true
         mode: "0775"
 
-    - name: remove downloaded file
+    - name: Remove downloaded file
       ansible.builtin.file:
         path: "/home/{{ ansible_user }}/ocp.tgz"
-  when: ocp4_network_type|default("OVNKubernetes") == "Calico"

--- a/ansible/roles/host-ocp4-installer/tasks/install_installer.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/install_installer.yml
@@ -36,12 +36,20 @@
         ocp4_installer_version
       ) }}
       {%- else -%}
-      {% if   ansible_distribution_major_version is version_compare('9', '>=') -%}
-      {{ '{0}/ocp/stable-{1}/openshift-install-rhel{2}linux.tar.gz'.format(
+      {%   if ansible_distribution_major_version is version_compare('9', '>=') -%}
+      {%     if ansible_architecture == 'x86_64' %}
+      {{ '{0}/ocp/stable-{1}/openshift-install-rhel{2}-amd64.tar.gz'.format(
         ocp4_installer_root_url | default("https://mirror.openshift.com/pub/openshift-v4/clients"),
         ocp4_installer_version,
         ansible_distribution_major_version
       ) }}
+      {%      else %}
+      {{ '{0}/ocp/stable-{1}/openshift-install-linux-{2}.tar.gz'.format(
+        ocp4_installer_root_url | default("https://mirror.openshift.com/pub/openshift-v4/clients"),
+        ocp4_installer_version,
+        ansible_architecture
+      ) }}
+      {%      endif %}
       {%-   else -%}
       {{ '{0}/ocp/stable-{1}/openshift-install-linux.tar.gz'.format(
         ocp4_installer_root_url | default("https://mirror.openshift.com/pub/openshift-v4/clients"),
@@ -70,6 +78,13 @@
     that:
     - ocp4_installer_url | default('') | length > 0
     - ocp4_client_url    | default('') | length > 0
+
+- name: Debug URLs
+  ansible.builtin.debug:
+    msg: "{{ item }}"
+  loop:
+  - "OpenShift Installer URL: {{ ocp4_installer_url }}"
+  - "OpenShift Client URL: {{ ocp4_client_url }}"
 
 - name: Get the OpenShift Installer
   become: true

--- a/ansible/roles/host-ocp4-installer/tasks/install_installer.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/install_installer.yml
@@ -30,10 +30,25 @@
   - (ocp4_installer_version | string).split('.') | length == 2
   ansible.builtin.set_fact:
     ocp4_installer_url: >-
+      {% if ocp4_installer_version is version_compare('4.15', '<=') -%}
       {{ '{0}/ocp/stable-{1}/openshift-install-linux.tar.gz'.format(
         ocp4_installer_root_url | default("https://mirror.openshift.com/pub/openshift-v4/clients"),
         ocp4_installer_version
       ) }}
+      {%- else -%}
+      {% if   ansible_distribution_major_version is version_compare('9', '>=') -%}
+      {{ '{0}/ocp/stable-{1}/openshift-install-rhel{2}linux.tar.gz'.format(
+        ocp4_installer_root_url | default("https://mirror.openshift.com/pub/openshift-v4/clients"),
+        ocp4_installer_version,
+        ansible_distribution_major_version
+      ) }}
+      {%-   else -%}
+      {{ '{0}/ocp/stable-{1}/openshift-install-linux.tar.gz'.format(
+        ocp4_installer_root_url | default("https://mirror.openshift.com/pub/openshift-v4/clients"),
+        ocp4_installer_version
+      ) }}
+      {%-   endif %}
+      {%- endif %}
     ocp4_client_url: >-
       {% if ocp4_installer_version is version_compare('4.14', '<=') -%}
       {{ '{0}/ocp/stable-{1}/openshift-client-linux{2}.tar.gz'.format(
@@ -59,7 +74,7 @@
 - name: Get the OpenShift Installer
   become: true
   ansible.builtin.unarchive:
-    src: "{{ ocp4_installer_url}}"
+    src: "{{ ocp4_installer_url }}"
     remote_src: true
     dest: /usr/bin
     mode: "0755"

--- a/ansible/roles/host-ocp4-installer/tasks/install_installer.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/install_installer.yml
@@ -100,6 +100,19 @@
   retries: 10
   delay: 30
 
+- name: Check if the installer is a FIPS installer
+  ansible.builtin.stat:
+    path: /usr/bin/openshift-install-fips
+  register: r_installer_fips
+
+- name: Hard link the FIPS installer if it exists
+  when: r_installer_fips.stat.exists
+  ansible.builtin.file:
+    path: /usr/bin/openshift-install-fips
+    dest: /usr/bin/openshift-install
+    state: hard
+    mode: "0755"
+
 - name: Get the OpenShift CLI
   become: true
   ansible.builtin.unarchive:

--- a/ansible/roles/host-ocp4-installer/tasks/install_installer.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/install_installer.yml
@@ -107,6 +107,7 @@
 
 - name: Hard link the FIPS installer if it exists
   when: r_installer_fips.stat.exists
+  become: true
   ansible.builtin.file:
     src: /usr/bin/openshift-install-fips
     dest: /usr/bin/openshift-install

--- a/ansible/roles/host-ocp4-installer/tasks/install_installer.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/install_installer.yml
@@ -92,7 +92,7 @@
     src: "{{ ocp4_installer_url }}"
     remote_src: true
     dest: /usr/bin
-    mode: "0755"
+    mode: "u=rwx,g=rwx,o=rx"
     owner: root
     group: root
   register: r_installer
@@ -108,10 +108,12 @@
 - name: Hard link the FIPS installer if it exists
   when: r_installer_fips.stat.exists
   ansible.builtin.file:
-    path: /usr/bin/openshift-install-fips
+    src: /usr/bin/openshift-install-fips
     dest: /usr/bin/openshift-install
     state: hard
-    mode: "0755"
+    owner: root
+    group: root
+    mode: "u=rwx,g=rwx,o=rx"
 
 - name: Get the OpenShift CLI
   become: true
@@ -119,7 +121,7 @@
     src: "{{ ocp4_client_url }}"
     remote_src: true
     dest: /usr/bin
-    mode: "0775"
+    mode: "u=rwx,g=rwx,o=rx"
     owner: root
     group: root
   register: r_client

--- a/ansible/roles/host-ocp4-installer/tasks/main.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/main.yml
@@ -3,7 +3,9 @@
   ansible.builtin.import_tasks: install_installer.yml
 
 - name: Enable FIPS mode on host
-  when: ocp4_fips_enable | default(false) | bool
+  when:
+  - ocp4_fips_enable | default(false) | bool
+  - ocp4_installer_version | is version_compare('stable-4.16', '>=') or (ocp4_installer_version | is version_compare('4.16', '>='))
   become: true
   ansible.builtin.import_tasks: setup-fips-host.yml
 

--- a/ansible/roles/host-ocp4-installer/tasks/main.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/main.yml
@@ -2,6 +2,10 @@
 - name: Install client and OpenShift Installer binaries
   ansible.builtin.import_tasks: install_installer.yml
 
+- name: Enable FIPS mode on host
+  when: ocp4_fips_enable | default(false) | bool
+  ansible.builtin.import_tasks: setup-fips-host.yml
+
 ## Open the port for the api
 - name: OpenStack specific requirement - find network port id
   when:

--- a/ansible/roles/host-ocp4-installer/tasks/main.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: Enable FIPS mode on host
   when:
   - ocp4_fips_enable | default(false) | bool
-  - ocp4_installer_version is version_compare('stable-4.16', '>=') or ocp4_installer_version is version_compare('4.16', '>=')
+  - ocp4_installer_version is version_compare('4.16', '>=')
   become: true
   ansible.builtin.import_tasks: setup-fips-host.yml
 

--- a/ansible/roles/host-ocp4-installer/tasks/main.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/main.yml
@@ -4,6 +4,7 @@
 
 - name: Enable FIPS mode on host
   when: ocp4_fips_enable | default(false) | bool
+  become: true
   ansible.builtin.import_tasks: setup-fips-host.yml
 
 ## Open the port for the api

--- a/ansible/roles/host-ocp4-installer/tasks/main.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: Enable FIPS mode on host
   when:
   - ocp4_fips_enable | default(false) | bool
-  - ocp4_installer_version | is version_compare('stable-4.16', '>=') or ocp4_installer_version | is version_compare('4.16', '>=')
+  - ocp4_installer_version is version_compare('stable-4.16', '>=') or ocp4_installer_version is version_compare('4.16', '>=')
   become: true
   ansible.builtin.import_tasks: setup-fips-host.yml
 

--- a/ansible/roles/host-ocp4-installer/tasks/main.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: Enable FIPS mode on host
   when:
   - ocp4_fips_enable | default(false) | bool
-  - ocp4_installer_version | is version_compare('stable-4.16', '>=') or (ocp4_installer_version | is version_compare('4.16', '>='))
+  - ocp4_installer_version | is version_compare('stable-4.16', '>=') or ocp4_installer_version | is version_compare('4.16', '>=')
   become: true
   ansible.builtin.import_tasks: setup-fips-host.yml
 

--- a/ansible/roles/host-ocp4-installer/tasks/setup-fips-host.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/setup-fips-host.yml
@@ -1,0 +1,8 @@
+---
+- name: Setup FIPS mode on the host
+  ansible.builtin.command:
+    cmd: fips-mode-setup --enable
+
+- name: Reboot host
+  ansible.builtin.reboot:
+    msg: Rebooting to enable FIPS mode.

--- a/ansible/roles_ocp_workloads/ocp4_workload_authentication/tasks/setup_htpasswd.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_authentication/tasks/setup_htpasswd.yml
@@ -41,7 +41,7 @@
   - name: Generate user passwords array for common password
     ansible.builtin.set_fact:
       _ocp4_workload_authentication_htpasswd_user_passwords: >-
-        {{ _ocp4_workload_authentication_htpasswd_user_passwords + [ _ocp4_workload_authentication_htpasswd_user_password ] }}
+        {{ _ocp4_workload_authentication_htpasswd_user_passwords + [_ocp4_workload_authentication_htpasswd_user_password] }}
     loop: "{{ range(0, ocp4_workload_authentication_htpasswd_user_count | int, 1) | list }}"
 
 - name: Create temporary htpasswd file
@@ -50,12 +50,15 @@
     suffix: htpasswd
   register: r_htpasswd
 
+# Use hash scheme ldap_sha1 instead of the default scheme to work on FIPS
 - name: Add admin user to htpasswd file
   community.general.htpasswd:
     path: "{{ r_htpasswd.path }}"
     name: "{{ ocp4_workload_authentication_admin_user }}"
     password: "{{ _ocp4_workload_authentication_admin_password }}"
+    hash_scheme: ldap_sha1
 
+# Use hash scheme ldap_sha1 instead of the default scheme to work on FIPS
 - name: Add users and passwords to htpasswd file
   community.general.htpasswd:
     path: "{{ r_htpasswd.path }}"
@@ -66,6 +69,7 @@
       {{ ocp4_workload_authentication_htpasswd_user_base }}{{ item + 1 }}
       {%- endif -%}
     password: "{{ _ocp4_workload_authentication_htpasswd_user_passwords[ item ] }}"
+    hash_scheme: ldap_sha1
   loop: "{{ range(0, ocp4_workload_authentication_htpasswd_user_count | int, 1) | list }}"
 
 - name: Read contents of htpasswd file
@@ -93,12 +97,12 @@
 - name: Create htpasswd Secret
   kubernetes.core.k8s:
     state: present
-    definition: "{{ lookup('template', 'secret-htpasswd.yaml.j2' ) | from_yaml }}"
+    definition: "{{ lookup('template', 'secret-htpasswd.yaml.j2') | from_yaml }}"
 
 - name: Update OAuth configuration
   kubernetes.core.k8s:
     state: present
-    definition: "{{ lookup('file', 'oauth-htpasswd.yaml' ) | from_yaml }}"
+    definition: "{{ lookup('file', 'oauth-htpasswd.yaml') | from_yaml }}"
 
 - name: Print user information messages
   when: ocp4_workload_authentication_enable_user_info_messages | bool
@@ -179,16 +183,16 @@
   block:
   - name: Save user information for user access
     agnosticd_user_info:
-      user: "{{ ocp4_workload_authentication_htpasswd_user_base }}{{ n +1 }}"
+      user: "{{ ocp4_workload_authentication_htpasswd_user_base }}{{ n + 1 }}"
       data:
-        user: "{{ ocp4_workload_authentication_htpasswd_user_base }}{{ n +1 }}"
+        user: "{{ ocp4_workload_authentication_htpasswd_user_base }}{{ n + 1 }}"
         password: "{{ _ocp4_workload_authentication_htpasswd_user_passwords[ n ] }}"
         console_url: "{{ _ocp4_workload_authentication_console_route }}"
         openshift_console_url: "{{ _ocp4_workload_authentication_console_route }}"
         openshift_cluster_ingress_domain: "{{ _ocp4_workload_authentication_cluster_ingress_domain }}"
         login_command: >-
           oc login --insecure-skip-tls-verify=false
-          -u {{ ocp4_workload_authentication_htpasswd_user_base }}{{ n +1 }}
+          -u {{ ocp4_workload_authentication_htpasswd_user_base }}{{ n + 1 }}
           -p {{ _ocp4_workload_authentication_htpasswd_user_passwords[ n ] }}
           {{ _ocp4_workload_authentication_api_server }}
     loop: "{{ range(0, ocp4_workload_authentication_htpasswd_user_count | int) | list }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_authentication/tasks/setup_htpasswd.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_authentication/tasks/setup_htpasswd.yml
@@ -68,7 +68,7 @@
       {%- else -%}
       {{ ocp4_workload_authentication_htpasswd_user_base }}{{ item + 1 }}
       {%- endif -%}
-    password: "{{ _ocp4_workload_authentication_htpasswd_user_passwords[ item ] }}"
+    password: "{{ _ocp4_workload_authentication_htpasswd_user_passwords[item] }}"
     hash_scheme: ldap_sha1
   loop: "{{ range(0, ocp4_workload_authentication_htpasswd_user_count | int, 1) | list }}"
 
@@ -143,7 +143,7 @@
         created with password `{{ _ocp4_workload_authentication_htpasswd_user_passwords[0] }}`
         {%- else -%}
         User `{{ ocp4_workload_authentication_htpasswd_user_base }}{{ n + 1 }}`,
-        Password: `{{ _ocp4_workload_authentication_htpasswd_user_passwords[ n ] }}`
+        Password: `{{ _ocp4_workload_authentication_htpasswd_user_passwords[n] }}`
         {%- endif -%}
     loop: "{{ range(0, ocp4_workload_authentication_htpasswd_user_count | int) | list }}"
     loop_control:

--- a/ansible/roles_ocp_workloads/ocp4_workload_le_certificates/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_le_certificates/tasks/workload.yml
@@ -196,7 +196,6 @@
         path: /home/{{ ansible_user }}/.rfc2136.ini
       when: _certbot_setup_complete
 
-
   - name: Install redeploy hook scripts
     ansible.builtin.template:
       src: ./templates/deploy_certs.sh.j2


### PR DESCRIPTION
##### SUMMARY

Installing a FIPS cluster changed in 4.16. It now needs a FIPS enabled RHEL to run the installer. The installer has a different name as well. And finally the way that we created passwords in the authentication workload using `htpasswd` was not FIPS compliant either.

Fixed all of that.
Tested on 4.16, 4.15 and 4.14.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
host-ocp4-installer
ocp4_workload_authentication
