### PR TITLE
Lower cpu requests in ocp4_workload_showroom

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/defaults/main.yaml
@@ -40,7 +40,7 @@ ocp4_workload_showroom_second_terminal_tab_enable: false
 ocp4_workload_showroom_second_terminal_tab_display_name: "Terminal 2"
 
 # Requests and limits for the terminal pod (same vars for either showroom or wetty)
-ocp4_workload_showroom_terminal_requests_cpu: 500m
+ocp4_workload_showroom_terminal_requests_cpu: 50m
 ocp4_workload_showroom_terminal_requests_memory: 256Mi
 ocp4_workload_showroom_terminal_limits_cpu: 500m
 ocp4_workload_showroom_terminal_limits_memory: 1Gi
@@ -63,7 +63,7 @@ ocp4_workload_showroom_novnc_enable: false
 ocp4_workload_showroom_novnc_vnc_server_hostport: 128.0.0.1:5900
 ocp4_workload_showroom_novnc_vnc_server_password: password
 ocp4_workload_showroom_novnc_image: ghcr.io/rhpds/showroom-novnc:latest
-ocp4_workload_showroom_novnc_requests_cpu: 500m
+ocp4_workload_showroom_novnc_requests_cpu: 50m
 ocp4_workload_showroom_novnc_requests_memory: 256Mi
 ocp4_workload_showroom_novnc_limits_cpu: 550m
 ocp4_workload_showroom_novnc_limits_memory: 256Mi


### PR DESCRIPTION
##### SUMMARY

Lower CPU requests in ocp4_workload_showroom. Showroom pods mostly sit idle and reserving half a CPU for exclusive use by containers that are mostly idle wastes a lot of resources and drives up cost.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Role ocp4_workload_showroom