### PR TITLE
updated storage class to gp3

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_portworx/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_portworx/defaults/main.yml
@@ -15,7 +15,7 @@ ocp4_workload_portworx_csv: ""
 
 ocp4_workload_portworx_deploy_storagecluster: true
 ocp4_workload_portworx_storagecluster_name: portworx-storage-cluster
-ocp4_workload_portworx_storagecluster_storage_class: gp3-csi
+ocp4_workload_portworx_storagecluster_storage_class: gp3
 ocp4_workload_portworx_storagecluster_storage_size: 50
 
 # Define StorageCluster metadata (default when empty)


### PR DESCRIPTION

##### SUMMARY

Changed storage class to gp3 from gp3-csi

The AWS EBS CSI driver provisions EBS volumes and attaches them to pods as Persistent Volumes (PVs).
Portworx requires block devices to be attached to the nodes themselves, not to individual pods.
The CSI driver does not facilitate attaching volumes directly to nodes in a way that Portworx can utilize.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
ocp4_workload_portworx



```
