### PR TITLE
Adding new roles to install OCP4 cluster on a HCP with OCPVirt

### DIFF
--- a/ansible/configs/ocp4-cluster/destroy_env_openshift_cnv.yml
+++ b/ansible/configs/ocp4-cluster/destroy_env_openshift_cnv.yml
@@ -3,23 +3,29 @@
   hosts: localhost
   gather_facts: false
   tasks:
-  - name: Run host-ocp4-assisted-destroy role
-    ansible.builtin.include_role:
-      name: host-ocp4-assisted-destroy
-
-  - name: Remove ocp workloads
-    when: remove_workloads | default("") | length > 0
-    block:
-    - name: Invoke roles to remove ocp workloads
+    - name: Run host-ocp4-assisted-destroy role
+      when: software_to_deploy == "openshift4_assisted"
       ansible.builtin.include_role:
-        name: "{{ workload_loop_var }}"
-      vars:
-        ocp_username: "system:admin"
-        ACTION: "remove"
-        silent: false
-      loop: "{{ remove_workloads }}"
-      loop_control:
-        loop_var: workload_loop_var
+        name: host-ocp4-assisted-destroy
+
+    - name: Run host-ocp4-hcp-cnv-destroy role
+      when: software_to_deploy == "openshift4_hcp_cnv"
+      ansible.builtin.include_role:
+        name: host-ocp4-hcp-cnv-destroy
+
+    - name: Remove ocp workloads
+      when: remove_workloads | default("") | length > 0
+      block:
+        - name: Invoke roles to remove ocp workloads
+          ansible.builtin.include_role:
+            name: "{{ workload_loop_var }}"
+          vars:
+            ocp_username: "system:admin"
+            ACTION: "remove"
+            silent: false
+          loop: "{{ remove_workloads }}"
+          loop_control:
+            loop_var: workload_loop_var
 
 - name: Import default cloud provider destroy playbook
   ansible.builtin.import_playbook: "../../cloud_providers/{{ cloud_provider }}_destroy_env.yml"

--- a/ansible/configs/osp-on-ocp/pre_software.yml
+++ b/ansible/configs/osp-on-ocp/pre_software.yml
@@ -154,29 +154,6 @@
         state: restarted
         enabled: true
 
-    - name: Download required os images for the lab from S3
-      ansible.builtin.get_url:
-        url: "https://catalog-item-assets.s3.us-east-2.amazonaws.com/qcow_images/{{ item }}"
-        dest: "/var/www/html/{{ item }}"
-        mode: '0440'
-        owner: apache
-        group: apache
-      loop:
-        - Fedora35.qcow2
-        - Windows2019.iso
-      async: 600
-      poll: 0
-      register: download_results
-
-    - name: Wait 6 minutes max for all lab os images downloads to complete
-      async_status:
-        jid: "{{ item.ansible_job_id }}"
-      loop: "{{ download_results.results }}"
-      retries: 70
-      delay: 10
-      register: job_results
-      until: job_results.finished
-
 - name: PreSoftware flight-check
   hosts: localhost
   connection: local

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
@@ -128,6 +128,9 @@
               pageSize: "1Gi"
         resources:
           overcommitGuestOverhead: true
+          limits: 
+            memory: "{{ _instance.memory }}"
+            cpu: {{ _instance.cores }}
           requests:
             memory: "{{ ((_instance.memory |  regex_replace('[^0-9]') | int) / 2)|int|string + (_instance.memory |  regex_replace('[0-9]')) }}"
             #memory: "{{ _instance.memory }}"

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/start_instances.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/start_instances.yaml
@@ -12,7 +12,7 @@
   loop: "{{ r_vm_list.resources }}"
   loop_control:
     loop_var: _instance
-  when: _instance.spec.running|default("") == false
+  when: _instance.spec.running | default(false) | bool
   kubevirt.core.kubevirt_vm:
     host: "{{ sandbox_openshift_api_url }}"
     api_key: "{{ k8s_auth_results.k8s_auth.api_key|default(sandbox_openshift_api_key) }}"
@@ -29,7 +29,7 @@
   loop: "{{ r_vm_list.resources }}"
   loop_control:
     loop_var: _instance
-  when: _instance.spec.runStrategy|default("") == "Halted"
+  when: _instance.spec.runStrategy | default("") == "Halted"
   kubevirt.core.kubevirt_vm:
     host: "{{ sandbox_openshift_api_url }}"
     api_key: "{{ k8s_auth_results.k8s_auth.api_key|default(sandbox_openshift_api_key) }}"

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/start_instances.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/start_instances.yaml
@@ -8,10 +8,11 @@
   retries: "{{ openshift_cnv_retries }}"
   delay: "{{ openshift_cnv_delay }}"
 
-- name: Start the Virtual Machines
+- name: Start the Virtual Machines (running)
   loop: "{{ r_vm_list.resources }}"
   loop_control:
     loop_var: _instance
+  when: _instance.spec.running|default("") == false
   kubevirt.core.kubevirt_vm:
     host: "{{ sandbox_openshift_api_url }}"
     api_key: "{{ k8s_auth_results.k8s_auth.api_key|default(sandbox_openshift_api_key) }}"
@@ -23,3 +24,19 @@
   until: r_vmstart is success
   retries: "{{ openshift_cnv_retries }}"
   delay: "{{ openshift_cnv_delay }}"
+
+- name: Start the Virtual Machines (run_strategy)
+  loop: "{{ r_vm_list.resources }}"
+  loop_control:
+    loop_var: _instance
+  when: _instance.spec.runStrategy|default("") == "Halted"
+  kubevirt.core.kubevirt_vm:
+    host: "{{ sandbox_openshift_api_url }}"
+    api_key: "{{ k8s_auth_results.k8s_auth.api_key|default(sandbox_openshift_api_key) }}"
+    validate_certs: false
+    run_strategy: "Always"
+    name: "{{ _instance.metadata.name }}"
+    namespace: "{{ openshift_cnv_namespace }}"
+  register: r_vmstart
+  until: r_vmstart is success
+  retries: "{{ openshift_cnv_retries }}"

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/stop_instances.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/stop_instances.yaml
@@ -1,23 +1,41 @@
 ---
 - name: Get a list of VMIs
   kubernetes.core.k8s_info:
-    kind: VirtualMachineInstance
+    kind: VirtualMachine
     namespace: "{{ openshift_cnv_namespace }}"
-  register: r_vmi_list
-  until: r_vmi_list is success
+  register: r_vm_list
+  until: r_vm_list is success
   retries: "{{ openshift_cnv_retries }}"
   delay: "{{ openshift_cnv_delay }}"
 
 
-- name: Stop the Virtual Machines
-  loop: "{{ r_vmi_list.resources }}"
+- name: Stop the Virtual Machines (running)
+  loop: "{{ r_vm_list.resources }}"
   loop_control:
     loop_var: _instance
+  when: _instance.spec.running | default(false) | bool
   kubevirt.core.kubevirt_vm:
     host: "{{ sandbox_openshift_api_url }}"
-    api_key: "{{ k8s_auth_results.k8s_auth.api_key|default(sandbox_openshift_api_key) }}"
+    api_key: "{{ k8s_auth_results.k8s_auth.api_key | default(sandbox_openshift_api_key) }}"
     validate_certs: false
     running: false
