### PR TITLE
Preserve user-data across run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,9 @@ virtualenv/
 .DS_Store
 my_*_vars.yml
 user-data.yaml
+*-user-data.yaml
 user-info.yaml
+*-user-info.yaml
 .vscode/settings.json
 __pycache__
 *.pyc

--- a/ansible/action_plugins/agnosticd_odcr.py
+++ b/ansible/action_plugins/agnosticd_odcr.py
@@ -602,6 +602,8 @@ class ActionModule(ActionBase):
             if total_canceled > 0:
                 result['changed'] = True
         except Exception as err:
+            display.error(f"Reservations failed in region {region}")
+            result['region'] = region
             result['failed'] = True
             result['error'] = str(err)
             return result
@@ -622,6 +624,8 @@ class ActionModule(ActionBase):
 
                 r_ok, result['reservations'] = odcr.do_region(region, reservations)
             except Exception as err:
+                display.error(f"Reservations failed in region {region}")
+                result['region'] = region
                 result['failed'] = True
                 result['error'] = str(err)
                 break

--- a/ansible/action_plugins/agnosticd_user_info.py
+++ b/ansible/action_plugins/agnosticd_user_info.py
@@ -95,6 +95,13 @@ class ActionModule(ActionBase):
                     )
                 )
             )
+            ACTION = self._templar.template(
+                task_vars.get('ACTION',
+                    task_vars['hostvars'].get('localhost',{}).get('ACTION',
+                                                                  'provision'
+                    )
+                )
+            )
 
             # Attempt to make output_dir if not exists
             try:
@@ -103,7 +110,7 @@ class ActionModule(ActionBase):
                 pass
 
             if not user and msg != None:
-                fh = open(os.path.join(output_dir, 'user-info.yaml'), 'a')
+                fh = open(os.path.join(output_dir, f'{ACTION}-user-info.yaml'), 'a')
                 if isinstance(msg, list):
                     for m in msg:
                         fh.write('- ' + json.dumps(m) + "\n")
@@ -111,13 +118,13 @@ class ActionModule(ActionBase):
                     fh.write('- ' + json.dumps(msg) + "\n")
                 fh.close()
             if not user and body != None:
-                fh = open(os.path.join(output_dir, 'user-body.yaml'), 'a')
+                fh = open(os.path.join(output_dir, f'{ACTION}-user-body.yaml'), 'a')
                 fh.write('- ' + json.dumps(body) + "\n")
                 fh.close()
             if data or user:
                 user_data = None
                 try:
-                    fh = open(os.path.join(output_dir, 'user-data.yaml'), 'r')
+                    fh = open(os.path.join(output_dir, f'{ACTION}-user-data.yaml'), 'r')
                     user_data = yaml.safe_load(fh)
                     fh.close()
                 except FileNotFoundError:
@@ -149,7 +156,7 @@ class ActionModule(ActionBase):
                 else:
                     user_data.update(data)
 
-                fh = open(os.path.join(output_dir, 'user-data.yaml'), 'w')
+                fh = open(os.path.join(output_dir, f'{ACTION}-user-data.yaml'), 'w')
                 yaml.safe_dump(user_data, stream=fh, explicit_start=True)
                 fh.close()
             result['failed'] = False

--- a/ansible/action_plugins/agnosticd_user_info.py
+++ b/ansible/action_plugins/agnosticd_user_info.py
@@ -88,21 +88,8 @@ class ActionModule(ActionBase):
             result['user'] = user
 
         try:
-            output_dir = self._templar.template(
-                task_vars.get('output_dir',
-                    task_vars['hostvars'].get('localhost',{}).get('output_dir',
-                        task_vars.get('playbook_dir', '.')
-                    )
-                )
-            )
-            ACTION = self._templar.template(
-                task_vars.get('ACTION',
-                    task_vars['hostvars'].get('localhost',{}).get('ACTION',
-                                                                  'provision'
-                    )
-                )
-            )
-
+            action = self._templar.template('{{ ACTION | default(hostvars.localhost.ACTION) | default("provision") }}')
+            output_dir = self._templar.template('{{ output_dir | default(hostvars.localhost.output_dir) | default(playbook_dir) | default(".") }}')
             # Attempt to make output_dir if not exists
             try:
                 os.makedirs(output_dir)
@@ -110,7 +97,7 @@ class ActionModule(ActionBase):
                 pass
 
             if not user and msg != None:
-                fh = open(os.path.join(output_dir, f'{ACTION}-user-info.yaml'), 'a')
+                fh = open(os.path.join(output_dir, f'{action}-user-info.yaml'), 'a')
                 if isinstance(msg, list):
                     for m in msg:
                         fh.write('- ' + json.dumps(m) + "\n")
@@ -118,13 +105,13 @@ class ActionModule(ActionBase):
                     fh.write('- ' + json.dumps(msg) + "\n")
                 fh.close()
             if not user and body != None:
