### PR TITLE
Role common , Update dnf module to use package

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -9,13 +9,13 @@
   tags: packer
   block:
   - name: Update all packages
-    ansible.builtin.dnf:
+    ansible.builtin.package:
       name: '*'
       state: latest
       nobest: true
-    register: r_dnf
+    register: r_package
     retries: 3
-    until: r_dnf is succeeded
+    until: r_package is succeeded
     async: 3600
     poll: 30
 


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
This role was using "ansible.builtin.dnf" to update all packages on systems. This module will not work for RHEL 7 systems.
The "ansible.bultin.package" module will allow us to run this role on legacy systems as it acts as a proxy to the underlying package manager module. While all arguments will be passed to the underlying module.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
Role: common
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
