### PR TITLE
add retries for certmanager cert checks

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/cert_manager_api_cert_check.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/cert_manager_api_cert_check.yml
@@ -1,3 +1,4 @@
+---
 - block:
   - name: Wait until API Certificate is ready
     when: not api_cert_ready | default(false) | bool
@@ -15,8 +16,9 @@
     ignore_errors: true
     register: r_certificate_api
 
-  - ansible.builtin.set_fact:
+  - name: Mark cert ready
     when: not r_certificate_api is failed
+    ansible.builtin.set_fact:
       api_cert_ready: true
 
   rescue:
@@ -32,7 +34,7 @@
 
   - ansible.builtin.set_fact:
       api_cert_retry_counter: "{{ api_cert_retry_counter | int + 1 }}"
-  
+
   - name: Report fail on api certificate failure
     when:
       - (api_cert_retry_counter | int > api_cert_max_retries | int)

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/cert_manager_api_cert_check.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/cert_manager_api_cert_check.yml
@@ -37,8 +37,8 @@
 
   - name: Report fail on api certificate failure
     when:
-      - (api_cert_retry_counter | int > api_cert_max_retries | int)
-      - r_certificate_api is failed
+    - (api_cert_retry_counter | int > api_cert_max_retries | int)
+    - r_certificate_api is failed
     block:
     - name: Print error message if requesting certificates failed
       when: ocp4_workload_cert_manager_ignore_errors | bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/cert_manager_api_cert_check.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/cert_manager_api_cert_check.yml
@@ -1,0 +1,49 @@
+- block:
+  - name: Wait until API Certificate is ready
+    when: not api_cert_ready | default(false) | bool
+    kubernetes.core.k8s_info:
+      api_version: cert-manager.io/v1
+      kind: Certificate
+      name: cert-manager-api-cert
+      namespace: openshift-api
+      wait: true
+      wait_sleep: 5
+      wait_timeout: 800
+      wait_condition:
+        type: "Ready"
+        status: "True"
+    ignore_errors: true
+    register: r_certificate_api
+
+  - ansible.builtin.set_fact:
+    when: not r_certificate_api is failed
+      api_cert_ready: true
+
+  rescue:
+  - name: Restart cert-manager on failure
+    kubernetes.core.k8s:
+      api_version: v1
+      kind: Pod
+      state: absent
+      label_selectors:
+      - app.kubernetes.io/instance=cert-manager
+      - app.kubernetes.io/component=controller
+      namespace: cert-manager
+
+  - ansible.builtin.set_fact:
+      api_cert_retry_counter: "{{ api_cert_retry_counter | int + 1 }}"
+  
+  - name: Report fail on api certificate failure
+    when:
+      - (api_cert_retry_counter | int > api_cert_max_retries | int)
+      - r_certificate_api is failed
+    block:
+    - name: Print error message if requesting certificates failed
+      when: ocp4_workload_cert_manager_ignore_errors | bool
+      ansible.builtin.debug:
+        msg: "Requesting certificate for API servers failed after {{ api_cert_max_retries }} retries."
+
+    - name: Fail if requesting certificates failed
+      when: not ocp4_workload_cert_manager_ignore_errors | bool
+      ansible.builtin.fail:
+        msg: "Requesting certificate for API servers failed after {{ api_cert_max_retries }} retries."

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/cert_manager_ingress_cert_check.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/cert_manager_ingress_cert_check.yml
@@ -37,8 +37,8 @@
 
   - name: Report fail on ingress certificate failure
     when:
-      - (ingress_cert_retry_counter | int > ingress_cert_max_retries | int)
-      - r_certificate_ingress is failed
+    - (ingress_cert_retry_counter | int > ingress_cert_max_retries | int)
+    - r_certificate_ingress is failed
     block:
     - name: Print error message if requesting certificates failed
       when: ocp4_workload_cert_manager_ignore_errors | bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/cert_manager_ingress_cert_check.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/cert_manager_ingress_cert_check.yml
@@ -1,0 +1,49 @@
+- block:
+  - name: Wait until Ingress Certificate is ready
+    when: not ingress_cert_ready | default(false) | bool
+    kubernetes.core.k8s_info:
+      api_version: cert-manager.io/v1
+      kind: Certificate
+      name: cert-manager-ingress-cert
+      namespace: openshift-ingress
+      wait: true
+      wait_sleep: 5
+      wait_timeout: 600
+      wait_condition:
+        type: "Ready"
+        status: "True"
+    ignore_errors: true
+    register: r_certificate_ingress
+
+  - ansible.builtin.set_fact:
+    when: not r_certificate_ingress is failed
+      ingress_cert_ready: true
+
+  rescue:
+  - name: Restart cert-manager on failure
+    kubernetes.core.k8s:
+      api_version: v1
+      kind: Pod
+      state: absent
+      label_selectors:
+      - app.kubernetes.io/instance=cert-manager
+      - app.kubernetes.io/component=controller
+      namespace: cert-manager
+
+  - ansible.builtin.set_fact:
+      ingress_cert_retry_counter: "{{ ingress_cert_retry_counter | int + 1 }}"
+  
+  - name: Report fail on ingress certificate failure
+    when:
+      - (ingress_cert_retry_counter | int > ingress_cert_max_retries | int)
+      - r_certificate_ingress is failed
+    block:
+    - name: Print error message if requesting certificates failed
+      when: ocp4_workload_cert_manager_ignore_errors | bool
+      ansible.builtin.debug:
+        msg: "Requesting certificate for Ingress controllers failed after {{ ingress_cert_max_retries }} retries."
+
+    - name: Fail if requesting certificates failed
+      when: not ocp4_workload_cert_manager_ignore_errors | bool
+      ansible.builtin.fail:
+        msg: "Requesting certificate for Ingress controllers failed after {{ ingress_cert_max_retries }} retries."

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/cert_manager_ingress_cert_check.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/cert_manager_ingress_cert_check.yml
@@ -1,3 +1,4 @@
+---
 - block:
   - name: Wait until Ingress Certificate is ready
     when: not ingress_cert_ready | default(false) | bool
