### PR TITLE
Fix missing quotes in asset_injector role

### DIFF
--- a/ansible/roles/asset_injector/tasks/main.yml
+++ b/ansible/roles/asset_injector/tasks/main.yml
@@ -78,7 +78,7 @@
   ansible.builtin.unarchive:
     src: "{{ _asset.src }}"
     dest: "{{ _asset.dest }}"
-    remote_src: {{ _asset.remote_src | default(false) }}
+    remote_src: "{{ _asset.remote_src | default(false) }}"
   loop: "{{ asset_injector_assets }}"
   loop_control:
     loop_var: _asset


### PR DESCRIPTION
##### SUMMARY

Missing quotes around var broke role - how did the linters not pick this up

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

roles/asset_injector

##### ADDITIONAL INFORMATION
