### PR TITLE
Adding NovaNoVNC config

### DIFF
--- a/ansible/configs/osp-on-ocp/post_software.yml
+++ b/ansible/configs/osp-on-ocp/post_software.yml
@@ -165,6 +165,7 @@
           192.168.123.11 console-openshift-console.apps.ocp.example.com
           192.168.123.11 oauth-openshift.apps.ocp.example.com
           192.168.123.11 zzzzz.apps.ocp.example.com
+          192.168.123.11 nova-novncproxy-cell1-public-openstack.apps.ocp.example.com
 
 - name: Print informations
   hosts: localhost

--- a/ansible/configs/osp-on-ocp/templates/httpd/ssl.conf
+++ b/ansible/configs/osp-on-ocp/templates/httpd/ssl.conf
@@ -68,6 +68,36 @@ Header edit Location "apps.ocp.example.com/auth/callback" "apps.{{ guid }}.{{ cl
 
 <VirtualHost *:443>
 
+ServerName nova-novncproxy-cell1-public-openstack.apps.{{ guid }}.{{ cluster_dns_zone }}
+LogLevel warn
+SSLEngine on
+SSLHonorCipherOrder on
+SSLCipherSuite PROFILE=SYSTEM
+SSLProxyCipherSuite PROFILE=SYSTEM
+SSLCertificateFile /root/certbot/config/live/api.{{ guid }}.{{ cluster_dns_zone }}/fullchain.pem
+SSLCertificateKeyFile /root/certbot/config/live/api.{{ guid }}.{{ cluster_dns_zone }}/privkey.pem
+
+ProxyRequests off
+ProxyVia on
+ProxyPreserveHost On
+ProxyTimeout 300
+
+ProxyPass /  https://nova-novncproxy-cell1-public-openstack.apps.ocp.example.com/
+ProxyPassReverse /  https://nova-novncproxy-cell1-public-openstack.apps.ocp.example.com/
+
+SSLProxyEngine on
+SSLProxyVerify none
+SSLProxyCheckPeerCN off
+SSLProxyCheckPeerName off
+RewriteEngine On
+RewriteCond %{HTTP:Connection} upgrade [NC]
+RewriteCond %{HTTP:Upgrade} websocket [NC]
+RewriteRule /(.*)  wss://nova-novncproxy-cell1-public-openstack.apps.ocp.example.com/$1 [P,L]
+
+</VirtualHost>
+
+<VirtualHost *:443>
+
 ServerAlias *.apps.{{ guid }}.{{ cluster_dns_zone }}
 ErrorLog logs/ssl_apps_error_log
 TransferLog logs/ssl_app_access_log


### PR DESCRIPTION
Adds a httpd virtualhost enabling the Nova-NoVNC console to work from within the Openstack deployment. 

This requires a websocket upgrade that isn't in the existing wildcard virtual host. 