### PR TITLE
Create basic agnosticd.ai collection for AI, InstructLab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,8 @@
 *secrets[_-]var.yaml
 ansible/workdir/*
 ansible/judd.sh
-ansible/collections
+ansible/collections/ansible_collections/*
+!ansible/collections/ansible_collections/agnosticd
 ansible/configs/*/roles
 ansible/configs/archive/*/roles
 *.swp

--- a/ansible/collections/ansible_collections/agnosticd/ai/README.md
+++ b/ansible/collections/ansible_collections/agnosticd/ai/README.md
@@ -1,0 +1,7 @@
+#  agnosticd.ai
+
+Collection for automating ai specfic configurations
+
+
+
+

--- a/ansible/collections/ansible_collections/agnosticd/ai/galaxy.yml
+++ b/ansible/collections/ansible_collections/agnosticd/ai/galaxy.yml
@@ -1,0 +1,69 @@
+### REQUIRED
+# The namespace of the collection. This can be a company/brand/organization or product namespace under which all
+# content lives. May only contain alphanumeric lowercase characters and underscores. Namespaces cannot start with
+# underscores or numbers and cannot contain consecutive underscores
+namespace: agnosticd
+
+# The name of the collection. Has the same character restrictions as 'namespace'
+name: ai
+
+# The version of the collection. Must be compatible with semantic versioning
+version: 1.0.0
+
+# The path to the Markdown (.md) readme file. This path is relative to the root of the collection
+readme: README.md
+
+# A list of the collection's content authors. Can be just the name or in the format 'Full Name <email> (url)
+# @nicks:irc/im.site#channel'
+authors:
+- your name <example@domain.com>
+
+
+### OPTIONAL but strongly recommended
+# A short summary description of the collection
+description: your collection description
+
+# Either a single license or a list of licenses for content inside of a collection. Ansible Galaxy currently only
+# accepts L(SPDX,https://spdx.org/licenses/) licenses. This key is mutually exclusive with 'license_file'
+license:
+- GPL-2.0-or-later
+
+# The path to the license file for the collection. This path is relative to the root of the collection. This key is
+# mutually exclusive with 'license'
+license_file: ''
+
+# A list of tags you want to associate with the collection for indexing/searching. A tag name has the same character
+# requirements as 'namespace' and 'name'
+tags: []
+
+# Collections that this collection requires to be installed for it to be usable. The key of the dict is the
+# collection label 'namespace.name'. The value is a version range
+# L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification). Multiple version
+# range specifiers can be set and are separated by ','
+dependencies: {}
+
+# The URL of the originating SCM repository
+repository: http://example.com/repository
+
+# The URL to any online docs
+documentation: http://docs.example.com
+
+# The URL to the homepage of the collection/project
+homepage: http://example.com
+
+# The URL to the collection issue tracker
+issues: http://example.com/issue/tracker
+
+# A list of file glob-like patterns used to filter any files or directories that should not be included in the build
+# artifact. A pattern is matched from the relative path of the file or directory of the collection directory. This
+# uses 'fnmatch' to match the files or directories. Some directories and files like 'galaxy.yml', '*.pyc', '*.retry',
+# and '.git' are always filtered. Mutually exclusive with 'manifest'
+build_ignore: []
+
+# A dict controlling use of manifest directives used in building the collection artifact. The key 'directives' is a
+# list of MANIFEST.in style
+# L(directives,https://packaging.python.org/en/latest/guides/using-manifest-in/#manifest-in-commands). The key
+# 'omit_default_directives' is a boolean that controls whether the default directives are used. Mutually exclusive
+# with 'build_ignore'
+# manifest: null
+

--- a/ansible/collections/ansible_collections/agnosticd/ai/meta/runtime.yml
+++ b/ansible/collections/ansible_collections/agnosticd/ai/meta/runtime.yml
@@ -1,0 +1,52 @@
+---
+# Collections must specify a minimum required ansible version to upload
+# to galaxy
+# requires_ansible: '>=2.9.10'
+
+# Content that Ansible needs to load from another location or that has
+# been deprecated/removed
+# plugin_routing:
+#   action:
+#     redirected_plugin_name:
+#       redirect: ns.col.new_location
+#     deprecated_plugin_name:
+#       deprecation:
+#         removal_version: "4.0.0"
+#         warning_text: |
+#           See the porting guide on how to update your playbook to
+#           use ns.col.another_plugin instead.
+#     removed_plugin_name:
+#       tombstone:
+#         removal_version: "2.0.0"
+#         warning_text: |
+#           See the porting guide on how to update your playbook to
+#           use ns.col.another_plugin instead.
+#   become:
+#   cache:
+#   callback:
+#   cliconf:
+#   connection:
+#   doc_fragments:
+#   filter:
+#   httpapi:
+#   inventory:
+#   lookup:
+#   module_utils:
+#   modules:
+#   netconf:
+#   shell:
+#   strategy:
+#   terminal:
+#   test:
+#   vars:
+
+# Python import statements that Ansible needs to load from another location
+# import_redirection:
+#   ansible_collections.ns.col.plugins.module_utils.old_location:
+#     redirect: ansible_collections.ns.col.plugins.module_utils.new_location
+
+# Groups of actions/modules that take a common set of options
+# action_groups:
+#   group_name:
+#     - module1
+#     - module2

--- a/ansible/collections/ansible_collections/agnosticd/ai/plugins/README.md
+++ b/ansible/collections/ansible_collections/agnosticd/ai/plugins/README.md
@@ -1,0 +1,31 @@
+# Collections Plugins Directory
+
+This directory can be used to ship various plugins inside an Ansible collection. Each plugin is placed in a folder that
+is named after the type of plugin it is in. It can also include the `module_utils` and `modules` directory that
+would contain module utils and modules respectively.
+
+Here is an example directory of the majority of plugins currently supported by Ansible:
+
+```
+└── plugins
+    ├── action
+    ├── become
+    ├── cache
+    ├── callback
+    ├── cliconf
+    ├── connection
+    ├── filter
+    ├── httpapi
+    ├── inventory
+    ├── lookup
+    ├── module_utils
+    ├── modules
+    ├── netconf
+    ├── shell
+    ├── strategy
+    ├── terminal
+    ├── test
+    └── vars
+```
+
+A full list of plugin types can be found at [Working With Plugins](https://docs.ansible.com/ansible-core/2.15/plugins/plugins.html).

--- a/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_instructlab/README.adoc
+++ b/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_instructlab/README.adoc
@@ -1,0 +1,60 @@
+= setup_instructlab
+
+This role will install instructlab on a RHEL or Fedora machine.
+Currently it is opininated and assumes that the machine has an Nvidia GPU and CUDA
+
+It currently supports:
+
+- RHEL 9 (tested aginst RHEL 9.3)
+- Fedora (tested against Fedora 39)
+
+In addition it stores a small number of pre-requsities (e.g. `gcc`) that are required for the installation of the NVIDIA drivers and CUDA Toolkit.
+
+== Role Variables
+
+This role is entirely self container ie is _fire and forget_ and does not require any variables to be set.
+
+However the following link:./defaults/main.yml[variables] can be set to control the installation:
++
+
+[source,sh]
+----
+
+setup_instructlab_repo_url: "https://github.com/instructlab/instructlab"
+setup_instructlab_taxonomy_repo_url: "https://github.com/instructlab/taxonomy"
+setup_instructlab_user: "instruct"
+setup_instructlab_install_path_base: "/home/{{ setup_instructlab_user }}"  # Change this to your path
+setup_instructlab_cuda_home: "/usr/local/cuda"
+setup_instructlab_cuda_lib_path: "/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64"
+
+setup_instructlab_developer_packages:
+  - g++
+  - gcc
+  - git
+  - make
+  - python3.11
+----
+
+== Dependencies
+
+None
+
+== Example Playbook
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+[source,yaml]
+----
+---
+- name: Test EDA dispatcher
+  hosts: localhost
+  gather_facts: true
+  become: true
+
+  roles:
+    - setup_instructlab
+----
+
+== Author Information
+
+Tony Kay (tok@redhat.com) 2024-05-01

--- a/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_instructlab/defaults/main.yml
+++ b/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_instructlab/defaults/main.yml
@@ -1,0 +1,38 @@
+---
+
+# Instruct lab homes
+
+setup_instructlab_developer_preview: false
+
+# NOTE:: Currently this var may be highly changeable and should be managed in AgV
+
+setup_instructlab_llama_cpp_python_version: "0.2.79"
+setup_instructlab_git_ref: "stable"
+
+# Sets up instance for Fine Tunning, needs significant GPU resources
+
+setup_instructlab_developer_preview: false
+setup_instructlab_summit2024_mode: false
+
+setup_instructlab_repo_url: "https://github.com/instructlab/instructlab"
+setup_instructlab_taxonomy_repo_url: "https://github.com/instructlab/taxonomy"
+setup_instructlab_git_tag: main
+
+# TODO: Make this Distribution agnostic
+
+setup_instructlab_user: "instruct"
+setup_instructlab_home: "{{ setup_instructlab_install_path_base }}/instructlab"
+setup_instructlab_install_path_base: "/home/{{ setup_instructlab_user}}"  # Change this to your path
+
+setup_instructlab_cuda_home: "/usr/local/cuda"
+setup_instructlab_cuda_lib_path: "/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64"
+
+setup_instructlab_python_version: "3.11"
+
+setup_instructlab_developer_packages:
+  - g++
+  - gcc
+  - git
+  - make
+  - "python{{ setup_instructlab_python_version }}"
+  - "python{{ setup_instructlab_python_version }}-devel"

--- a/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_instructlab/files/qna.yaml
+++ b/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_instructlab/files/qna.yaml
@@ -1,0 +1,60 @@
+created_by: instructlab-team
+domain: instructlab
+seed_examples:
+- answer: InstructLab is a model-agnostic open source AI project that facilitates
+    contributions to Large Language Models (LLMs).
+    We are on a mission to let anyone shape generative AI by enabling contributed
+    updates to existing LLMs in an accessible way. Our community welcomes all those who
+    would like to help us enable everyone to shape the future of generative AI.
+  question: What is InstructLab?
+- answer: Check out the Instructlab Community README to get started
+    with using and contributing to the project.
+    If you want to jump right in, head to the InstructLab CLI
+    documentation to get InstructLab set up and running.
+    Learn more about the skills and knowledge you can add to models.
+    You may wish to read through the project's FAQ to get more familiar
+    with all aspects of InstructLab. You can find all the ways to
+    collaborate with project maintainers and your fellow users of
+    InstructLab beyond GitHub by visiting our project collaboration page.
+  question: How to get started with InstructLab
+- answer: There are many projects rapidly embracing and extending
+    permissively licensed AI models, but they are faced with three
+    main challenges like Contribution to LLMs is not possible directly.
+    They show up as forks, which forces consumers to choose a “best-fit”
+    model that is not easily extensible. Also, the forks are expensive
+    for model creators to maintain. The ability to contribute ideas is
+    limited by a lack of AI/ML expertise. One has to learn how to fork,
+    train, and refine models to see their idea move forward.
+    This is a high barrier to entry. There is no direct community
+    governance or best practice around review, curation, and
+    distribution of forked models.
+  question: What problems is Instructlab aiming to solve?
+- answer: InstructLab was created by Red Hat and IBM Research.
+  question: Who created Instructlab?
+- answer: The project enables community contributors to add
+    additional "skills" or "knowledge" to a particular model. InstructLab's
+    model-agnostic technology gives model upstreams with sufficient
+    infrastructure resources the ability to create regular builds of
+    their open source licensed models not by rebuilding and retraining
+    the entire model but by composing new skills into it.
+    The community welcomes all those who would like to help enable
+    everyone to shape the future of generative AI.
+  question: How does Instructlab enable community collaboration?
+- answer: Yes, InstructLab is a model-agnostic open source AI project
+    that facilitates contributions to Large Language Models (LLMs).
+  question: Is Instructlab an open source project?
+- answer: InstructLab uses a novel synthetic data-based alignment
+    tuning method for Large Language Models (LLMs.)
+    The "lab" in InstructLab stands for Large-Scale Alignment for ChatBots
+  question: What is the tuning method for Instructlab?
+- answer: The mission of instructlab is to let everyone shape generative AI
+    by enabling contributed updates to existing LLMs in an accessible way.
+    The community welcomes all those who would like to help enable everyone
+    to shape the future of generative AI.
+  question: What is the mission of Instructlab?
+task_description: 'Details on instructlab community project'
+document:
+  repo: https://github.com/instructlab/.github
+  commit: 83d9852ad97c6b27d4b24508f7cfe7ff5dd04d0d
+  patterns:
+    - README.md

--- a/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_instructlab/tasks/10-nvidia-customizations.yml
+++ b/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_instructlab/tasks/10-nvidia-customizations.yml
@@ -1,0 +1,21 @@
+---
+
+- name: Set CUDA related vars for all users
+  ansible.builtin.blockinfile:
+    path: /etc/environment
+    block: |
+      CUDA_HOME={{ setup_instructlab_cuda_home }}
+      LD_LIBRARY_PATH={{ setup_instructlab_cuda_lib_path }}
+    marker: "# {mark} ANSIBLE MANAGED BLOCK"
+    create: true
+
+- name: Set CUDA related vars etc in .bashrc
+  ansible.builtin.blockinfile:
+    path: "/home/{{ setup_instructlab_user }}/.bashrc"
+    block: |
+      export CUDA_HOME={{ setup_instructlab_cuda_home }}
+      export LD_LIBRARY_PATH={{ setup_instructlab_cuda_lib_path }}
+      export PATH=$PATH:/usr/local/cuda/bin
+    marker: "# {mark} ANSIBLE MANAGED BLOCK"
+    create: true
+  become_user: "{{ setup_instructlab_user | default('instruct') }}"

--- a/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_instructlab/tasks/20-developer-customizations.yml
+++ b/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_instructlab/tasks/20-developer-customizations.yml
@@ -1,0 +1,16 @@
+---
+
+- name: Setup AI developer packages
+  ansible.builtin.dnf:
+    name: "{{ package }}"
+    state: present
+  loop: "{{ setup_instructlab_developer_packages }}"
+  loop_control:
+    loop_var: package
+
+- name: "Set system default Python version, to {{ setup_instructlab_python_version }}"
+  ansible.builtin.alternatives:
+    name: python
+    link: /usr/bin/python3
+    path: "/usr/bin/python{{ setup_instructlab_python_version | default('3.11') }}"
+

--- a/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_instructlab/tasks/30-instruct-repos.yml
+++ b/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_instructlab/tasks/30-instruct-repos.yml
@@ -1,0 +1,26 @@
+---
+
+- name: Setup the users InstructLab environment
+  block:
+
+    - name: Clone InstructLab repository
+      ansible.builtin.git:
+        repo: "{{ setup_instructlab_repo_url }}"
+        dest: "{{ setup_instructlab_home }}"
+        version: "{{ setup_instructlab_git_ref }}"
+        clone: true
+        update: true
+      register: r_git_clone_instructlab
+
+    - name: Clone taxonomy repository if not present
+      when: not setup_instructlab_summit2024_mode | bool
+      ansible.builtin.git:
+        repo: "{{ setup_instructlab_taxonomy_repo_url }}"
+        dest: "{{ setup_instructlab_home }}/taxonomy"
+        version: "main"
+        clone: true
+        update: true
+      register: r_git_clone_taxonomy
+
+  become_user: "{{ setup_instructlab_user | default('instruct') }}"
+

--- a/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_instructlab/tasks/40-instructlab-runtime-setup.yml
+++ b/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_instructlab/tasks/40-instructlab-runtime-setup.yml
@@ -1,0 +1,66 @@
+---
+- name: Venv and iLab Python setup
+  block:
+
+    - name: "Setup a Python {{ setup_instructlab_python_version }} virtual environment"
+      ansible.builtin.command:
+        cmd: "python{{ setup_instructlab_python_version }} -m venv /home/{{ setup_instructlab_user }}/instructlab/venv"
+      args:
+        creates: "/home/{{ setup_instructlab_user }}/instructlab/venv"
+
+    - name: Install InstructLab package from local git repo
+      when: r_git_clone_instructlab.changed
+      ansible.builtin.command:
+        cmd: >-
+          /home/{{ setup_instructlab_user }}/instructlab/venv/bin/pip
+          install {{ setup_instructlab_home }}
+    
+    # TODO: Remove or deactivate this hack when no longer needed
+
+    - name: Replace tokenizer.eos_token with tokenizer.unk_token in linux_train.py
+      ansible.builtin.replace:
+        path: >-
+          {{ setup_instructlab_home }}/venv/lib/python{{ setup_instructlab_python_version }}/site-packages/instructlab/train/linux_train.py
+        regexp: 'tokenizer\.eos_token'
+        replace: 'tokenizer.unk_token'
+
+    - name: Install InstructLab package from local git repo again after change - rebuild wheel
+      when: r_git_clone_instructlab.changed
+      ansible.builtin.command:
+        cmd: >-
+          /home/{{ setup_instructlab_user }}/instructlab/venv/bin/pip
+          install {{ setup_instructlab_home }}
+
+    - name: Setup llama-cpp-python with CUDA Support
+      ansible.builtin.command:
+        cmd: >-
+            {{ setup_instructlab_home }}/venv/bin/pip install --force-reinstall 
+            --no-cache-dir "llama-cpp-python[server]=={{ setup_instructlab_llama_cpp_python_version }}"
+      environment:
+        CUDACXX: /usr/local/cuda-12/bin/nvcc 
+        CMAKE_ARGS: "-DLLAMA_CUBLAS=on -DCMAKE_CUDA_ARCHITECTURES=all-major" 
+        FORCE_CMAKE: 1 
+
+    #TODO: Remove or deactivate this hack when no longer needed
+    # This will download numpy *but* generate errors which we can ignore
+
+    - name: Downgrade numpy
+      ansible.builtin.command:
+        cmd: >-
+          /home/{{ setup_instructlab_user }}/instructlab/venv/bin/pip
+          install 'numpy<2.0'
+      ignore_errors: yes
+
+    - name: Ensure files directory exists for assets
+      ansible.builtin.file:
+        path: "/home/{{ setup_instructlab_user }}/files"
+        state: directory
+        mode: '0755'
+
+    - name: Download qna.yaml file
+      ansible.builtin.get_url:
+        url: "https://raw.githubusercontent.com/gshipley/backToTheFuture/summitconnect/qna.yaml"
+        dest: "/home/{{ setup_instructlab_user }}/files/qna.yaml"
+
+  become: true
+  become_user: "{{ setup_instructlab_user }}"

--- a/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_instructlab/tasks/main.yml
+++ b/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_instructlab/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+
+- name: Setup Nvidia customizations
+  ansible.builtin.include_tasks:
+    file: 10-nvidia-customizations.yml
+  tags:
+    - setup-instructlab-nvidia
+
+- name: Setup Developer customizations
+  ansible.builtin.include_tasks:
+    file: 20-developer-customizations.yml
+  tags:
+    - setup-instructlab-developer
+
+- name: Setup InstructLab Repos
+  ansible.builtin.include_tasks:
+    file: 30-instruct-repos.yml
+  tags:
+    - setup-instructlab-repos
+
+- name: Setup InstructLab Runtime env
+  ansible.builtin.include_tasks:
+    file: 40-instructlab-runtime-setup.yml
+  tags:
+    - setup-instructlab-runtime
+

--- a/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_nvidia_cuda/README.adoc
+++ b/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_nvidia_cuda/README.adoc
@@ -1,0 +1,64 @@
+= ai_setup_nvidia_cuda
+
+This role will install NVIDIA drivers and their CUDA Toolkit on the target machine(s). 
+
+It currently supports:
+
+- RHEL 9 (tested aginst RHEL 9.3)
+- Fedora (tested against Fedora 39)
+
+In addition it stores a small number of pre-requsities (e.g. `gcc`) that are required for the installation of the NVIDIA drivers and CUDA Toolkit.
+
+== Role Variables
+
+This role is entirely self container ie is _fire and forget_ and does not require any variables to be set.
+
+However the following link:./defaults/main.yml[variables] can be set to control the installation:
++
+
+[source,sh]
+----
+# Common Vars (to both RHEL and Fedora)
+
+ai_setup_nvidia_cuda_python_version:
+ai_setup_nvidia_cuda_cuda_version:
+ai_setup_nvidia_cuda_debug:
+
+ai_setup_nvidia_cuda_rhel_repos:
+ai_setup_nvidia_cuda_common_dnf_packages:
+
+# RHEL Vars
+
+ai_setup_nvidia_cuda_nvidia_rhel_dnf_packages: 
+ai_setup_nvidia_cuda_rhel_repos:
+
+# Fedora Vars
+
+ai_setup_nvidia_cuda_fedora_version:
+ai_setup_nvidia_cuda_nvidia_fedora_dnf_packages: 
+
+----
+
+== Dependencies
+
+None
+
+== Example Playbook
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+[source,yaml]
+----
+---
+- name: Test EDA dispatcher
+  hosts: localhost
+  gather_facts: true
+  become: true
+
+  roles:
+    - ai_setup_nvidia_cuda
+----
+
+== Author Information
+
+Tony Kay (tok@redhat.com) 2024-04-25

--- a/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_nvidia_cuda/defaults/main.yml
+++ b/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_nvidia_cuda/defaults/main.yml
@@ -1,0 +1,58 @@
+---
+# defaults file for fedora-cuda
+
+# Common vars
+
+setup_nvidia_cuda_python_version: '3.11'
+setup_nvidia_cuda_cuda_version: '12-4'
+setup_nvidia_cuda_debug: false
+
+setup_nvidia_cuda_rhel_repos:
+
+  - name: CUDA
+    description: CUDA Repository
+    baseurl: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo
+    enabled: true
+    gpgcheck: false
+
+setup_nvidia_cuda_common_dnf_packages:
+
+  - "python{{ setup_nvidia_cuda_python_version }}"
+  - "python{{ setup_nvidia_cuda_python_version }}-devel"
+  - "python{{ setup_nvidia_cuda_python_version }}-pip"
+  - pciutils
+  - nvtop
+  - screen
+  - tmux
+  - hyperfine
+
+# RHEL Vars
+
+setup_nvidia_cuda_nvidia_rhel_dnf_packages: 
+
+  - "@nvidia-driver:latest-dkms"
+  - cuda-toolkit
+  - nvidia-gds
+
+setup_nvidia_cuda_rhel_repos:
+
+  # - name: epel-release-latest-9.noarch
+  #   description: EPEL Repository
+  #   baseurl: https://dl.fedoraproject.org/pub/epel
+  #   enabled: true
+  #   gpgcheck: false
+
+  - name: cuda-rhel-x86_64
+    description: NVIDIA CUDA Repository
+    baseurl: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64
+    enabled: true
+    gpgcheck: false
+
+# Nvidia Vars
+
+setup_nvidia_cuda_fedora_version: 39
+
+setup_nvidia_cuda_nvidia_fedora_dnf_packages: 
+
+  - "@nvidia-driver:open-dkms"
+  - cuda-toolkit-12-4

--- a/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_nvidia_cuda/tasks/main.yml
+++ b/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_nvidia_cuda/tasks/main.yml
@@ -1,0 +1,87 @@
+---
+- name: Setup Nvidia Drivers and CUDA for RHEL
+  when: ansible_distribution == 'RedHat'
+  block:
+
+    - name: Install EPEL
+      ansible.builtin.dnf:
+        name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
+        state: present
+        validate_certs: no
+        disable_gpg_check: yes
+
+    - name: Setup repos
+      ansible.builtin.yum_repository:
+        name: "{{ repo.name }}"
+        description: "{{ repo.description }}"
+        baseurl: "{{ repo.baseurl }}"
+        enabled: "{{ repo.enabled | default(true) }}"
+        gpgcheck: "{{ repo.gpgcheck | default(false) }}"
+      loop: "{{ setup_nvidia_cuda_rhel_repos }}"
+      loop_control:
+        loop_var: repo
+
+    - name: Install nvdia drivers and CUDA
+      ansible.builtin.dnf:
+        name: "{{ package }}"
+        state: present
+      loop: "{{  setup_nvidia_cuda_nvidia_rhel_dnf_packages }}"
+      loop_control:
+        loop_var: package
+
+- name: Setup Nvidia Drivers and CUDA for Fedora
+  when: ansible_distribution == 'Fedora'
+  block:
+
+    - name: Add a DNF repository
+      ansible.builtin.yum_repository:
+        name: cuda-fedora39
+        description: NVIDIA CUDA Repository
+        baseurl: https://developer.download.nvidia.com/compute/cuda/repos/fedora39/x86_64
+        enabled: true
+        gpgcheck: false
+
+    - name: Setup nvdia repo, drivers, and cuda
+      ansible.builtin.dnf:
+        name: "{{ package }}"
+        state: present
+      loop: "{{ setup_nvidia_cuda_nvidia_fedora_dnf_packages }}"
+      loop_control:
+        loop_var: package
+
+- name: Debug - Setup Nvidia Drivers and CUDA
+  when: setup_nvidia_cuda_debug | default(false) | bool
+  block:
+
+    - name: Check video driver
+      ansible.builtin.shell: "lspci -nn -k | grep -A 2 -e VGA -e 3D"
+      register: r_video_driver_check
+      changed_when: false
+      ignore_errors: true
+
+    - name: Output video driver check
+      ansible.builtin.debug:
+        var: r_video_driver_check.stdout_lines
+
+# Common tasks to RHEL and Fedora
+
+- name: Install common AI centric toolchain packages
+  ansible.builtin.dnf:
+    name: "{{ package }}"
+    state: present
+  loop: "{{ setup_nvidia_cuda_common_dnf_packages }}"
+  loop_control:
+    loop_var: package
+
+# TODO: Need to add a check here to see if the video driver is in use, if not, reboot the machine
+
+# TODO: Is reboot really necessary here? Investigate
+
+# - name: Reboot the machine
+#   ansible.builtin.reboot:
+#     msg: "Reboot initiated by Ansible"
+#     connect_timeout: 5
+#     reboot_timeout: 600
+#     pre_reboot_delay: 0
+#     post_reboot_delay: 30
+#     test_command: uptime


### PR DESCRIPTION
##### SUMMARY

Creates the skeleton with 2 active roles for the `agnosticd.ai` collection, which can potentially be broken out of the main repo at a later date. 

Gives superior structure and encapsulation than simple roles and allows the addition of role-based collection playbooks e.g
`ansible-playbook agnosticd.ai.setup_ai_stack.yml`, for example

Tested with multiple AI-centric CIs
Modifies .gitignore to allow `agnosticd` collections but no others

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ansible/collections/ansible_collections/agnosticd/ai

##### ADDITIONAL INFORMATION
