### PR TITLE
[ocp4_workload_virt_roadshow_vms] Change database to use bios and not efi

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/templates/multi_user/vm_database.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/templates/multi_user/vm_database.yaml.j2
@@ -56,7 +56,7 @@ spec:
             enabled: true
         firmware:
           bootloader:
-            efi: {}
+            bios: {}
         machine:
           type: {{ ocp4_workload_virt_roadshow_vms_machine_type }}
         resources:

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/templates/single_user/vm_database.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/templates/single_user/vm_database.yaml.j2
@@ -55,7 +55,7 @@ spec:
             enabled: true
         firmware:
           bootloader:
-            efi: {}
+            bios: {}
         machine:
           type: {{ ocp4_workload_virt_roadshow_vms_machine_type }}
         resources:


### PR DESCRIPTION
##### SUMMARY

Database VM for roadshow is a image not using EFI

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_virt_roadshow_vms role

