### PR TITLE
[host-ocp4-assisted-installer] Specify evictionStrategy to none for ctl planes

### DIFF
--- a/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_masters_etcd.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_masters_etcd.yaml
@@ -101,7 +101,7 @@
           multus:
             networkName: "{{ network_name }}"
       terminationGracePeriodSeconds: 180
-      evictionStrategy: shutdown
+      evictionStrategy: None
       volumes:
         - dataVolume:
             name: "{{ vmname }}"


### PR DESCRIPTION
**SUMMARY**
Control plane VMs are using local disk, so LiveMigration (default) it is not possible

**ISSUE TYPE**
Bugfix Pull Request

**COMPONENT NAME**
host-ocp4-assisted-installer Role