### PR TITLE
[host-ocp4-hcp-cnv-install] Enable the option to disable default kubervirt csi

### DIFF
--- a/ansible/roles/host-ocp4-hcp-cnv-install/defaults/main.yaml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/defaults/main.yaml
@@ -22,3 +22,4 @@ hcp_worker_autoscale: false
 hcp_worker_instance_min_count: 3
 hcp_worker_instance_max_count: 5
 hcp_quay_api_url: "https://quay.io/api/v1/repository/openshift-release-dev/ocp-release/tag/?filter_tag_name=like:{{ hcp_cluster_version }}.%-x86_64&onlyActiveTags=true"
+hcp_disable_storage_class: false

--- a/ansible/roles/host-ocp4-hcp-cnv-install/templates/hostedcluster.yaml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/templates/hostedcluster.yaml
@@ -62,6 +62,10 @@ spec:
           key: kubeconfig
           name: hcp-{{ guid }}-infra-credentials
         infraNamespace: {{ namespace }}
+{% if hcp_disable_storage_class | default(False) %}
+      storageDriver:
+        type: None
+{% endif %}
     type: KubeVirt
   pullSecret:
     name: hcp-{{ guid }}-pull-secret


### PR DESCRIPTION
##### SUMMARY

External ODF has better performance / features than the kubevirt csi, this change allows to specify the variable **hcp_disable_storage_class** to true to disable configure it.

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
host-ocp4-hcp-cnv-install Role
