### PR TITLE
[ocp4_workload_virt_roadshow_vmware] Using vcenter_folder_info instead folder_moid

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/tasks/vcenter_setup_create_folder_and_vms.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/tasks/vcenter_setup_create_folder_and_vms.yml
@@ -58,6 +58,7 @@
     powered_on: false
   retries: 5
   delay: 10
+  until: r_vmc_instance is success
   loop: "{{ ocp4_workload_virt_roadshow_vmware_vms }}"
   loop_control:
     loop_var: vm

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/tasks/vcenter_setup_create_folder_and_vms.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/tasks/vcenter_setup_create_folder_and_vms.yml
@@ -17,15 +17,27 @@
   ansible.builtin.debug:
     msg: "vcenter folder: {{ r_vcenter_folder }}"
 
+# Bug: https://github.com/ansible-collections/vmware.vmware_rest/issues/324
+# - name: Set folder ID fact
+#   ansible.builtin.set_fact:
+#     _ocp4_workload_virt_roadshow_vmware_vcenter_folder_id: >-
+#       {{ lookup('vmware.vmware_rest.folder_moid',
+#       '/' + vcenter_datacenter + '/vm/Workloads/' + _ocp4_workload_virt_roadshow_vmware_vcenter_folder,
+#       **_ocp4_workload_virt_roadshow_vmware_connection_args) }}
+#   retries: 10
+#   delay: 15
+#   until: _ocp4_workload_virt_roadshow_vmware_vcenter_folder_id | length > 0
+#
+- name: Get folder information
+  vmware.vmware_rest.vcenter_folder_info:
+    type: VIRTUAL_MACHINE
+    names:
+      - "{{ _ocp4_workload_virt_roadshow_vmware_vcenter_folder }}"
+  register: r_folder_info
+
 - name: Set folder ID fact
-  ansible.builtin.set_fact:
-    _ocp4_workload_virt_roadshow_vmware_vcenter_folder_id: >-
-      {{ lookup('vmware.vmware_rest.folder_moid',
-      '/' + vcenter_datacenter + '/vm/Workloads/' + _ocp4_workload_virt_roadshow_vmware_vcenter_folder,
-      **_ocp4_workload_virt_roadshow_vmware_connection_args) }}
-  retries: 10
-  delay: 5
-  until: _ocp4_workload_virt_roadshow_vmware_vcenter_folder_id | length > 0
+  set_fact:
+    _ocp4_workload_virt_roadshow_vmware_vcenter_folder_id: "{{ r_folder_info.value[0].folder }}"
 
 - name: Create VMs
   environment:
@@ -34,7 +46,7 @@
     VMWARE_PASSWORD: "{{ vcenter_password }}"
     VMWARE_VALIDATE_CERTS: "{{ ocp4_workload_virt_roadshow_vmware_enable_cert_validation }}"
   vmware.vmware_rest.vcenter_vmtemplate_libraryitems:
-    name: "{{ vm.name }}{{ _ocp4_workload_virt_roadshow_vmware_vcenter_vmname_suffix }}"
+    name: "{{ vm.name }}"
     library: '{{ _ocp4_workload_virt_roadshow_vmware_template_library_id }}'
     template_library_item: "{{ (_ocp4_workload_virt_roadshow_vmware_templates | selectattr('name', 'equalto', vm.template + '-l') | first).id }}"
     placement:
@@ -46,7 +58,6 @@
     powered_on: false
   retries: 5
   delay: 10
-  until: r_vmc_instance is success
   loop: "{{ ocp4_workload_virt_roadshow_vmware_vms }}"
   loop_control:
     loop_var: vm

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/tasks/vcenter_setup_create_folder_and_vms.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/tasks/vcenter_setup_create_folder_and_vms.yml
@@ -46,7 +46,7 @@
     VMWARE_PASSWORD: "{{ vcenter_password }}"
     VMWARE_VALIDATE_CERTS: "{{ ocp4_workload_virt_roadshow_vmware_enable_cert_validation }}"
   vmware.vmware_rest.vcenter_vmtemplate_libraryitems:
-    name: "{{ vm.name }}"
+    name: "{{ vm.name }}{{ _ocp4_workload_virt_roadshow_vmware_vcenter_vmname_suffix }}"
     library: '{{ _ocp4_workload_virt_roadshow_vmware_template_library_id }}'
     template_library_item: "{{ (_ocp4_workload_virt_roadshow_vmware_templates | selectattr('name', 'equalto', vm.template + '-l') | first).id }}"
     placement:


### PR DESCRIPTION
##### SUMMARY

We are hitting the following bug:

https://github.com/ansible-collections/vmware.vmware_rest/issues/324

This is a workaround till new version of the vmware.vmware_rest will be released

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_virt_roadshow_vmware role

