### PR TITLE
Add enhanced tmux.conf with cross-platform copy and paste to showroom

### DIFF
--- a/ansible/roles/showroom/tasks/22-showroom-users-security.yml
+++ b/ansible/roles/showroom/tasks/22-showroom-users-security.yml
@@ -109,10 +109,9 @@
         mode: u=rwx,g=rx,o=rx
 
     - name: Setup mouse scrolling for tmux via user tmux.conf
-      ansible.builtin.lineinfile:
-        path: "/home/{{ __showroom_lab_user }}/.tmux.conf"
-        line: "set -g mouse on"
-        create: true
+      ansible.builtin.template:
+        src: tmux.conf.j2
+        dest: "/home/{{ __showroom_lab_user }}/.tmux.conf"
         mode: u=rw,g-rwx,o-rwx
         owner: "{{ __showroom_lab_user }}"
         group: users

--- a/ansible/roles/showroom/templates/tmux.conf.j2
+++ b/ansible/roles/showroom/templates/tmux.conf.j2
@@ -1,0 +1,45 @@
+# Enable vi mode
+setw -g mode-keys vi
+
+# Enable mouse support
+set -g mouse on
+
+# Start selection with 'v' and copy with 'y'
+bind-key -T copy-mode-vi v send-keys -X begin-selection
+bind-key -T copy-mode-vi y send-keys -X copy-selection-and-cancel
+
+# Copy to system clipboard
+if-shell "uname | grep -q Darwin" {
+    # macOS
+    bind-key -T copy-mode-vi 'y' send -X copy-pipe-and-cancel 'pbcopy'
+    bind-key -T copy-mode-vi Enter send -X copy-pipe-and-cancel 'pbcopy'
+    bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel 'pbcopy'
+} {
+    if-shell "uname | grep -q Linux" {
+        # Linux with xclip
+        bind-key -T copy-mode-vi 'y' send -X copy-pipe-and-cancel 'xclip -in -selection clipboard'
+        bind-key -T copy-mode-vi Enter send -X copy-pipe-and-cancel 'xclip -in -selection clipboard'
+        bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel 'xclip -in -selection clipboard'
+    } {
+        # Windows (assuming WSL with clip.exe)
+        bind-key -T copy-mode-vi 'y' send -X copy-pipe-and-cancel 'clip.exe'
+        bind-key -T copy-mode-vi Enter send -X copy-pipe-and-cancel 'clip.exe'
+        bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel 'clip.exe'
+    }
+}
+
+# Paste from system clipboard
+if-shell "uname | grep -q Darwin" {
+    # macOS
+    bind ] run "pbpaste | tmux load-buffer - && tmux paste-buffer"
+} {
+    if-shell "uname | grep -q Linux" {
+        # Linux with xclip
+        bind ] run "xclip -out -selection clipboard | tmux load-buffer - && tmux paste-buffer"
+    } {
+        # Windows (assuming WSL)
+        bind ] run "powershell.exe -command 'Get-Clipboard' | tmux load-buffer - && tmux paste-buffer"
+    }
+}
+
+unbind-key -T root MouseDown3Pane


### PR DESCRIPTION
##### SUMMARY

Enhances showrooms `tmux` option by allowing seamless copy and paste across major OS client platforms:

- Linux
- MacOS
- Windows

Disables tmux right-click menu (was clashing with OS based right click menus)
Avoids truncation of pasted commands which occurred on windows and linux

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

roles/showroom

##### ADDITIONAL INFORMATION
