### PR TITLE
[infra-openshift-cnv-resources] Default to BIOS instead UEFI

### DIFF
--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
@@ -116,6 +116,8 @@
       domain:
         firmware:
           uuid: "{{ 99999999 | random | to_uuid }}"
+          bootloader:
+            bios: {}
         cpu:
           cores: {{ _instance.cores }}
           model: host-passthrough


### PR DESCRIPTION
##### SUMMARY

On new cluster it sets default UEFI (Secure) as default, trying UEFI as well is making the boot really slow.

This PR is to specify we want to boot with legacy bios.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
infra-openshift-cnv-resources Role
