### PR TITLE
fix typo in start/stop for vmware

### DIFF
--- a/ansible/roles-infra/infra-vmc-resources/tasks/start_instances.yaml
+++ b/ansible/roles-infra/infra-vmc-resources/tasks/start_instances.yaml
@@ -6,7 +6,7 @@
     show_attribute: true
 
 - name: Start the VMs
-  when: not instance.hw_is_template
+  when: not item.hw_is_template
   register: r_vmc_instances
   community.vmware.vmware_guest:
     folder: "/Workloads/{{env_type}}-{{ guid }}"

--- a/ansible/roles-infra/infra-vmc-resources/tasks/start_instances.yaml
+++ b/ansible/roles-infra/infra-vmc-resources/tasks/start_instances.yaml
@@ -4,9 +4,10 @@
   community.vmware.vmware_vm_info:
     folder: "/{{ vcenter_datacenter }}/vm/Workloads/{{ env_type }}-{{ guid }}"
     show_attribute: true
+  ignore_errors: True
 
 - name: Start the VMs
-  when: not item.hw_is_template
+  when: not item.hw_is_template | default(false) | bool
   register: r_vmc_instances
   community.vmware.vmware_guest:
     folder: "/Workloads/{{env_type}}-{{ guid }}"

--- a/ansible/roles-infra/infra-vmc-resources/tasks/stop_instances.yaml
+++ b/ansible/roles-infra/infra-vmc-resources/tasks/stop_instances.yaml
@@ -7,7 +7,7 @@
   ignore_errors: True
 
 - name: Stop the VMs
-  when: not instance.hw_is_template
+  when: not item.hw_is_template
   register: r_vmc_instances
   community.vmware.vmware_guest:
     folder: "/Workloads/{{env_type}}-{{ guid }}"

--- a/ansible/roles-infra/infra-vmc-resources/tasks/stop_instances.yaml
+++ b/ansible/roles-infra/infra-vmc-resources/tasks/stop_instances.yaml
@@ -7,7 +7,7 @@
   ignore_errors: True
 
 - name: Stop the VMs
-  when: not item.hw_is_template
+  when: not item.hw_is_template | default(false) | bool
   register: r_vmc_instances
   community.vmware.vmware_guest:
     folder: "/Workloads/{{env_type}}-{{ guid }}"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
fix typo in start/stop for vmware
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
infra-vmc-resources

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
