### PR TITLE
Update to use git_revision variable to commit pin in rollouts repo

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rollouts_workshop/files/gitops-operator/subscription.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rollouts_workshop/files/gitops-operator/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openshift-gitops-operator
   namespace: openshift-gitops-operator
 spec:
-  channel: gitops-1.11
+  channel: gitops-1.13
   installPlanApproval: Automatic
   name: openshift-gitops-operator
   source: redhat-operators

--- a/ansible/roles_ocp_workloads/ocp4_workload_rollouts_workshop/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rollouts_workshop/tasks/workload.yml
@@ -109,15 +109,13 @@
   delay: 5
   until: result is not failed
 
-- name: Deploy Pipeline operator
+- name: Deploy infra applications
   kubernetes.core.k8s:
     state: present
-    definition: "{{ lookup('file', 'applications/pipelines-operator.yaml') | from_yaml }}"
-
-- name: Deploy Web Terminal operator
-  kubernetes.core.k8s:
-    state: present
-    definition: "{{ lookup('file', 'applications/web-terminal-operator.yaml') | from_yaml }}"
+    definition: "{{ lookup('template', item) }}"
+  with_items:
+    - pipelines-operator.yaml.j2
+    - rollouts-manager.yaml.j2
 
 # Todo: Check health of apps
 - name: Wait 30 seconds for deployment

--- a/ansible/roles_ocp_workloads/ocp4_workload_rollouts_workshop/templates/pipelines-operator.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rollouts_workshop/templates/pipelines-operator.yaml.j2
@@ -23,5 +23,5 @@ spec:
         maxDuration: 3m
   source:
     repoURL: https://github.com/OpenShiftDemos/argo-rollouts-workshop
-    targetRevision: main
+    targetRevision: "{{ gitops_revision }}"
     path: bootstrap/infra/pipelines-operator/base

--- a/ansible/roles_ocp_workloads/ocp4_workload_rollouts_workshop/templates/rollouts-manager.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rollouts_workshop/templates/rollouts-manager.yaml.j2
@@ -2,11 +2,11 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: web-terminal
+  name: rollouts-manager
   namespace: openshift-gitops
 spec:
   destination:
-    namespace: openshift-operators
+    namespace: openshift-gitops
     server: 'https://kubernetes.default.svc'
   project: default
   syncPolicy:
@@ -21,5 +21,5 @@ spec:
         maxDuration: 3m
   source:
     repoURL: https://github.com/OpenShiftDemos/argo-rollouts-workshop
-    targetRevision: main
-    path: bootstrap/infra/web-terminal-operator/base
+    targetRevision: "{{ gitops_revision }}"
+    path: bootstrap/infra/rollouts-manager/base

--- a/ansible/roles_ocp_workloads/ocp4_workload_rollouts_workshop/templates/user-appset.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rollouts_workshop/templates/user-appset.yaml.j2
@@ -25,10 +25,10 @@ spec:
         - CreateNamespace=true
         automated:
           prune: false
-          selfHeal: false
+          selfHeal: true
       source:
         repoURL: https://github.com/OpenShiftDemos/argo-rollouts-workshop
-        targetRevision: main
+        targetRevision: "{{ gitops_revision }}"
         path: bootstrap/user
         helm:
           values: |


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

- Adds a new variable from agnosticv called `git_revision` that is used to pin apps in rollouts repo to better support environments and staged promotions
- Bumps the OpenShift GitOps version to 1.13 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_rollouts_workshop

##### ADDITIONAL INFORMATION
Part of updating workshop to use Showroom for improved user experience