+    name: "{{ _instance.metadata.name }}"
+    namespace: "{{ openshift_cnv_namespace }}"
+  register: r_stop_vm
+  until: r_stop_vm is success
+  retries: "{{ openshift_cnv_retries }}"
+  delay: "{{ openshift_cnv_delay }}"
+
+- name: Stop the Virtual Machines (run_strategy)
+  loop: "{{ r_vm_list.resources }}"
+  loop_control:
+    loop_var: _instance
+  when: _instance.spec.runStrategy | default("") == "Always"
+  kubevirt.core.kubevirt_vm:
+    host: "{{ sandbox_openshift_api_url }}"
+    api_key: "{{ k8s_auth_results.k8s_auth.api_key | default(sandbox_openshift_api_key) }}"
+    validate_certs: false
+    run_strategy: "Halted"
     name: "{{ _instance.metadata.name }}"
     namespace: "{{ openshift_cnv_namespace }}"
   register: r_stop_vm

--- a/ansible/roles/host-ocp4-hcp-cnv-destroy/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-hcp-cnv-destroy/tasks/main.yaml
@@ -1,0 +1,30 @@
+---
+- name: Log in (obtain access token)
+  community.okd.openshift_auth:
+    username: "{{ sandbox_openshift_username }}"
+    password: "{{ sandbox_openshift_password }}"
+    host: "{{ sandbox_openshift_api_url }}"
+  register: k8s_auth_results
+  when: sandbox_openshift_username | default(false) | bool
+
+- name: Install OCP using HCP
+  module_defaults:
+    group/k8s:
+      host: "{{ sandbox_openshift_api_url }}"
+      api_key: "{{ k8s_auth_results.k8s_auth.api_key | default(sandbox_openshift_api_key) }}"
+      validate_certs: false
+
+  block:
+    - name: Remove the HostedCluster
+      kubernetes.core.k8s:
+        api_version: hypershift.openshift.io/v1beta1
+        kind: HostedCluster
+        name: "hcp-{{ guid }}"
+        namespace: "{{ hcp_ocp_namespace }}"
+        state: absent
+        wait: true
+        wait_timeout: 1800
+      register: r_remove_hostedcluster
+      delay: 60
+      retries: 3
+      until: r_remove_hostedcluster is success

--- a/ansible/roles/host-ocp4-hcp-cnv-destroy/vars/main.yaml
+++ b/ansible/roles/host-ocp4-hcp-cnv-destroy/vars/main.yaml
@@ -1,0 +1,4 @@
+---
+hcp_ssh_authorized_key: "{{ lookup('ansible.builtin.file', hostvars.localhost.ssh_provision_pubkey_path) }}"
+hcp_cluster_name: "{{ guid }}"
+hcp_ocp_namespace: "{{ sandbox_openshift_namespace | default(env_type + '-' + guid)}}"

--- a/ansible/roles/host-ocp4-hcp-cnv-install/defaults/main.yaml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/defaults/main.yaml
@@ -1,7 +1,7 @@
 ---
 hcp_ssh_authorized_key: "{{ lookup('ansible.builtin.file', hostvars.localhost.ssh_provision_pubkey_path) }}"
 hcp_cluster_name: "{{ guid }}"
-hcp_cluster_version: "{{ ocp4_installer_version | default('4.13') }}"
+hcp_cluster_version: "{{ ocp4_installer_version | default('4.16.10') }}"
 hcp_storage_class: "ocs-external-storagecluster-ceph-rbd"
 hcp_ocp_namespace: "{{ sandbox_openshift_namespace | default(env_type + '-' + guid)}}"
 hcp_cluster_issuer: "letsencrypt"

--- a/ansible/roles/host-ocp4-hcp-cnv-install/defaults/main.yaml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/defaults/main.yaml
@@ -13,10 +13,10 @@ hcp_user_passwords: []
 hcp_controller_availability_policy: SingleReplica
 hcp_authentication: "htpasswd"
 hcp_etcd_pvc_size: "8Gi"
-hcp_workers_cores: 16
-hcp_workers_memory: 32Gi
-hcp_workers_root_volume_size: 100Gi
-hcp_workers_instance_count: "{{ worker_instance_count }}"
-hcp_workers_autoscale: false
-hcp_workers_instance_min_count: 3
-hcp_workers_instance_max_count: 5
+hcp_worker_cores: 16
+hcp_worker_memory: 32Gi
+hcp_worker_root_volume_size: 100Gi
+hcp_worker_instance_count: "{{ worker_instance_count }}"
+hcp_worker_autoscale: false
+hcp_worker_instance_min_count: 3
+hcp_worker_instance_max_count: 5

--- a/ansible/roles/host-ocp4-hcp-cnv-install/defaults/main.yaml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/defaults/main.yaml
@@ -1,7 +1,7 @@
 ---
 hcp_ssh_authorized_key: "{{ lookup('ansible.builtin.file', hostvars.localhost.ssh_provision_pubkey_path) }}"
 hcp_cluster_name: "{{ guid }}"
-hcp_cluster_version: "{{ ocp4_installer_version | default('4.16.10') }}"
+hcp_cluster_version: "{{ ocp4_installer_version | default('4.16') }}"
 hcp_storage_class: "ocs-external-storagecluster-ceph-rbd"
 hcp_ocp_namespace: "{{ sandbox_openshift_namespace | default(env_type + '-' + guid)}}"
 hcp_cluster_issuer: "letsencrypt"

--- a/ansible/roles/host-ocp4-hcp-cnv-install/defaults/main.yaml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/defaults/main.yaml
@@ -1,0 +1,24 @@
+---
+hcp_ssh_authorized_key: "{{ lookup('ansible.builtin.file', hostvars.localhost.ssh_provision_pubkey_path) }}"
+hcp_cluster_name: "{{ guid }}"
+hcp_cluster_version: "{{ ocp4_installer_version | default('4.13') }}"
+hcp_workers_cores: 16
+hcp_workers_memory: 64Gi
+hcp_storage_class: "ocs-external-storagecluster-ceph-rbd"
+hcp_ocp_namespace: "{{ sandbox_openshift_namespace | default(env_type + '-' + guid)}}"
+hcp_cluster_issuer: "letsencrypt"
+hcp_admin_password_length: 16
+hcp_user_password_length: 16
+hcp_user_base: "user"
+hcp_admin_user: "admin"
+hcp_user_passwords: []
+hcp_controller_availability_policy: SingleReplica
+hcp_authentication: "htpasswd"
+hcp_etcd_pvc_size: "8Gi"
+hcp_worker_cores: 16
+hcp_worker_memory: 32Gi
+hcp_worker_root_volume_size: 100Gi
+hcp_worker_instance_count: "{{ worker_instance_count }}"
+hcp_worker_autoscale: false
+hcp_worker_instance_min_count: 3
+hcp_worker_instance_max_count: 5

--- a/ansible/roles/host-ocp4-hcp-cnv-install/defaults/main.yaml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/defaults/main.yaml
@@ -20,4 +20,4 @@ hcp_worker_instance_count: "{{ worker_instance_count }}"
 hcp_worker_autoscale: false
 hcp_worker_instance_min_count: 3
 hcp_worker_instance_max_count: 5
