### PR TITLE
Adds extra checks when OCP images task fails

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/pre_workload.yml
@@ -541,15 +541,30 @@
       ansible.builtin.stat:
         path: "/opt/webcache/data/{{ rhcos_live_image }}"
       register: rhcos_live_image_file
+    - name: "{{ rhcos_live_image }} was not downloaded. Re-downloading again..."
+      ansible.builtin.get_url:
+        url: "{{ rhcos_live_image_url }}"
+        dest: "/opt/webcache/data/"
+        mode: "0644"
+      register: download_live_result
+      until: not download_live_result.failed
+      retries: 3
+      delay: 10
+      when: not rhcos_live_image_file.stat.exists
     - name: Check status of {{ rhcos_rootfs_image }}
       ansible.builtin.stat:
         path: "/opt/webcache/data/{{ rhcos_rootfs_image }}"
       register: rhcos_rootfs_image_file
-    - name: Fail if files were not downloaded
-      ansible.builtin.fail:
-        msg: "rootfs or image files were not downloaded successfully"
-      when: (not rhcos_live_image_file.stat.exists or not rhcos_rootfs_image_file.stat.exists)
-
+    - name: "{{ rhcos_rootfs_image }} was not downloaded. Re-downloading again..."
+      ansible.builtin.get_url:
+        url: "{{ rhcos_rootfs_image_url }}"
+        dest: "/opt/webcache/data/"
+        mode: "0644"
+      register: download_rootfs_result
+      until: not download_rootfs_result.failed
+      retries: 3
+      delay: 10
+      when: not rhcos_rootfs_image_file.stat.exists     
 
 # Leave this as the last task in the playbook.
 - name: pre_workload tasks complete

--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/pre_workload.yml
@@ -564,7 +564,7 @@
       until: not download_rootfs_result.failed
       retries: 3
       delay: 10
-      when: not rhcos_rootfs_image_file.stat.exists     
+      when: not rhcos_rootfs_image_file.stat.exists
 
 # Leave this as the last task in the playbook.
 - name: pre_workload tasks complete


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

Adds extra check if the RHCOS images are not downloaded. The async job fails often.

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

- Role: ocp4_workload_5gran_deployments_lab


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
