### PR TITLE
Increase retry because it failing a lot during summit connect deployment

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/tasks/workload.yml
@@ -119,7 +119,7 @@
       namespace: "{{ ocp4_workload_gitea_operator_project }}"
     register: r_gitea
     until: r_gitea.resources[0].status.giteaRoute is defined
-    retries: 90
+    retries: 180
     delay: 10
 
   - name: Set gitea route variable


### PR DESCRIPTION

##### SUMMARY
Increase retry because it failing a lot during summit connect deployment

```
TASK [ocp4_workload_gitea_operator : Create Gitea instance] ********************
fatal: [bastion.h4rl5.internal]: FAILED! => {"changed": false, "msg": "HTTPSConnectionPool(host='api.cluster-XXXX.XXX', port=YYYY): Max retries exceeded with url: /version (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0xYYYYYYYFDc0>: Failed to establish a new connection: [Errno 111] Connection refused'))"}
```


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/tasks/workload.yml
TASK [ocp4_workload_gitea_operator : Create Gitea instance]