-hcp_quay_api_url: "https://quay.io/api/v1/repository/openshift-release-dev/ocp-release/tag/?filter_tag_name=like:{{ quay_api_url }}.%-x86_64&onlyActiveTags=true"
+hcp_quay_api_url: "https://quay.io/api/v1/repository/openshift-release-dev/ocp-release/tag/?filter_tag_name=like:{{ hcp_cluster_version }}.%-x86_64&onlyActiveTags=true"

--- a/ansible/roles/host-ocp4-hcp-cnv-install/defaults/main.yaml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/defaults/main.yaml
@@ -20,3 +20,4 @@ hcp_worker_instance_count: "{{ worker_instance_count }}"
 hcp_worker_autoscale: false
 hcp_worker_instance_min_count: 3
 hcp_worker_instance_max_count: 5
+hcp_quay_api_url: "https://quay.io/api/v1/repository/openshift-release-dev/ocp-release/tag/?filter_tag_name=like:{{ quay_api_url }}.%-x86_64&onlyActiveTags=true"

--- a/ansible/roles/host-ocp4-hcp-cnv-install/defaults/main.yaml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/defaults/main.yaml
@@ -2,8 +2,6 @@
 hcp_ssh_authorized_key: "{{ lookup('ansible.builtin.file', hostvars.localhost.ssh_provision_pubkey_path) }}"
 hcp_cluster_name: "{{ guid }}"
 hcp_cluster_version: "{{ ocp4_installer_version | default('4.13') }}"
-hcp_workers_cores: 16
-hcp_workers_memory: 64Gi
 hcp_storage_class: "ocs-external-storagecluster-ceph-rbd"
 hcp_ocp_namespace: "{{ sandbox_openshift_namespace | default(env_type + '-' + guid)}}"
 hcp_cluster_issuer: "letsencrypt"
@@ -15,10 +13,10 @@ hcp_user_passwords: []
 hcp_controller_availability_policy: SingleReplica
 hcp_authentication: "htpasswd"
 hcp_etcd_pvc_size: "8Gi"
-hcp_worker_cores: 16
-hcp_worker_memory: 32Gi
-hcp_worker_root_volume_size: 100Gi
-hcp_worker_instance_count: "{{ worker_instance_count }}"
-hcp_worker_autoscale: false
-hcp_worker_instance_min_count: 3
-hcp_worker_instance_max_count: 5
+hcp_workers_cores: 16
+hcp_workers_memory: 32Gi
+hcp_workers_root_volume_size: 100Gi
+hcp_workers_instance_count: "{{ worker_instance_count }}"
+hcp_workers_autoscale: false
+hcp_workers_instance_min_count: 3
+hcp_workers_instance_max_count: 5

