### PR TITLE
adding task and condition for aap2.5

### DIFF
--- a/ansible/roles/ansible_bu_setup_workshop/defaults/main.yml
+++ b/ansible/roles/ansible_bu_setup_workshop/defaults/main.yml
@@ -6,6 +6,12 @@
 workshop_type: rhel
 workshop_version: 1.0.18
 
+# Enable offline image base AAP repo
+ansible_bu_setup_workshop_enable_offline_aap_repo: true
+ansible_bu_setup_workshop_aap_packages:
+  - ansible-core
+  - ansible-navigator
+
 # Ansible BU exercise base directory 
 ansible_bu_setup_workshop_exercise_src: ansible_rhel
 # Destination directory where exercise will be copied 

--- a/ansible/roles/ansible_bu_setup_workshop/tasks/common/ansible-navigator.yml
+++ b/ansible/roles/ansible_bu_setup_workshop/tasks/common/ansible-navigator.yml
@@ -9,6 +9,7 @@
   delegate_to: localhost
 
 - name: Enable offline automation controller repo
+  when: ansible_bu_setup_workshop_enable_offline_aap_repo | bool
   community.general.ini_file:
     path: "/etc/yum.repos.d/ansible-automation-platform.repo"
     section: ansible-automation-platform
@@ -17,9 +18,7 @@
 
 - name: Install ansible core & navigator
   ansible.builtin.dnf:
-    name:
-      - ansible-core
-      - ansible-navigator
+    name: "{{ ansible_bu_setup_workshop_aap_packages }}"
     state: present
 
 - name: Install ansible.cfg in home directory

--- a/ansible/roles/automation_platform_loader/defaults/main.yml
+++ b/ansible/roles/automation_platform_loader/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 automation_platform_loader_generate_ssh_keypair: true
+automation_platform_loader_aap_version: 2.4
 
 automation_platform_loader_ssh_key_type: ed25519
 automation_platform_loader_ssh_key_path: "/tmp/id_{{ automation_platform_loader_ssh_key_type }}"

--- a/ansible/roles/automation_platform_loader/defaults/main.yml
+++ b/ansible/roles/automation_platform_loader/defaults/main.yml
@@ -1,8 +1,6 @@
 ---
 automation_platform_loader_generate_ssh_keypair: true
-
-# Set to false to work with AAP2.5
-automation_platform_loader_create_token: true
+automation_platform_loader_create_token: 2.4
 
 automation_platform_loader_ssh_key_type: ed25519
 automation_platform_loader_ssh_key_path: "/tmp/id_{{ automation_platform_loader_ssh_key_type }}"

--- a/ansible/roles/automation_platform_loader/defaults/main.yml
+++ b/ansible/roles/automation_platform_loader/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 automation_platform_loader_generate_ssh_keypair: true
-automation_platform_loader_aap_version: 2.4
+
+# Set to false to work with AAP2.5
+automation_platform_loader_create_token: true
 
 automation_platform_loader_ssh_key_type: ed25519
 automation_platform_loader_ssh_key_path: "/tmp/id_{{ automation_platform_loader_ssh_key_type }}"

--- a/ansible/roles/automation_platform_loader/tasks/main.yml
+++ b/ansible/roles/automation_platform_loader/tasks/main.yml
@@ -28,6 +28,9 @@
       retries: 30
       delay: 30
 
+    - pause:
+        minutes: 5
+
     - name: Create a new AAP2 Auth token using controller username/password
       when: automation_platform_loader_create_token | bool
       awx.awx.token:

--- a/ansible/roles/automation_platform_loader/tasks/main.yml
+++ b/ansible/roles/automation_platform_loader/tasks/main.yml
@@ -21,7 +21,7 @@
   block:
 
     - name: Create a new AAP2 Auth token using controller username/password
-      when: automation_platform_loader_aap_version <= 2.4
+      when: automation_platform_loader_create_token | bool
       awx.awx.token:
         description: Creating token to configure AAP2 resources
         scope: write
@@ -31,18 +31,8 @@
       retries: 10
       delay: 30
 
-    - name: Create a new AAP2 Auth token using controller username/password
-      when: automation_platform_loader_aap_version > 2.4
-      ansible.controller.token:
-        description: Creating token to configure AAP2 resources
-        scope: write
-        state: present
-      register: r_aap2_token
-      until: r_aap2_token.failed == false
-      retries: 10
-      delay: 30
-
     - name: Set agnosticd_user_info ssh data
