### PR TITLE
Allow bastion dnf package install to be turned off, on by default

### DIFF
--- a/ansible/roles/bastion-base/defaults/main.yml
+++ b/ansible/roles/bastion-base/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# By default role will install basic packages but this can be disabled eg immutable OS
+bastion_install_basic_packages: true

--- a/ansible/roles/bastion-base/tasks/main.yml
+++ b/ansible/roles/bastion-base/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Setup Red Hat packages for bastion
-  when: not bastion_install_basic_packages | default(false)
+  when: bastion_install_basic_packages | bool
   ansible.builtin.package:
     state: present
     name: "{{ agd_bastion_packages }}"

--- a/ansible/roles/bastion-base/tasks/main.yml
+++ b/ansible/roles/bastion-base/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 - name: Setup Red Hat packages for bastion
+  when: not bastion_install_basic_packages | default(false)
   ansible.builtin.package:
     state: present
     name: "{{ agd_bastion_packages }}"


### PR DESCRIPTION
##### SUMMARY

Allows bastion-base role to NOT install packages if set

- Packages will install by default, unless `bastion_install_basic_packages: true`

Motivated by immutable OS images like RHEL AI, however, a useful feature independent of motivation

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

roles/bastion-base

##### ADDITIONAL INFORMATION
