### PR TITLE
software_playbook none is too opininated, allows forced import to do …

### DIFF
--- a/ansible/software_playbooks/empty.yml
+++ b/ansible/software_playbooks/empty.yml
@@ -1,0 +1,7 @@
+---
+- name: Truly empty Software to Deploy playbook
+  hosts: localhost
+  gather_facts: false
+  become: false
+
+  tasks:


### PR DESCRIPTION

##### SUMMARY

`software_to_deploy` is always forced and the `none.yml` playbook is poorly named

- eg it forces the insertion of an ansible inventory on the bastion

This creates an empty playbook `empty.yml` so allowing a true no change at this stage to take place

(main.yml forces an import)


##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ansible/software_playbooks

##### ADDITIONAL INFORMATION
