### PR TITLE
Set defaults to null strings for AWS vars in s3_asset_injector

### DIFF
--- a/ansible/roles/s3_asset_injector/defaults/main.yml
+++ b/ansible/roles/s3_asset_injector/defaults/main.yml
@@ -12,9 +12,9 @@ s3_asset_injector_mode: get
 
 # AWS auth
 
-s3_asset_injector_aws_access_key: "{{ s3_aws_access_key }}"
-s3_asset_injector_aws_secret_key: "{{ s3_aws_secret_key }}"
-s3_asset_injector_aws_region: "{{ aws_region }}"
+s3_asset_injector_aws_access_key: "{{ s3_aws_access_key | default('') }}"
+s3_asset_injector_aws_secret_key: "{{ s3_aws_secret_key | default('') }}"
+s3_asset_injector_aws_region: "{{ aws_region | default('us-east-2') }}"
 
 # Unarchive if tar archive
 


### PR DESCRIPTION
##### SUMMARY

Set safe, empty, defaults for AWS vars in s3_asset_injector role

It avoids unnecessary errors if vars are not set

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME

roles/s3_asset_injector

##### ADDITIONAL INFORMATION
