### PR TITLE
Add support to kasten-k10 workload to set up a demo environment for single (cluster-admin) and multi-user clusters.

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/defaults/main.yml
@@ -1,33 +1,62 @@
 ---
 ocp_username: "system:admin"
 
+# -------------------------------------------------------------------
+# Kasten Operator
+# -------------------------------------------------------------------
+
 # Namespace to deploy the Kasten Operator into
-ocp4_workload_kasten_namespace: kasten-io
-
-ocp4_workload_kasten_deploy_k10: true
-
-# Name of the Kasten K10 instance when ocp4_workload_kasten_deploy_k10 is set to true
-ocp4_workload_kasten_name: k10
-
-# Authentication type to use. Options are:
-# - openshift
-# - htpasswd
-ocp4_workload_kasten_authentication_type: openshift
-
-# For HTpasswd provide User ID and password as a htpasswd string.
-# ocp4_workload_kasten_authentication_htpasswd_string: "kasten:{SHA}XXXXXXXXXXX"
+ocp4_workload_kasten_k10_namespace: kasten-io
 
 # Channel to subscribe to
-ocp4_workload_kasten_channel: stable
-ocp4_workload_kasten_automatic_install_plan_approval: true
+ocp4_workload_kasten_k10_channel: stable
+ocp4_workload_kasten_k10_automatic_install_plan_approval: true
 
 # Kasten subscription. Valid values:
 # - k10-kasten-operator-paygo-rhmp
 # - k10-kasten-operator-rhmp
 # - k10-kasten-operator-term-rhmp
-ocp4_workload_kasten_subscription: k10-kasten-operator-paygo-rhmp
+ocp4_workload_kasten_k10_subscription: k10-kasten-operator-paygo-rhmp
 
 # Starting CSV. Recommended to be left empty. If set match
 # to subscription.
-# ocp4_workload_kasten_starting_csv: k10-kasten-operator-paygo-rhmp.v7.0.8
-ocp4_workload_kasten_starting_csv: ""
+# ocp4_workload_kasten_k10_starting_csv: k10-kasten-operator-paygo-rhmp.v7.0.8
+ocp4_workload_kasten_k10_starting_csv: ""
+
+# -------------------------------------------------------------------
+# Deploy Kasten K10?
+# -------------------------------------------------------------------
+ocp4_workload_kasten_k10_deploy_k10: true
+
+# Name of the Kasten K10 instance when ocp4_workload_kasten_k10_deploy_k10 is set to true
+ocp4_workload_kasten_k10_name: k10
+
+# Authentication type to use. Options are:
+# - openshift
+# - htpasswd
+ocp4_workload_kasten_k10_authentication_type: openshift
+
+# For HTpasswd provide User ID and password as a htpasswd string.
+# ocp4_workload_kasten_k10_authentication_htpasswd_string: "kasten:{SHA}XXXXXXXXXXX"
+
+# -------------------------------------------------------------------
+# Setup for a demo?
+# -------------------------------------------------------------------
+# - Create one ObjectBucketRequest for each user
+# - Set up authorization for normal users to use K10
+ocp4_workload_kasten_k10_setup_demo: false
+
+# ObjectBucket properties
+ocp4_workload_kasten_k10_objectbucket_name: kastenbackups
+ocp4_workload_kasten_k10_objectbucket_storage_class: openshift-storage.noobaa.io
+
+# Set up a single (cluster admin) user or multiple (regular) users
+ocp4_workload_kasten_k10_multi_user: false
+
+# Single User
+ocp4_workload_kasten_k10_objectbucket_namespace: backuptarget
+
+# Multi User
+ocp4_workload_kasten_k10_num_users: 2
+ocp4_workload_kasten_k10_objectbucket_user_base: user
+ocp4_workload_kasten_k10_objectbucket_namespace_base: "backuptarget-{{ ocp4_workload_kasten_k10_objectbucket_user_base }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/readme.adoc
@@ -1,3 +1,6 @@
-= ocp4_workload_kasten_k10 - Deploy Veeam Kasten K10 to a cluster
+= ocp4_workload_kasten_k10_k10 - Deploy Veeam Kasten K10 to a cluster
+
+Optionally set up a single (cluster-admin) or multi-user demo environment.
+
 
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/tasks/workload.yml
@@ -4,18 +4,18 @@
     name: install_operator
   vars:
     install_operator_action: install
-    install_operator_name: "{{ ocp4_workload_kasten_subscription }}"
-    install_operator_namespace: "{{ ocp4_workload_kasten_namespace }}"
+    install_operator_name: "{{ ocp4_workload_kasten_k10_subscription }}"
+    install_operator_namespace: "{{ ocp4_workload_kasten_k10_namespace }}"
     install_operator_manage_namespaces:
