### PR TITLE
S3 asset injector role for assets greater than CloudFront's 20GB limit

### DIFF
--- a/ansible/roles/s3_asset_injector/README.adoc
+++ b/ansible/roles/s3_asset_injector/README.adoc
@@ -1,0 +1,67 @@
+== s3_asset_injector
+
+Injects asset into host directly from S3 bucket ie no CloudFront. Useful if asset is > 20GB eg LLM tar archives etc
+
+=== Capabilities
+
+Copies a single S3 asset to a host. This is useful for large assets that are too big to be served by CloudFront.
+This could easily be extended to loop if need be
+
+=== Requirements
+
+N/A - these are basic ansible modules that should be available in any ansible installation.
+
+=== Role Variables
+
+See `defaults/main.yml` for the list of variables that can be overridden.
+
+----
+
+# Venv path
+
+s3_asset_injector_venv_path: /tmp/s3_venv
+
+# S3 asset data
+
+s3_asset_injector_bucket: ""
+s3_asset_injector_path: ""
+s3_asset_injector_dest: ""
+s3_asset_injector_mode: get
+
+# AWS auth
+
+s3_asset_injector_aws_access_key: "{{ s3_aws_access_key }}"
+s3_asset_injector_aws_secret_key: "{{ s3_aws_secret_key }}"
+s3_asset_injector_aws_region: "{{ aws_region }}"
+
+# Unarchive if tar archive
+
+s3_asset_injector_unarchive: false
+s3_asset_injector_unarchive_path: ""
+----
+
+=== Dependencies
+
+`boto3` python module on remote host, however this will be installed in a virtualenv on the remote host by the role
+
+=== Example Playbook
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+[source,yaml]
+----
+- hosts: servers
+  tasks:
+
+    - name: Inject assets
+      include_role:
+        name:s3_asset_injector
+----
+
+=== License
+
+BSD
+
+== Author Information
+
+tony kay tok@redhat.com

--- a/ansible/roles/s3_asset_injector/defaults/main.yml
+++ b/ansible/roles/s3_asset_injector/defaults/main.yml
@@ -1,0 +1,22 @@
+---
+# Venv path
+
+s3_asset_injector_venv_path: /tmp/s3_venv
+
+# S3 asset data
+
+s3_asset_injector_bucket: ""
+s3_asset_injector_path: ""
+s3_asset_injector_dest: ""
+s3_asset_injector_mode: get
+
+# AWS auth
+
+s3_asset_injector_aws_access_key: "{{ s3_aws_access_key }}"
+s3_asset_injector_aws_secret_key: "{{ s3_aws_secret_key }}"
+s3_asset_injector_aws_region: "{{ aws_region }}"
+
+# Unarchive if tar archive
+
+s3_asset_injector_unarchive: false
+s3_asset_injector_unarchive_path: ""

--- a/ansible/roles/s3_asset_injector/tasks/main.yml
+++ b/ansible/roles/s3_asset_injector/tasks/main.yml
@@ -1,0 +1,39 @@
+---
+
+- name: Ansible tmp venv as it needs boto3 on the target host(s)
+  block:
+
+    - name: Create Python virtual environment
+      ansible.builtin.command:
+        cmd: "/bin/python -m venv {{ s3_asset_injector_venv_path }}"
+        creates: "{{ s3_asset_injector_venv_path }}/bin/python"
+
+    - name: Install boto3 in the virtual environment
+      ansible.builtin.pip:
+        name: boto3
+        virtualenv: "{{ s3_asset_injector_venv_path }}"
+        state: present
+
+- name: Download asset
+  amazon.aws.aws_s3:
+    bucket: "{{ s3_asset_injector_bucket }}" #rhdp-private
+    object: "{{ s3_asset_injector_path }}"
+    dest: "{{ s3_asset_injector_dest }}"
+    mode: "{{ s3_asset_injector_mode | default('get') }}"
+    aws_access_key:  "{{ s3_asset_injector_aws_access_key }}"
+    aws_secret_key: "{{ s3_asset_injector_aws_secret_key }}"
+    region: "{{ s3_asset_injector_aws_region }}"
+  vars:
+    ansible_python_interpreter: "{{ s3_asset_injector_venv_path }}/bin/python"
+
+- name: If tar archive eg LLM models etc unarchive
+  when: s3_asset_injector_unarchive | bool
+  ansible.builtin.unarchive:
+    src: "{{ s3_asset_injector_dest }}"
+    dest: "{{ s3_asset_injector_unarchive_path }}"
+    remote_src: true
+
+- name: Remove tmp boto3 venv directory
+  ansible.builtin.file:
+    path: "{{ s3_asset_injector_venv_path }}"
+    state: absent


### PR DESCRIPTION
##### SUMMARY

Allows aws_s3 copies eg for large artifact copies where CloudFront can't be used

##### ISSUE TYPE

- New role Pull Request

##### COMPONENT NAME

roles/s3_asset_injector

##### ADDITIONAL INFORMATION
