### PR TITLE
[GPTEINFRA-12416] [install_operator] Retry checking CSV

### DIFF
--- a/ansible/roles/install_operator/tasks/install.yml
+++ b/ansible/roles/install_operator/tasks/install.yml
@@ -111,36 +111,73 @@
   kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('template', 'installplan.yaml.j2') }}"
-
-- name: "Get Installed CSV ({{ install_operator_name }})"
-  kubernetes.core.k8s_info:
-    api_version: operators.coreos.com/v1alpha1
-    kind: Subscription
-    name: "{{ install_operator_name }}"
-    namespace: "{{ install_operator_namespace }}"
-  register: r_subscription
-  retries: 30
-  delay: 10
-  until:
-  - r_subscription.resources[0].status.currentCSV is defined
-  - r_subscription.resources[0].status.currentCSV | length > 0
-
-- name: "Print CSV version to be installed ({{ install_operator_name }})"
-  when: install_operator_starting_csv is defined
-  ansible.builtin.debug:
-    msg: "Starting CSV: {{ install_operator_starting_csv }}"
-
-- name: "Wait until CSV is installed ({{ install_operator_name }})"
-  kubernetes.core.k8s_info:
-    api_version: operators.coreos.com/v1alpha1
-    kind: ClusterServiceVersion
-    name: "{{ r_subscription.resources[0].status.currentCSV }}"
-    namespace: "{{ install_operator_namespace }}"
-  register: r_csv
-  retries: 120
-  delay: 30
-  until:
-  - r_csv.resources[0].status.phase is defined
-  - r_csv.resources[0].status.phase | length > 0
-  - r_csv.resources[0].status.phase == "Succeeded"
-  ignore_errors: "{{ install_operator_install_csv_ignore_error }}"
+- name: Get installed CSV and wait till is installed
+  block:
+  - name: "Get Installed CSV ({{ install_operator_name }})"
+    kubernetes.core.k8s_info:
+      api_version: operators.coreos.com/v1alpha1
+      kind: Subscription
+      name: "{{ install_operator_name }}"
+      namespace: "{{ install_operator_namespace }}"
+    register: r_subscription
+    retries: 30
+    delay: 10
+    until:
+    - r_subscription.resources[0].status.currentCSV is defined
+    - r_subscription.resources[0].status.currentCSV | length > 0
+  
+  - name: "Print CSV version to be installed ({{ install_operator_name }})"
+    when: install_operator_starting_csv is defined
+    ansible.builtin.debug:
+      msg: "Starting CSV: {{ install_operator_starting_csv }}"
+  
+  - name: "Wait until CSV is installed ({{ install_operator_name }})"
+    kubernetes.core.k8s_info:
+      api_version: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      name: "{{ r_subscription.resources[0].status.currentCSV }}"
+      namespace: "{{ install_operator_namespace }}"
+    register: r_csv
+    retries: 60
+    delay: 30
+    until:
+    - r_csv.resources[0].status.phase is defined
+    - r_csv.resources[0].status.phase | length > 0
+    - r_csv.resources[0].status.phase == "Succeeded"
+    ignore_errors: "{{ install_operator_install_csv_ignore_error }}"
+  rescue:
+  - name: Pause for 5 minute waiting for CSV replacements
+    ansible.builtin.pause:
+      minutes: 5
+  - name: "Get Installed CSV ({{ install_operator_name }})"
+    kubernetes.core.k8s_info:
+      api_version: operators.coreos.com/v1alpha1
+      kind: Subscription
+      name: "{{ install_operator_name }}"
+      namespace: "{{ install_operator_namespace }}"
+    register: r_subscription
+    retries: 30
+    delay: 10
+    until:
+    - r_subscription.resources[0].status.currentCSV is defined
+    - r_subscription.resources[0].status.currentCSV | length > 0
+  
+  - name: "Print CSV version to be installed ({{ install_operator_name }})"
+    when: install_operator_starting_csv is defined
+    ansible.builtin.debug:
+      msg: "Starting CSV: {{ install_operator_starting_csv }}"
+  
+  - name: "Wait until CSV is installed ({{ install_operator_name }})"
+    kubernetes.core.k8s_info:
+      api_version: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      name: "{{ r_subscription.resources[0].status.currentCSV }}"
+      namespace: "{{ install_operator_namespace }}"
+    register: r_csv
+    retries: 60
+    delay: 30
+    until:
+    - r_csv.resources[0].status.phase is defined
+    - r_csv.resources[0].status.phase | length > 0
+    - r_csv.resources[0].status.phase == "Succeeded"
+    ignore_errors: "{{ install_operator_install_csv_ignore_error }}"


### PR DESCRIPTION
##### SUMMARY

Installing an operator usually replaces the CSV till get the latest version, this is a race condition situation causing issues.

This PR adds a waiting of 5 minutes in case of failure, and it retries.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
install_operator Role