### PR TITLE
[ocp4_workload_virt_roadshow_vmware] Add missing until on vcenter_setup_create_folder_and_vms.yml

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/tasks/vcenter_setup_create_folder_and_vms.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/tasks/vcenter_setup_create_folder_and_vms.yml
@@ -46,6 +46,7 @@
     powered_on: false
   retries: 5
   delay: 10
+  until: r_vmc_instance is success
   loop: "{{ ocp4_workload_virt_roadshow_vmware_vms }}"
   loop_control:
     loop_var: vm


### PR DESCRIPTION
##### SUMMARY

Task contains retries and delay but until parameter was missing

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
Role ocp4_workload_virt_roadshow_vmware

