### PR TITLE
[ocp4-cluster] Update requirements_k8s.txt to specify another version of aiohttp

### DIFF
--- a/ansible/configs/ocp4-cluster/files/requirements_k8s.txt
+++ b/ansible/configs/ocp4-cluster/files/requirements_k8s.txt
@@ -1,4 +1,4 @@
-aiohttp==3.10.2
+aiohttp==3.8.6
 adal==1.2.2
 ansible==2.9.27
 asn1crypto==1.3.0


### PR DESCRIPTION
##### SUMMARY

Specify a different version for aiohttp

In RHEL86 throws this error:
ERROR: Could not find a version that satisfies the requirement aiohttp==3.10.2

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
ocp4-cluster Role

