### PR TITLE
[ocp4_workload_cert_manager] Add default ocp4_workload_cert_manager_ec2_hostedzoneid

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/defaults/main.yml
@@ -50,7 +50,7 @@ ocp4_workload_cert_manager_zerossl_hmac_key: ""
 ocp4_workload_cert_manager_ec2_region: "{{ aws_region }}"
 ocp4_workload_cert_manager_ec2_access_key_id: "{{ hostvars.localhost.route53user_access_key }}"
 ocp4_workload_cert_manager_ec2_secret_access_key: "{{ hostvars.localhost.route53user_secret_access_key }}"
-ocp4_workload_cert_manager_ec2_hostedzoneid: "{{ route53_aws_zone_id }}"
+ocp4_workload_cert_manager_ec2_hostedzoneid: "{{ hostvars.localhost.route53_aws_zone_id }}"
 
 # If a HostedZoneID is provided use that one, otherwise determine dynamically
 ocp4_workload_cert_manager_ec2_hostedzoneid: ""

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/defaults/main.yml
@@ -53,7 +53,7 @@ ocp4_workload_cert_manager_ec2_secret_access_key: "{{ hostvars.localhost.route53
 ocp4_workload_cert_manager_ec2_hostedzoneid: "{{ hostvars.localhost.route53_aws_zone_id }}"
 
 # If a HostedZoneID is provided use that one, otherwise determine dynamically
-ocp4_workload_cert_manager_ec2_hostedzoneid: ""
+#ocp4_workload_cert_manager_ec2_hostedzoneid: ""
 
 # ---------------------------------------------------------------
 # Settings for GCP

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/defaults/main.yml
@@ -50,6 +50,7 @@ ocp4_workload_cert_manager_zerossl_hmac_key: ""
 ocp4_workload_cert_manager_ec2_region: "{{ aws_region }}"
 ocp4_workload_cert_manager_ec2_access_key_id: "{{ hostvars.localhost.route53user_access_key }}"
 ocp4_workload_cert_manager_ec2_secret_access_key: "{{ hostvars.localhost.route53user_secret_access_key }}"
+ocp4_workload_cert_manager_ec2_hostedzoneid: "{{ route53_aws_zone_id }}"
 
 # If a HostedZoneID is provided use that one, otherwise determine dynamically
 ocp4_workload_cert_manager_ec2_hostedzoneid: ""

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/defaults/main.yml
@@ -50,7 +50,7 @@ ocp4_workload_cert_manager_zerossl_hmac_key: ""
 ocp4_workload_cert_manager_ec2_region: "{{ aws_region }}"
 ocp4_workload_cert_manager_ec2_access_key_id: "{{ hostvars.localhost.route53user_access_key }}"
 ocp4_workload_cert_manager_ec2_secret_access_key: "{{ hostvars.localhost.route53user_secret_access_key }}"
-ocp4_workload_cert_manager_ec2_hostedzoneid: "{{ hostvars.localhost.route53_aws_zone_id }}"
+ocp4_workload_cert_manager_ec2_hostedzoneid: "{{ hostvars.localhost.route53_aws_zone_id | default ('') }}"
 
 # If a HostedZoneID is provided use that one, otherwise determine dynamically
 #ocp4_workload_cert_manager_ec2_hostedzoneid: ""


### PR DESCRIPTION
##### SUMMARY

Adding the default **ocp4_workload_cert_manager_ec2_hostedzoneid** to point to the variable **route53_aws_zone_id**

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
Role ocp4_workload_cert_manager

