### PR TITLE
deploy_automationcontroller role - Modify init.yml in certificate_authority role

### DIFF
--- a/ansible/roles/deploy_automationcontroller/tasks/main.yml
+++ b/ansible/roles/deploy_automationcontroller/tasks/main.yml
@@ -32,6 +32,16 @@
     src: automationcontroller_inventory.j2
     dest: /tmp/automationcontroller_installer/inventory
 
+- name: Modify init.yml in certificate_authority role to use dnf module and specific versioning of python3-cryptography for 2.4.x install bundle
+  ansible.builtin.replace:
+    path: /tmp/automationcontroller_installer/collections/ansible_collections/ansible/automation_platform_installer/roles/certificate_authority/tasks/init.yml
+    regexp: '^(.*){{ item.key }}(.*)$'
+    replace: '\1{{ item.value }}\2'
+  loop:
+    - {key: "package", value: "ansible.builtin.dnf"}
+    - {key: "python3-cryptography", value: "python3-cryptography <= 38.0.5"}
+  when: deploy_automationcontroller_installer_url | d('false') | regex_search('bundle-2\.4')
+
 - name: Run the automation controller installer
   ansible.builtin.shell: "source /opt/venvs/venv_automationcontroller_install/bin/activate; ./setup.sh"
   args:

--- a/ansible/roles/deploy_automationcontroller/tasks/main.yml
+++ b/ansible/roles/deploy_automationcontroller/tasks/main.yml
@@ -32,9 +32,11 @@
     src: automationcontroller_inventory.j2
     dest: /tmp/automationcontroller_installer/inventory
 
-- name: Modify init.yml in certificate_authority role to use dnf module and specific versioning of python3-cryptography for 2.4.x install bundle
+- name: "Modify init.yml in certificate_authority role \
+        to use dnf module and specific versioning of python3-cryptography for 2.4.x install bundle"
   ansible.builtin.replace:
-    path: /tmp/automationcontroller_installer/collections/ansible_collections/ansible/automation_platform_installer/roles/certificate_authority/tasks/init.yml
+    path: "/tmp/automationcontroller_installer/collections/ansible_collections/\
+          ansible/automation_platform_installer/roles/certificate_authority/tasks/init.yml"
     regexp: '^(.*){{ item.key }}(.*)$'
     replace: '\1{{ item.value }}\2'
   loop:


### PR DESCRIPTION
##### SUMMARY
Ansible Automation Platform installer failing due to improper version of python3-cryptography RPM package being installed during AAP install automation. An additional task is included to modify init.yml in certificate_authority role within Ansible Automation Platform installer code to use dnf module and specific versioning of python3-cryptography. This additional task is included _prior_ to the installer setup.sh being instantiated.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible/roles/deploy_automationcontroller

