### PR TITLE
Add missing permission on backuptarget namespaces

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/tasks/workload.yml
@@ -65,6 +65,7 @@
     - objectbucketclaim.yaml.j2
     - clusterrolebinding.yaml.j2
     - rolebinding.yaml.j2
+    - rolebinding-namespace.yaml.j2
     loop_control:
       loop_var: resource
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/templates/rolebinding-namespace.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/templates/rolebinding-namespace.yaml.j2
@@ -1,0 +1,18 @@
+{% if ocp4_workload_kasten_k10_multi_user | bool %}
+{%   for user_number in range(1, ocp4_workload_kasten_k10_num_users | int + 1) %}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: admin-{{ ocp4_workload_kasten_k10_objectbucket_namespace_base }}{{ user_number }}
+  namespace: {{ ocp4_workload_kasten_k10_objectbucket_namespace_base }}{{ user_number }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: {{ ocp4_workload_kasten_k10_objectbucket_user_base }}{{ user_number }}
+{%   endfor %}
+{% endif %}

--- a/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/templates/rolebinding.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/templates/rolebinding.yaml.j2
@@ -4,12 +4,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: view-{{ ocp4_workload_kasten_k10_objectbucket_user_base }}{{ user_number }}
+  name: edit-{{ ocp4_workload_kasten_k10_objectbucket_user_base }}{{ user_number }}
   namespace: kasten-io
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: view
+  name: edit
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User


### PR DESCRIPTION
##### SUMMARY

Users didn't have permissions for their backuptarget namespaces. Adding admin role.
\
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_kasten_k10