### PR TITLE
[host-ocp4-hcp-cnv-destroy] Increase times and tgnore errors to destroy HostedCluster

### DIFF
--- a/ansible/roles/host-ocp4-hcp-cnv-destroy/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-hcp-cnv-destroy/tasks/main.yaml
@@ -26,5 +26,6 @@
         wait_timeout: 1800
       register: r_remove_hostedcluster
       delay: 60
-      retries: 3
+      retries: 5
       until: r_remove_hostedcluster is success
+      ignore_errors: true


### PR DESCRIPTION
##### SUMMARY

Increase the retries to destroy a HostedCluster, if it fails we ignore errors as we want to continue with the destroy process. HostedClusters will be monitored, and if stays for long time destroying a manual action is required.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
host-ocp4-hcp-cnv-destroy Role
