### PR TITLE
Equinix Legacy patch: ROADSHOW and BOOTCAMP: add GUID to vmname

### DIFF
--- a/ansible/configs/experience-ocpvirt/vcenter-setup-webapp-vms.yml
+++ b/ansible/configs/experience-ocpvirt/vcenter-setup-webapp-vms.yml
@@ -65,7 +65,7 @@
       state: poweredoff
       folder: "/Workloads/{{ hostvars['localhost']['vcenter_folder'] }}"
       template: "{{ item.template }}"
-      name: "{{ item.name }}"
+      name: "{{ item.name }}-{{ guid }}"
       wait_for_ip_address: false
       disk:
       - datastore: "{{ vcenter_datastore }}"


### PR DESCRIPTION

- Bugfix Pull Request

VMware directory services do not handle multiple identical VM names at all well.

This adds GUIDs to the vmnames.