### PR TITLE
Fix single user bucket name for MinIO workload

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_minio/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_minio/defaults/main.yml
@@ -41,6 +41,9 @@ ocp4_workload_minio_image_tag: RELEASE.2020-10-28T08-16-50Z
 ocp4_workload_minio_root_user: "root_user"
 ocp4_workload_minio_root_password: "root_password"
 
+# Name of the MinIO instance to set up
+ocp4_workload_minio_name: localminio
+
 # Create minio Bucket after installation
 ocp4_workload_minio_bucket_setup: false
 # Set up one bucket for each user

--- a/ansible/roles_ocp_workloads/ocp4_workload_minio/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_minio/defaults/main.yml
@@ -40,6 +40,7 @@ ocp4_workload_minio_image_tag: RELEASE.2020-10-28T08-16-50Z
 # Should be overwritten via Global Variables !!!
 ocp4_workload_minio_root_user: "root_user"
 ocp4_workload_minio_root_password: "root_password"
+ocp4_workload_minio_root_policy: readwrite
 
 # Name of the MinIO instance to set up
 ocp4_workload_minio_name: localminio

--- a/ansible/roles_ocp_workloads/ocp4_workload_minio/meta/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_minio/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   description: |
     Set up Minio (S3 Storage) on an OpenShift Cluster
   license: MIT
-  min_ansible_version: 2.9
+  min_ansible_version: "2.9"
   platforms:
   - linux
   galaxy_tags:

--- a/ansible/roles_ocp_workloads/ocp4_workload_minio/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_minio/tasks/main.yml
@@ -1,20 +1,13 @@
 ---
+# --------------------------------------------------
+# Do not modify this file
+# --------------------------------------------------
 - name: Running Pre Workload Tasks
-  when: ACTION == "create" or ACTION == "provision"
+  when: ACTION == "provision"
   ansible.builtin.include_tasks:
     file: ./pre_workload.yml
 
-- name: Running Workload Tasks
-  when: ACTION == "create" or ACTION == "provision"
-  ansible.builtin.include_tasks:
-    file: ./workload.yml
-
-- name: Running Post Workload Tasks
-  when: ACTION == "create" or ACTION == "provision"
-  ansible.builtin.include_tasks:
-    file: ./post_workload.yml
-
 - name: Running Workload removal Tasks
-  when: ACTION == "destroy" or ACTION == "remove"
+  when: ACTION == "destroy"
   ansible.builtin.include_tasks:
     file: ./remove_workload.yml

--- a/ansible/roles_ocp_workloads/ocp4_workload_minio/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_minio/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: Running Pre Workload Tasks
   when: ACTION == "provision"
   ansible.builtin.include_tasks:
-    file: ./pre_workload.yml
+    file: ./workload.yml
 
 - name: Running Workload removal Tasks
   when: ACTION == "destroy"

--- a/ansible/roles_ocp_workloads/ocp4_workload_minio/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_minio/tasks/main.yml
@@ -5,9 +5,9 @@
 - name: Running Pre Workload Tasks
   when: ACTION == "provision"
   ansible.builtin.include_tasks:
-    file: ./workload.yml
+    file: workload.yml
 
 - name: Running Workload removal Tasks
   when: ACTION == "destroy"
   ansible.builtin.include_tasks:
-    file: ./remove_workload.yml
+    file: remove_workload.yml

--- a/ansible/roles_ocp_workloads/ocp4_workload_minio/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_minio/tasks/post_workload.yml
@@ -1,8 +1,0 @@
----
-# Implement your Post Workload deployment tasks here
-
-# Leave this as the last task in the playbook.
-- name: Post_workload tasks complete
-  when: not silent | bool
-  ansible.builtin.debug:
-    msg: "Post-Workload Tasks completed successfully."

--- a/ansible/roles_ocp_workloads/ocp4_workload_minio/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_minio/tasks/pre_workload.yml
@@ -1,8 +1,0 @@
----
-# Implement your Pre Workload deployment tasks here
-
-# Leave this as the last task in the playbook.
-- name: pre_workload tasks complete
-  when: not silent | bool
-  ansible.builtin.debug:
-    msg: "Pre-Workload tasks completed successfully."

--- a/ansible/roles_ocp_workloads/ocp4_workload_minio/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_minio/tasks/remove_workload.yml
@@ -1,14 +1,7 @@
 ---
-# Implement your Workload removal tasks here
 - name: Remove Minio Object Storage Project
   kubernetes.core.k8s:
-    name: "{{ ocp4_workload_minio_project }}"
+    state: absent
     api_version: v1
     kind: Namespace
