### PR TITLE
[ocp4_workload_kubevirt] Add cloneStrategy and fix volumeMode

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/tasks/workload.yml
@@ -90,7 +90,7 @@
         spec:
           dataImportCronSourceFormat: pvc
 
-  - name: If we are using Hosted Control Planes, it is needed to set default accessMode and volumeMode
+  - name: If we are using Hosted Control Planes, it is needed to set default accessMode, volumeMode and cloneStrategy
     when: _ocp4_workload_kubevirt_default_storage_class == "kubevirt-csi-infra-default"
     kubernetes.core.k8s:
       state: patched
@@ -103,6 +103,7 @@
           - accessModes:
             - ReadWriteMany
           volumeMode: Block
+          cloneStrategy: copy
 
   - name: Finally patch HyperConverged to import boot sources now using PVCs
     kubernetes.core.k8s:

--- a/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/tasks/workload.yml
@@ -103,7 +103,7 @@
           - accessModes:
             - ReadWriteMany
             volumeMode: Block
-          cloneStrategy: csi-clone
+          cloneStrategy: copy
 
   - name: Finally patch HyperConverged to import boot sources now using PVCs
     kubernetes.core.k8s:

--- a/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/tasks/workload.yml
@@ -103,7 +103,7 @@
           - accessModes:
             - ReadWriteMany
             volumeMode: Block
-          cloneStrategy: copy
+          cloneStrategy: csi-clone
 
   - name: Finally patch HyperConverged to import boot sources now using PVCs
     kubernetes.core.k8s:

--- a/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kubevirt/tasks/workload.yml
@@ -102,7 +102,7 @@
           claimPropertySets:
           - accessModes:
             - ReadWriteMany
-          volumeMode: Block
+            volumeMode: Block
           cloneStrategy: copy
 
   - name: Finally patch HyperConverged to import boot sources now using PVCs


### PR DESCRIPTION
##### SUMMARY

During functional tests of OcpVirt Roadshow, we detected default snapshot is not working

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
ocp4_workload_kubevirt role

