### PR TITLE
[host-ocp4-assisted-destroy] Ignore errors for cleanup ceph

### DIFF
--- a/ansible/roles/host-ocp4-assisted-destroy/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-destroy/tasks/main.yaml
@@ -20,6 +20,10 @@
         definition: "{{ lookup('ansible.builtin.template', 'templates/cleanup-ceph.yaml.j2') }}"
         wait: true
         wait_timeout: 300
+      register: r_cleanup
+      retries: 6
+      delay: 30
+      ignore_errors: true
 
     - name: Delete dns records
       when: cluster_dns_server is defined


### PR DESCRIPTION
##### SUMMARY

If the service account is not valid, destroying the environment fails here. This can happen if the cluster is reinstalled or other situations where the SA doesnt  xist anymore.

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
host-ocp4-assisted-destroy role
