### PR TITLE
Fix openshift gitops kustomize plugin

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/defaults/main.yml
@@ -44,6 +44,9 @@ ocp4_workload_openshift_gitops_update_route_tls: false
 # What is written below are the defaults as of GitOps 1.6.1
 # Set to true only the component that you want to update
 
+ocp4_workload_openshift_gitops_kustomize_plugin: false
+ocp4_workload_openshift_gitops_kustomize_plugin_image: registry.access.redhat.com/ubi9/perl-532:latest
+
 # ApplicationSet Controller
 ocp4_workload_openshift_gitops_applicationset_controller_update: false
 ocp4_workload_openshift_gitops_applicationset_controller_requests_cpu: 250m

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/files/cm-kustomize-envvar.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/files/cm-kustomize-envvar.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kustomize-envvar
+  namespace: openshift-gitops
+data:
+  plugin.yaml: |
+    apiVersion: argoproj.io/v1alpha1
+    kind: ConfigManagementPlugin
+    metadata:
+      name: kustomize-envvar
+    spec:
+      generate:
+        command: ["sh", "-c"]
+        args: ["kustomize build --enable-helm . | perl -pe 's{\\$(\\{)?(\\w+)(?(1)\\})}{$ENV{$2} // $&}ge'"]

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/workload.yml
@@ -54,6 +54,12 @@
   - r_openshift_gitops.resources is defined
   - r_openshift_gitops.resources | length == 1
 
+- name: Create the kustomize-envvar plugin configmap
+  when: ocp4_workload_openshift_gitops_kustomize_plugin | bool
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('file', 'cm-kustomize-envvar.yaml') | from_yaml }}"
+
 - name: Update the openshift-gitops ArgoCD instance
   kubernetes.core.k8s:
     state: patched

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/templates/openshift-gitops.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/templates/openshift-gitops.yaml.j2
@@ -5,11 +5,6 @@ metadata:
   name: openshift-gitops
   namespace: openshift-gitops
 spec:
-  configManagementPlugins: |-
-    - name: kustomize-envvar
-      generate:
-        command: ["sh", "-c"]
-        args: ["kustomize build --enable-helm . | perl -pe 's{\\$(\\{)?(\\w+)(?(1)\\})}{$ENV{$2} // $&}ge'"]
   kustomizeBuildOptions: "--enable-helm --enable-alpha-plugins"
 {% if ocp4_workload_openshift_gitops_rbac_update | default(false) | bool %}
   rbac:
@@ -62,6 +57,28 @@ spec:
     env:
     - name: SUB_DOMAIN
       value: {{ _ocp4_workload_openshift_gitops_domain }}
+{% if ocp4_workload_openshift_gitops_kustomize_plugin | default(false) | bool %}
+    sidecarContainers:
+      - name: cmp
+        command: [/var/run/argocd/argocd-cmp-server]
+        image: {{ ocp4_workload_openshift_gitops_kustomize_plugin_image }}
+        securityContext:
+          runAsNonRoot: true
+        volumeMounts:
+          - mountPath: /var/run/argocd
+            name: var-files
+          - mountPath: /home/argocd/cmp-server/plugins
+            name: plugins
+          - mountPath: /tmp
+            name: tmp
+          - mountPath: /home/argocd/cmp-server/config/plugin.yaml
+            subPath: plugin.yaml
+            name: kustomize-envvar
+    volumes:
+      - configMap:
+          name: kustomize-envvar
+        name: kustomize-envvar
+{% endif %}
 {% if ocp4_workload_openshift_gitops_repo_update | default(false) | bool %}
     resources:
       limits:

--- a/tools/runner/README.md
+++ b/tools/runner/README.md
@@ -69,7 +69,6 @@ ocp4_workload_openshift_gitops_catalog_snapshot_image: quay.io/gpte-devops-autom
 ocp4_workload_openshift_gitops_catalog_snapshot_image_tag: v4.13_2023_06_26
 
 ocp4_workload_openshift_gitops_setup_cluster_admin: true
-ocp4_workload_openshift_gitops_update_resources: true
 ocp4_workload_openshift_gitops_update_route_tls: true
 
 ocp4_workload_openshift_gitops_rbac_update: true


### PR DESCRIPTION
Since ArgoCD 2.8, configManagementPlugins no longer works, and the sidecar approach is now required.​