### PR TITLE
[ocp4_workload_cert_manager] Create cert_manager_openshift_cnv.yml

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/cert_manager_openshift_cnv.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/cert_manager_openshift_cnv.yml
@@ -1,0 +1,31 @@
+---
+- name: Use provided HostedZoneID
+  when: ocp4_workload_cert_manager_ec2_hostedzoneid | default("") | length > 0
+  ansible.builtin.set_fact:
+    _ocp4_workload_cert_manager_hostedzoneid: >-
+      {{ ocp4_workload_cert_manager_ec2_hostedzoneid }}
+
+- name: Determine HostedZoneID
+  when: ocp4_workload_cert_manager_ec2_hostedzoneid | default("") | length == 0
+  block:
+  - name: Get HostedZoneID
+    kubernetes.core.k8s_info:
+      api_version: config.openshift.io/v1
+      kind: DNS
+      name: cluster
+    register: r_hostedzoneid
+
+  - name: Set HostedZoneID fact
+    ansible.builtin.set_fact:
+      _ocp4_workload_cert_manager_hostedzoneid: >-
+        {{ r_hostedzoneid.resources[0].spec.publicZone.id }}
+
+- name: Print HostedZoneID
+  ansible.builtin.debug:
+    msg: >-
+      HostedZoneID: {{ _ocp4_workload_cert_manager_hostedzoneid }}
+
+- name: Create AWS credentials secret for cert manager
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('template', 'secret-aws-credentials.yaml.j2') }}"


### PR DESCRIPTION
##### SUMMARY

Openshift CNV uses EC2 as default DNS provider

To avoid confusion about cloud provider variable, we clone the ec2 file to openshift_cnv

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
ocp4_workload_cert_manager role
