### PR TITLE
[host-ocp4-hcp-cnv-install] Adding variable openshift_console_url to user data

### DIFF
--- a/ansible/roles/host-ocp4-hcp-cnv-install/tasks/setup_htpasswd_authentication.yml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/tasks/setup_htpasswd_authentication.yml
@@ -84,6 +84,7 @@
       user: "{{ hcp_user_base }}{{ n + 1 }}"
       password: "{{ hcp_user_passwords[ n ] }}"
       openshift_cluster_console_url: "{{ _hcp_console_url }}"
+      openshift_console_url: "{{ _hcp_console_url }}"
   loop: "{{ range(0, num_users | int) | list }}"
   loop_control:
     loop_var: n


### PR DESCRIPTION
##### SUMMARY

Some showroom instructions uses openshift_console_url instead openshift_cluster_console_url variable, this will cover more use cases

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
host-ocp4-hcp-cnv-install Role
