### PR TITLE
[infra-openshift-cnv-resources] Add proper apiVersion to NaD

### DIFF
--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
@@ -2,7 +2,7 @@
 - name: Create network {{ _network.name }}
   kubernetes.core.k8s:
     definition:
-      apiVersion: v1
+      apiVersion: k8s.cni.cncf.io/v1
       kind: NetworkAttachmentDefinition
       metadata:
         name: "{{ _network.name }}{{ guid }}"


### PR DESCRIPTION
##### SUMMARY

OCP 4.16 requires to be strict with the apiVersion

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
infra-openshift-cnv-resources role

