### PR TITLE
[host-ocp4-hcp-cnv-install] Wait more time for the cluster to be ready

### DIFF
--- a/ansible/roles/host-ocp4-hcp-cnv-install/tasks/print_cluster_info.yml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/tasks/print_cluster_info.yml
@@ -7,7 +7,7 @@
     namespace: openshift-console
     kubeconfig: /home/{{ ansible_user }}/.kube/config
   retries: 15
-  delay: 60
+  delay: 120
   until:
     - r_route_console.resources is defined
     - r_route_console.resources | length > 0


### PR DESCRIPTION
##### SUMMARY

Check every two minutes, 15 times, in total 30 minutes. Before we were just waiting 15 minutes, and in some overload clusters were not enough.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
host-ocp4-hcp-cnv-install Role

