### PR TITLE
Update 5G RAN Lab to OCP 4.16

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/defaults/main.yml
@@ -3,12 +3,12 @@ become_override: true
 ocp_username: opentlc-mgr
 silent: false
 
-lab_version: "lab-4.15"
+lab_version: "lab-4.16"
 repo_user: "RHsyseng"
 # yamllint disable rule:line-length
-kcli_rpm: "https://github.com/{{ repo_user }}/5g-ran-deployments-on-ocp-lab/raw/{{ lab_version }}/lab-materials/kcli-rpm/kcli-99.0.0.git.202404020919.bde3a19-0.el9.x86_64.rpm"
+kcli_rpm: "https://github.com/{{ repo_user }}/5g-ran-deployments-on-ocp-lab/raw/{{ lab_version }}/lab-materials/kcli-rpm/kcli-99.0.0.git.202409091407.2293cfe-0.el9.x86_64.rpm"
 # yamllint enable rule:line-length
-ocp4_major_release: "4.15"
+ocp4_major_release: "4.16"
 lab_network_cidr: "192.168.125.0/24"
 lab_network_domain: "5g-deployment.lab"
 lab_sriov_domain: "sriov-network.lab"
@@ -24,8 +24,8 @@ lab_sno_vm_memory: 24000
 lab_sno_vm_disk: 200
 extra_disk_libvirt_images: true
 # yamllint disable rule:line-length
-rhcos_live_image_url: 'https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.15/4.15.0/rhcos-4.15.0-x86_64-live.x86_64.iso'
-rhcos_rootfs_image_url: 'https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.15/4.15.0/rhcos-4.15.0-x86_64-live-rootfs.x86_64.img'
+rhcos_live_image_url: 'https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.16/4.16.0/rhcos-4.16.0-x86_64-live.x86_64.iso'
+rhcos_rootfs_image_url: 'https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.16/4.16.0/rhcos-4.16.0-x86_64-live-rootfs.x86_64.img'
 lab_url: "https://labs.sysdeseng.com/5g-ran-deployments-on-ocp-lab/{{ ocp4_major_release }}/index.html"
 # yamllint enable rule:line-length
 aap2_webconsole_user: "admin"

--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/pre_workload.yml
@@ -90,36 +90,27 @@
     name: "{{ kcli_rpm }}"
     disable_gpg_check: true
 
-#- name: Add the RHEL9 Beta repo for QEMU SR-IOV support
-#  ansible.builtin.shell:
-#    cmd: >
-#      grep -Pzo '\[rhel-9-for-x86_64-appstream-rpms\]\n(?:.|\n)*?(?=\n\[|$)' /etc/yum.repos.d/redhat.repo
-#      | sed "s|content/dist|content/beta|g"
-#      | sed "s|name = .*|name = Red Hat Enterprise Linux 9 for x86_64 - AppStream Beta (RPMs)|g"
-#      | sed "s|appstream-rpms|appstream-beta-rpms|g" | tr -d '\0'
-#      | sudo tee /etc/yum.repos.d/rhel9-appstream-beta.repo
-
-- name: Add CentOS Stream 9 repository to upgrade QEMU KVM
-  ansible.builtin.yum_repository:
-    name: centos-stream-9-appstream
-    description: CentOS Stream 9 AppStream
-    baseurl: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/
-    gpgcheck: false
-    enabled: true
-
-- name: Upgrade QEMU from BETA for SR-IOV support
-  ansible.builtin.dnf:
-    name:
-      - qemu-kvm
-    state: latest
-    update_only: true
-
-- name: Remove the CentOS Stream 9 repo
-  ansible.builtin.yum_repository:
-    name: centos-stream-9-appstream
-    enabled: false
-    state: absent
-    gpgcheck: false
+#- name: Add CentOS Stream 9 repository to upgrade QEMU KVM
+#  ansible.builtin.yum_repository:
+#    name: centos-stream-9-appstream
+#    description: CentOS Stream 9 AppStream
+#    baseurl: https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/
+#    gpgcheck: false
+#    enabled: true
+#
+#- name: Upgrade QEMU from BETA for SR-IOV support
+#  ansible.builtin.dnf:
+#    name:
+#      - qemu-kvm
+#    state: latest
+#    update_only: true
+#
+#- name: Remove the CentOS Stream 9 repo
+#  ansible.builtin.yum_repository:
+#    name: centos-stream-9-appstream
+#    enabled: false
+#    state: absent
+#    gpgcheck: false
 
 - name: Ensure libvirtd service is enabled and running
   ansible.builtin.systemd:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

- Added basic changes to deploy OCP 4.16 and the latest version of operators.
- Removed extra QEMU-KVM configuration since now SR-IOV is supported in RHEL9 by default.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New config Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

- Role: ocp4_workload_5gran_deployments_lab


##### ADDITIONAL INFORMATION

The change updates the 5G RAN Lab to run on the latest 4.16 bits along with the latest telco configurations and operators.


<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->