--- a/ansible/roles/host-ocp4-hcp-cnv-install/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/tasks/main.yaml
@@ -1,0 +1,294 @@
+---
+- name: Set Ansible Python interpreter to k8s virtualenv
+  ansible.builtin.set_fact:
+    ansible_python_interpreter: /opt/virtualenvs/k8s/bin/python
+
+- name: Set URLs for OpenShift GA releases (specific version)
+  when: (ocp4_installer_version | string).split('.') | length >= 3
+  ansible.builtin.set_fact:
+    ocp4_client_url: >-
+      {{ '{0}/ocp/{1}/openshift-client-linux-{1}.tar.gz'.format(
+        ocp4_installer_root_url | default("https://mirror.openshift.com/pub/openshift-v4/clients"),
+        ocp4_installer_version
+      ) }}
+
+- name: Set URLs for OpenShift GA releases (latest stable)
+  when: (ocp4_installer_version | string).split('.') | length == 2
+  set_fact:
+    ocp4_client_url: >-
+      {{ '{0}/ocp/stable-{1}/openshift-client-linux.tar.gz'.format(
+        ocp4_installer_root_url | default("https://mirror.openshift.com/pub/openshift-v4/clients"),
+        ocp4_installer_version
+      ) }}
+
+- name: Get the OpenShift CLI
+  become: true
+  ansible.builtin.unarchive:
+    src: "{{ ocp4_client_url }}"
+    remote_src: true
+    dest: /usr/bin
+    mode: 0775
+    owner: root
+    group: root
+  register: r_client
+  until: r_client is success
+  retries: 10
+  delay: 30
+
+- name: Log in (obtain access token)
+  community.okd.openshift_auth:
+    username: "{{ sandbox_openshift_username }}"
+    password: "{{ sandbox_openshift_password }}"
+    host: "{{ sandbox_openshift_api_url }}"
+  register: k8s_auth_results
+  when: sandbox_openshift_username | default(false) | bool
+
+- name: Install OCP using HCP
+  module_defaults:
+    group/k8s:
+      host: "{{ sandbox_openshift_api_url }}"
+      api_key: "{{ k8s_auth_results.k8s_auth.api_key | default(sandbox_openshift_api_key) }}"
+      validate_certs: false
+
+  block:
+    - name: Add the certificate definition for OAuth service
+      kubernetes.core.k8s:
+        definition: "{{ lookup('ansible.builtin.template', 'certificate.yaml') }}"
+        wait: true
+        wait_timeout: 300
+      vars:
+        namespace: "{{ hcp_ocp_namespace }}"
+
+    - name: Wait until Oauth Certificate is ready
+      kubernetes.core.k8s_info:
+        api_version: cert-manager.io/v1
+        kind: Certificate
+        name: oauth-{{ guid }}
+        namespace: "{{ hcp_ocp_namespace }}"
+        wait: true
+        wait_sleep: 5
+        wait_timeout: 800
+        wait_condition:
+          type: "Ready"
+          status: "True"
+
+    - name: Add the pull secret
+      kubernetes.core.k8s:
+        definition: "{{ lookup('ansible.builtin.template', 'pullsecret.yaml') }}"
+        wait: true
+        wait_timeout: 300
+      vars:
+        namespace: "{{ hcp_ocp_namespace }}"
+
+    - name: Set variable for kubeconfig
+      set_fact:
+        kubeconfig_base64: "{{ lookup('ansible.builtin.template', 'kubeconfig.yaml') | ansible.builtin.b64encode }}"
+      vars:
+        sandbox_openshift_api_url_name: "{{ sandbox_openshift_api_url.replace('https://','').replace('.','_') }}"
+
+    - name: Create the kubeconfig secret
+      kubernetes.core.k8s:
+        definition: "{{ lookup('ansible.builtin.template', 'kubeconfigsecret.yaml') }}"
+        wait: true
+        wait_timeout: 300
+      vars:
+        namespace: "{{ hcp_ocp_namespace }}"
+
+    - name: Create htpasswd secret for admin and userX
+      include_tasks: setup_htpasswd_authentication.yml
+
+    - name: Create the HostedCluster
+      kubernetes.core.k8s:
+        definition: "{{ lookup('ansible.builtin.template', 'hostedcluster.yaml') }}"
+        wait: true
+        wait_timeout: 300
+      vars:
+        namespace: "{{ hcp_ocp_namespace }}"
+
+    - name: Create the NodePool
+      kubernetes.core.k8s:
+        definition: "{{ lookup('ansible.builtin.template', 'nodepool.yaml') }}"
+        wait: true
+        wait_timeout: 300
+      vars:
+        namespace: "{{ hcp_ocp_namespace }}"
+
+    - name: Get HostedCluster
+      kubernetes.core.k8s_info:
+        api_version: hypershift.openshift.io/v1beta1
+        kind: HostedCluster
+        name: "hcp-{{ guid }}"
+        namespace: "{{ hcp_ocp_namespace }}"
+      register: r_hosted_cluster
+      retries: 120
+      delay: 10
+      until:
+        - r_hosted_cluster.resources[0].status.kubeconfig is defined
+        - r_hosted_cluster.resources[0].status.kubeconfig.name is defined
+        - r_hosted_cluster.resources[0].status.kubeconfig.name | length > 0
+
+    - name: Get the OpenShift admin kubeconfig secret
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Secret
+        name: hcp-{{ guid }}-admin-kubeconfig
+        namespace: "{{ hcp_ocp_namespace }}"
+      register: kubeadmin_secret_result
+
+    - name: Get the OpenShift secret
+      when: hcp_authentication | default('') != 'htpasswd'
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Secret
+        name: hcp-{{ guid }}-kubeadmin-password
+        namespace: "{{ hcp_ocp_namespace }}"
+      register: password_secret_result
+
+    - name: Decode the kubeconfig secret
+      set_fact:
+        kubeconfig_decoded: "{{ kubeadmin_secret_result.resources[0].data.kubeconfig | b64decode }}"
+
+    - name: Decode the kubeadmin password secret
+      when: hcp_authentication | default('') != 'htpasswd'
+      set_fact:
+        kubeadmin_password: "{{ password_secret_result.resources[0].data.password | b64decode }}"
+
+    - name: Generate /tmp/kubeconfig
+      copy:
+        dest: /tmp/kubeconfig
+        content: "{{ kubeconfig_decoded }}"
+
+- name: Get information about the router-nodeport-default service
+  kubernetes.core.k8s_info:
+    kubeconfig: /tmp/kubeconfig
+    api_version: v1
+    kind: Service
+    namespace: openshift-ingress
+    name: router-nodeport-default
+  register: service_info
+  retries: 10
+  delay: 30
+  until:
+    - service_info.resources[0].spec.ports is defined
+    - service_info.resources[0].spec.ports | length > 0
+
+- name: Extract nodeport for http
+  set_fact:
+    nodeport_http: "{{ service_info.resources[0].spec.ports | selectattr('name', 'equalto', 'http') | map(attribute='nodePort') | first }}"
+
+- name: Extract nodeport for https
+  set_fact:
+    nodeport_https: "{{ service_info.resources[0].spec.ports | selectattr('name', 'equalto', 'https') | map(attribute='nodePort') | first }}"
+
+- name: Post-Install tasks
+  module_defaults:
+    group/k8s:
+      host: "{{ sandbox_openshift_api_url }}"
+      api_key: "{{ k8s_auth_results.k8s_auth.api_key | default(sandbox_openshift_api_key) }}"
+      validate_certs: false
+
+  block:
+    - name: Add the service (type LoadBalancer) for the apps
+      kubernetes.core.k8s:
+        definition: "{{ lookup('ansible.builtin.template', 'workers_svc.yaml') }}"
+        wait: true
+        wait_timeout: 300
+      vars:
+        namespace: "{{ hcp_ocp_namespace }}"
+
+    - name: Wait for the LoadBalancer value - workers
+      register: svc_apps
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Service
+        name: "svc-{{ guid }}-apps"
+        namespace: "{{ hcp_ocp_namespace }}"
+      until: svc_apps.resources[0].status.loadBalancer.ingress[0].ip | default('') != ''
+      retries: 10
+      delay: 2
+
+    - name: Add A dns record - apps
+      amazon.aws.route53:
+        state: present
+        aws_access_key_id: "{{ route53_aws_access_key_id }}"
+        aws_secret_access_key: "{{ route53_aws_secret_access_key }}"
+        hosted_zone_id: "{{ route53_aws_zone_id }}"
+        record: "*.apps.hcp-{{ guid }}.{{ cluster_dns_zone }}"
+        zone: "{{ cluster_dns_zone  }}"
+        value: "{{ svc_apps.resources[0].status.loadBalancer.ingress[0].ip }}"
+        type: A
+      register: r_route53_add_record
+      until: r_route53_add_record is success
+      retries: 10
+      delay: 30
+
+    - name: Make sure .kube directory exists for {{ ansible_user }}
+      ansible.builtin.file:
+        state: directory
+        path: /home/{{ ansible_user }}/.kube
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+        mode: "0700"
+
+    - name: Make sure .kube directory exists for root
+      become: true
+      ansible.builtin.file:
+        state: directory
+        path: /root/.kube
+        owner: root
+        group: root
+        mode: "0700"
+
+    - name: Copy cluster kubeconfig to /home/{{ ansible_user }}/.kube/config
+      ansible.builtin.copy:
+        remote_src: true
+        src: "/tmp/kubeconfig"
+        dest: "/home/{{ ansible_user }}/.kube/config"
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+        mode: "0600"
+
+    - name: Copy cluster kubeconfig to /root/.kube/config
+      become: true
+      ansible.builtin.copy:
+        remote_src: true
+        src: /tmp/kubeconfig
+        dest: /root/.kube/config
+        owner: root
+        group: root
+        mode: "0600"
+
+    - name: Set up Student User
+      when: install_student_user | bool
+      block:
+        - name: Make sure .kube directory exists in /home/{{ student_name }}
+          become: true
+          ansible.builtin.file:
+            state: directory
+            path: "/home/{{ student_name }}/.kube"
+            owner: "{{ student_name }}"
+            group: users
+            mode: "0700"
+
+        - name: Copy /tmp/kubeconfig to /home/{{ student_name }}/.kube
+          become: true
+          ansible.builtin.copy:
+            src: /tmp/kubeconfig
+            dest: /home/{{ student_name }}/.kube/config
+            remote_src: true
+            owner: "{{ student_name }}"
+            group: users
+            mode: 0600
+
+    - name: Create OpenShift Bash completion file
+      become: true
+      ansible.builtin.shell: oc completion bash >/etc/bash_completion.d/openshift
+
+- name: Assign cluster-admin role to admin user
+  environment:
+    K8S_AUTH_KUBECONFIG: /home/{{ ansible_user }}/.kube/config
+  kubernetes.core.k8s:
+    definition: "{{ lookup('ansible.builtin.template', 'clusterrolebinding.yaml') }}"
+
+- name: Gather and Print cluster info
+  ansible.builtin.import_tasks: print_cluster_info.yml

--- a/ansible/roles/host-ocp4-hcp-cnv-install/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/tasks/main.yaml
@@ -35,6 +35,21 @@
   retries: 10
   delay: 30
 
