### PR TITLE
[host-ocp4-hcp-cnv-install] Increase delays/retries

### DIFF
--- a/ansible/roles/host-ocp4-hcp-cnv-install/tasks/print_cluster_info.yml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/tasks/print_cluster_info.yml
@@ -6,8 +6,8 @@
     name: console
     namespace: openshift-console
     kubeconfig: /home/{{ ansible_user }}/.kube/config
-  retries: 10
-  delay: 30
+  retries: 15
+  delay: 60
   until:
     - r_route_console.resources is defined
     - r_route_console.resources | length > 0


### PR DESCRIPTION


##### SUMMARY

Current values were optimistic values. On overreload cluster will take more than 5 minutes.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
host-ocp4-hcp-cnv-install Role