-                fh = open(os.path.join(output_dir, f'{ACTION}-user-body.yaml'), 'a')
+                fh = open(os.path.join(output_dir, f'{action}-user-body.yaml'), 'a')
                 fh.write('- ' + json.dumps(body) + "\n")
                 fh.close()
             if data or user:
                 user_data = None
                 try:
-                    fh = open(os.path.join(output_dir, f'{ACTION}-user-data.yaml'), 'r')
+                    fh = open(os.path.join(output_dir, f'{action}-user-data.yaml'), 'r')
                     user_data = yaml.safe_load(fh)
                     fh.close()
                 except FileNotFoundError:
@@ -156,7 +143,7 @@ class ActionModule(ActionBase):
                 else:
                     user_data.update(data)
 
-                fh = open(os.path.join(output_dir, f'{ACTION}-user-data.yaml'), 'w')
+                fh = open(os.path.join(output_dir, f'{action}-user-data.yaml'), 'w')
                 yaml.safe_dump(user_data, stream=fh, explicit_start=True)
                 fh.close()
             result['failed'] = False

--- a/ansible/cloud_providers/ec2_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/ec2_infrastructure_deployment.yml
@@ -15,15 +15,22 @@
       include_role:
         name: infra-images
 
-    # If infra-aws-capacity-reservation role was not executed, run it
-    - when: >-
-        agnosticd_aws_capacity_reservation_results is not defined or
-        agnosticd_aws_capacity_reservation_results.reservations | default({}) | length == 0
-      name: Run infra-aws-capacity-reservation
+    - name: Run infra-aws-capacity-reservation
       include_role:
         name: infra-aws-capacity-reservation
       vars:
         ACTION: provision
+
+    - when: >-
+        agnosticd_aws_capacity_reservation_results.reservations | default({}) | length > 0
+      block:
+        - name: Empty the agnosticd_images and run the detection again
+          set_fact:
+            agnosticd_images: {}
+
+        - name: Run infra-images again to use the proper region selected by the reservations
+          include_role:
+            name: infra-images
 
     - name: Run infra-aws-open-environment Role
       include_role:

--- a/ansible/completion_callback.yml
+++ b/ansible/completion_callback.yml
@@ -10,9 +10,9 @@
       - agnosticd_callback_url != ''
       - agnosticd_callback_token != ''
       vars:
-        user_body_yaml: "{{ output_dir ~ '/user-body.yaml' }}"
-        user_data_yaml: "{{ output_dir ~ '/user-data.yaml' }}"
-        user_info_yaml: "{{ output_dir ~ '/user-info.yaml' }}"
+        user_body_yaml: "{{ [ output_dir, ACTION ~ '-user-body.yaml' ] | path_join }}"
+        user_data_yaml: "{{ [ output_dir, ACTION ~ '-user-data.yaml' ] | path_join }}"
+        user_info_yaml: "{{ [ output_dir, ACTION ~ '-user-info.yaml' ] | path_join }}"
       uri:
         url: "{{ agnosticd_callback_url }}"
         method: POST

--- a/ansible/configs/base-infra/default_vars.yml
+++ b/ansible/configs/base-infra/default_vars.yml
@@ -72,13 +72,17 @@ common_packages_el8:
 update_packages: true      # Do you want to run a full yum update
 
 agd_bastion_packages:
+
   - at
   - bash-completion
   - bind-utils
   - git
   - python3.9
   - python3-devel
+  - ripgrep
   - tree
   - vim-enhanced
   - wget
   - zsh
+
+student_name: "{{ requester_username | default('lab-user') }}"

--- a/ansible/configs/base-infra/default_vars.yml
+++ b/ansible/configs/base-infra/default_vars.yml
@@ -72,14 +72,12 @@ common_packages_el8:
 update_packages: true      # Do you want to run a full yum update
 
 agd_bastion_packages:
-
   - at
   - bash-completion
   - bind-utils
   - git
   - python3.9
   - python3-devel
-  - ripgrep
   - tree
   - vim-enhanced
   - wget

--- a/ansible/configs/base-infra/default_vars_ec2.yml
+++ b/ansible/configs/base-infra/default_vars_ec2.yml
@@ -3,7 +3,6 @@
 
 ansible_user: ec2-user
 remote_user: ec2-user
-aws_region: us-east-2
 
 ### Networking and DNS (AWS)
 

--- a/ansible/configs/base-infra/post_software.yml
+++ b/ansible/configs/base-infra/post_software.yml
@@ -64,6 +64,9 @@
     - name: Output ssh user_info for ec2 based deploys
       when:
         - cloud_provider == "ec2"
+      vars:
+        student_password: "{{ hostvars[groups['bastions'][0]]['student_password'] }}"
+        student_username: "{{ hostvars[groups['bastions'][0]]['student_name'] }}"
       block:
         - name: Set ssh user_info
           agnosticd_user_info:

--- a/ansible/configs/base-infra/pre_software.yml
+++ b/ansible/configs/base-infra/pre_software.yml
@@ -76,6 +76,11 @@
       ansible.builtin.import_role:
         name: bastion-base
 