-    - "{{ ocp4_workload_kasten_namespace }}"
-    install_operator_channel: "{{ ocp4_workload_kasten_channel }}"
+    - "{{ ocp4_workload_kasten_k10_namespace }}"
+    install_operator_channel: "{{ ocp4_workload_kasten_k10_channel }}"
     install_operator_catalog: redhat-marketplace
-    install_operator_automatic_install_plan_approval: "{{ ocp4_workload_kasten_automatic_install_plan_approval | default(true) }}"
-    install_operator_starting_csv: "{{ ocp4_workload_kasten_starting_csv }}"
+    install_operator_automatic_install_plan_approval: "{{ ocp4_workload_kasten_k10_automatic_install_plan_approval | default(true) }}"
+    install_operator_starting_csv: "{{ ocp4_workload_kasten_k10_starting_csv }}"
     install_operator_catalogsource_setup: false
 
 - name: Deploy K10
-  when: ocp4_workload_kasten_deploy_k10 | bool
+  when: ocp4_workload_kasten_k10_deploy_k10 | bool
   block:
   - name: Create K10
     kubernetes.core.k8s:
@@ -30,8 +30,8 @@
     kubernetes.core.k8s_info:
       api_version: apik10.kasten.io/v1alpha1
       kind: k10s
-      name: "{{ ocp4_workload_kasten_name }}"
-      namespace: "{{ ocp4_workload_kasten_namespace }}"
+      name: "{{ ocp4_workload_kasten_k10_name }}"
+      namespace: "{{ ocp4_workload_kasten_k10_namespace }}"
       wait: true
       wait_sleep: 5
       wait_timeout: 1200
@@ -44,8 +44,8 @@
     kubernetes.core.k8s_info:
       api_version: route.openshift.io/v1
       kind: Route
-      name: "{{ ocp4_workload_kasten_name }}-route"
-      namespace: "{{ ocp4_workload_kasten_namespace }}"
+      name: "{{ ocp4_workload_kasten_k10_name }}-route"
+      namespace: "{{ ocp4_workload_kasten_k10_namespace }}"
     register: r_kasten_route
 
   - name: Save access information
@@ -53,3 +53,45 @@
     agnosticd_user_info:
       data:
         kasten_dashboard: "https://{{ r_kasten_route.resources[0].spec.host }}/k10/"
+
+  # Jinja templates handle single/multi-user deployment
+  - name: Set up Demo environment
+    when: ocp4_workload_kasten_k10_setup_demo
+    kubernetes.core.k8s:
+      state: present
+      # template: objectbucketclaim.yaml.j2
+      definition: "{{ lookup('template', resource | from_yaml) }}"
+    loop:
+    - namespace.yaml.j2
+    - objectbucketclaim.yaml.j2
+    - clusterrolebinding.yaml.j2
+    - rolebinding.yaml.j2
+    loop_control:
+      loop_var: resource
+
+  - name: Save AgnosticD user information for single user
+    when:
+    - ocp4_workload_kasten_k10_setup_demo | bool
+    - not ocp4_workload_kasten_k10_multi_user | bool
+    agnosticd_user_info:
+      data:
+        kasten_backup_bucket_name: "{{ ocp4_workload_kasten_k10_objectbucket_name }}"
+        kasten_backup_bucket_namespace: "{{ ocp4_workload_kasten_k10_objectbucket_namespace }}"
+        kasten_backup_bucket_host: s3.openshift-storage.svc
+        kasten_backup_bucket_port: 443
+
+  - name: Save AgnosticD user information for multi user
+    when:
+    - ocp4_workload_kasten_k10_setup_demo | bool
+    - ocp4_workload_kasten_k10_multi_user | bool
+    agnosticd_user_info:
+      user: "{{ ocp4_workload_kasten_k10_objectbucket_user_base }}{{ user_number }}"
+      data:
+        kasten_dashboard: "https://{{ r_kasten_route.resources[0].spec.host }}/k10/"
+        kasten_backup_bucket_name: "{{ ocp4_workload_kasten_k10_objectbucket_name }}"
+        kasten_backup_bucket_namespace: "{{ ocp4_workload_kasten_k10_objectbucket_namespace_base }}{{ user_number }}"
+        kasten_backup_bucket_host: s3.openshift-storage.svc
+        kasten_backup_bucket_port: 443
+    loop: "{{ range(1, ocp4_workload_kasten_k10_num_users | int + 1) | list }}"
+    loop_control:
+      loop_var: user_number

