### PR TITLE
Update ocp4_workload_virt_roadshow_vmware to use pool VMs

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/defaults/main.yml
@@ -3,6 +3,17 @@ become_override: false
 ocp_username: opentlc-mgr
 silent: false
 
+# Assign permission to precreated VMs instead to create new VMs
+# VMs are precreated as database-userX, winweb01-userX and winweb-userX
+# If this is enabled but the VM doesnt exist, it will create the VMs anyway
+ocp4_workload_virt_roadshow_vmware_use_pool: false
+
+# Folder where the pool VMs (described above) are located
+ocp4_workload_virt_roadshow_vmware_vcenter_pool_folder: "Roadshow"
+
+# Role to assign to the VMs in the pool
+ocp4_workload_virt_roadshow_vmware_vcenter_pool_role: "Sandbox User - Read-Only"
+
 # Enable/disable certificate validation on vCenter API
 ocp4_workload_virt_roadshow_vmware_enable_cert_validation: true
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/tasks/remove_workload.yml
@@ -3,8 +3,14 @@
 - name: Set up prerequisites
   ansible.builtin.include_tasks: vcenter_setup_prerequisites.yml
 
+# Even the ocp4_workload_virt_roadshow_vmware_use_pool is true, remove users just in case
+# The failsafe (Create VMs) happened during creation
 - name: Remove User(s)
   ansible.builtin.include_tasks: vcenter_remove_users.yml
+
+- name: Remove User(s) pool
+  ansible.builtin.include_tasks: vcenter_remove_pool_users.yml
+  when: ocp4_workload_virt_roadshow_vmware_use_pool | default(true) | bool
 
 - name: Single user VM and folder Remove
   when: ocp4_workload_virt_roadshow_vmware_num_users | int == 1

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/tasks/workload.yml
@@ -2,11 +2,18 @@
 - name: Set up prerequisites
   ansible.builtin.include_tasks: vcenter_setup_prerequisites.yml
 
-- name: Create folder and VMs in vCenter
-  ansible.builtin.include_tasks: vcenter_setup_vms.yml
+- name: Grant permissions to existing pool VMs or create the VMs if doesnt exist
+  when: ocp4_workload_virt_roadshow_vmware_use_pool | default(true) | bool
+  ansible.builtin.include_tasks: vcenter_setup_pool_users.yml
 
-- name: Create user(s) in AD and assign permissions on vSphere
-  ansible.builtin.include_tasks: vcenter_setup_users.yml
+- name: Create VMs and assign permissions (no pool)
+  when: not ocp4_workload_virt_roadshow_vmware_use_pool | default(true) | bool
+  block:
+  - name: Create folder and VMs in vCenter
+    ansible.builtin.include_tasks: vcenter_setup_vms.yml
+
+  - name: Create user(s) in AD and assign permissions on vSphere
+    ansible.builtin.include_tasks: vcenter_setup_users.yml
 
 - name: If desired, add vddk support and configure MTV
   when: ocp4_workload_virt_roadshow_vmware_enable_mtv | bool


### PR DESCRIPTION
##### SUMMARY

To speed up the deployment of OpenShift Virtualization Roadshow and similar ones, a list of precreated VMs exists now in the cluster to be used for the migration, only permission needs to be set.

To enable this feature, configure the variable **ocp4_workload_virt_roadshow_vmware_use_pool** to **true**

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
ocp4_workload_virt_roadshow_vmware  role

##### ADDITIONAL INFORMATION
The VMs are called database-userX, haproxy-userX, winweb01-userX and winweb02-userX, if the VM doesnt exist it will try to create it.