### PR TITLE
ocp4_workload_kasten_k10: fix kasten kind: k10s, not k10

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/tasks/workload.yml
@@ -29,12 +29,12 @@
   - name: Wait for K10 deployment to be completed
     kubernetes.core.k8s_info:
       api_version: apik10.kasten.io/v1alpha1
-      kind: K10
+      kind: k10s
       name: "{{ ocp4_workload_kasten_name }}"
       namespace: "{{ ocp4_workload_kasten_namespace }}"
       wait: true
       wait_sleep: 5
-      wait_timeout: 600
+      wait_timeout: 1200
       wait_condition:
         type: "Initialized"
         status: "True"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

Resource is actually `kind: k10s`