+- name: Get list of OpenShift images from Quay.io
+  uri:
+    url: "{{ hcp_quay_api_url }}"
+    return_content: true
+  register: r_quay_response
+
+- name: Find the latest OpenShift image for the specified version
+  set_fact:
+    _ocp_latest_image: "{{ r_quay_response.json.tags | first | replace('multi-','') }}"
+
+- name: Show the latest OpenShift image
+  debug:
+    msg: "The latest OpenShift image for version {{ hcp_cluster_version }} is: {{ _ocp_latest_image.name }}"
+
+
 - name: Log in (obtain access token)
   community.okd.openshift_auth:
     username: "{{ sandbox_openshift_username }}"

--- a/ansible/roles/host-ocp4-hcp-cnv-install/tasks/print_cluster_info.yml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/tasks/print_cluster_info.yml
@@ -1,0 +1,70 @@
+---
+- name: Get console route
+  kubernetes.core.k8s_info:
+    api_version: route.openshift.io/v1
+    kind: Route
+    name: console
+    namespace: openshift-console
+    kubeconfig: /home/{{ ansible_user }}/.kube/config
+  retries: 10
+  delay: 30
+  until:
+    - r_route_console.resources is defined
+    - r_route_console.resources | length > 0
+    - r_route_console.resources[0].spec is defined
+    - r_route_console.resources[0].spec.host is defined
+  register: r_route_console
+
+- name: Get OpenShift Infrastructure info
+  kubernetes.core.k8s_info:
+    api_version: config.openshift.io/v1
+    kind: Infrastructure
+    name: cluster
+    kubeconfig: /home/{{ ansible_user }}/.kube/config
+  retries: 10
+  delay: 30
+  until:
+    - r_api_url.resources is defined
+    - r_api_url.resources | length > 0
+    - r_api_url.resources[0].status is defined
+    - r_api_url.resources[0].status.apiServerURL is defined
+  register: r_api_url
+
+- name: Get OpenShift Ingress Domain
+  kubernetes.core.k8s_info:
+    api_version: config.openshift.io/v1
+    kind: Ingress
+    name: cluster
+    kubeconfig: /home/{{ ansible_user }}/.kube/config
+  retries: 10
+  delay: 30
+  until:
+    - r_ingress_domain.resources is defined
+    - r_ingress_domain.resources | length > 0
+    - r_ingress_domain.resources[0].spec is defined
+    - r_ingress_domain.resources[0].spec.domain is defined
+  register: r_ingress_domain
+
+- name: Set facts for OpenShift console and API
+  ansible.builtin.set_fact:
+    openshift_client_download_url: "{{ ocp4_client_url }}"
+    openshift_api_server_url: "{{ r_api_url.resources[0].status.apiServerURL }}"
+    openshift_console_url: "https://{{ r_route_console.resources[0].spec.host }}"
+    openshift_cluster_ingress_domain: "{{ r_ingress_domain.resources[0].spec.domain }}"
+
+- name: Set user data for OpenShift access
+  agnosticd_user_info:
+    data:
+      openshift_api_server_url: "{{ openshift_api_server_url }}"
+      openshift_console_url: "{{ openshift_console_url }}"
+      openshift_client_download_url: "{{ openshift_client_download_url }}"
+      openshift_cluster_ingress_domain: "{{ openshift_cluster_ingress_domain }}"
+
+- name: Show user messages for OpenShift access
+  agnosticd_user_info:
+    msg: |-
+      OpenShift Console: {{ openshift_console_url }}
+      OpenShift API for command line 'oc' client: {{ openshift_api_server_url }}
+      Download oc client from {{ ocp4_client_url }}
+
+      User `{{ hcp_admin_user }}` with password `{{ _hcp_admin_password }}` is cluster admin.

--- a/ansible/roles/host-ocp4-hcp-cnv-install/tasks/setup_htpasswd_authentication.yml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/tasks/setup_htpasswd_authentication.yml
@@ -72,7 +72,6 @@
       openshift_cluster_num_users: "{{ num_users }}"
       openshift_cluster_user_base: "{{ hcp_user_base }}"
 
-
 - name: Set hosted cluster console URL
   ansible.builtin.set_fact:
     _hcp_console_url: >-

--- a/ansible/roles/host-ocp4-hcp-cnv-install/tasks/setup_htpasswd_authentication.yml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/tasks/setup_htpasswd_authentication.yml
@@ -1,0 +1,90 @@
+---
+- name: Generate admin user password
+  ansible.builtin.set_fact:
+    _hcp_admin_password: >-
+      {{ lookup('password', '/dev/null chars=ascii_letters,digits '
+          ~ 'length=' ~ hcp_admin_password_length
+      ) }}
+
+- name: Set up randomized user password array
+  ansible.builtin.set_fact:
+    hcp_user_passwords: >-
+      {{ hcp_user_passwords + [ lookup('password',
+        '/dev/null chars=ascii_letters,digits '
+        ~ 'length=' ~ hcp_user_password_length ) ] }}
+  loop: "{{ range(0, num_users, 1) | list }}"
+
+- name: Create temporary htpasswd file
+  ansible.builtin.tempfile:
+    state: file
+    suffix: htpasswd
+  register: r_htpasswd
+
+- name: Add admin user to htpasswd file
+  community.general.htpasswd:
+    path: "{{ r_htpasswd.path }}"
+    name: "{{ hcp_admin_user }}"
+    password: "{{ _hcp_admin_password }}"
+    mode: "0664"
+
+- name: Add users and passwords to htpasswd file
+  community.general.htpasswd:
+    path: "{{ r_htpasswd.path }}"
+    name: "{{ hcp_user_base }}{{ item + 1 }}"
+    password: "{{ hcp_user_passwords[item] }}"
+    mode: "0664"
+  loop: "{{ range(0, num_users, 1) | list }}"
+
+- name: Read contents of htpasswd file
+  ansible.builtin.slurp:
+    src: "{{ r_htpasswd.path }}"
+  register: r_htpasswd_file
+
+- name: Remove generated htpasswd file
+  ansible.builtin.file:
+    path: "{{ r_htpasswd.path }}"
+    state: absent
+
+- name: Ensure htpasswd secret is absent
+  kubernetes.core.k8s:
+    state: absent
+    api_version: v1
+    kind: Secret
+    name: "htpasswd-{{ guid }}"
+    namespace: "{{ hcp_ocp_namespace }}"
+  register: r_htpasswd_secret_absent
+  retries: 5
+  delay: 10
+  until: r_htpasswd_secret_absent is success
+
+- name: Create secret htpasswd-{{ guid }}
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('template', 'secret-htpasswd.yaml') | from_yaml }}"
+  vars:
+    namespace: "{{ hcp_ocp_namespace }}"
+
+- name: Save admin user information
+  agnosticd_user_info:
+    data:
+      openshift_cluster_admin_username: "{{ hcp_admin_user }}"
+      openshift_cluster_admin_password: "{{ _hcp_admin_password }}"
+      openshift_cluster_num_users: "{{ num_users }}"
+      openshift_cluster_user_base: "{{ hcp_user_base }}"
+
+
+- name: Set hosted cluster console URL
+  ansible.builtin.set_fact:
+    _hcp_console_url: >-
+      https://console-openshift-console.apps.hcp-{{ guid }}.{{ cluster_dns_zone }}
+
+- name: Save user information for each user
+  agnosticd_user_info:
+    user: "{{ hcp_user_base }}{{ n + 1 }}"
+    data:
+      user: "{{ hcp_user_base }}{{ n + 1 }}"
+      password: "{{ hcp_user_passwords[ n ] }}"
+      openshift_cluster_console_url: "{{ _hcp_console_url }}"
+  loop: "{{ range(0, num_users | int) | list }}"
+  loop_control:
+    loop_var: n

