### PR TITLE
Fixes 5gran hub cluster deployment

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/workload.yml
@@ -1,13 +1,11 @@
 ---
 # Implement your Workload deployment tasks here
 
-- name: Ensure hub cluster is deployed via kcli
+- name: Kickoff hub cluster deployment via kcli
   ansible.builtin.shell:
-    cmd: kcli create cluster openshift --pf hub.yml -P force=true &> /root/kcli-hub-deploy.log
+    cmd: kcli create cluster openshift --pf hub.yml -P force=true &> /root/kcli-hub-deploy.log &
   args:
     chdir: /root/
-  async: 3600
-  poll: 0
 
 - name: Ensure kubernetes manifests are downloaded
   ansible.builtin.get_url:

--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/workload.yml
@@ -1,11 +1,19 @@
 ---
 # Implement your Workload deployment tasks here
 
-- name: Kickoff hub cluster deployment via kcli
+- name: Deploy hub cluster via kcli
   ansible.builtin.shell:
-    cmd: "(kcli create cluster openshift --pf hub.yml -P force=true &> /root/kcli-hub-deploy.log &)"
+    cmd: kcli create cluster openshift --pf hub.yml -P force=true &> /root/kcli-hub-deploy.log
   args:
     chdir: /root/
+
+- name: Ensure we can login into the hub cluster with the generated credentials
+  ansible.builtin.shell:
+    cmd: oc login https://{{ lab_api_host }} -u admin -p {{ strong_admin_password }}  --insecure-skip-tls-verify=true > /dev/null
+  register: result
+  until: result.rc == 0
+  retries: 120
+  delay: 60
 
 - name: Ensure kubernetes manifests are downloaded
   ansible.builtin.get_url:
@@ -19,14 +27,6 @@
     - {url: "https://raw.githubusercontent.com/{{ repo_user }}/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/hub-cluster/sno1-argoapp.yaml", destination: "/tmp/sno1-argoapp.yaml", mode: "0644"}
     - {url: "https://raw.githubusercontent.com/{{ repo_user }}/5g-ran-deployments-on-ocp-lab/{{ lab_version }}/lab-materials/lab-env-data/hub-cluster/argocd-clusterrolebinding.yaml", destination: "/tmp/argocd-clusterrolebinding.yaml", mode: "0644"}
   # yamllint enable rule:line-length
-
-- name: Wait for hub cluster to be deployed via kcli
-  ansible.builtin.shell:
-    cmd: oc login https://{{ lab_api_host }} -u admin -p {{ strong_admin_password }}  --insecure-skip-tls-verify=true > /dev/null
-  register: result
-  until: result.rc == 0
-  retries: 120
-  delay: 60
 
 - name: Ensure we have the kubeconfig file for the hub cluster copied in the bastion
   ansible.builtin.copy:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
Fixes cluster deployment task being killed when running in background.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4_workload_5gran_deployments_lab
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
