### PR TITLE
Fix annotation for storageclass

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/tasks/workload.yml
@@ -96,7 +96,7 @@
         definition:
           metadata:
             annotations:
-              k10.kasten.io/sc-supports-block-mode-exports=true
+              k10.kasten.io/sc-supports-block-mode-exports: "true"
       loop: "{{ ocp4_workload_kasten_k10_storageclasses }}"
       loop_control:
         loop_var: storageclass


### PR DESCRIPTION
##### SUMMARY

Syntax to annotate the storage class was wrong. Fixed.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_kasten_k10