--- a/ansible/roles/host-ocp4-hcp-cnv-install/templates/certificate.yaml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/templates/certificate.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: oauth-{{ guid }}
+  namespace: {{ namespace }}
+spec:
+  commonName: "{{ guid }}.{{ sandbox_openshift_apps_domain }}"
+  dnsNames:
+    - "{{ guid }}.{{ sandbox_openshift_apps_domain }}"
+    - "oauth-{{ namespace }}-hcp-{{ guid }}.{{ sandbox_openshift_apps_domain }}"
+  isCA: false
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: {{ hcp_cluster_issuer }}
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: oauth-{{ guid }}

--- a/ansible/roles/host-ocp4-hcp-cnv-install/templates/clusterrolebinding.yaml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/templates/clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "cluster-admin-{{ hcp_admin_user }}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: "{{ hcp_admin_user }}"

--- a/ansible/roles/host-ocp4-hcp-cnv-install/templates/hostedcluster.yaml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/templates/hostedcluster.yaml
@@ -65,7 +65,7 @@ spec:
   pullSecret:
     name: hcp-{{ guid }}-pull-secret
   release:
-    image: quay.io/openshift-release-dev/ocp-release:{{ _ocp_latest_image.name }}-x86_64
+    image: quay.io/openshift-release-dev/ocp-release:{{ _ocp_latest_image.name }}
   services:
   - service: APIServer
     servicePublishingStrategy:

--- a/ansible/roles/host-ocp4-hcp-cnv-install/templates/hostedcluster.yaml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/templates/hostedcluster.yaml
@@ -65,7 +65,7 @@ spec:
   pullSecret:
     name: hcp-{{ guid }}-pull-secret
   release:
-    image: quay.io/openshift-release-dev/ocp-release:{{ ocp4_installer_version }}-x86_64
+    image: quay.io/openshift-release-dev/ocp-release:{{ _ocp_latest_image.name }}-x86_64
   services:
   - service: APIServer
     servicePublishingStrategy:

--- a/ansible/roles/host-ocp4-hcp-cnv-install/templates/hostedcluster.yaml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/templates/hostedcluster.yaml
@@ -1,0 +1,89 @@
+---
+apiVersion: hypershift.openshift.io/v1beta1
+kind: HostedCluster
+metadata:
+  creationTimestamp: null
+  name: hcp-{{ guid }}
+  namespace: {{ namespace }}
+spec:
+  autoscaling: {}
+  configuration:
+    apiServer:
+      servingCerts:
+        namedCertificates:
+          - servingCertificate:
+              name: oauth-{{ guid }}
+            names:
+              - oauth-{{ namespace }}-hcp-{{ guid }}.{{ sandbox_openshift_apps_domain }}
+{% if hcp_authentication | default('none') == "htpasswd" %}
+    oauth:
+      identityProviders:
+      - name: democreds
+        type: HTPasswd
+        htpasswd:
+          fileData:
+            name: htpasswd-{{ guid }}
+        mappingMethod: claim
+      templates:
+        error:
+          name: ""
+        login:
+          name: ""
+        providerSelection:
+          name: ""
+      tokenConfig: {}
+{% endif %}
+
+  controllerAvailabilityPolicy: {{ hcp_controller_availability_policy }}
+  dns:
+    baseDomain: {{ cluster_dns_zone }}
+  etcd:
+    managed:
+      storage:
+        persistentVolume:
+          size: {{ hcp_etcd_pvc_size }}
+        type: PersistentVolume
+    managementType: Managed
+  fips: false
+  infraID: hcp-{{ guid }}-{{ lookup('community.general.random_string', upper=false, numbers=false, special=false) }}
+  networking:
+    clusterNetwork:
+    - cidr: 10.132.0.0/14
+    networkType: OVNKubernetes
+    serviceNetwork:
+    - cidr: 172.31.0.0/16
+  olmCatalogPlacement: management
+  platform:
+    kubevirt:
+      baseDomainPassthrough: true
+      credentials:
+        infraKubeConfigSecret:
+          key: kubeconfig
+          name: hcp-{{ guid }}-infra-credentials
+        infraNamespace: {{ namespace }}
+    type: KubeVirt
+  pullSecret:
+    name: hcp-{{ guid }}-pull-secret
+  release:
+    image: quay.io/openshift-release-dev/ocp-release:{{ ocp4_installer_version }}-x86_64
+  services:
+  - service: APIServer
+    servicePublishingStrategy:
+      type: LoadBalancer
+  - service: OAuthServer
+    servicePublishingStrategy:
+      type: Route
+  - service: Konnectivity
+    servicePublishingStrategy:
+      type: Route
+  - service: Ignition
+    servicePublishingStrategy:
+      type: Route
+  - service: OVNSbDb
+    servicePublishingStrategy:
+      type: Route
+  sshKey: {}
+status:
+  controlPlaneEndpoint:
+    host: ""
+    port: 0

--- a/ansible/roles/host-ocp4-hcp-cnv-install/templates/kubeconfig.yaml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/templates/kubeconfig.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+clusters:
+- cluster:
+    server: {{ sandbox_openshift_api_url }}
+  name: {{ sandbox_openshift_api_url_name }}
+contexts:
+- context:
+    cluster: {{ sandbox_openshift_api_url_name }}
+    user: system:serviceaccount:{{ hcp_ocp_namespace }}:sandbox/{{ sandbox_openshift_api_url_name }}
+  name: /{{ sandbox_openshift_api_url_name }}/system:serviceaccount:{{ hcp_ocp_namespace }}:sandbox
+current-context: /{{ sandbox_openshift_api_url_name }}/system:serviceaccount:{{ hcp_ocp_namespace }}:sandbox
+kind: Config
+preferences: {}
+users:
+- name: system:serviceaccount:{{ hcp_ocp_namespace }}:sandbox/{{ sandbox_openshift_api_url_name }}
+  user:
+    token: {{ sandbox_openshift_api_key }}

--- a/ansible/roles/host-ocp4-hcp-cnv-install/templates/kubeconfigsecret.yaml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/templates/kubeconfigsecret.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+data:
+  kubeconfig: {{ kubeconfig_base64 }}
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: hcp-{{ guid }}-infra-credentials
+  namespace: {{ namespace }}
+type: Opaque

--- a/ansible/roles/host-ocp4-hcp-cnv-install/templates/nodepool.yaml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/templates/nodepool.yaml
@@ -25,7 +25,7 @@ spec:
         type: Persistent
     type: KubeVirt
   release:
-    image: quay.io/openshift-release-dev/ocp-release:{{ ocp4_installer_version }}-x86_64
+    image: quay.io/openshift-release-dev/ocp-release:{{ _ocp_latest_image.name }}-x86_64
 {% if hcp_worker_autoscale %}
   autoScaling:
     min: {{ hcp_worker_instance_min_count | int }}

