### PR TITLE
virt binder fixups to enable workloads and remove kubeconfig+cluster_name reference

### DIFF
--- a/ansible/configs/virt-roadshow-binder/post_software.yml
+++ b/ansible/configs/virt-roadshow-binder/post_software.yml
@@ -29,41 +29,29 @@
         remote_user: lab-user
         ansible_ssh_extra_args: "-o StrictHostKeyChecking=no"
 
-# # Deploy Workloads
-# - name: Step 005.2 - Deploy Infra and Student Workloads
-#   ansible.builtin.import_playbook: workloads.yml
-
-- name: Install workloads
+- name: Run Workloads
   hosts: bastions
-  gather_facts: true
-  become: false
+  gather_facts: false
   tasks:
-
-    - name: Set Ansible Python interpreter to k8s virtualenv
+    - name: Set Ansible Python interpreter to virtualenv
       ansible.builtin.set_fact:
-        ansible_python_interpreter: /opt/virtualenvs/k8s/bin/python
+        ansible_python_interpreter: "/opt/virtualenvs/k8s/bin/python"
 
-    - name: Install ocp-infra workloads
+    - name: Install ocp-infra-workloads
       when: infra_workloads | default("") | length > 0
-      tags:
-        infra_workloads
       block:
-        - name: Install ocp-infra-workloads
-          when: infra_workloads | default("") | length > 0
-          block:
 
-            - name: Deploy ocp-infra workloads
-              ansible.builtin.include_role:
-                name: "{{ workload_loop_var }}"
-                tasks_from: "{{ run_tasks_from }}"
-              vars:
-                run_tasks_from: >-
-                  {{ ( workload_loop_var == "ocp4_workload_virt_roadshow_vmware" ) | ternary("mtv", "main") }}
-                ocp_username: "system:admin"
-                ACTION: "provision"
-              loop: "{{ infra_workloads }}"
-              loop_control:
-                loop_var: workload_loop_var
+        - name: Deploy ocp-infra workloads
+          ansible.builtin.include_role:
+            name: "{{ workload_loop_var }}"
+            tasks_from: "{{ run_tasks_from }}"
+          vars:
+            run_tasks_from: >-
+              {{ (workload_loop_var == "ocp4_workload_virt_roadshow_vmware") | ternary("mtv", "main") }}
+            ocp_username: "system:admin"
+          loop: "{{ infra_workloads }}"
+          loop_control:
+            loop_var: workload_loop_var
 
 - name: Exiting the virt-roadshow-binder post_software.yml
   hosts: localhost

--- a/ansible/roles_ocp_workloads/ocp4_workload_external_odf/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_external_odf/tasks/workload.yml
@@ -1,7 +1,5 @@
 ---
 - name: Install Operator and configure external Ceph
-  environment:
-    KUBECONFIG: /home/{{ ansible_user }}/{{ cluster_name }}/auth/kubeconfig
   block:
   - name: Set up ODF operator
     kubernetes.core.k8s:


### PR DESCRIPTION
- New config Pull Request

* Update the config/virt-roadshow-binder to handle differences in calling the vmware role
* remove environment setup because `cluster_name` is not available when workload is not called from config/ocp4-cluster