+    - name: Install basic bastion configuration
+      when: agd_install_student_user | default(true) | bool
+      ansible.builtin.import_role:
+        name: bastion-student-user
+
     - name: Install control student user configuration
       when: agd_user_create_ansible_service_account | default(true) | bool
       ansible.builtin.include_role:

--- a/ansible/configs/base-infra/sample_files/multiple_regions_fallback_with_odcr.yaml
+++ b/ansible/configs/base-infra/sample_files/multiple_regions_fallback_with_odcr.yaml
@@ -1,0 +1,54 @@
+---
+cloud_provider: ec2
+env_type: base-infra
+
+node_instance_image: RHEL9-default
+bastion_instance_image: RHEL9-default
+
+# Use the information from the infra-images role to determine the platform
+bastion_instance_platform: >-
+  {%- if agnosticd_images.bastion.platform_details | default('') == 'Red Hat BYOL Linux' -%}
+  Linux/UNIX
+  {%- else -%}
+  Red Hat Enterprise Linux
+  {%- endif -%}
+
+bastion_instance_type: t3a.small
+node_instance_type: t3a.small
+
+# Use the information from the infra-images role to determine the platform
+node_instance_platform: >-
+  {%- if agnosticd_images.node.platform_details | default('') == 'Red Hat BYOL Linux' -%}
+  Linux/UNIX
+  {%- else -%}
+  Red Hat Enterprise Linux
+  {%- endif -%}
+
+node_instance_count: 1
+
+# Instead of aws_region, specify a list of regions you want to loop on
+agnosticd_aws_capacity_reservation_regions:
+  - eu-west-3
+  - eu-central-1
+  - us-east-2
+  - us-east-1
+  - us-west-2
+  - us-west-1
+
+agnosticd_aws_capacity_reservations:
+  az1:
+    - instance_count: 1
+      instance_platform: "{{ bastion_instance_platform }}"
+      instance_type: "{{ bastion_instance_type }}"
+    - instance_count: "{{ node_instance_count }}"
+      instance_platform: "{{ node_instance_platform }}"
+      instance_type: "{{ node_instance_type }}"
+
+# Define the availability zone based on the results of the on-demand capacity reservation
+# module. Use the az 'az1' as defined above.
+# That variable is then used in the default cloudformation template to place the VPC.
+aws_availability_zone: >-
+  {{ agnosticd_aws_capacity_reservation_results.reservations.az1.availability_zone }}
+
+# Don't install common packages
+install_common: false

--- a/ansible/configs/base-infra/sample_files/multiple_regions_fallback_with_odcr.yaml
+++ b/ansible/configs/base-infra/sample_files/multiple_regions_fallback_with_odcr.yaml
@@ -1,8 +1,9 @@
 ---
 cloud_provider: ec2
 env_type: base-infra
+inventory_groups:
+  - bastions
 
-node_instance_image: RHEL9-default
 bastion_instance_image: RHEL9-default
 
 # Use the information from the infra-images role to determine the platform
@@ -14,17 +15,11 @@ bastion_instance_platform: >-
   {%- endif -%}
 
 bastion_instance_type: t3a.small
-node_instance_type: t3a.small
-
-# Use the information from the infra-images role to determine the platform
-node_instance_platform: >-
-  {%- if agnosticd_images.node.platform_details | default('') == 'Red Hat BYOL Linux' -%}
-  Linux/UNIX
-  {%- else -%}
-  Red Hat Enterprise Linux
-  {%- endif -%}
-
-node_instance_count: 1
+# If you try with one of those:
+#bastion_instance_type: g5.xlarge
+#bastion_instance_type: g6.xlarge
+#bastion_instance_type: g6.12xlarge
+# it'll loop on different regions until it gets a reservation.
 
 # Instead of aws_region, specify a list of regions you want to loop on
 agnosticd_aws_capacity_reservation_regions:
@@ -40,9 +35,6 @@ agnosticd_aws_capacity_reservations:
     - instance_count: 1
       instance_platform: "{{ bastion_instance_platform }}"
       instance_type: "{{ bastion_instance_type }}"
-    - instance_count: "{{ node_instance_count }}"
-      instance_platform: "{{ node_instance_platform }}"
-      instance_type: "{{ node_instance_type }}"
 
 # Define the availability zone based on the results of the on-demand capacity reservation
 # module. Use the az 'az1' as defined above.
@@ -51,4 +43,7 @@ aws_availability_zone: >-
   {{ agnosticd_aws_capacity_reservation_results.reservations.az1.availability_zone }}
 
 # Don't install common packages
-install_common: false
+update_packages: false  # Do you want to run a full yum update
+bastion_install_basic_packages: false
+agd_install_common: false # Immutable OS
+config_user_preferred_python: false

--- a/ansible/configs/just-a-bunch-of-nodes/default_vars.yml
+++ b/ansible/configs/just-a-bunch-of-nodes/default_vars.yml
@@ -54,7 +54,7 @@ instances:
       - key: "ostype"
         value: "linux"
       - key: "instance_filter"
