### PR TITLE
Add ocp4_workload_authentication_htpasswd_user workload

### DIFF
--- a/ansible/roles/host-ocp4-set-facts/tasks/main.yml
+++ b/ansible/roles/host-ocp4-set-facts/tasks/main.yml
@@ -62,13 +62,16 @@
     openshift_api_url: >-
       https://api.{{ openshift_cluster_ingress_domain | regex_replace('^apps\.') }}:6443
 
-- name: Get openshift-console console route
+- name: Get current OpenShift user
   kubernetes.core.k8s_info:
     api_version: user.openshift.io/v1
     kind: User
     name: '~'
   register: r_openshift_user
   failed_when: r_openshift_user.resources | length != 1
+  until: r_openshift_user is successful
+  retries: 10
+  delay: 3
 
 - name: Set ocp_username
   ansible.builtin.set_fact:

--- a/ansible/roles_ocp_workloads/ocp4_workload_authentication_htpasswd_user/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_authentication_htpasswd_user/defaults/main.yml
@@ -1,0 +1,18 @@
+---
+become_override: false
+ocp_username: "system:admin"
+silent: false
+
+ocp4_workload_authentication_htpasswd_user_name: user-{{ guid }}
+
+# If no password is provided a common random password will be generated
+#ocp4_workload_authentication_htpasswd_user_password: ""
+# Length of generated password
+ocp4_workload_authentication_htpasswd_user_password_length: 16
+
+# Control number of attempts to add user to htpasswd
+ocp4_workload_authentication_htpasswd_user_attempts: 10
+
+# Controls for agnosticd_user_info
+ocp4_workload_authentication_htpasswd_user_enable_data: true
+ocp4_workload_authentication_htpasswd_user_enable_messsages: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_authentication_htpasswd_user/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_authentication_htpasswd_user/defaults/main.yml
@@ -8,7 +8,7 @@ ocp4_workload_authentication_htpasswd_user_name: user-{{ guid }}
 # If no password is provided a common random password will be generated
 #ocp4_workload_authentication_htpasswd_user_password: ""
 # Length of generated password
-ocp4_workload_authentication_htpasswd_user_password_length: 16
+ocp4_workload_authentication_htpasswd_user_password_length: 8
 
 # Control number of attempts to add user to htpasswd
 ocp4_workload_authentication_htpasswd_user_attempts: 10

--- a/ansible/roles_ocp_workloads/ocp4_workload_authentication_htpasswd_user/meta/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_authentication_htpasswd_user/meta/main.yml
@@ -1,0 +1,13 @@
+---
+galaxy_info:
+  role_name: ocp4_workload_authentication_htpasswd_user
+  author: Johnathan Kupferer <jkupfere@redhat.com>
+  description: |
+    Configure a user within OpenShift OAuth htpasswd file.
+  license: MIT
+  min_ansible_version: 2.9
+  platforms: []
+  galaxy_tags:
+  - ocp
+  - openshift
+dependencies: []