-    state: absent
-
-# Leave this as the last task in the playbook.
-- name: Remove_workload tasks complete
-  when: not silent | bool
-  ansible.builtin.debug:
-    msg: "Remove Workload tasks completed successfully."
+    name: "{{ ocp4_workload_minio_project }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_minio/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_minio/tasks/workload.yml
@@ -59,6 +59,10 @@
           {{ ocp4_workload_minio_name }} http://localhost:9000 \
           {{ ocp4_workload_minio_root_user }} {{ ocp4_workload_minio_root_password }}; \
 
+        mc admin policy attach {{ ocp4_workload_minio_name }} \
+          {{ ocp4_workload_minio_root_policy }} \
+          --user {{ ocp4_workload_minio_root_user }};
+
         echo "Creating buckets..."; \
         buckets=(); \
         if [ "{{ ocp4_workload_minio_bucket_multi_user }}" == "True" ]; then \

--- a/ansible/roles_ocp_workloads/ocp4_workload_minio/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_minio/tasks/workload.yml
@@ -1,5 +1,5 @@
 ---
-- name: Create OpenShift Objects for Minio Object Storage
+- name: Create OpenShift objects for MinIO object storage
   kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('template', item) | from_yaml }}"
@@ -10,7 +10,7 @@
   - ./templates/deployment.yaml.j2
   - ./templates/service.yaml.j2
 
-- name: Create OpenShift routes for Minio Object Storage
+- name: Create OpenShift routes for MinIO object storage
   when: ocp4_workload_minio_expose_route | bool
   kubernetes.core.k8s:
     state: present
@@ -19,10 +19,10 @@
   - ./templates/route_minio.yaml.j2
   - ./templates/route_console.yaml.j2
 
-- name: Set up a Minio Bucket
+- name: Set up a MinIO bucket
   when: ocp4_workload_minio_bucket_setup | bool
   block:
-  - name: Wait until Minio Deployment is running
+  - name: Wait until MinIO Deployment is running
     kubernetes.core.k8s_info:
       api_version: "apps/v1"
       kind: Deployment
@@ -32,7 +32,7 @@
       wait_sleep: 10
       wait_timeout: 360
 
-  - name: Get Minio Pod
+  - name: Get MinIO Pod
     kubernetes.core.k8s_info:
       api_version: v1
       kind: Pod
@@ -41,7 +41,7 @@
       - app = minio
     register: r_minio_pod
 
-  # Set up Minio with a bucket
+  # Set up MinIO with a bucket
   # POD=$(oc get pod -n minio -lapp=minio -o jsonpath='{range.items[*]}{.metadata.name}{"\n"}{end}')
   # oc -n minio rsh ${POD} mc alias set --insecure localminio localhost:9000 root-user root-user-password
   # oc -n minio rsh ${POD} mc mb localminio/testbucket
@@ -49,14 +49,14 @@
   # oc -n minio rsh ${POD} mc ls localminio
 
   # `mc` commands can be repeated without failure
-  - name: Set up Minio bucket (Single and Multi-User)
+  - name: Set up MinIO bucket (Single and Multi-User)
     kubernetes.core.k8s_exec:
       namespace: "{{ ocp4_workload_minio_project }}"
       pod: "{{ r_minio_pod.resources[0].metadata.name }}"
       command: |
         /bin/bash --login -c 'echo "Setting up Minio server..."; \
         mc alias set --insecure \
-          localminio http://localhost:9000 \
+          {{ ocp4_workload_minio_name }} http://localhost:9000 \
           {{ ocp4_workload_minio_root_user }} {{ ocp4_workload_minio_root_password }}; \
 
         echo "Creating buckets..."; \
@@ -68,17 +68,11 @@
           done; \
         else \
           echo "Single-User: {{ ocp4_workload_minio_bucket_multi_user }}"; \
-          buckets+=("{{ ocp4_workload_minio_bucket_base }}"); \
+          buckets+=("{{ ocp4_workload_minio_bucket_name }}"); \
         fi; \
         for bucket in ${buckets[@]}; do \
-          mc mb localminio/${bucket} --ignore-existing; \
+          mc mb {{ ocp4_workload_minio_name }}/${bucket} --ignore-existing; \
         done'
     register: r_minio_bucket_mu
     until: r_minio_bucket_mu is success
     failed_when: r_minio_bucket_mu.rc != 0
-
-# Leave this as the last task in the playbook.
-- name: Workload tasks complete
-  when: not silent | bool
-  ansible.builtin.debug:
-    msg: "Workload Tasks completed successfully."


### PR DESCRIPTION
##### SUMMARY

The MinIO Workload used the wrong variable name (ocp4_workload_minio_bucket_base instead of ocp4_workload_minio_bucket_name) for the single user deployment.

Also updated to latest coding guidelines.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_minio