### PR TITLE
[GPTEINFRA-12416][ocp4_workload_openshift_gitops] Add missing retries/delay

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/workload.yml
@@ -49,6 +49,8 @@
     name: openshift-gitops
     namespace: openshift-gitops
   register: r_openshift_gitops
+  retries: 10
+  delay: 30
   until:
   - r_openshift_gitops is defined
   - r_openshift_gitops.resources is defined


### PR DESCRIPTION
##### SUMMARY

The task "Wait until openshift-gitops ArgoCD instance has been created" has defined an until but not a retries/delay

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
ocp4_workload_openshift_gitops Role