-        value: "{{ env_type }}-{{ email }}"
+        value: "{{ env_type }}-{{ email | default(requester_username, true) | default('unknownuser', true) }}"
     volumes:
       - name: '/dev/sda1'
         size: 20
@@ -73,7 +73,7 @@ instances:
       - key: "ostype"
         value: "linux"
       - key: "instance_filter"
-        value: "{{ env_type }}-{{ email }}"
+        value: "{{ env_type }}-{{ email | default(requester_username, true) | default('unknownuser', true) }}"
     security_groups:
       - DefaultSG
 

--- a/ansible/configs/just-a-bunch-of-nodes/default_vars_ec2.yml
+++ b/ansible/configs/just-a-bunch-of-nodes/default_vars_ec2.yml
@@ -11,7 +11,7 @@ ansible_user: ec2-user
 remote_user: ec2-user
 
 # The region to be used, if not specified by -e in the command line
-aws_region: us-east-1
+#aws_region: us-east-1
 
 node_instance_image: RHEL8-default
 bastion_instance_image: RHEL8-default

--- a/ansible/configs/just-a-bunch-of-nodes/sample_vars_multiple_region_retry.yaml
+++ b/ansible/configs/just-a-bunch-of-nodes/sample_vars_multiple_region_retry.yaml
@@ -1,0 +1,60 @@
+##### AgnosticV
+
+cloud_provider: ec2
+env_type: just-a-bunch-of-nodes
+
+node_instance_image: RHEL8-default
+bastion_instance_image: RHEL8-default
+
+# Use the information from the infra-images role to determine the platform
+bastion_instance_platform: >-
+  {%- if agnosticd_images.bastion.platform_details | default('') == 'Red Hat BYOL Linux' -%}
+  Linux/UNIX
+  {%- else -%}
+  Red Hat Enterprise Linux
+  {%- endif -%}
+
+bastion_instance_type:
+  ec2: "t3a.small"
+
+node_instance_type:
+  # TODO change to gpu later
+  #ec2: "g5.xlarge"
+  ec2: "t3a.small"
+
+# Use the information from the infra-images role to determine the platform
+node_instance_platform: >-
+  {%- if agnosticd_images.node.platform_details | default('') == 'Red Hat BYOL Linux' -%}
+  Linux/UNIX
+  {%- else -%}
+  Red Hat Enterprise Linux
+  {%- endif -%}
+
+node_instance_count: 1
+
+
+# Instead of aws_region, specify a list of regions you want to loop on
+agnosticd_aws_capacity_reservation_regions:
+  - eu-west-3
+  - eu-central-1
+  - us-east-2
+  - us-east-1
+  - us-west-2
+  - us-west-1
+
+aws_availability_zone: >-
+  {{ agnosticd_aws_capacity_reservation_results.reservations.az1.availability_zone }}
+
+agnosticd_aws_capacity_reservation_ttl: 10m
+
+agnosticd_aws_capacity_reservations:
+  az1:
+    - instance_count: 1
+      instance_platform: "{{ bastion_instance_platform }}"
+      instance_type: "{{ bastion_instance_type.ec2 }}"
+    - instance_count: "{{ node_instance_count }}"
+      instance_platform: "{{ node_instance_platform }}"
+      instance_type: "{{ node_instance_type.ec2 }}"
+
+# Don't install common packages
+install_common: false

--- a/ansible/destroy.yml
+++ b/ansible/destroy.yml
@@ -4,6 +4,20 @@
 ############ Step 006 Destroy Workshop using workshop_prefix
 ################################################################################
 ################################################################################
+- name: Step 0000 Set Action
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  tags:
+    - must
+    - step0000
+    - setup_runtime
+  become: false
+  tasks:
+    - name: Set ACTION to provision
+      when: ACTION is undefined
+      set_fact:
+        ACTION: destroy
 
 - import_playbook: setup_runtime.yml
 

--- a/ansible/destroy.yml
+++ b/ansible/destroy.yml
@@ -14,7 +14,7 @@
     - setup_runtime
   become: false
   tasks:
-    - name: Set ACTION to provision
+    - name: Set ACTION to destroy
       when: ACTION is undefined
       set_fact:
         ACTION: destroy

--- a/ansible/lifecycle.yml
+++ b/ansible/lifecycle.yml
@@ -1,8 +1,19 @@
 ---
+# Quickly setup output dir and include vars.
+# Do not run the full setup_runtime.yml playbook because
+# it installs galaxy dependencies and that is too slow for
+# lifecycle actions.
+#
+# Output dir:
+- import_playbook: setup_output_dir.yml
+
+# include global vars from the config
+- import_playbook: include_vars.yml
+
+
 # This file is the default playbook for common actions.
 # You should implement those actions in your config if you
 # need a specific process.
-
 - name: Run stop/start/status/... actions
   hosts: localhost
   connection: local

