### PR TITLE
[host-ocp4-assisted-destroy] Fixing LAB variable

### DIFF
--- a/ansible/roles/host-ocp4-assisted-destroy/templates/cleanup-ceph.yaml.j2
+++ b/ansible/roles/host-ocp4-assisted-destroy/templates/cleanup-ceph.yaml.j2
@@ -15,7 +15,7 @@ spec:
         - "/etc/ceph/cleanup-script.sh"
         env:
         - name: LAB
-          value: {{ ai_ocp_namespace }}
+          value: {{ env_type }}-{{ guid }}
         volumeMounts:
         - name: keyring-volume
           mountPath: /etc/ceph


### PR DESCRIPTION

##### SUMMARY

Using sandbox the name of the namespace is not the same as the volumePrefixName we use on external ODF:

https://github.com/redhat-cop/agnosticd/blob/5e9712854f03f64a618774d66abaa473a8a30d23/ansible/roles_ocp_workloads/ocp4_workload_external_odf/templates/storageclass.yaml.j2#L21

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
host-ocp4-assisted-destroy role

