### PR TITLE
[ocp4_workload_cert_manager] Defaults to ec2 as cloud_provider

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/defaults/main.yml
@@ -27,7 +27,7 @@ ocp4_workload_cert_manager_wait_for_rollout: false
 # Set to the cloud provider to be used:
 # Valid values are: ec2, azure, gcp, osp, vmc
 # NOTE: Right now only ec2 and gcp are implemented
-ocp4_workload_cert_manager_cloud_provider: "{{ cloud_provider }}"
+ocp4_workload_cert_manager_cloud_provider: "{{ cloud_provider if cloud_provider in ['ec2', 'gcp'] else 'ec2' }}"
 
 # Set to either letsencrypt or zerossl
 ocp4_workload_cert_manager_provider: letsencrypt


### PR DESCRIPTION
##### SUMMARY

Currently only ec2 and gcp are supported.

Platforms we use (equinix, vmware, cnv) are using ec2, so setting as a default

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME
ocp4_workload_cert_manager Role
