### PR TITLE
add dns back into certbot role for zerossl

### DIFF
--- a/ansible/roles/host-lets-encrypt-certs-certbot/tasks/main.yml
+++ b/ansible/roles/host-lets-encrypt-certs-certbot/tasks/main.yml
@@ -10,9 +10,7 @@
     key: "{{ _certbot_user }}"
 
 - name: Check on AWS credentials
-  when:
-  - certbot_cert_manager_provider == "letsencrypt"
-  - _certbot_dns_provider is match('route53')
+  when: _certbot_dns_provider is match('route53')
   block:
     - name: Verify if AWS Credentials exist on the host
       stat:
@@ -25,9 +23,7 @@
         msg: AWS Credentials are required when requesting certificates for a wildcard domain
 
 - name: Check on azure credentials
-  when:
-  - certbot_cert_manager_provider == "letsencrypt"
-  - _certbot_dns_provider is match('azure')
+  when: _certbot_dns_provider is match('azure')
   block:
     - name: Verify if Azure Credentials exist on the host
       stat:
@@ -40,9 +36,7 @@
         msg: Azure Credentials are required when requesting certificates for a wildcard domain
 
 - name: Check on GCP credentials
-  when:
-  - certbot_cert_manager_provider == "letsencrypt"
-  - _certbot_dns_provider is match('gcp')
+  when: _certbot_dns_provider is match('gcp')
   block:
     - name: Verify if GCP Credentials exist on the host
       stat:
@@ -55,9 +49,7 @@
         msg: GCP Credentials are required when requesting certificates for a wildcard domain
 
 - name: Check on DDNS credentials
-  when:
-  - certbot_cert_manager_provider == "letsencrypt"
-  - _certbot_dns_provider is match('rfc2136')
+  when: _certbot_dns_provider is match('rfc2136')
   block:
     - name: Verify credential are present on host
       when: _certbot_dns_provider is match('rfc2136')
@@ -174,9 +166,7 @@
     - "{{ _certbot_dir }}/renewal-hooks/deploy"
      
   - name: Request Certificates from Let's Encrypt (force or no cache)
-    when:
-    - certbot_cert_manager_provider == "letsencrypt"
-    - _certbot_force_issue|bool or not _certbot_setup_complete|bool
+    when: _certbot_force_issue|bool or not _certbot_setup_complete|bool
     block:
     - name: Download Let's Encrypt  account file 
       when: certbot_account_url is defined
@@ -253,18 +243,6 @@
         file:
           name: "{{ _certbot_dir }}/accounts"
           state: absent
-
-  - name: Request Certificates from ZeroSSL
-    when:
-    - certbot_cert_manager_provider == "zerossl"
-    block:
-    - name: Request API and Wildcard Certificates
-      become_user: "{{ _certbot_user }} "
-      command: "{{ _certbot_virtualenv }}/bin/run-certbot"
-      retries: 5
-      delay: 30
-      register: r_request_le
-      until: r_request_le is succeeded
 
 - name: Install the certificates into {{ _certbot_install_dir }}
   block:

--- a/ansible/roles/host-lets-encrypt-certs-certbot/templates/run-certbot.j2
+++ b/ansible/roles/host-lets-encrypt-certs-certbot/templates/run-certbot.j2
@@ -7,24 +7,22 @@ certbot certonly -n --agree-tos --email {{ _certbot_le_email }} \
   {{ (_certbot_wildcard_domain|length>0)|ternary('-d','')}} {{ (_certbot_wildcard_domain|length>0)|ternary(_certbot_wildcard_domain,'')}} \
 {% if certbot_cert_manager_provider is match('zerossl') %}
   --eab-kid "{{ certbot_cert_manager_zerossl_eab_key_id }}" --eab-hmac-key "{{ certbot_cert_manager_zerossl_hmac_key }}" --server "{{ certbot_cert_manager_acme_url }}" \
-{% else %}
- {% if _certbot_dns_provider is match('rfc2136') %}
+{% endif %}
+{% if _certbot_dns_provider is match('rfc2136') %}
   --dns-rfc2136-credentials /home/{{ _certbot_user }}/.rfc2136.ini \
   --dns-rfc2136-propagation-seconds 15 \
   {{ (_certbot_wildcard_certs|bool)|ternary('--dns-rfc2136', '') }} \
- {% elif _certbot_dns_provider is match('azure') %}
+{% elif _certbot_dns_provider is match('azure') %}
   --authenticator dns-azure \
   --dns-azure-config /home/{{ _certbot_user }}/.azure.ini \
- {% elif _certbot_dns_provider is match('gcp') %}
+{% elif _certbot_dns_provider is match('gcp') %}
   --dns-google \
   --dns-google-credentials /home/{{ _certbot_user }}/.gcp/osServiceAccount.json \
   --dns-google-propagation-seconds 15 \
   --dns-google-project {{ project_name }} \
- {% else %}
+{% else %}
   {{ (_certbot_wildcard_certs|bool)|ternary('--dns-'+_certbot_dns_provider, '') }} \
- {% endif %}
 {% endif %}
-
   --config-dir={{ _certbot_dir }}/config \
   --work-dir={{ _certbot_dir }}/work \
   --logs-dir={{ _certbot_dir }}/logs \


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
add dns back into certbot role for zerossl
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
host-lets-encrypt-certs-certbot

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
