### PR TITLE
Pre-deployed VMs were working before. Fix for roadshow

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/defaults/main.yml
@@ -17,3 +17,9 @@ ocp4_workload_virt_roadshow_vms_namespace: vmimported
 # Multi-user (num users > 1)
 ocp4_workload_virt_roadshow_vms_userbase: user
 ocp4_workload_virt_roadshow_vms_base_namespace: vmimported-
+
+# Roadshow Setup
+# When set to true (default) then the application made up from the VMs will not
+# work until instructions are followed.
+# When false the application will work out of the box without changes
+ocp4_workload_virt_roadshow_vms_roadshow_setup: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/templates/multi_user/service_database.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/templates/multi_user/service_database.yaml.j2
@@ -1,4 +1,5 @@
-{% for user_number in range(1, ocp4_workload_virt_roadshow_vms_num_users | int + 1) %}
+{% if not ocp4_workload_virt_roadshow_vms_roadshow_setup | bool %}
+{%   for user_number in range(1, ocp4_workload_virt_roadshow_vms_num_users | int + 1) %}
 ---
 apiVersion: v1
 kind: Service
@@ -12,4 +13,5 @@ spec:
   - protocol: TCP
     port: 3306
     targetPort: 3306
-{% endfor %}
+{%   endfor %}
+{% endif %}

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/templates/multi_user/vm_winweb01.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/templates/multi_user/vm_winweb01.yaml.j2
@@ -26,9 +26,11 @@ spec:
             storage: 90Gi
   running: {{ ocp4_workload_virt_roadshow_vms_start_vms | bool }}
   template:
+{% if not ocp4_workload_virt_roadshow_vms_roadshow_setup | bool %}
     metadata:
       labels:
         env: webapp
+{% endif %}
     spec:
       domain:
         clock:

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/templates/multi_user/vm_winweb02.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/templates/multi_user/vm_winweb02.yaml.j2
@@ -26,9 +26,11 @@ spec:
             storage: 90Gi
   running: {{ ocp4_workload_virt_roadshow_vms_start_vms | bool }}
   template:
+{% if not ocp4_workload_virt_roadshow_vms_roadshow_setup | bool %}
     metadata:
       labels:
         env: webapp
+{% endif %}
     spec:
       domain:
         clock:

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/templates/single_user/service_database.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/templates/single_user/service_database.yaml.j2
@@ -1,3 +1,4 @@
+{% if not ocp4_workload_virt_roadshow_vms_roadshow_setup | bool %}
 ---
 apiVersion: v1
 kind: Service
@@ -11,3 +12,4 @@ spec:
   - protocol: TCP
     port: 3306
     targetPort: 3306
+{% endif %}

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/templates/single_user/vm_winweb01.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/templates/single_user/vm_winweb01.yaml.j2
@@ -25,9 +25,11 @@ spec:
             storage: 90Gi
   running: {{ ocp4_workload_virt_roadshow_vms_start_vms | bool }}
   template:
+{% if not ocp4_workload_virt_roadshow_vms_roadshow_setup | bool %}
     metadata:
       labels:
         env: webapp
+{% endif %}
     spec:
       domain:
         clock:

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/templates/single_user/vm_winweb02.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/templates/single_user/vm_winweb02.yaml.j2
@@ -25,9 +25,11 @@ spec:
             storage: 90Gi
   running: {{ ocp4_workload_virt_roadshow_vms_start_vms | bool }}
   template:
+{% if not ocp4_workload_virt_roadshow_vms_roadshow_setup | bool %}
     metadata:
       labels:
         env: webapp
+{% endif %}
     spec:
       domain:
         clock:


### PR DESCRIPTION
##### SUMMARY

The VMs that are pre-populated for the roadshow were fully functioning. The roadshow instructions however expect the students to fix the labels on the VMs and create the service for the database.

A new flag ocp4_workload_virt_roadshow_vms_roadshow_setup has been created (defaults to true) that will make the VMs "roadshow ready".

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_virt_roadshow_vms