### PR TITLE
[ocp4_workload_virt_roadshow_vmware] Adding missing environment variables

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/tasks/vcenter_setup_create_folder_and_vms.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/tasks/vcenter_setup_create_folder_and_vms.yml
@@ -29,6 +29,11 @@
 #   until: _ocp4_workload_virt_roadshow_vmware_vcenter_folder_id | length > 0
 #
 - name: Get folder information
+  environment:
+    VMWARE_HOST: "{{ vcenter_hostname }}"
+    VMWARE_USER: "{{ vcenter_username }}"
+    VMWARE_PASSWORD: "{{ vcenter_password }}"
+    VMWARE_VALIDATE_CERTS: "{{ ocp4_workload_virt_roadshow_vmware_enable_cert_validation }}"
   vmware.vmware_rest.vcenter_folder_info:
     type: VIRTUAL_MACHINE
     names:


### PR DESCRIPTION
##### SUMMARY

The workaround https://github.com/redhat-cop/agnosticd/pull/8551 was missing the environment variables

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
ocp4_workload_virt_roadshow_vmware role