--- a/ansible/lifecycle_ec2.yml
+++ b/ansible/lifecycle_ec2.yml
@@ -1,4 +1,9 @@
 ---
+- name: Retrieve the region from user-data.yaml
+  when: aws_region | default('') == ''
+  set_fact:
+    aws_region: "{{ lookup('agnosticd_user_data', 'aws_region') }}"
+
 - environment:
     AWS_ACCESS_KEY_ID: "{{aws_access_key_id}}"
     AWS_SECRET_ACCESS_KEY: "{{aws_secret_access_key}}"

--- a/ansible/lookup_plugins/agnosticd_user_data.py
+++ b/ansible/lookup_plugins/agnosticd_user_data.py
@@ -46,14 +46,14 @@ from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 
 class LookupModule(LookupBase): 
-    def run(self, terms, user=None, **kwargs):
+    def run(self, terms, action='provision', user=None, **kwargs):
         self.set_options(direct=kwargs)
         ret = []
 
         output_dir = self._templar.template('{{ output_dir | default(playbook_dir) | default(".") }}')
         user_data = {}
         try:
-            fh = open(os.path.join(output_dir, 'user-data.yaml'), 'r')
+            fh = open(os.path.join(output_dir, f'{action}-user-data.yaml'), 'r')
             user_data = yaml.safe_load(fh)
             fh.close()
         except FileNotFoundError:

--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -6,6 +6,20 @@
 ############ Step 0000 Setup Runtime
 ################################################################################
 ################################################################################
+- name: Step 0000 Set Action
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  tags:
+    - must
+    - step0000
+    - setup_runtime
+  become: false
+  tasks:
+    - name: Set ACTION to provision
+      when: ACTION is undefined
+      set_fact:
+        ACTION: provision
 
 - import_playbook: setup_runtime.yml
   tags:

--- a/ansible/roles-infra/infra-aws-capacity-reservation/tasks/create.yaml
+++ b/ansible/roles-infra/infra-aws-capacity-reservation/tasks/create.yaml
@@ -15,6 +15,7 @@
   set_fact:
     aws_region: "{{ agnosticd_aws_capacity_reservation_results.region }}"
 
+
 - name: Ensure aws_region is not passed as extra vars and different
   assert:
     that: aws_region == agnosticd_aws_capacity_reservation_results.region
@@ -26,3 +27,14 @@
   when: agnosticd_aws_capacity_reservation_results.single_availability_zone | default('') != ''
   set_fact:
     aws_availability_zone: "{{ agnosticd_aws_capacity_reservation_results.single_availability_zone }}"
+
+- name: Save region in user-data
+  agnosticd_user_info:
+    data:
+      aws_region: "{{ agnosticd_aws_capacity_reservation_results.region }}"
+
+- name: Save AZ in user-data
+  when: agnosticd_aws_capacity_reservation_results.single_availability_zone | default('') != ''
+  agnosticd_user_info:
+    data:
+      aws_availability_zone: "{{ agnosticd_aws_capacity_reservation_results.single_availability_zone }}"

--- a/ansible/roles-infra/infra-aws-capacity-reservation/tasks/create.yaml
+++ b/ansible/roles-infra/infra-aws-capacity-reservation/tasks/create.yaml
@@ -1,40 +1,55 @@
 ---
 # TODO: test DryRun capacity reservation
 
-- name: Create on-demand capacity reservations and save result
-  agnosticd_odcr:
-    reservations: "{{ agnosticd_aws_capacity_reservations }}"
-    regions: "{{ agnosticd_aws_capacity_reservation_regions }}"
-    aws_access_key_id: "{{ aws_access_key_id }}"
-    aws_secret_access_key: "{{ aws_secret_access_key }}"
-    distinct: "{{ agnosticd_aws_capacity_reservation_distinct }}"
-    single_zone: "{{ agnosticd_aws_capacity_reservation_single_zone }}"
-  register: agnosticd_aws_capacity_reservation_results
-
-- name: Set AZ and region
+- name: Retrieve stack_deployed from provision-user-data.yaml
+  when: stack_deployed is undefined
   set_fact:
-    aws_region: "{{ agnosticd_aws_capacity_reservation_results.region }}"
+    stack_deployed: >-
+      {{ lookup('agnosticd_user_data', 'stack_deployed')
+      | default(false, true)
+      | bool }}
 
-
-- name: Ensure aws_region is not passed as extra vars and different
-  assert:
-    that: aws_region == agnosticd_aws_capacity_reservation_results.region
-    msg: >-
-      If you want to use on-demand capacity reservations, do not set
-      aws_region as extra-vars.
-
-- name: Set default aws_availability_zone (single AZ)
-  when: agnosticd_aws_capacity_reservation_results.single_availability_zone | default('') != ''
+- name: Retrieve the region from user-data.yaml
+  when: aws_region | default('', true) == ''
   set_fact:
