### PR TITLE
Add api_version to kubevirt.io/v1

### DIFF
--- a/ansible/roles-infra/infra-openshift-cnv-create-inventory/tasks/create_inventory.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-create-inventory/tasks/create_inventory.yaml
@@ -1,6 +1,7 @@
 ---
 - name: Search for all running pods
   kubernetes.core.k8s_info:
+    api_version: kubevirt.io/v1
     kind: VirtualMachine
     namespace: "{{ openshift_cnv_namespace }}"
   register: r_openshift_cnv_instances

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
@@ -141,7 +141,7 @@
       volumes: {{ _instance_volumes | replace('INSTANCENAME', _instance_name) }}
   kubernetes.core.k8s:
     definition:
-      apiVersion: v1
+      apiVersion: kubevirt.io/v1
       kind: VirtualMachine
       metadata:
         name: "{{ _instance_name }}"

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/start_instances.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/start_instances.yaml
@@ -1,6 +1,7 @@
 ---
 - name: Get a list of VMs
   kubernetes.core.k8s_info:
+    api_version: kubevirt.io/v1
     kind: VirtualMachine
     namespace: "{{ openshift_cnv_namespace }}"
   register: r_vm_list

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/status_instances.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/status_instances.yaml
@@ -1,6 +1,7 @@
 ---
 - name: Get a list of VMs
   kubernetes.core.k8s_info:
+    api_version: kubevirt.io/v1
     kind: VirtualMachine
     namespace: "{{ openshift_cnv_namespace }}"
   register: r_vm_list

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/stop_instances.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/stop_instances.yaml
@@ -1,6 +1,7 @@
 ---
 - name: Get a list of VMIs
   kubernetes.core.k8s_info:
+    api_version: kubevirt.io/v1
     kind: VirtualMachine
     namespace: "{{ openshift_cnv_namespace }}"
   register: r_vm_list

--- a/ansible/roles-infra/infra-vmc-resources/tasks/status_instances.yaml
+++ b/ansible/roles-infra/infra-vmc-resources/tasks/status_instances.yaml
@@ -1,7 +1,7 @@
 ---
-
 - name: Get a list of VMs
   k8s_info:
+    api_version: kubevirt.io/v1
     kind: VirtualMachine
     namespace: "{{ openshift_cnv_namespace }}"
   register: r_vm_list

--- a/ansible/roles-infra/infra-vmc-resources/tasks/status_instances.yaml
+++ b/ansible/roles-infra/infra-vmc-resources/tasks/status_instances.yaml
@@ -1,7 +1,6 @@
 ---
 - name: Get a list of VMs
   k8s_info:
-    api_version: kubevirt.io/v1
     kind: VirtualMachine
     namespace: "{{ openshift_cnv_namespace }}"
   register: r_vm_list

--- a/ansible/roles-infra/infra_vmware_ibm_resources/tasks/status_instances.yaml
+++ b/ansible/roles-infra/infra_vmware_ibm_resources/tasks/status_instances.yaml
@@ -1,7 +1,7 @@
 ---
-
 - name: Get a list of VMs
   k8s_info:
+    api_version: kubevirt.io/v1
     kind: VirtualMachine
     namespace: "{{ openshift_cnv_namespace }}"
   register: r_vm_list

--- a/ansible/roles-infra/infra_vmware_ibm_resources/tasks/status_instances.yaml
+++ b/ansible/roles-infra/infra_vmware_ibm_resources/tasks/status_instances.yaml
@@ -1,7 +1,6 @@
 ---
 - name: Get a list of VMs
   k8s_info:
-    api_version: kubevirt.io/v1
     kind: VirtualMachine
     namespace: "{{ openshift_cnv_namespace }}"
   register: r_vm_list

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_masters_etcd.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_masters_etcd.yaml
@@ -115,6 +115,7 @@
 
 - name: Wait till VM is running
   kubernetes.core.k8s_info:
+    api_version: kubevirt.io/v1
     host: "{{ sandbox_openshift_api_url }}"
     api_key: "{{ k8s_auth_results.k8s_auth.api_key|default(sandbox_openshift_api_key) }}"
     validate_certs: false

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_masters_etcd.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_masters_etcd.yaml
@@ -1,6 +1,7 @@
 ---
 - name: Create Master virtual machine
   kubevirt.core.kubevirt_vm:
+    api_version: kubevirt.io/v1
     host: "{{ sandbox_openshift_api_url }}"
     api_key: "{{ k8s_auth_results.k8s_auth.api_key|default(sandbox_openshift_api_key) }}"
     validate_certs: false

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_workers.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_workers.yaml
@@ -93,6 +93,7 @@
 
 - name: Wait till VM is running
   kubernetes.core.k8s_info:
+    api_version: kubevirt.io/v1
     host: "{{ sandbox_openshift_api_url }}"
     api_key: "{{ k8s_auth_results.k8s_auth.api_key|default(sandbox_openshift_api_key) }}"
     validate_certs: false

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_workers.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_workers.yaml
@@ -1,6 +1,7 @@
 ---
 - name: Create Worker virtual machine
   kubevirt.core.kubevirt_vm:
+    api_version: kubevirt.io/v1
     host: "{{ sandbox_openshift_api_url }}"
     api_key: "{{ k8s_auth_results.k8s_auth.api_key|default(sandbox_openshift_api_key) }}"
     validate_certs: false


### PR DESCRIPTION
##### SUMMARY

New OCP versions requires to specify kubevirt.io/v1 for the k8s and k8s_info  modules are throwing the following error: 

too many values to unpack (expected 2)

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
infra-openshift-cnv-resources  Role
infra-openshift-cnv-create-inventory Role
host-ocp4-assisted-installer Role