+      when: automation_platform_loader_create_token | bool
       agnosticd_user_info:
         data:
           aap_controller_token: "{{ r_aap2_token.ansible_facts.controller_token.token }}"

--- a/ansible/roles/automation_platform_loader/tasks/main.yml
+++ b/ansible/roles/automation_platform_loader/tasks/main.yml
@@ -21,7 +21,19 @@
   block:
 
     - name: Create a new AAP2 Auth token using controller username/password
+      when: automation_platform_loader_aap_version <= 2.4
       awx.awx.token:
+        description: Creating token to configure AAP2 resources
+        scope: write
+        state: present
+      register: r_aap2_token
+      until: r_aap2_token.failed == false
+      retries: 10
+      delay: 30
+
+    - name: Create a new AAP2 Auth token using controller username/password
+      when: automation_platform_loader_aap_version > 2.4
+      ansible.controller.token:
         description: Creating token to configure AAP2 resources
         scope: write
         state: present

--- a/ansible/roles/automation_platform_loader/tasks/main.yml
+++ b/ansible/roles/automation_platform_loader/tasks/main.yml
@@ -20,20 +20,20 @@
     CONTROLLER_VERIFY_SSL: "{{ aap_auth.controller_verify_ssl | default('true') }}"
   block:
 
-    - name: Wait until a Automation Controller URL is reachable
-      ansible.builtin.uri:
-        url: "https://{{ aap_auth.controller_host | default(aap_controller_web_url) }}"
-      register: r_ac_url_status
-      until: r_ac_url_status.status == 200
-      retries: 30
+    - name: Create a new AAP2 Auth token using controller username/password
+      when: automation_platform_loader_aap_version <= 2.4
+      awx.awx.token:
+        description: Creating token to configure AAP2 resources
+        scope: write
+        state: present
+      register: r_aap2_token
+      until: r_aap2_token.failed == false
+      retries: 10
       delay: 30
 
-    # - pause:
-    #     minutes: 5
-
     - name: Create a new AAP2 Auth token using controller username/password
-      when: automation_platform_loader_create_token | bool
-      awx.awx.token:
+      when: automation_platform_loader_aap_version > 2.4
+      ansible.controller.token:
         description: Creating token to configure AAP2 resources
         scope: write
         state: present

--- a/ansible/roles/automation_platform_loader/tasks/main.yml
+++ b/ansible/roles/automation_platform_loader/tasks/main.yml
@@ -28,8 +28,8 @@
       retries: 30
       delay: 30
 
-    - pause:
-        minutes: 5
+    # - pause:
+    #     minutes: 5
 
     - name: Create a new AAP2 Auth token using controller username/password
       when: automation_platform_loader_create_token | bool
@@ -49,5 +49,6 @@
           aap_controller_token: "{{ r_aap2_token.ansible_facts.controller_token.token }}"
 
     - name: Configure AAP2 Controller and Hub
+      become: false
       ansible.builtin.import_role:
         name: infra.controller_configuration.dispatch

--- a/ansible/roles/automation_platform_loader/tasks/main.yml
+++ b/ansible/roles/automation_platform_loader/tasks/main.yml
@@ -20,6 +20,14 @@
     CONTROLLER_VERIFY_SSL: "{{ aap_auth.controller_verify_ssl | default('true') }}"
   block:
 
+    - name: Wait until a Automation Controller URL is reachable
+      ansible.builtin.uri:
+        url: "https://{{ aap_auth.controller_host | default(aap_controller_web_url) }}"
+      register: r_ac_url_status
+      until: r_ac_url_status.status == 200
+      retries: 30
+      delay: 30
+
     - name: Create a new AAP2 Auth token using controller username/password
       when: automation_platform_loader_create_token | bool
       awx.awx.token:

--- a/ansible/roles/automation_platform_loader/tasks/main.yml
+++ b/ansible/roles/automation_platform_loader/tasks/main.yml
@@ -49,6 +49,5 @@
           aap_controller_token: "{{ r_aap2_token.ansible_facts.controller_token.token }}"
 
     - name: Configure AAP2 Controller and Hub
-      become: false
       ansible.builtin.import_role:
         name: infra.controller_configuration.dispatch


### PR DESCRIPTION
##### SUMMARY

1- Added condition to create token to support Ansible Automation Platform 2.5 
Cause: awx.awx.token module doesn't work with AAP2.5 at the moment

2- Updated ansible-bu-setup-workshop role to be compatible with AAP2.5


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
role: 
  - automation_platform_loader 
  - ansible_bu_setup_workshop 