### PR TITLE
Showroom role, add conditional to disable tmux scrolling

### DIFF
--- a/ansible/roles/showroom/defaults/main.yml
+++ b/ansible/roles/showroom/defaults/main.yml
@@ -84,6 +84,7 @@ showroom_base_services:
   - traefik_httpd                     # Combines a traefik reverse proxy with httpd as a "pair"
 
 showroom_ttys_enable_tmux: false
+showroom_ttys_tumx_scrolling: true
 
 showroom_tab_services:                # double_terminal | codeserver | docs TODO: validate
   - single_terminal

--- a/ansible/roles/showroom/tasks/22-showroom-users-security.yml
+++ b/ansible/roles/showroom/tasks/22-showroom-users-security.yml
@@ -109,6 +109,7 @@
         mode: u=rwx,g=rx,o=rx
 
     - name: Setup mouse scrolling for tmux via user tmux.conf
+      when: showroom_ttys_tumx_scrolling | default(true) | bool
       ansible.builtin.template:
         src: tmux.conf.j2
         dest: "/home/{{ __showroom_lab_user }}/.tmux.conf"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
This conditional is to avoid larger changes to the showroom role. For zero-touch items we have the need to run the showroom on a separate server with ssh connection to another box. The changed task was failing due to the showroom role attempting to place the file in the improper directory on the wrong system.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
role: showroom
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
