### PR TITLE
add passthrough data to user_data.users.userN

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/prepare-variables.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/prepare-variables.yaml
@@ -9,6 +9,17 @@
     quiet: true
     fail_msg: Required variables not defined
 
+- name: Set passthrough variables to per-user data, if desired
+  when:
+  - agnosticd_passthrough_user_data is defined
+  - ocp4_workload_showroom_passthrough_user_data is true | default(false) | bool
+  agnosticd_user_info:
+    data: "{{ agnosticd_passthrough_user_data | default('', true) }}"
+    user: "user{{ n }}"
+  loop: "{{ range(1, num_users | int + 1) | list }}"
+  loop_control:
+    loop_var: n
+
 - name: Set showroom_user_data fact from lookup - global value
   ansible.builtin.set_fact:
     _showroom_user_data: "{{ _showroom_user_data | combine(lookup('agnosticd_user_data', '*')) }}"


### PR DESCRIPTION
ocp-showroom enable passthrough data to individual users

change variable name

indent

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
