### PR TITLE
[infra-ec2-template-create] Set stack_deployed at the end of the block

### DIFF
--- a/ansible/roles-infra/infra-ec2-template-create/tasks/main.yml
+++ b/ansible/roles-infra/infra-ec2-template-create/tasks/main.yml
@@ -94,20 +94,6 @@
         verbosity: 2
       tags: provision_cf_template
 
-    - set_fact:
-        stack_deployed: true
-      when: cloudformation_out is succeeded
-
-    - name: Save stack deployed for futur runs (idempotent)
-      when: cloudformation_out is succeeded
-      agnosticd_user_info:
-        data:
-          stack_deployed: true
-
-    - set_fact:
-        stack_deployed: false
-      when: cloudformation_out is failed
-
     - when:
         - cloudformation_out is failed
         - fallback_regions is defined
@@ -196,3 +182,17 @@
       when:
         - cloudformation_out is succeeded
         - aws_region != aws_region_final
+
+    - set_fact:
+        stack_deployed: true
+      when: cloudformation_out is succeeded
+
+    - name: Save stack deployed for futur runs (idempotent)
+      when: cloudformation_out is succeeded
+      agnosticd_user_info:
+        data:
+          stack_deployed: true
+
+    - set_fact:
+        stack_deployed: false
+      when: cloudformation_out is failed


### PR DESCRIPTION
##### SUMMARY

Setting stack_deployed to true, it skips the tasks after the set_fact

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
infra-ec2-template-create role

