### PR TITLE
Add action name prefix to user-data/body/info.yaml

### DIFF
--- a/ansible/action_plugins/agnosticd_user_info.py
+++ b/ansible/action_plugins/agnosticd_user_info.py
@@ -88,13 +88,8 @@ class ActionModule(ActionBase):
             result['user'] = user
 
         try:
-            output_dir = self._templar.template(
-                task_vars.get('output_dir',
-                    task_vars['hostvars'].get('localhost',{}).get('output_dir',
-                        task_vars.get('playbook_dir', '.')
-                    )
-                )
-            )
+            action = self._templar.template('{{ ACTION | default("provision") }}')
+            output_dir = self._templar.template('{{ output_dir | default(playbook_dir) | default(".") }}')
 
             # Attempt to make output_dir if not exists
             try:
@@ -103,7 +98,7 @@ class ActionModule(ActionBase):
                 pass
 
             if not user and msg != None:
-                fh = open(os.path.join(output_dir, 'user-info.yaml'), 'a')
+                fh = open(os.path.join(output_dir, action + '-user-info.yaml'), 'a')
                 if isinstance(msg, list):
                     for m in msg:
                         fh.write('- ' + json.dumps(m) + "\n")
@@ -111,13 +106,13 @@ class ActionModule(ActionBase):
                     fh.write('- ' + json.dumps(msg) + "\n")
                 fh.close()
             if not user and body != None:
-                fh = open(os.path.join(output_dir, 'user-body.yaml'), 'a')
+                fh = open(os.path.join(output_dir, action + '-user-body.yaml'), 'a')
                 fh.write('- ' + json.dumps(body) + "\n")
                 fh.close()
             if data or user:
                 user_data = None
                 try:
-                    fh = open(os.path.join(output_dir, 'user-data.yaml'), 'r')
+                    fh = open(os.path.join(output_dir, action + '-user-data.yaml'), 'r')
                     user_data = yaml.safe_load(fh)
                     fh.close()
                 except FileNotFoundError:
@@ -149,7 +144,7 @@ class ActionModule(ActionBase):
                 else:
                     user_data.update(data)
 
-                fh = open(os.path.join(output_dir, 'user-data.yaml'), 'w')
+                fh = open(os.path.join(output_dir, action + '-user-data.yaml'), 'w')
                 yaml.safe_dump(user_data, stream=fh, explicit_start=True)
                 fh.close()
             result['failed'] = False

--- a/ansible/completion_callback.yml
+++ b/ansible/completion_callback.yml
@@ -10,9 +10,9 @@
       - agnosticd_callback_url != ''
       - agnosticd_callback_token != ''
       vars:
-        user_body_yaml: "{{ output_dir ~ '/user-body.yaml' }}"
-        user_data_yaml: "{{ output_dir ~ '/user-data.yaml' }}"
-        user_info_yaml: "{{ output_dir ~ '/user-info.yaml' }}"
+        user_body_yaml: "{{ output_dir ~ '/' ~ ACTION ~ '-user-body.yaml' }}"
+        user_data_yaml: "{{ output_dir ~ '/' ~ ACTION ~ '-user-data.yaml' }}"
+        user_info_yaml: "{{ output_dir ~ '/' ~ ACTION ~ '-user-info.yaml' }}"
       uri:
         url: "{{ agnosticd_callback_url }}"
         method: POST

--- a/ansible/library/agnosticd_user_info.py
+++ b/ansible/library/agnosticd_user_info.py
@@ -32,7 +32,7 @@ version_added: "2.9"
 
 description:
 - This module provides the capability of displaying user information in agnosticd processing while saving the output as a YAML in the output directory.
-- Files "user-info.yaml" stores a list of messages to deliver to the environment owner and "user-data.yaml" store structured data.
+- Files "{{ ACTION }}-user-info.yaml" stores a list of messages to deliver to the environment owner and "{{ ACTION }}-user-data.yaml" store structured data.
 - Messages and data can be stored for specific users to support multi-user environments.
 - The string "user.info: " is prepended to the displayed output for compatibility with the prior practice of using the debug module with this special prefix string.
 

--- a/ansible/lookup_plugins/agnosticd_user_data.py
+++ b/ansible/lookup_plugins/agnosticd_user_data.py
@@ -46,14 +46,14 @@ from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 
 class LookupModule(LookupBase): 
-    def run(self, terms, user=None, **kwargs):
+    def run(self, terms, action='provision', user=None, **kwargs):
         self.set_options(direct=kwargs)
         ret = []
 
         output_dir = self._templar.template('{{ output_dir | default(playbook_dir) | default(".") }}')
         user_data = {}
         try:
-            fh = open(os.path.join(output_dir, 'user-data.yaml'), 'r')
+            fh = open(os.path.join(output_dir, action + '-user-data.yaml'), 'r')
             user_data = yaml.safe_load(fh)
             fh.close()
         except FileNotFoundError:

--- a/ansible/setup_runtime.yml
+++ b/ansible/setup_runtime.yml
@@ -48,15 +48,23 @@
       include_role:
         name: agnosticd_restore_output_dir
 
-    - name: Create empty user-info.yaml and user-data.yaml in output dir
-      when: not agnosticd_preserve_user_data | default(false) | bool
+    - name: Create empty {{ ACTION }}-user-info.yaml and {{ ACTION }}-user-data.yaml in output dir
+      when: >
+        not (output_dir ~ '/' ~ item) is exists or
+        not agnosticd_preserve_user_data | default(false) | bool
       copy:
         content: |
           ---
         dest: "{{ output_dir }}/{{ item }}"
       loop:
-      - user-info.yaml
-      - user-data.yaml
+      - {{ ACTION }}-user-info.yaml
+      - {{ ACTION }}-user-data.yaml
+
+    - name: Create symlink from user-data.yaml to {{ ACTION }}-user-data.yaml
+      file:
+        dest: "{{ output_dir }}/user-data.yaml"
+        src: "{{ output_dir }}/{{ ACTION }}-user-data.yaml"
+        state: link
 
 # include global vars from the config
 - import_playbook: include_vars.yml


### PR DESCRIPTION
##### SUMMARY

- Add action name prefix to user-data.yaml, user-info.yaml, user-body.yaml.
- Default agnosticd_user_info lookup to look in provision-user-data.yaml

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Core