### PR TITLE
Add restart/retry to ocp4_workload_cert_manager

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/workload.yml
@@ -103,6 +103,32 @@
       namespace: openshift-ingress
       wait: true
       wait_sleep: 5
+      wait_timeout: 120
+      wait_condition:
+        type: "Ready"
+        status: "True"
+    ignore_errors: true
+    register: r_certificate_ingress
+
+  - name: Restart cert-manager on failure
+    when: r_certificate_ingress is failed
+    kubernetes.core.k8s:
+      api_version: v1
+      kind: Pod
+      state: absent
+      label_selectors:
+      - app.kubernetes.io/instance=cert-manager
+      - app.kubernetes.io/component=controller
+      namespace: cert-manager
+
+  - name: Wait until Ingress Certificate is ready (retry)
+    kubernetes.core.k8s_info:
+      api_version: cert-manager.io/v1
+      kind: Certificate
+      name: cert-manager-ingress-cert
+      namespace: openshift-ingress
+      wait: true
+      wait_sleep: 5
       wait_timeout: 600
       wait_condition:
         type: "Ready"


### PR DESCRIPTION
##### SUMMARY

Restart cert-manager if ingress cert fails to become available.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role ocp4_workload_cert_manager