-    aws_availability_zone: "{{ agnosticd_aws_capacity_reservation_results.single_availability_zone }}"
+    aws_region: "{{ lookup('agnosticd_user_data', 'aws_region') }}"
 
-- name: Save region in user-data
-  agnosticd_user_info:
-    data:
-      aws_region: "{{ agnosticd_aws_capacity_reservation_results.region }}"
+- when: stack_deployed is not defined or stack_deployed == false
+  block:
+    - name: Create on-demand capacity reservations and save result
+      agnosticd_odcr:
+        reservations: "{{ agnosticd_aws_capacity_reservations }}"
+        regions: "{{ agnosticd_aws_capacity_reservation_regions }}"
+        aws_access_key_id: "{{ aws_access_key_id }}"
+        aws_secret_access_key: "{{ aws_secret_access_key }}"
+        distinct: "{{ agnosticd_aws_capacity_reservation_distinct }}"
+        single_zone: "{{ agnosticd_aws_capacity_reservation_single_zone }}"
+      register: agnosticd_aws_capacity_reservation_results
 
-- name: Save AZ in user-data
-  when: agnosticd_aws_capacity_reservation_results.single_availability_zone | default('') != ''
-  agnosticd_user_info:
-    data:
-      aws_availability_zone: "{{ agnosticd_aws_capacity_reservation_results.single_availability_zone }}"
+    - name: Set AZ and region
+      set_fact:
+        aws_region: "{{ agnosticd_aws_capacity_reservation_results.region }}"
+
+
+    - name: Ensure aws_region is not passed as extra vars and different
+      assert:
+        that: aws_region == agnosticd_aws_capacity_reservation_results.region
+        msg: >-
+          If you want to use on-demand capacity reservations, do not set
+          aws_region as extra-vars.
+
+    - name: Set default aws_availability_zone (single AZ)
+      when: agnosticd_aws_capacity_reservation_results.single_availability_zone | default('') != ''
+      set_fact:
+        aws_availability_zone: "{{ agnosticd_aws_capacity_reservation_results.single_availability_zone }}"
+
+    - name: Save region in user-data
+      agnosticd_user_info:
+        data:
+          aws_region: "{{ agnosticd_aws_capacity_reservation_results.region }}"
+
+    - name: Save AZ in user-data
+      when: agnosticd_aws_capacity_reservation_results.single_availability_zone | default('') != ''
+      agnosticd_user_info:
+        data:
+          aws_availability_zone: "{{ agnosticd_aws_capacity_reservation_results.single_availability_zone }}"

--- a/ansible/roles-infra/infra-aws-capacity-reservation/tasks/destroy.yaml
+++ b/ansible/roles-infra/infra-aws-capacity-reservation/tasks/destroy.yaml
@@ -8,11 +8,12 @@
     state: absent
   register: r_odcr
 
-- name: Set fallback_regions (for deletion in the right region)
-  set_fact:
-    fallback_regions: "{{ agnosticd_aws_capacity_reservation_regions }}"
-
 - name: Retrieve the region from user-data.yaml
   when: aws_region | default('') == ''
   set_fact:
     aws_region: "{{ lookup('agnosticd_user_data', 'aws_region') }}"
+
+- name: Set fallback_regions (for deletion in the right region) if lookup didn't work
+  when: aws_region | default('') == ''
+  set_fact:
+    fallback_regions: "{{ agnosticd_aws_capacity_reservation_regions }}"

--- a/ansible/roles-infra/infra-aws-capacity-reservation/tasks/destroy.yaml
+++ b/ansible/roles-infra/infra-aws-capacity-reservation/tasks/destroy.yaml
@@ -11,3 +11,8 @@
 - name: Set fallback_regions (for deletion in the right region)
   set_fact:
     fallback_regions: "{{ agnosticd_aws_capacity_reservation_regions }}"
+
+- name: Retrieve the region from user-data.yaml
+  when: aws_region | default('') == ''
+  set_fact:
+    aws_region: "{{ lookup('agnosticd_user_data', 'aws_region') }}"

--- a/ansible/roles-infra/infra-ec2-template-create/tasks/main.yml
+++ b/ansible/roles-infra/infra-ec2-template-create/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+- name: Retrieve stack_deployed from provision-user-data.yaml
+  when: stack_deployed is undefined
+  set_fact:
+    stack_deployed: >-
+      {{ lookup('agnosticd_user_data', 'stack_deployed')
+      | default(false, true)
+      | bool }}
+
 # This condition cannot be set outside of the role
 # If set in the 'when' of the loop, it's not evaluated between calls
 # and this role will run everytime.
@@ -85,6 +93,20 @@
         var: cloudformation_out
         verbosity: 2
       tags: provision_cf_template
+
+    - set_fact:
+        stack_deployed: true
+      when: cloudformation_out is succeeded
+
+    - name: Save stack deployed for futur runs (idempotent)
+      when: cloudformation_out is succeeded
+      agnosticd_user_info:
+        data:
+          stack_deployed: true
+
+    - set_fact:
+        stack_deployed: false
+      when: cloudformation_out is failed
 
     - when:
         - cloudformation_out is failed
