### PR TITLE
Name customizable, auth customizable, user info

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/defaults/main.yml
@@ -6,6 +6,17 @@ ocp4_workload_kasten_namespace: kasten-io
 
 ocp4_workload_kasten_deploy_k10: true
 
+# Name of the Kasten K10 instance when ocp4_workload_kasten_deploy_k10 is set to true
+ocp4_workload_kasten_name: k10
+
+# Authentication type to use. Options are:
+# - openshift
+# - htpasswd
+ocp4_workload_kasten_authentication_type: openshift
+
+# For HTpasswd provide User ID and password as a htpasswd string.
+ocp4_workload_kasten_authentication_htpasswd_string: "kasten:{SHA}+pZlbdvQvNdqHU2/FX8UwLzrDXI="
+
 # Channel to subscribe to
 ocp4_workload_kasten_channel: stable
 ocp4_workload_kasten_automatic_install_plan_approval: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/tasks/remove_workload.yml
@@ -1,12 +1,4 @@
 ---
-# Implement your workload removal tasks here
-# ------------------------------------------
-
-
-# Leave this as the last task in the playbook.
-# --------------------------------------------
-
-- name: remove_workload tasks complete
-  debug:
-    msg: "Remove Workload tasks completed successfully."
-  when: not silent|bool
+- name: Print not implemented
+  ansible.builtin.debug:
+    msg: "Remove Workload is not currently implemented."

--- a/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/tasks/workload.yml
@@ -30,7 +30,7 @@
     kubernetes.core.k8s_info:
       api_version: apik10.kasten.io/v1alpha1
       kind: K10
-      name: k10
+      name: "{{ ocp4_workload_kasten_name }}"
       namespace: "{{ ocp4_workload_kasten_namespace }}"
       wait: true
       wait_sleep: 5
@@ -39,3 +39,17 @@
         type: "Initialized"
         status: "True"
     register: r_k10
+
+  - name: Get Kasten Route
+    kubernetes.core.k8s_info:
+      api_version: route.openshift.io/v1
+      kind: Route
+      name: "{{ ocp4_workload_kasten_name }}-route"
+      namespace: "{{ ocp4_workload_kasten_namespace }}"
+    register: r_kasten_route
+
+  - name: Save access information
+    when: r_kasten_route.resources | length > 0
+    agnosticd_user_info:
+      data:
+        kasten_dashboard: "https://{{ r_kasten_route.resources[0].spec.host }}/k10"

--- a/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/templates/k10.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/templates/k10.yaml.j2
@@ -2,15 +2,22 @@
 apiVersion: apik10.kasten.io/v1alpha1
 kind: K10
 metadata:
-  name: k10
+  name: {{ ocp4_workload_kasten_name }}
   namespace: {{ ocp4_workload_kasten_namespace }}
 spec:
   auth:
+{% if ocp4_workload_kasten_authentication_type == "openshift" %}
     openshift:
-      dashboardURL: https://k10-route-kasten-io.{{ openshift_cluster_ingress_domain }}/k10/
+      dashboardURL: https://{{ ocp4_workload_kasten_name }}-route-kasten-io.{{ openshift_cluster_ingress_domain }}/k10/
       enabled: true
       insecureCA: true
       openshiftURL: https://apiserver.openshift-kube-apiserver.svc.cluster.local
+{% elif ocp4_workload_kasten_authentication_type == "htpasswd" %}
+    basicAuth:
+      enabled: true
+      htpasswd: '{{ ocp4_workload_kasten_authentication_htpasswd_string }}'
+      secretName: ""
+{% endif %}
   global:
     persistence:
       catalog:


### PR DESCRIPTION
##### SUMMARY

More minor enhancements to the kasten k10 workload.

Made name of the K10 instance customizable.
Added option to either set basicAuth or OpenShift auth
Save Kasten Dashboard to agnosticd_user_info.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_kasten_k10