### PR TITLE
Add shared ocp showroom to config base-infra

### DIFF
--- a/ansible/configs/base-infra/destroy_env.yml
+++ b/ansible/configs/base-infra/destroy_env.yml
@@ -14,5 +14,12 @@
     vars:
       ACTION: destroy
 
+  - name: Remove OpenShift Shared Showroom
+    when: showroom_deploy_shared_cluster_enable | default(false) | bool
+    vars:
+      ACTION: "destroy"
+    ansible.builtin.include_role:
+      name: ocp4_workload_showroom
+
 - name: Import default destroy playbook
   import_playbook: ../../cloud_providers/{{ cloud_provider }}_destroy_env.yml

--- a/ansible/configs/base-infra/post_software.yml
+++ b/ansible/configs/base-infra/post_software.yml
@@ -153,6 +153,11 @@
     - post_flight_check
   tasks:
 
+    - name: Deploy Showroom on shared cluster
+      when: showroom_deploy_shared_cluster_enable | default(false) | bool
+      include_role:
+        name: ocp4_workload_showroom
+
     - name: "Post-Software checks completed successfully"
       ansible.builtin.debug:
         msg: "Post-Software checks completed successfully"


### PR DESCRIPTION
##### SUMMARY

Allows config base-infra to used the shared OpenShift showroom role, and clean it up on destroy

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

configs/base-infra

##### ADDITIONAL INFORMATION
