### PR TITLE
[infra-openshift-cnv-resources] Wait till the VM is running

### DIFF
--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
@@ -180,7 +180,7 @@
   until: r_vm_status.resources[0].status.printableStatus | default('') == "Running"
   retries: 30
   delay: 10
-  loop: "{{ range(1, _instance.count|default(1)|int+1) | list }}"
+  loop: "{{ range(1, _instance.count | default(1) | int+1) | list }}"
   loop_control:
     index_var: _index
 

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
@@ -170,7 +170,7 @@
 
 - name: Wait till VM is running
   vars:
-    _instance_name: "{{ _instance.name }}{{ _index+1 if _instance.count|d(1)|int > 1 }}"
+    _instance_name: "{{ _instance.name }}{{ _index+1 if _instance.count | default(1) | int > 1 }}"
   kubernetes.core.k8s_info:
     api_version: kubevirt.io/v1
     kind: VirtualMachine

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
@@ -177,7 +177,7 @@
     name: "{{ _instance_name }}"
     namespace: "{{ openshift_cnv_namespace }}"
   register: r_vm_status
-  until: r_vm_status.resources[0].status.printableStatus|default('') == "Running"
+  until: r_vm_status.resources[0].status.printableStatus | default('') == "Running"
   retries: 30
   delay: 10
   loop: "{{ range(1, _instance.count|default(1)|int+1) | list }}"

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
@@ -168,6 +168,22 @@
   retries: "{{ openshift_cnv_retries }}"
   delay: "{{ openshift_cnv_delay }}"
 
+- name: Wait till VM is running
+  vars:
+    _instance_name: "{{ _instance.name }}{{ _index+1 if _instance.count|d(1)|int > 1 }}"
+  kubernetes.core.k8s_info:
+    api_version: kubevirt.io/v1
+    kind: VirtualMachine
+    name: "{{ _instance_name }}"
+    namespace: "{{ openshift_cnv_namespace }}"
+  register: r_vm_status
+  until: r_vm_status.resources[0].status.printableStatus|default('') == "Running"
+  retries: 30
+  delay: 10
+  loop: "{{ range(1, _instance.count|default(1)|int+1) | list }}"
+  loop_control:
+    index_var: _index
+
 - ansible.builtin.set_fact:
     r_openshift_cnv_instances: "{{ r_openshift_cnv_instances + [item] }}"
   loop: "{{ r_openshift_cnv_instance.results | list }}"


### PR DESCRIPTION
##### SUMMARY

New versions of Execution Environment gets stuck on the wait_for_connection for the VM. This PR adds a task to wait for the VM to be running. This doesn't solve the problem but mitigates it.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
infra-openshift-cnv-resources Role