--- a/ansible/roles/host-ocp4-hcp-cnv-install/templates/nodepool.yaml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/templates/nodepool.yaml
@@ -16,20 +16,20 @@ spec:
     kubevirt:
       attachDefaultNetwork: true
       compute:
-        cores: {{ hcp_worker_cores }}
-        memory: {{ hcp_worker_memory }}
+        cores: {{ hcp_workers_cores }}
+        memory: {{ hcp_workers_memory }}
         qosClass: Guaranteed
       rootVolume:
         persistent:
-          size: {{ hcp_worker_root_volume_size }}
+          size: {{ hcp_workers_root_volume_size }}
         type: Persistent
     type: KubeVirt
   release:
     image: quay.io/openshift-release-dev/ocp-release:{{ ocp4_installer_version }}-x86_64
-{% if hcp_worker_autoscale %}
+{% if hcp_workers_autoscale %}
   autoScaling:
-    min: {{ hcp_worker_instance_min_count | int }}
-    max: {{ hcp_worker_instance_max_count | int }}
+    min: {{ hcp_workers_instance_min_count | int }}
+    max: {{ hcp_workers_instance_max_count | int }}
 {% else %}
-    replicas: {{ hcp_worker_instance_count | int }}
+    replicas: {{ hcp_workers_instance_count | int }}
 {% endif %}

--- a/ansible/roles/host-ocp4-hcp-cnv-install/templates/nodepool.yaml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/templates/nodepool.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: hypershift.openshift.io/v1beta1
+kind: NodePool
+metadata:
+  creationTimestamp: null
+  name: hcp-{{ guid }}
+  namespace: {{ namespace }}
+spec:
+  arch: amd64
+  clusterName: hcp-{{ guid }}
+  management:
+    autoRepair: false
+    upgradeType: Replace
+  nodeDrainTimeout: 0s
+  platform:
+    kubevirt:
+      attachDefaultNetwork: true
+      compute:
+        cores: {{ hcp_worker_cores }}
+        memory: {{ hcp_worker_memory }}
+        qosClass: Guaranteed
+      rootVolume:
+        persistent:
+          size: {{ hcp_worker_root_volume_size }}
+        type: Persistent
+    type: KubeVirt
+  release:
+    image: quay.io/openshift-release-dev/ocp-release:{{ ocp4_installer_version }}-x86_64
+{% if hcp_worker_autoscale %}
+  autoScaling:
+    min: {{ hcp_worker_instance_min_count | int }}
+    max: {{ hcp_worker_instance_max_count | int }}
+{% else %}
+    replicas: {{ hcp_worker_instance_count | int }}
+{% endif %}

--- a/ansible/roles/host-ocp4-hcp-cnv-install/templates/nodepool.yaml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/templates/nodepool.yaml
@@ -16,20 +16,20 @@ spec:
     kubevirt:
       attachDefaultNetwork: true
       compute:
-        cores: {{ hcp_workers_cores }}
-        memory: {{ hcp_workers_memory }}
+        cores: {{ hcp_worker_cores }}
+        memory: {{ hcp_worker_memory }}
         qosClass: Guaranteed
       rootVolume:
         persistent:
-          size: {{ hcp_workers_root_volume_size }}
+          size: {{ hcp_worker_root_volume_size }}
         type: Persistent
     type: KubeVirt
   release:
     image: quay.io/openshift-release-dev/ocp-release:{{ ocp4_installer_version }}-x86_64
-{% if hcp_workers_autoscale %}
+{% if hcp_worker_autoscale %}
   autoScaling:
-    min: {{ hcp_workers_instance_min_count | int }}
-    max: {{ hcp_workers_instance_max_count | int }}
+    min: {{ hcp_worker_instance_min_count | int }}
+    max: {{ hcp_worker_instance_max_count | int }}
 {% else %}
-    replicas: {{ hcp_workers_instance_count | int }}
+    replicas: {{ hcp_worker_instance_count | int }}
 {% endif %}

--- a/ansible/roles/host-ocp4-hcp-cnv-install/templates/nodepool.yaml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/templates/nodepool.yaml
@@ -31,5 +31,5 @@ spec:
     min: {{ hcp_worker_instance_min_count | int }}
     max: {{ hcp_worker_instance_max_count | int }}
 {% else %}
-    replicas: {{ hcp_worker_instance_count | int }}
+  replicas: {{ hcp_worker_instance_count | int }}
 {% endif %}

--- a/ansible/roles/host-ocp4-hcp-cnv-install/templates/nodepool.yaml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/templates/nodepool.yaml
@@ -25,7 +25,7 @@ spec:
         type: Persistent
     type: KubeVirt
   release:
-    image: quay.io/openshift-release-dev/ocp-release:{{ _ocp_latest_image.name }}-x86_64
+    image: quay.io/openshift-release-dev/ocp-release:{{ _ocp_latest_image.name }}
 {% if hcp_worker_autoscale %}
   autoScaling:
     min: {{ hcp_worker_instance_min_count | int }}

--- a/ansible/roles/host-ocp4-hcp-cnv-install/templates/pullsecret.yaml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/templates/pullsecret.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+data:
+  .dockerconfigjson: >-
+    {{ (ocp4_pull_secret | to_json if ocp4_pull_secret is mapping else ocp4_pull_secret) | b64encode }}
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: hcp-{{ guid }}-pull-secret
+  namespace: {{ namespace }}
+type: kubernetes.io/dockerconfigjson

--- a/ansible/roles/host-ocp4-hcp-cnv-install/templates/secret-htpasswd.yaml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/templates/secret-htpasswd.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: htpasswd-{{ guid }}
+  namespace: {{ namespace }}
+type: Opaque
+data:
+  htpasswd: {{ r_htpasswd_file['content'] }}

--- a/ansible/roles/host-ocp4-hcp-cnv-install/templates/workers_svc.yaml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/templates/workers_svc.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ guid }}
+  name: "svc-{{ guid }}-apps"
+  namespace: "{{ namespace }}"
+spec:
+  ports:
+    - name: https-443
+      port: 443
+      protocol: TCP
+      targetPort: {{ nodeport_https }}
+    - name: http-80
+      port: 80
+      protocol: TCP
+      targetPort: {{ nodeport_http }}
+  selector:
+    kubevirt.io: virt-launcher
+  type: LoadBalancer

--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/defaults/main.yml
@@ -3,12 +3,12 @@ become_override: true
 ocp_username: opentlc-mgr
 silent: false
 
-lab_version: "lab-4.15"
+lab_version: "lab-4.16"
 repo_user: "RHsyseng"
 # yamllint disable rule:line-length
-kcli_rpm: "https://github.com/{{ repo_user }}/5g-ran-deployments-on-ocp-lab/raw/{{ lab_version }}/lab-materials/kcli-rpm/kcli-99.0.0.git.202404020919.bde3a19-0.el9.x86_64.rpm"
+kcli_rpm: "https://github.com/{{ repo_user }}/5g-ran-deployments-on-ocp-lab/raw/{{ lab_version }}/lab-materials/kcli-rpm/kcli-99.0.0.git.202409091407.2293cfe-0.el9.x86_64.rpm"
 # yamllint enable rule:line-length
