### PR TITLE
HCP Telco Lab Fixes required auth for ksushy

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_telco_hypershift_lab/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_telco_hypershift_lab/tasks/pre_workload.yml
@@ -261,6 +261,9 @@
 - name: Ensure ksushy is listening for redfish connections
   ansible.builtin.uri:
     url: https://infra.{{ lab_network_domain }}:9000/redfish/v1/Systems/local/hosted-worker0
+    force_basic_auth: true
+    user: admin
+    password: admin
     method: GET
     status_code: 200
     validate_certs: false


### PR DESCRIPTION
Issue with ksushy:
```
TASK [ocp4_workload_telco_hypershift_lab : Ensure ksushy is listening for redfish connections] ***
Tuesday 05 November 2024  05:50:58 +0000 (0:00:02.266)       0:08:42.630 ****** 
fatal: [hypervisor]: FAILED! => {"changed": false, "connection": "close", "content_length": "772", "content_type": "text/html; charset=UTF-8", "date": "Tue, 05 Nov 2024 05:50:59 GMT", "elapsed": 0, "msg": "Status code was 401 and not [200]: HTTP Error 401: Unauthorized", "redirected": false, "server": "Cheroot/10.0.1", "status": 401, "url": "https://xxxx.yyy.vv/vvv/YYYYY-worker0", "www_authenticate": "Basic realm=\"private\""}
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_telco_hypershift_lab
ansible/roles_ocp_workloads/ocp4_workload_telco_hypershift_lab/tasks/pre_workload.yml

