### PR TITLE
[host-ocp4-assisted-installer] Add retries to find failed installer pods

### DIFF
--- a/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
@@ -569,7 +569,10 @@
       - app=installer
     field_selectors:
       - status.phase=Failed
-  register: pod_info
+  register: r_pod_info
+  delay: 30
+  retries: 10
+  until: r_pod_info is success
 
 - name: Delete Error Pods
   kubernetes.core.k8s:
@@ -580,7 +583,7 @@
         name: "{{ pod.metadata.name }}"
         namespace: "{{ pod.metadata.namespace }}"
     state: absent
-  loop: "{{ pod_info.resources }}"
+  loop: "{{ r_pod_info.resources }}"
   loop_control:
     loop_var: pod
     


### PR DESCRIPTION
##### SUMMARY

After the cluster is installed, in some strange cases, this task fails (DNS or API not accessible). Adding some retries to fix the problem.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
host-ocp4-assisted-installer role
