### PR TITLE
Removing Fedora 35 and Windows 2019 images aren't used in the OSP on …

### DIFF
--- a/ansible/configs/osp-on-ocp/pre_software.yml
+++ b/ansible/configs/osp-on-ocp/pre_software.yml
@@ -154,29 +154,6 @@
         state: restarted
         enabled: true
 
-    - name: Download required os images for the lab from S3
-      ansible.builtin.get_url:
-        url: "https://catalog-item-assets.s3.us-east-2.amazonaws.com/qcow_images/{{ item }}"
-        dest: "/var/www/html/{{ item }}"
-        mode: '0440'
-        owner: apache
-        group: apache
-      loop:
-        - Fedora35.qcow2
-        - Windows2019.iso
-      async: 600
-      poll: 0
-      register: download_results
-
-    - name: Wait 6 minutes max for all lab os images downloads to complete
-      async_status:
-        jid: "{{ item.ansible_job_id }}"
-      loop: "{{ download_results.results }}"
-      retries: 70
-      delay: 10
-      register: job_results
-      until: job_results.finished
-
 - name: PreSoftware flight-check
   hosts: localhost
   connection: local


### PR DESCRIPTION
##### SUMMARY
Fedora 35 and Windows 2019 aren't used in the OSP on OCP config, so deleting it

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
config: osp_on_ocp

##### ADDITIONAL INFORMATION
Fedora 35 and Windows 2019 aren't used, so deleting it
```paste below
TASK [Wait 6 minutes max for all lab os images downloads to complete] **********
Monday 16 September 2024  07:06:38 +0000 (0:00:06.428)       0:38:17.181 ****** 
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (70 retries left).
changed: [bastion-vm] => (item={'failed': 0, 'started': 1, 'finished': 0, 'ansible_job_id': 'j16942144895.4754', 'results_file': '/root/.ansible_async/j16942144895.4754', 'changed': True, 'item': 'Fedora35.qcow2', 'ansible_loop_var': 'item'})
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (70 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (69 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (68 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (67 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (66 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (65 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (64 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (63 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (62 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (61 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (60 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (59 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (58 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (57 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (56 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (55 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (54 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (53 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (52 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (51 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (50 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (49 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (48 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (47 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (46 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (45 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (44 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (43 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (42 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (41 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (40 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (39 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (38 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (37 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (36 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (35 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (34 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (33 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (32 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (31 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (30 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (29 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (28 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (27 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (26 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (25 retries left).
FAILED - RETRYING: [bastion-vm]: Wait 6 minutes max for all lab os images downloads to complete (24 retries left).
failed: [bastion-vm] (item={'failed': 0, 'started': 1, 'finished': 0, 'ansible_job_id': 'j770988491335.4866', 'results_file': '/root/.ansible_async/j770988491335.4866', 'changed': True, 'item': 'Windows2019.iso', 'ansible_loop_var': 'item'}) => {"ansible_job_id": "j770988491335.4866", "ansible_loop_var": "item", "attempts": 48, "changed": false, "child_pid": 4870, "finished": 1, "item": {"ansible_job_id": "j770988491335.4866", "ansible_loop_var": "item", "changed": true, "failed": 0, "finished": 0, "item": "Windows2019.iso", "results_file": "/root/.ansible_async/j770988491335.4866", "started": 1}, "msg": "Timeout exceeded", "results_file": "/root/.ansible_async/j770988491335.4866", "started": 1, "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
```
