### PR TITLE
[ocp4_machineset_config] Update machineset-group-aws.yml

### DIFF
--- a/ansible/roles/ocp4_machineset_config/tasks/machineset-group-aws.yml
+++ b/ansible/roles/ocp4_machineset_config/tasks/machineset-group-aws.yml
@@ -85,4 +85,4 @@
       ) | int }}
   when:
     - machineset_group.autoscale | default(false) | bool
-    - machineset_group.total_replicas_max > 0
+    - machineset_group.total_replicas_max | int > 0


### PR DESCRIPTION
SUMMARY
We can define the machineset dynamically, sometimes to disable a machineset we set the maxreplicas to 0

This PR skips the task if the max replicas is 0

AgnosticV reference: https://github.com/rhpds/agnosticv/blob/4168516a7c805fa4eab6f67fac1e44a50f9b4117/sandboxes-gpte/CLOUD_NATIVE_ROBOT/common.yaml#L267
Parameter: https://github.com/rhpds/agnosticv/blob/4168516a7c805fa4eab6f67fac1e44a50f9b4117/sandboxes-gpte/CLOUD_NATIVE_ROBOT/common.yaml#L375

ISSUE TYPE
Feature Pull Request
COMPONENT NAME
ocp4_machineset_config role