### PR TITLE
[host-ocp4-assisted-installer] For worker_instance_count to be an int

### DIFF
--- a/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
@@ -56,7 +56,7 @@
 
   block:
     - name: Configure a SNO cluster
-      when: worker_instance_count == 0
+      when: worker_instance_count | int == 0
       block:
         - name: Add the service (type LoadBalancer) for SNO
           kubernetes.core.k8s:


### PR DESCRIPTION
##### SUMMARY

AgnosticV is sending worker_instance_count as string when is a parameter

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
host-ocp4-assisted-installer role

