### PR TITLE
[infra-openshift-cnv-resources] Add limits to VM

### DIFF
--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
@@ -128,6 +128,9 @@
               pageSize: "1Gi"
         resources:
           overcommitGuestOverhead: true
+          limits: 
+            memory: "{{ _instance.memory }}"
+            cpu: {{ _instance.cores }}
           requests:
             memory: "{{ ((_instance.memory |  regex_replace('[^0-9]') | int) / 2)|int|string + (_instance.memory |  regex_replace('[0-9]')) }}"
             #memory: "{{ _instance.memory }}"


### PR DESCRIPTION

##### SUMMARY

For sandbox quotas, we require specify the limits for the VM

We set the limit to the request values.

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME
Role infra-openshift-cnv-resources
