### PR TITLE
Add missing / to the end of the kasten URL

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/tasks/workload.yml
@@ -52,4 +52,4 @@
     when: r_kasten_route.resources | length > 0
     agnosticd_user_info:
       data:
-        kasten_dashboard: "https://{{ r_kasten_route.resources[0].spec.host }}/k10"
+        kasten_dashboard: "https://{{ r_kasten_route.resources[0].spec.host }}/k10/"


### PR DESCRIPTION
##### SUMMARY

Kasten URL needs a trailing / to work.
Adding to the agd user info data.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_kasten_k10