### PR TITLE
Added missing type cast

### DIFF
--- a/ansible/roles/ocp4_machineset_config/tasks/machineset-group-aws.yml
+++ b/ansible/roles/ocp4_machineset_config/tasks/machineset-group-aws.yml
@@ -75,12 +75,12 @@
       {{ [cluster_label, machineset_group.name, availability_zone] | join('-') }}
     machineset_min_replicas: >-
       {{ (
-         (machineset_group.total_replicas_min|default(0) + loop_index) /
+         (machineset_group.total_replicas_min|default(0) | int + loop_index) /
          aws_worker_availability_zones | count
       ) | int }}
     machineset_max_replicas: >-
       {{ (
-         (machineset_group.total_replicas_max | default(100) + loop_index) /
+         (machineset_group.total_replicas_max | default(100) | int + loop_index) /
          aws_worker_availability_zones | count
       ) | int }}
   when: machineset_group.autoscale | default(false) | bool


### PR DESCRIPTION
##### SUMMARY

Added missing type cast

Based on https://redhat-internal.slack.com/archives/C04MLMA15MX/p1726674780813579

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ansible/roles/ocp4_machineset_config/tasks/machineset-group-aws.yml

##### ADDITIONAL INFORMATION

```paste below
TASK [ocp4_machineset_config : Define worker-gpu machineautoscalers] ***********
Wednesday 18 September 2024  15:30:17 +0000 (0:00:03.210)       0:51:44.465 *** 
fatal: [bastion.zqkhr.internal]: FAILED! => {"msg": "An unhandled exception occurred while running the lookup plugin 'template'. Error was a <class 'ansible.errors.AnsibleError'>, original message: An unhandled exception occurred while templating '{{ (\\n   (machineset_group.total_replicas_min|default(0) + loop_index) /\\n   aws_worker_availability_zones | count\\n) | int }}'. Error was a <class 'ansible.errors.AnsibleError'>, original message: Unexpected templating type error occurred on ({{ (\\n   (machineset_group.total_replicas_min|default(0) + loop_index) /\\n   aws_worker_availability_zones | count\\n) | int }}): can only concatenate str (not \\"int\\") to str. can only concatenate str (not \\"int\\") to str. An unhandled exception occurred while templating '{{ (\\n   (machineset_group.total_replicas_min|default(0) + loop_index) /\\n   aws_worker_availability_zones | count\\n) | int }}'. Error was a <class 'ansible.errors.AnsibleError'>, original message: Unexpected templating type error occurred on ({{ (\\n   (machineset_group.total_replicas_min|default(0) + loop_index) /\\n   aws_worker_availability_zones | count\\n) | int }}): can only concatenate str (not \\"int\\") to str. can only concatenate str (not \\"int\\") to str"}
```