--- a/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/templates/clusterrolebinding.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/templates/clusterrolebinding.yaml.j2
@@ -1,0 +1,17 @@
+{% if ocp4_workload_kasten_k10_multi_user | bool %}
+{%   for user_number in range(1, ocp4_workload_kasten_k10_num_users | int + 1) %}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k10-admin-{{ ocp4_workload_kasten_k10_objectbucket_user_base }}{{ user_number }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k10-admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: {{ ocp4_workload_kasten_k10_objectbucket_user_base }}{{ user_number }}
+{%   endfor %}
+{% endif %}

--- a/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/templates/k10.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/templates/k10.yaml.j2
@@ -2,20 +2,20 @@
 apiVersion: apik10.kasten.io/v1alpha1
 kind: K10
 metadata:
-  name: {{ ocp4_workload_kasten_name }}
-  namespace: {{ ocp4_workload_kasten_namespace }}
+  name: {{ ocp4_workload_kasten_k10_name }}
+  namespace: {{ ocp4_workload_kasten_k10_namespace }}
 spec:
   auth:
-{% if ocp4_workload_kasten_authentication_type == "openshift" %}
+{% if ocp4_workload_kasten_k10_authentication_type == "openshift" %}
     openshift:
-      dashboardURL: https://{{ ocp4_workload_kasten_name }}-route-kasten-io.{{ openshift_cluster_ingress_domain }}/k10/
+      dashboardURL: https://{{ ocp4_workload_kasten_k10_name }}-route-kasten-io.{{ openshift_cluster_ingress_domain }}/k10/
       enabled: true
       insecureCA: true
       openshiftURL: https://apiserver.openshift-kube-apiserver.svc.cluster.local
-{% elif ocp4_workload_kasten_authentication_type == "htpasswd" %}
+{% elif ocp4_workload_kasten_k10_authentication_type == "htpasswd" %}
     basicAuth:
       enabled: true
-      htpasswd: '{{ ocp4_workload_kasten_authentication_htpasswd_string }}'
+      htpasswd: '{{ ocp4_workload_kasten_k10_authentication_htpasswd_string }}'
       secretName: ""
 {% endif %}
   global:

--- a/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/templates/namespace.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/templates/namespace.yaml.j2
@@ -1,0 +1,15 @@
+{% if ocp4_workload_kasten_k10_multi_user | bool %}
+{%   for user_number in range(1, ocp4_workload_kasten_k10_num_users | int + 1) %}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ ocp4_workload_kasten_k10_objectbucket_namespace_base }}{{ user_number }}
+{%   endfor %}
+{% else %}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ ocp4_workload_kasten_k10_objectbucket_namespace }}
+{% endif %}

--- a/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/templates/objectbucketclaim.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/templates/objectbucketclaim.yaml.j2
@@ -1,0 +1,23 @@
+{% if ocp4_workload_kasten_k10_multi_user | bool %}
+{%   for user_number in range(1, ocp4_workload_kasten_k10_num_users | int + 1) %}
+---
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: {{ ocp4_workload_kasten_k10_objectbucket_name }}
+  namespace: {{ ocp4_workload_kasten_k10_objectbucket_namespace_base }}{{ user_number }}
+spec:
+  bucketName: {{ ocp4_workload_kasten_k10_objectbucket_name }}
+  storageClassName: {{ ocp4_workload_kasten_k10_objectbucket_storage_class }}
+{%   endfor %}
+{% else %}
+---
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: {{ ocp4_workload_kasten_k10_objectbucket_name }}
+  namespace: {{ ocp4_workload_kasten_k10_objectbucket_namespace }}
+spec:
+  bucketName: {{ ocp4_workload_kasten_k10_objectbucket_name }}
+  storageClassName: {{ ocp4_workload_kasten_k10_objectbucket_storage_class }}
+{% endif %}

--- a/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/templates/rolebinding.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/templates/rolebinding.yaml.j2
@@ -1,0 +1,18 @@
+{% if ocp4_workload_kasten_k10_multi_user | bool %}
+{%   for user_number in range(1, ocp4_workload_kasten_k10_num_users | int + 1) %}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: view-{{ ocp4_workload_kasten_k10_objectbucket_user_base }}{{ user_number }}
+  namespace: kasten-io
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: {{ ocp4_workload_kasten_k10_objectbucket_user_base }}{{ user_number }}
+{%   endfor %}
+{% endif %}


### PR DESCRIPTION
##### SUMMARY

- Fix variable naming (proper workload prefix)
- Add support to set up a demo environment for single-user (cluster-admin) and multi-user

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_kasten_k10