### PR TITLE
Add permissions to view (vm) templates for regular users

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_multi_user/files/clusterrolebinding-template-view.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_multi_user/files/clusterrolebinding-template-view.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: template-view-non-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: template:view
+subjects:
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: 'system:authenticated'

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_multi_user/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_multi_user/tasks/workload.yml
@@ -6,6 +6,7 @@
   loop:
   - clusterrole-operator-viewer.yaml
   - clusterrolebinding-operator-view.yaml
+  - clusterrolebinding-template-view.yaml
   loop_control:
     loop_var: resource
 


### PR DESCRIPTION
##### SUMMARY

In order to browse the (VM) template catalog in OpenShift Virtualization users need permission. Adding the `template:view` cluster role to authenticated users.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_virt_roadshow_multi_user