### PR TITLE
[host-ocp4-assisted-installer] Adjust mtu to 1500

### DIFF
--- a/ansible/roles/host-ocp4-assisted-installer/templates/net-attach-def.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/templates/net-attach-def.yaml
@@ -5,4 +5,4 @@ metadata:
   name: "{{ network_name }}"
   namespace: "{{ namespace }}"
 spec:
-  config: '{"cniVersion":"0.3.1","type":"ovn-k8s-cni-overlay","topology":"layer2","name": "{{ network_name }}", "netAttachDefName": "{{ namespace }}/{{ network_name }}"}'
+  config: '{"cniVersion":"0.3.1","type":"ovn-k8s-cni-overlay","topology":"layer2","name": "{{ network_name }}", "mtu": 1500, "netAttachDefName": "{{ namespace }}/{{ network_name }}"}'


### PR DESCRIPTION
##### SUMMARY

VM Live migration was really slow, the cause it is the default MTU set on the cluster (8800) has impact on it, setting to 1500 solves the issue.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
host-ocp4-assisted-installer role