@@ -174,11 +196,3 @@
       when:
         - cloudformation_out is succeeded
         - aws_region != aws_region_final
-
-    - set_fact:
-        stack_deployed: true
-      when: cloudformation_out is succeeded
-
-    - set_fact:
-        stack_deployed: false
-      when: cloudformation_out is failed

--- a/ansible/roles-infra/infra-images/tasks/ec2.yaml
+++ b/ansible/roles-infra/infra-images/tasks/ec2.yaml
@@ -19,5 +19,10 @@
       loop_control:
         label: "{{ item.key }}"
       debug:
-        msg: "{{ item.key }} - {{ item.value.name }} - {{ item.value.image_id }} - {{ item.value.platform_details }}"
+        msg: >-
+          {{ item.key }} -
+          {{ item.value.name }} -
+          {{ item.value.image_id }} -
+          {{ item.value.platform_details }} -
+          {{ aws_region_final | default(aws_region) | default('us-east-1') }}
       loop: "{{ agnosticd_images | dict2items }}"

--- a/ansible/setup_output_dir.yml
+++ b/ansible/setup_output_dir.yml
@@ -1,0 +1,53 @@
+---
+- name: Step 0000 Setup Output Directory
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  become: false
+  tasks:
+    - name: Set output_dir if not defined
+      set_fact:
+        output_dir: >-
+          {{
+          ANSIBLE_REPO_PATH + '/workdir' if ANSIBLE_REPO_PATH is defined
+          else '/tmp/output_dir'
+          }}
+      when: output_dir is not defined
+
+    - name: Create output_dir if it does not exists
+      file:
+        path: "{{ output_dir }}"
+        state: directory
+
+    - name: Attempt to restore output_dir contents
+      when: agnosticd_save_output_dir_archive is defined
+      include_role:
+        name: agnosticd_restore_output_dir
+
+    - name: Touch file provision-user-data.yaml and provision-user-info.yaml
+      file:
+        state: touch
+        path: "{{ [ output_dir, 'provision-' ~ item ] | path_join }}"
+      loop:
+        - user-info.yaml
+        - user-data.yaml
+
+    - name: Create empty user-info.yaml and user-data.yaml in output dir
+      when: not agnosticd_preserve_user_data | default(false) | bool
+      copy:
+        content: |
+          ---
+        dest: "{{ [ output_dir, ACTION ~ '-' ~ item ] | path_join }}"
+      loop:
+        - user-info.yaml
+        - user-data.yaml
+
+    - name: Create symlink user-data.yaml -> provision-user-data.yaml
+      file:
+        src: "{{ [ output_dir, 'provision-' ~ item ] | path_join }}"
+        dest: "{{ [ output_dir, item ] | path_join }}"
+        state: link
+        force: true
+      loop:
+        - user-info.yaml
+        - user-data.yaml

--- a/ansible/setup_runtime.yml
+++ b/ansible/setup_runtime.yml
@@ -29,51 +29,8 @@
         that: cloud_provider in agnosticd_cloud_providers
         msg: "Cloud provider {{ cloud_provider }} is not supported."
 
-    - name: Set output_dir if not defined
-      set_fact:
-        output_dir: >-
-          {{
-          ANSIBLE_REPO_PATH + '/workdir' if ANSIBLE_REPO_PATH is defined
-          else '/tmp/output_dir'
-          }}
-      when: output_dir is not defined
 
-    - name: Create output_dir if it does not exists
-      file:
-        path: "{{ output_dir }}"
-        state: directory
-
-    - name: Attempt to restore output_dir contents
-      when: agnosticd_save_output_dir_archive is defined
-      include_role:
-        name: agnosticd_restore_output_dir
-
-    - name: Touch file provision-user-data.yaml and provision-user-info.yaml
-      file:
-        state: touch
-        path: "{{ [ output_dir, 'provision-' ~ item ] | path_join }}"
-      loop:
-      - user-info.yaml
-      - user-data.yaml
-
-    - name: Create empty user-info.yaml and user-data.yaml in output dir
-      when: not agnosticd_preserve_user_data | default(false) | bool
-      copy:
-        content: |
-          ---
-        dest: "{{ [ output_dir, ACTION ~ '-' ~ item ] | path_join }}"
-      loop:
-      - user-info.yaml
-      - user-data.yaml
-
-    - name: Create symlink user-data.yaml -> provision-user-data.yaml
-      file:
-        src: "{{ [ output_dir, 'provision-' ~ item ] | path_join }}"
-        dest: "{{ [ output_dir, item ] | path_join }}"
-        state: link
-      loop:
-      - user-info.yaml
-      - user-data.yaml
+- import_playbook: setup_output_dir.yml
 
 # include global vars from the config
 - import_playbook: include_vars.yml

--- a/ansible/setup_runtime.yml
+++ b/ansible/setup_runtime.yml
@@ -48,6 +48,14 @@
       include_role:
         name: agnosticd_restore_output_dir
 
