### PR TITLE
[host-ocp4-assisted-installer] Add limits to the VMs

### DIFF
--- a/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_masters_etcd.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_masters_etcd.yaml
@@ -87,6 +87,8 @@
         resources:
           requests:
             memory: "{{ ai_control_plane_memory }}"
+          limits:
+            memory: "{{ ai_control_plane_memory }}"
       readinessProbe:
         httpGet:
           path: /healthz

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_workers.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_workers.yaml
@@ -69,6 +69,8 @@
         resources:
           requests:
             memory: "{{ ai_workers_memory }}"
+          limits:
+            memory: "{{ ai_workers_memory }}"
       readinessProbe:
         tcpSocket:
           port: 80


### PR DESCRIPTION
##### SUMMARY

With quota enabled by default in the clusters, it is required to specify the limit as well

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
host-ocp4-assisted-installer role