-ocp4_major_release: "4.15"
+ocp4_major_release: "4.16"
 lab_network_cidr: "192.168.125.0/24"
 lab_network_domain: "5g-deployment.lab"
 lab_sriov_domain: "sriov-network.lab"
@@ -24,8 +24,8 @@ lab_sno_vm_memory: 24000
 lab_sno_vm_disk: 200
 extra_disk_libvirt_images: true
 # yamllint disable rule:line-length
-rhcos_live_image_url: 'https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.15/4.15.0/rhcos-4.15.0-x86_64-live.x86_64.iso'
-rhcos_rootfs_image_url: 'https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.15/4.15.0/rhcos-4.15.0-x86_64-live-rootfs.x86_64.img'
+rhcos_live_image_url: 'https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.16/4.16.0/rhcos-4.16.0-x86_64-live.x86_64.iso'
+rhcos_rootfs_image_url: 'https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.16/4.16.0/rhcos-4.16.0-x86_64-live-rootfs.x86_64.img'
 lab_url: "https://labs.sysdeseng.com/5g-ran-deployments-on-ocp-lab/{{ ocp4_major_release }}/index.html"
 # yamllint enable rule:line-length
 aap2_webconsole_user: "admin"

--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/pre_workload.yml
@@ -137,10 +137,10 @@
 
 - name: Ensure oc/kubectl tooling is present
   ansible.builtin.command:
-    cmd: kcli download {{ item }} -P version=stable -P tag='{{ ocp4_major_release }}'
+    cmd: "kcli download {{ item.binary }} -P version={{ item.version }} -P tag='{{ ocp4_major_release }}'"
   with_items:
-    - oc
-    - kubectl
+    - {binary: "oc", version: "stable"}
+    - {binary: "kubectl", version: "latest"}
 
 - name: Ensure oc/kubectl are in the PATH
   ansible.builtin.copy:

--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/pre_workload.yml
@@ -90,36 +90,27 @@
     name: "{{ kcli_rpm }}"
     disable_gpg_check: true
 
-#- name: Add the RHEL9 Beta repo for QEMU SR-IOV support
-#  ansible.builtin.shell:
-#    cmd: >
-#      grep -Pzo '\[rhel-9-for-x86_64-appstream-rpms\]\n(?:.|\n)*?(?=\n\[|$)' /etc/yum.repos.d/redhat.repo
-#      | sed "s|content/dist|content/beta|g"
-#      | sed "s|name = .*|name = Red Hat Enterprise Linux 9 for x86_64 - AppStream Beta (RPMs)|g"
-#      | sed "s|appstream-rpms|appstream-beta-rpms|g" | tr -d '\0'
-#      | sudo tee /etc/yum.repos.d/rhel9-appstream-beta.repo
-
-- name: Add CentOS Stream 9 repository to upgrade QEMU KVM
-  ansible.builtin.yum_repository:
-    name: centos-stream-9-appstream
-    description: CentOS Stream 9 AppStream
-    baseurl: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/
-    gpgcheck: false
-    enabled: true
-
-- name: Upgrade QEMU from BETA for SR-IOV support
-  ansible.builtin.dnf:
-    name:
-      - qemu-kvm
-    state: latest
-    update_only: true
-
-- name: Remove the CentOS Stream 9 repo
-  ansible.builtin.yum_repository:
-    name: centos-stream-9-appstream
-    enabled: false
-    state: absent
-    gpgcheck: false
+#- name: Add CentOS Stream 9 repository to upgrade QEMU KVM
+#  ansible.builtin.yum_repository:
+#    name: centos-stream-9-appstream
+#    description: CentOS Stream 9 AppStream
+#    baseurl: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/
+#    gpgcheck: false
+#    enabled: true
+#
+#- name: Upgrade QEMU from BETA for SR-IOV support
+#  ansible.builtin.dnf:
+#    name:
+#      - qemu-kvm
+#    state: latest
+#    update_only: true
+#
+#- name: Remove the CentOS Stream 9 repo
+#  ansible.builtin.yum_repository:
+#    name: centos-stream-9-appstream
+#    enabled: false
+#    state: absent
+#    gpgcheck: false
 
 - name: Ensure libvirtd service is enabled and running
   ansible.builtin.systemd:

--- a/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/tasks/workload.yml
@@ -90,6 +90,20 @@
         spec:
           dataImportCronSourceFormat: pvc
 
+  - name: If we are using Hosted Control Planes, it is needed to set default accessMode and volumeMode
+    when: _ocp4_workload_kubevirt_default_storage_class == "kubevirt-csi-infra-default"
+    kubernetes.core.k8s:
+      state: patched
+      api_version: cdi.kubevirt.io/v1beta1
+      kind: StorageProfile
+      name: "{{ _ocp4_workload_kubevirt_default_storage_class }}"
+      definition:
+        spec:
+          claimPropertySets:
+          - accessModes:
+            - ReadWriteMany
+          volumeMode: Block
+
   - name: Finally patch HyperConverged to import boot sources now using PVCs
     kubernetes.core.k8s:
       state: patched

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/tasks/vcenter_setup_create_folder_and_vms.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/tasks/vcenter_setup_create_folder_and_vms.yml
@@ -29,6 +29,11 @@
 #   until: _ocp4_workload_virt_roadshow_vmware_vcenter_folder_id | length > 0
 #
 - name: Get folder information
+  environment:
+    VMWARE_HOST: "{{ vcenter_hostname }}"
+    VMWARE_USER: "{{ vcenter_username }}"
+    VMWARE_PASSWORD: "{{ vcenter_password }}"
+    VMWARE_VALIDATE_CERTS: "{{ ocp4_workload_virt_roadshow_vmware_enable_cert_validation }}"
   vmware.vmware_rest.vcenter_folder_info:
     type: VIRTUAL_MACHINE
     names:

--- a/ansible/software_playbooks/openshift4_hcp_cnv.yml
+++ b/ansible/software_playbooks/openshift4_hcp_cnv.yml
@@ -1,0 +1,15 @@
+---
+######################### Deploy OpenShift using HCP on CNV
+
+- name: Step 004.2 - Install OpenShift using HCP on CNV
+  hosts: bastions
+  gather_facts: false
+  become: false
+  tags:
+    - step004
+    - step004.2
+  tasks:
+    - name: Call Role to install OpenShift using HCP on CNV
+      when: install_ocp4 | default(true) | bool
+      ansible.builtin.include_role:
+        name: host-ocp4-hcp-cnv-install


### PR DESCRIPTION
##### SUMMARY

This PR includes the following roles:

**host-ocp4-hcp-cnv-install**: Installs OCP using HostedCluster and NodePool resources. It registers in the DNS, order a Certificate and configure authentication if needed.
**host-ocp4-hcp-cnv-destroy**: Removes the HostedCluster to release resources and be able to remove the namespace.

It improves the stop and the start of the VMs on OpenShift Virtualization. VMs can be started in two ways (**running**: true or **runningStrategy**: Always) and the same stopping it. HCP uses **runningStrategy** instead **running**, the only way we had in our code.

As well for the storageclass on the guest OCP cluster, the **claimPropertySets** properties is configured on the StorageProfile object, to define the accessModes and the volumeMode

##### ISSUE TYPE
- Feature Pull Request

