### PR TITLE
[ocp4_workload_openshift_gitops] Add retries waiting for ArgoCD

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/workload.yml
@@ -49,8 +49,8 @@
     name: openshift-gitops
     namespace: openshift-gitops
   register: r_openshift_gitops
-  retries: 10
-  delay: 30
+  retries: 16
+  delay: 60
   until:
   - r_openshift_gitops is defined
   - r_openshift_gitops.resources is defined


### PR DESCRIPTION
##### SUMMARY

Adding more retries/delay as in some busy environments ArgoCD takes more time

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
ocp4_workload_openshift_gitops Role