+    - name: Touch file provision-user-data.yaml and provision-user-info.yaml
+      file:
+        state: touch
+        path: "{{ [ output_dir, 'provision-' ~ item ] | path_join }}"
+      loop:
+      - user-info.yaml
+      - user-data.yaml
+
     - name: Create empty user-info.yaml and user-data.yaml in output dir
       when: not agnosticd_preserve_user_data | default(false) | bool
       copy:
@@ -63,7 +71,6 @@
         src: "{{ [ output_dir, 'provision-' ~ item ] | path_join }}"
         dest: "{{ [ output_dir, item ] | path_join }}"
         state: link
-        force: true
       loop:
       - user-info.yaml
       - user-data.yaml

--- a/ansible/setup_runtime.yml
+++ b/ansible/setup_runtime.yml
@@ -53,7 +53,17 @@
       copy:
         content: |
           ---
-        dest: "{{ output_dir }}/{{ item }}"
+        dest: "{{ [ output_dir, ACTION ~ '-' ~ item ] | path_join }}"
+      loop:
+      - user-info.yaml
+      - user-data.yaml
+
+    - name: Create symlink user-data.yaml -> provision-user-data.yaml
+      file:
+        src: "{{ [ output_dir, 'provision-' ~ item ] | path_join }}"
+        dest: "{{ [ output_dir, item ] | path_join }}"
+        state: link
+        force: true
       loop:
       - user-info.yaml
       - user-data.yaml

--- a/ansible/update.yml
+++ b/ansible/update.yml
@@ -10,7 +10,7 @@
     - setup_runtime
   become: false
   tasks:
-    - name: Set ACTION to provision
+    - name: Set ACTION to update
       when: ACTION is undefined
       set_fact:
         ACTION: update

--- a/ansible/update.yml
+++ b/ansible/update.yml
@@ -1,5 +1,19 @@
 ---
 # Entry point for update action.
+- name: Step 0000 Set Action
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  tags:
+    - must
+    - step0000
+    - setup_runtime
+  become: false
+  tasks:
+    - name: Set ACTION to provision
+      when: ACTION is undefined
+      set_fact:
+        ACTION: update
 
 - name: Setup AgnosticD Runtime
   import_playbook: setup_runtime.yml

--- a/docs/User_Info.adoc
+++ b/docs/User_Info.adoc
@@ -70,7 +70,7 @@ To set data to be consumed by other automation, such as the Babylon Events UI/Bo
         openshift_api_url: "{{ _openshift_api_url }}"
 ---------------------------------------------------------------
 
-Data values are saved as a dictionary to `user-data.yaml` in the output directory.
+Data values are saved as a dictionary to `provision-user-data.yaml` in the output directory.
 
 To use this data through bookbag Asciidoc deployed by the Babylon Events UI we recommend setting AsciiDoc macros:
 
@@ -117,4 +117,4 @@ User `data` dictionary values are combined with any values previously set for th
 If the same key is set twice for a user then the previous value is replaced.
 Environment data, set by calls to `agnosticd_user_info` without `user` will not be exposed to users.
 
-All user data and messages is collected in `user-data.yaml` with user data stored as a dictionary under the key "users".
+All user data and messages is collected in `ACTION-user-data.yaml` with user data stored as a dictionary under the key "users".

--- a/training/03_Infrastructure/02_Advanced/03_Understanding_Main_File.adoc
+++ b/training/03_Infrastructure/02_Advanced/03_Understanding_Main_File.adoc
@@ -346,8 +346,8 @@ Which is a file also on `agnosticd/ansible directory`, not on our own config dir
      - agnosticd_callback_url != ''
      - agnosticd_callback_token != ''
      vars:
-       user_data_yaml: "{{ output_dir ~ '/user-data.yaml' }}"
-       user_info_yaml: "{{ output_dir ~ '/user-info.yaml' }}"
+       user_data_yaml: "{{ [ output_dir, ACTION ~ '-user-data.yaml' ] | path_join }}"
+       user_info_yaml: "{{ [ output_dir, ACTION ~ '-user-info.yaml' ] | path_join }}"
      uri:
        url: "{{ agnosticd_callback_url }}"
        method: POST


### PR DESCRIPTION
- Add action name prefix to `user-data.yaml`, `user-info.yaml`, `user-body.yaml`.
- Default `agnosticd_user_info` lookup to look in `provision-user-data.yaml`

That allows agnosticd to use user-data from provision, duing destroy or stop/start when:

- developping locally
- agnosticd_restore/save_output_dir  role is used in production
- [x] Provision using JBON and micro instance to validate multiregion. Use a small TTL to reduce costs.
- [X] Validate stop / start / destroy is finding the right region. without specifying the region.
- [X] Patch agnosticd base-infra config too
- [X] Patch cloudformation to not run if it was executed already (idempotency)
- [X] Provide a sample var for multiple region fallback