@@ -15,8 +16,9 @@
     ignore_errors: true
     register: r_certificate_ingress
 
-  - ansible.builtin.set_fact:
+  - name: Mark cert ready
     when: not r_certificate_ingress is failed
+    ansible.builtin.set_fact:
       ingress_cert_ready: true
 
   rescue:
@@ -32,7 +34,7 @@
 
   - ansible.builtin.set_fact:
       ingress_cert_retry_counter: "{{ ingress_cert_retry_counter | int + 1 }}"
-  
+
   - name: Report fail on ingress certificate failure
     when:
       - (ingress_cert_retry_counter | int > ingress_cert_max_retries | int)

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/workload.yml
@@ -95,33 +95,13 @@
 - name: Install Ingress controller certificate
   when: ocp4_workload_cert_manager_install_ingress_certificates | bool
   block:
-  - name: Wait until Ingress Certificate is ready
-    kubernetes.core.k8s_info:
-      api_version: cert-manager.io/v1
-      kind: Certificate
-      name: cert-manager-ingress-cert
-      namespace: openshift-ingress
-      wait: true
-      wait_sleep: 5
-      wait_timeout: 600
-      wait_condition:
-        type: "Ready"
-        status: "True"
-    ignore_errors: true
-    register: r_certificate_ingress
+  vars:
+    ingress_cert_retry_counter: 0
+    ingress_cert_max_retries: 3
 
-  - name: Handle ingress certificate failure
-    when: r_certificate_ingress is failed
-    block:
-    - name: Print error message if requesting certificates failed
-      when: ocp4_workload_cert_manager_ignore_errors | bool
-      ansible.builtin.debug:
-        msg: "Requesting certificate for Ingress controllers failed."
-
-    - name: Fail if requesting certificates failed
-      when: not ocp4_workload_cert_manager_ignore_errors | bool
-      ansible.builtin.fail:
-        msg: "Requesting certificate for Ingress controllers failed."
+  - name: Run ingress controller certificate check task
+    ansible.builtin.include_tasks: cert_manager_ingress_cert_check.yml
+    with_sequence: start=0 end={{ ingress_cert_max_retries }}
 
   - name: Update Ingress controller to use certificate
     when: not r_certificate_ingress is failed
@@ -132,32 +112,13 @@
 - name: Install API Server certificate
   when: ocp4_workload_cert_manager_install_api_certificates | bool
   block:
-  - name: Wait until API Certificate is ready
-    kubernetes.core.k8s_info:
-      api_version: cert-manager.io/v1
-      kind: Certificate
-      name: cert-manager-api-cert
-      namespace: openshift-config
-      wait: true
-      wait_sleep: 5
-      wait_timeout: 800
-      wait_condition:
-        type: "Ready"
-        status: "True"
-    register: r_certificate_api
+  vars:
+    api_cert_retry_counter: 0
+    api_cert_max_retries: 3
 
-  - name: Handle API certificate failure
-    when: r_certificate_api is failed
-    block:
-    - name: Print error message if requesting certificates failed
-      when: ocp4_workload_cert_manager_ignore_errors | bool
-      ansible.builtin.debug:
-        msg: "Requesting certificate for API servers failed."
-
-    - name: Fail if requesting certificates failed
-      when: not ocp4_workload_cert_manager_ignore_errors | bool
-      ansible.builtin.fail:
-        msg: "Requesting certificate for API servers failed."
+  - name: Run API certificate check task
+    ansible.builtin.include_tasks: cert_manager_api_cert_check.yml
+    with_sequence: start=0 end={{ api_cert_max_retries }}
 
   - name: API Certificate successfull
     when: not r_certificate_api is failed

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/workload.yml
@@ -94,10 +94,10 @@
 
 - name: Install Ingress controller certificate
   when: ocp4_workload_cert_manager_install_ingress_certificates | bool
-  block:
   vars:
     ingress_cert_retry_counter: 0
     ingress_cert_max_retries: 3
+  block:
 
   - name: Run ingress controller certificate check task
     ansible.builtin.include_tasks: cert_manager_ingress_cert_check.yml
@@ -111,10 +111,10 @@
 
 - name: Install API Server certificate
   when: ocp4_workload_cert_manager_install_api_certificates | bool
-  block:
   vars:
     api_cert_retry_counter: 0
     api_cert_max_retries: 3
+  block:
 
   - name: Run API certificate check task
     ansible.builtin.include_tasks: cert_manager_api_cert_check.yml


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
add retries for certmanager cert checks
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4_workload_cert_manager
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