--- a/ansible/roles_ocp_workloads/ocp4_workload_authentication_htpasswd_user/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_authentication_htpasswd_user/readme.adoc
@@ -1,0 +1,74 @@
+= ocp4_workload_authentication_htpasswd_user - Add user to OpenShift htpasswd authentication
+
+This workload adds a single user to an existing OpenShift htpasswd oauth secret.
+
+== Role overview
+
+* This role enables authentication on an OpenShift 4 Cluster. It consists of the following tasks files:
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+ environment for the workload deployment.
+*** Debug task will print out: `pre_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to configure authentication
+*** Debug task will print out: `workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+ configure the workload after deployment
+*** This role doesn't do anything here
+*** Debug task will print out: `post_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+ delete the workload
+*** This role removes authentication from OCP 4. This role does *not* recreate the kubeadmin user - the only way to use OpenShift after removing the workload is via the `system:admin` user from the bastion VM.
+*** Debug task will print out: `remove_workload Tasks completed successfully.`
+
+== Review the defaults variable file
+
+* This file link:./defaults/main.yml[./defaults/main.yml] contains all the variables you need to define to control the deployment of your workload.
+* The variable *ocp_username* is mandatory to assign the workload to the correct OpenShift user.
+* A variable *silent=True* can be passed to suppress debug messages.
+* You can modify any of these default values by adding `-e "variable_name=variable_value"` to the command line
+
+=== Deploy the Workload with the `ocp-workloads` config
+
+----
+TARGET_HOST="bastion.gbhxg.sandbox379.opentlc.com"
+GUID=abcde
+OCP_USERNAME="user-${GUID}"
+WORKLOAD="ocp4_workload_authentication_htpasswd_user"
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, main.yml \
+    -e"env_type=ocp-workloads" \
+    -e"cloud_provider=none" \
+    -e"software_to_deploy=none" \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=ec2-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"silent=False" \
+    -e"guid=${GUID}" \
+    -e"ACTION=provision"
+----
+
+=== Remove user with using `ocp-workloads` config
+
+----
+TARGET_HOST="bastion.gbhxg.sandbox379.opentlc.com"
+GUID=abcde
+OCP_USERNAME="user-${GUID}"
+WORKLOAD="ocp4_workload_authentication_htpasswd_user"
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, main.yml \
+    -e"env_type=ocp-workloads" \
+    -e"cloud_provider=none" \
+    -e"software_to_deploy=none" \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=ec2-user" \
+    -e"ocp_username=${OCP_USERNAME}" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"silent=False" \
+    -e"guid=${GUID}" \
+    -e"ACTION=delete"
+----

--- a/ansible/roles_ocp_workloads/ocp4_workload_authentication_htpasswd_user/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_authentication_htpasswd_user/readme.adoc
@@ -1,74 +1,16 @@
 = ocp4_workload_authentication_htpasswd_user - Add user to OpenShift htpasswd authentication
 
-This workload adds a single user to an existing OpenShift htpasswd oauth secret.
-
 == Role overview
 
-* This role enables authentication on an OpenShift 4 Cluster. It consists of the following tasks files:
-** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
- environment for the workload deployment.
-*** Debug task will print out: `pre_workload Tasks completed successfully.`
+This workload adds a single user to an existing OpenShift htpasswd oauth secret.
 
-** Tasks: link:./tasks/workload.yml[workload.yml] - Used to configure authentication
-*** Debug task will print out: `workload Tasks completed successfully.`
-
-** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
- configure the workload after deployment
-*** This role doesn't do anything here
-*** Debug task will print out: `post_workload Tasks completed successfully.`
-
-** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
- delete the workload
-*** This role removes authentication from OCP 4. This role does *not* recreate the kubeadmin user - the only way to use OpenShift after removing the workload is via the `system:admin` user from the bastion VM.
-*** Debug task will print out: `remove_workload Tasks completed successfully.`
+The provisioning infrastructure will set a variable `ACTION` to be either `provision` or `destroy` depending on the operation.
 
 == Review the defaults variable file
 
-* This file link:./defaults/main.yml[./defaults/main.yml] contains all the variables you need to define to control the deployment of your workload.
-* The variable *ocp_username* is mandatory to assign the workload to the correct OpenShift user.
-* A variable *silent=True* can be passed to suppress debug messages.
-* You can modify any of these default values by adding `-e "variable_name=variable_value"` to the command line
-
-=== Deploy the Workload with the `ocp-workloads` config
-
-----
-TARGET_HOST="bastion.gbhxg.sandbox379.opentlc.com"
-GUID=abcde
-OCP_USERNAME="user-${GUID}"
-WORKLOAD="ocp4_workload_authentication_htpasswd_user"
-
-# a TARGET_HOST is specified in the command line, without using an inventory file
-ansible-playbook -i ${TARGET_HOST}, main.yml \
-    -e"env_type=ocp-workloads" \
-    -e"cloud_provider=none" \
-    -e"software_to_deploy=none" \
-    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
-    -e"ansible_user=ec2-user" \
-    -e"ocp_username=${OCP_USERNAME}" \
-    -e"ocp_workload=${WORKLOAD}" \
-    -e"silent=False" \
-    -e"guid=${GUID}" \
-    -e"ACTION=provision"
-----
-
-=== Remove user with using `ocp-workloads` config
-
-----
-TARGET_HOST="bastion.gbhxg.sandbox379.opentlc.com"
-GUID=abcde
-OCP_USERNAME="user-${GUID}"
-WORKLOAD="ocp4_workload_authentication_htpasswd_user"
-
-# a TARGET_HOST is specified in the command line, without using an inventory file
-ansible-playbook -i ${TARGET_HOST}, main.yml \
-    -e"env_type=ocp-workloads" \
-    -e"cloud_provider=none" \
-    -e"software_to_deploy=none" \
-    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
-    -e"ansible_user=ec2-user" \
-    -e"ocp_username=${OCP_USERNAME}" \
-    -e"ocp_workload=${WORKLOAD}" \
-    -e"silent=False" \
-    -e"guid=${GUID}" \
-    -e"ACTION=delete"
-----
+* This file link:./defaults/main.yml[./defaults/main.yml] configures this workload.
+** `ocp4_workload_authentication_htpasswd_user_name` is the user name to add and defaults to `user-{{ guid }}`.
+** `ocp4_workload_authentication_htpasswd_user_password` allows password to be configured. If omitted then a password will be dynamically generated.
+** `ocp4_workload_authentication_htpasswd_user_password_length` configures length of generated password.
+** `ocp4_workload_authentication_htpasswd_user_enable_data` enable reporting user data for user name and password.
+** `ocp4_workload_authentication_htpasswd_user_enable_messages` enable reporting user messages for user name and password.

--- a/ansible/roles_ocp_workloads/ocp4_workload_authentication_htpasswd_user/tasks/add_user_to_htpasswd_secret.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_authentication_htpasswd_user/tasks/add_user_to_htpasswd_secret.yml
@@ -9,7 +9,7 @@
   failed_when: >-
     r_get_htpasswd_secret is failed or
     r_get_htpasswd_secret.resources | length != 1
-  
+
 - name: Add user to htpasswd secret with retries
   block:
   # If secret metadata.resourceVersion has changed then this will fail and retry.

--- a/ansible/roles_ocp_workloads/ocp4_workload_authentication_htpasswd_user/tasks/add_user_to_htpasswd_secret.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_authentication_htpasswd_user/tasks/add_user_to_htpasswd_secret.yml
@@ -1,0 +1,53 @@
+---
+- name: Get htpasswd secret
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    name: "{{ ocp4_workload_authentication_htpasswd_secret }}"
+    namespace: openshift-config
+  register: r_get_htpasswd_secret
+  failed_when: >-
+    r_get_htpasswd_secret is failed or
+    r_get_htpasswd_secret.resources | length != 1
+  
+- name: Add user to htpasswd secret with retries
+  block:
+  # If secret metadata.resourceVersion has changed then this will fail and retry.
+  # This protects against race conditions.
+  - name: Attempt to add user to htpasswd secret
+    vars:
+      __secret: >-
+        {{ r_get_htpasswd_secret.resources[0] }}
+      __htpasswd_content: |
+        {% for __line in
+           (__secret.data.htpasswd | ansible.builtin.b64decode).splitlines()
+           | json_query('[?!starts_with(@,`' ~ (ocp4_workload_authentication_htpasswd_user_name ~ ':') | to_json ~ '`)]')
+        %}
+        {{ __line }}
+        {% endfor %}
+        {{ __htpasswd_line }}
+    kubernetes.core.k8s:
+      definition: >-
+        {{
+          __secret | combine({
+            "data": {
+              "htpasswd": __htpasswd_content | ansible.builtin.b64encode
+            }
+          })
+        }}
+
+  rescue:
+  - name: Fail if attempts exhausted
+    when: >-
+      __ocp4_workload_authentication_htpasswd_user_attempt | int >= ocp4_workload_authentication_htpasswd_user_attempts
+    fail:
+      msg: Attempts exhausted to add user to htpasswd secret
+
+  - name: Increment __ocp4_workload_authentication_htpasswd_user_attempt
+    ansible.builtin.set_fact:
+      __ocp4_workload_authentication_htpasswd_user_attempt: >-
+        {{ __ocp4_workload_authentication_htpasswd_user_attempt | int + 1 }}
+
+  - name: Retry add user to htpasswd secret
+    ansible.builtin.include_tasks:
+      file: add_user_to_htpasswd_secret.yml

--- a/ansible/roles_ocp_workloads/ocp4_workload_authentication_htpasswd_user/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_authentication_htpasswd_user/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: Running Pre Workload Tasks
+  ansible.builtin.include_tasks:
+    file: pre_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+
+- name: Running Workload Tasks
+  when: ACTION == "provision"
+  ansible.builtin.include_tasks:
+    file: workload.yml
+    apply:
+      become: "{{ become_override | bool }}"
+
+- name: Running Workload removal Tasks
+  when: ACTION == "destroy"
+  ansible.builtin.include_tasks:
+    file: remove_workload.yml
+    apply:
+      become: "{{ become_override | bool }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_authentication_htpasswd_user/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_authentication_htpasswd_user/tasks/pre_workload.yml
@@ -1,0 +1,19 @@
+---
+- name: Get oauth configuration
+  kubernetes.core.k8s_info:
+    api_version: config.openshift.io/v1
+    kind: OAuth
+    name: cluster
+  register: r_oauth_cluster
+
+- name: Set ocp4_workload_authentication_htpasswd_secret
+  ansible.builtin.set_fact:
+    ocp4_workload_authentication_htpasswd_secret: >-
+      {{ r_oauth_cluster.resources[0]
+       | json_query("spec.identityProviders[?type=='HTPasswd']|[0].htpasswd.fileData.name")
+      }}
+
+- name: pre_workload tasks complete
+  when: not silent | bool
+  ansible.builtin.debug:
+    msg: "Pre-Workload tasks completed successfully."

--- a/ansible/roles_ocp_workloads/ocp4_workload_authentication_htpasswd_user/tasks/remove_user_from_htpasswd_secret.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_authentication_htpasswd_user/tasks/remove_user_from_htpasswd_secret.yml
@@ -1,0 +1,52 @@
+---
+- name: Get htpasswd secret
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    name: "{{ ocp4_workload_authentication_htpasswd_secret }}"
+    namespace: openshift-config
+  register: r_get_htpasswd_secret
+  failed_when: >-
+    r_get_htpasswd_secret is failed or
+    r_get_htpasswd_secret.resources | length != 1
+  
+- name: Remove user from htpasswd secret with retries
+  block:
+  # If secret metadata.resourceVersion has changed then this will fail and retry.
+  # This protects against race conditions.
+  - name: Attempt to remove user from htpasswd secret
+    vars:
+      __secret: >-
+        {{ r_get_htpasswd_secret.resources[0] }}
+      __htpasswd_content: |
+        {% for __line in
+           (__secret.data.htpasswd | ansible.builtin.b64decode).splitlines()
+           | json_query('[?!starts_with(@,`' ~ (ocp4_workload_authentication_htpasswd_user_name ~ ':') | to_json ~ '`)]')
+        %}
+        {{ __line }}
+        {% endfor %}
+    kubernetes.core.k8s:
+      definition: >-
+        {{
+          __secret | combine({
+            "data": {
+              "htpasswd": __htpasswd_content | ansible.builtin.b64encode
+            }
+          })
+        }}
+
+  rescue:
+  - name: Fail if attempts exhausted
+    when: >-
+      __ocp4_workload_authentication_htpasswd_user_attempt | int >= ocp4_workload_authentication_htpasswd_user_attempts
+    fail:
+      msg: Attempts exhausted to remove user from htpasswd secret
+
+  - name: Increment __ocp4_workload_authentication_htpasswd_user_attempt
+    ansible.builtin.set_fact:
+      __ocp4_workload_authentication_htpasswd_user_attempt: >-
+        {{ __ocp4_workload_authentication_htpasswd_user_attempt | int + 1 }}
+
+  - name: Retry remove user from htpasswd secret
+    ansible.builtin.include_tasks:
+      file: remove_user_from_htpasswd_secret.yml

--- a/ansible/roles_ocp_workloads/ocp4_workload_authentication_htpasswd_user/tasks/remove_user_from_htpasswd_secret.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_authentication_htpasswd_user/tasks/remove_user_from_htpasswd_secret.yml
@@ -9,7 +9,7 @@
   failed_when: >-
     r_get_htpasswd_secret is failed or
     r_get_htpasswd_secret.resources | length != 1
-  
+
 - name: Remove user from htpasswd secret with retries
   block:
   # If secret metadata.resourceVersion has changed then this will fail and retry.

--- a/ansible/roles_ocp_workloads/ocp4_workload_authentication_htpasswd_user/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_authentication_htpasswd_user/tasks/remove_workload.yml
@@ -1,0 +1,14 @@
+---
+- name: Initialize retry attempt fact
+  ansible.builtin.set_fact:
+    __ocp4_workload_authentication_htpasswd_user_attempt: 1
+
+- name: Remove user from htpasswd secret
+  ansible.builtin.include_tasks:
+    file: remove_user_from_htpasswd_secret.yml
+
+# Leave this as the last task in the playbook.
+- name: remove_workload tasks complete
+  when: not silent | bool
+  ansible.builtin.debug:
+    msg: "Remove Workload tasks completed successfully."

--- a/ansible/roles_ocp_workloads/ocp4_workload_authentication_htpasswd_user/tasks/setup_htpasswd.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_authentication_htpasswd_user/tasks/setup_htpasswd.yml
@@ -1,0 +1,200 @@
+- name: Generate cluster admin password
+  when: ocp4_workload_authentication_htpasswd_admin_password | default('') | length == 0
+  ansible.builtin.set_fact:
+    _ocp4_workload_authentication_admin_password: >-
+      {{ lookup('password', '/dev/null chars=ascii_letters,digits '
+          ~ 'length=' ~ ocp4_workload_authentication_htpasswd_admin_password_length
+      ) }}
+
+- name: Use provided admin password
+  when: ocp4_workload_authentication_htpasswd_admin_password | default('') | length > 0
+  ansible.builtin.set_fact:
+    _ocp4_workload_authentication_admin_password: >-
+      {{ ocp4_workload_authentication_htpasswd_admin_password }}
+
+- name: Set up randomized user password array
+  when: ocp4_workload_authentication_htpasswd_user_password_randomized | bool
+  ansible.builtin.set_fact:
+    _ocp4_workload_authentication_htpasswd_user_passwords: >-
+      {{ _ocp4_workload_authentication_htpasswd_user_passwords + [ lookup('password',
+        '/dev/null chars=ascii_letters,digits '
+        ~ 'length=' ~ ocp4_workload_authentication_htpasswd_user_password_length ) ] }}
+  loop: "{{ range(0, ocp4_workload_authentication_htpasswd_user_count | int, 1) | list }}"
+
+- name: Set up common user password array
+  when: not ocp4_workload_authentication_htpasswd_user_password_randomized | bool
+  block:
+  - name: Generate common user password
+    when: ocp4_workload_authentication_htpasswd_user_password | default('') | length == 0
+    ansible.builtin.set_fact:
+      _ocp4_workload_authentication_htpasswd_user_password: >-
+        {{ lookup('password', '/dev/null chars=ascii_letters,digits '
+            ~ 'length=' ~ ocp4_workload_authentication_htpasswd_user_password_length
+        ) }}
+
+  - name: Use provided user password
+    when: ocp4_workload_authentication_htpasswd_user_password | default('') | length > 0
+    ansible.builtin.set_fact:
+      _ocp4_workload_authentication_htpasswd_user_password: >-
+        {{ ocp4_workload_authentication_htpasswd_user_password }}
+
+  - name: Generate user passwords array for common password
+    ansible.builtin.set_fact:
+      _ocp4_workload_authentication_htpasswd_user_passwords: >-
+        {{ _ocp4_workload_authentication_htpasswd_user_passwords + [_ocp4_workload_authentication_htpasswd_user_password] }}
+    loop: "{{ range(0, ocp4_workload_authentication_htpasswd_user_count | int, 1) | list }}"
+
+- name: Create temporary htpasswd file
+  ansible.builtin.tempfile:
+    state: file
+    suffix: htpasswd
+  register: r_htpasswd
+
+# Use hash scheme ldap_sha1 instead of the default scheme to work on FIPS
+- name: Add admin user to htpasswd file
+  community.general.htpasswd:
+    path: "{{ r_htpasswd.path }}"
+    name: "{{ ocp4_workload_authentication_admin_user }}"
+    password: "{{ _ocp4_workload_authentication_admin_password }}"
+    hash_scheme: ldap_sha1
+
+# Use hash scheme ldap_sha1 instead of the default scheme to work on FIPS
+- name: Add users and passwords to htpasswd file
+  community.general.htpasswd:
+    path: "{{ r_htpasswd.path }}"
+    name: >-
+      {%- if ocp4_workload_authentication_htpasswd_user_count | int == 1 -%}
+      {{ ocp4_workload_authentication_htpasswd_user_name }}
+      {%- else -%}
+      {{ ocp4_workload_authentication_htpasswd_user_base }}{{ item + 1 }}
+      {%- endif -%}
+    password: "{{ _ocp4_workload_authentication_htpasswd_user_passwords[item] }}"
+    hash_scheme: ldap_sha1
+  loop: "{{ range(0, ocp4_workload_authentication_htpasswd_user_count | int, 1) | list }}"
+
+- name: Read contents of htpasswd file
+  ansible.builtin.slurp:
+    src: "{{ r_htpasswd.path }}"
+  register: r_htpasswd_file
+
+- name: Remove generated htpasswd file
+  ansible.builtin.file:
+    path: "{{ r_htpasswd.path }}"
+    state: absent
+
+- name: Ensure htpasswd Secret is absent
+  kubernetes.core.k8s:
+    state: absent
+    api_version: v1
+    kind: Secret
+    name: htpasswd
+    namespace: openshift-config
+  register: r_htpasswd_secret_absent
+  retries: 5
+  delay: 10
+  until: r_htpasswd_secret_absent is success
+
+- name: Create htpasswd Secret
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('template', 'secret-htpasswd.yaml.j2') | from_yaml }}"
+
+- name: Update OAuth configuration
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('file', 'oauth-htpasswd.yaml') | from_yaml }}"
+
+- name: Print user information messages
+  when: ocp4_workload_authentication_enable_user_info_messages | bool
+  block:
+  - name: Print common user information messages
+    agnosticd_user_info:
+      msg: >-
+        Authentication via htpasswd is enabled on this cluster.
+
+
+        User `{{ ocp4_workload_authentication_admin_user }}`
+        with password `{{ _ocp4_workload_authentication_admin_password }}`
+        is cluster admin.
+
+  - name: Print user information for common password
+    when:
+    - ocp4_workload_authentication_htpasswd_user_count | int > 0
+    - not ocp4_workload_authentication_htpasswd_user_password_randomized | bool
+    agnosticd_user_info:
+      msg: >-
+        {%- if ocp4_workload_authentication_htpasswd_user_count | int == 1 -%}
+        Normal user `{{ ocp4_workload_authentication_htpasswd_user_name }}`
+        created with password `{{ _ocp4_workload_authentication_htpasswd_user_password }}`
+        {%- else -%}
+        Users `{{ ocp4_workload_authentication_htpasswd_user_base }}1` ..
+        `{{ ocp4_workload_authentication_htpasswd_user_base ~ ocp4_workload_authentication_htpasswd_user_count }}`
+        created with password `{{ _ocp4_workload_authentication_htpasswd_user_password }}`
+        {%- endif -%}
+
+  - name: Print user information for randomized password
+    when:
+    - ocp4_workload_authentication_htpasswd_user_count | int > 0
+    - ocp4_workload_authentication_htpasswd_user_password_randomized | bool
+    agnosticd_user_info:
+      msg: >-
+        {%- if ocp4_workload_authentication_htpasswd_user_count  | int== 1 -%}
+        Normal user `{{ ocp4_workload_authentication_htpasswd_user_name }}`
+        created with password `{{ _ocp4_workload_authentication_htpasswd_user_passwords[0] }}`
+        {%- else -%}
+        User `{{ ocp4_workload_authentication_htpasswd_user_base }}{{ n + 1 }}`,
+        Password: `{{ _ocp4_workload_authentication_htpasswd_user_passwords[n] }}`
+        {%- endif -%}
+    loop: "{{ range(0, ocp4_workload_authentication_htpasswd_user_count | int) | list }}"
+    loop_control:
+      loop_var: n
+
+- name: Save common user and cluster admin information
+  agnosticd_user_info:
+    # Pass data as dict to preserve integer type for openshift_cluster_user_count
+    data: >-
+      {{
+        {
+          "openshift_api_server_url": _ocp4_workload_authentication_api_server,
+          "openshift_cluster_admin_username": ocp4_workload_authentication_admin_user,
+          "openshift_cluster_admin_password": _ocp4_workload_authentication_admin_password,
+          "openshift_cluster_console_url": _ocp4_workload_authentication_console_route,
+          "openshift_cluster_num_users": ocp4_workload_authentication_htpasswd_user_count | int,
+          "openshift_cluster_user_base": ocp4_workload_authentication_htpasswd_user_base,
+          "openshift_cluster_user_count": ocp4_workload_authentication_htpasswd_user_count | int,
+        }
+      }}
+
+- name: Save user name for single user configuration
+  when:
+  - ocp4_workload_authentication_htpasswd_user_count | int == 1
+  agnosticd_user_info:
+    data:
+      openshift_cluster_user_name: "{{ ocp4_workload_authentication_htpasswd_user_name }}"
+
+- name: Save common user password if not randomized
+  when: not ocp4_workload_authentication_htpasswd_user_password_randomized | bool
+  agnosticd_user_info:
+    data:
+      openshift_cluster_user_password: "{{ _ocp4_workload_authentication_htpasswd_user_password }}"
+
+- name: Save user information
+  when: ocp4_workload_authentication_enable_user_info_data | bool
+  block:
+  - name: Save user information for user access
+    agnosticd_user_info:
+      user: "{{ ocp4_workload_authentication_htpasswd_user_base }}{{ n + 1 }}"
+      data:
+        user: "{{ ocp4_workload_authentication_htpasswd_user_base }}{{ n + 1 }}"
+        password: "{{ _ocp4_workload_authentication_htpasswd_user_passwords[ n ] }}"
+        console_url: "{{ _ocp4_workload_authentication_console_route }}"
+        openshift_console_url: "{{ _ocp4_workload_authentication_console_route }}"
+        openshift_cluster_ingress_domain: "{{ _ocp4_workload_authentication_cluster_ingress_domain }}"
+        login_command: >-
+          oc login --insecure-skip-tls-verify=false
+          -u {{ ocp4_workload_authentication_htpasswd_user_base }}{{ n + 1 }}
+          -p {{ _ocp4_workload_authentication_htpasswd_user_passwords[ n ] }}
+          {{ _ocp4_workload_authentication_api_server }}
+    loop: "{{ range(0, ocp4_workload_authentication_htpasswd_user_count | int) | list }}"
+    loop_control:
+      loop_var: n

--- a/ansible/roles_ocp_workloads/ocp4_workload_authentication_htpasswd_user/tasks/setup_ldap.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_authentication_htpasswd_user/tasks/setup_ldap.yml
@@ -1,0 +1,85 @@
+- name: Check for LDAP bind password
+  when: ocp4_workload_authentication_ldap_bind_password is not defined
+  ansible.builtin.fail:
+    msg: >-
+      LDAP authentication is configured but LDAP bind password
+      (ocp4_workload_authentication_ldap_bind_password) is not defined.
+
+- name: Create temporary directory
+  ansible.builtin.tempfile:
+    state: directory
+  register: r_temp_dir
+
+- name: Get IPA CA certificate
+  ansible.builtin.get_url:
+    url: "{{ ocp4_workload_authentication_ldap_ca_url }}"
+    dest: "{{ r_temp_dir.path }}/ipa-ca.crt"
+    mode: 0660
+
+- name: Read contents of CA certificate file
+  ansible.builtin.slurp:
+    src: "{{ r_temp_dir.path }}/ipa-ca.crt"
+  register: r_ipa_ca_certificate_file
+
+- name: Delete temporary directory
+  ansible.builtin.file:
+    state: absent
+    path: "{{ r_temp_dir.path }}"
+
+- name: Ensure ldap-ca-cert ConfigMap is absent
+  kubernetes.core.k8s:
+    state: absent
+    api_version: v1
+    kind: ConfigMap
+    name: ldap-ca-cert
+    namespace: openshift-config
+
+- name: Create ldap-ca-cert ConfigMap
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('template', 'configmap-ldap-ca-cert.yaml.j2' ) | from_yaml }}"
+
+- name: Ensure ldap-bind-password Secret is absent
+  kubernetes.core.k8s:
+    state: absent
+    api_version: v1
+    kind: Secret
+    name: ldap-bind-password
+    namespace: openshift-config
+
+- name: Create ldap-bind-password Secret
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('template', 'secret-ldap-bind-password.yaml.j2' ) | from_yaml }}"
+
+- name: Update OAuth configuration
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('template', 'oauth-opentlc-ldap.yaml.j2' ) | from_yaml }}"
+
+- name: Print user information for LDAP
+  when: ocp4_workload_authentication_enable_user_info_messages | bool
+  block:
+  - name: Print user information for LDAP
+    agnosticd_user_info:
+      msg: "{{ item }}"
+    loop:
+    - ""
+    - "OpenTLC LDAP Authentication is enabled on this cluster."
+    - "Use your OpenTLC user and Password to log into this cluster."
+
+  - name: Print user information for cluster admin access
+    when: ocp4_workload_authentication_admin_user | length > 0
+    agnosticd_user_info:
+      msg: >-
+        User `{{ ocp4_workload_authentication_admin_user }}` is cluster admin.
+
+- name: Save user information
+  when: ocp4_workload_authentication_enable_user_info_data | bool
+  block:
+  - name: Save user information for cluster admin access
+    agnosticd_user_info:
+      data:
+        openshift_cluster_admin_username: "{{ ocp4_workload_authentication_admin_user }}"
+        openshift_cluster_console_url: "{{ _ocp4_workload_authentication_console_route }}"
+        openshift_api_server_url: "{{ _ocp4_workload_authentication_api_server }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_authentication_htpasswd_user/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_authentication_htpasswd_user/tasks/workload.yml
@@ -1,0 +1,60 @@
+---
+- name: Set ocp4_workload_authentication_htpasswd_user_password
+  when: ocp4_workload_authentication_htpasswd_user_password is undefined
+  set_fact:
+    ocp4_workload_authentication_htpasswd_user_password: >-
+      {{ lookup('password', '/dev/null chars=ascii_letters,digits '
+          ~ 'length=' ~ ocp4_workload_authentication_htpasswd_user_password_length
+      ) }}
+
+- name: Create temporary htpasswd file
+  ansible.builtin.tempfile:
+    state: file
+    suffix: htpasswd
+  register: r_htpasswd
+  delegate_to: localhost
+
+- name: Add user to temporary htpasswd file
+  community.general.htpasswd:
+    path: "{{ r_htpasswd.path }}"
+    name: "{{ ocp4_workload_authentication_htpasswd_user_name }}"
+    password: "{{ ocp4_workload_authentication_htpasswd_user_password }}"
+    hash_scheme: ldap_sha1
+  delegate_to: localhost
+
+- name: Initialize retry attempt fact
+  ansible.builtin.set_fact:
+    __ocp4_workload_authentication_htpasswd_user_attempt: 1
+
+- name: Add user to htpasswd secret
+  ansible.builtin.include_tasks:
+    file: add_user_to_htpasswd_secret.yml
+  vars:
+    __htpasswd_line: >-
+      {{ lookup('ansible.builtin.file', r_htpasswd.path) }}
+
+- name: Remove temporary htpasswd file
+  ansible.builtin.file:
+    path: "{{ r_htpasswd.path }}"
+    state: absent
+  delegate_to: localhost
+
+- name: Report user name and password as data
+  when: ocp4_workload_authentication_htpasswd_user_enable_data | bool
+  agnosticd_user_info:
+    data:
+      user: "{{ ocp4_workload_authentication_htpasswd_user_name }}"
+      password: "{{ ocp4_workload_authentication_htpasswd_user_password }}"
+
+- name: Report user name and password as message
+  when: ocp4_workload_authentication_htpasswd_user_enable_messsages | bool
+  agnosticd_user_info:
+    msg: >-
+      User `{{ ocp4_workload_authentication_htpasswd_user_name }}` created with password
+      `{{ ocp4_workload_authentication_htpasswd_user_password }}`
+
+# Leave this as the last task in the playbook.
+- name: workload tasks complete
+  ansible.builtin.debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent | bool


### PR DESCRIPTION
##### SUMMARY

Add `ocp4_workload_authentication_htpasswd_user` workload for adding users to a cluster's htpasswd authentication configuration.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Workload role `ocp4_workload_authentication_htpasswd_user`