### PR TITLE
ocp4_workload_rhacm_hypershift:  Support OCP 4.17 AWS authn

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/tasks/create_hypershift_cluster.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/tasks/create_hypershift_cluster.yml
@@ -13,6 +13,11 @@
   delay: 30
   until: r_crd.resources | length | int > 0
 
+- name: Include AWS Role Prep for OCP >= 4.17
+  when:
+    - ocp4_installer_version is version('4.17', '>=')
+  include_tasks: prep_aws_roles.yaml
+
 - name: Ensure hosted cluster doesn't already exist
   kubernetes.core.k8s_info:
     api_version: hypershift.openshift.io/v1beta1
@@ -21,10 +26,55 @@
     namespace: local-cluster
   register: r_hosted_cluster
 
-- name: Deploy hosted cluster {{ _ocp4_workload_rhacm_hypershift_cluster_name }}
+- name: Deploy hosted cluster (OCP >= 4.17) {{ _ocp4_workload_rhacm_hypershift_cluster_name }}
+  when:
+  - r_hosted_cluster.resources | length == 0
+  - ocp4_installer_version is version('4.17', '>=')
+  environment:
+    AWS_ACCESS_KEY_ID: "{{ aws_access_key_id }}"
+    AWS_SECRET_ACCESS_KEY: "{{ aws_secret_access_key }}"
+    AWS_REGION: "{{ ocp4_workload_rhacm_hypershift_s3_bucket_region }}"
+  block:
+  - name: Run hcp CLI to deploy hosted cluster (OCP >= 4.17)
+    ansible.builtin.command: >-
+      /usr/bin/hcp create cluster aws
+        --auto-repair
+        --control-plane-availability-policy {{ _ocp4_workload_rhacm_hypershift_cluster_control_plane_availability }}
+        --etcd-storage-class {{ _ocp4_workload_rhacm_hypershift_cluster_etc_storage_class }}
+        --infra-availability-policy {{ _ocp4_workload_rhacm_hypershift_cluster_infra_availability }}
+        --infra-id {{ _ocp4_workload_rhacm_hypershift_cluster_infra_id }}
+        --instance-type {{ _ocp4_workload_rhacm_hypershift_cluster_worker_instance_type }}
+        --name {{ _ocp4_workload_rhacm_hypershift_cluster_name }}
+        --namespace local-cluster
+        --network-type {{ _ocp4_workload_rhacm_hypershift_cluster_network_type }}
+        --node-pool-replicas {{ _ocp4_workload_rhacm_hypershift_cluster_nodepool_replicas }}
+        --region {{ _ocp4_workload_rhacm_hypershift_cluster_region }}
+        --release-image quay.io/openshift-release-dev/ocp-release:{{ _ocp4_workload_rhacm_hypershift_cluster_ocp_release }}-x86_64
+        --root-volume-size {{ _ocp4_workload_rhacm_hypershift_cluster_root_volume_size }}
+        --root-volume-type {{ _ocp4_workload_rhacm_hypershift_cluster_root_volume_type }}
+        --secret-creds aws-credentials
+        --zones {{ _ocp4_workload_rhacm_hypershift_cluster_zones | join(',') }}
+        --role-arn {{ r_role_arn.stdout }}
+        --sts-creds /tmp/sts-creds-default.json
+        --base-domain {{ subdomain_base }}
+        --endpoint-access=Public
+        --generate-ssh
+    register: r_hcp_create_cluster
+    ignore_errors: true
+
+  - name: Print hcp command output
+    ansible.builtin.debug:
+      msg: "{{ r_hcp_create_cluster.stdout }}"
+
+  - name: Abort
+    when: r_hcp_create_cluster.rc > 0
+    ansible.builtin.fail:
+      msg: "Cluster creation failed. Aborting."
+
+- name: Deploy hosted cluster (OCP <= 4.16) {{ _ocp4_workload_rhacm_hypershift_cluster_name }}
   when: r_hosted_cluster.resources | length == 0
   block:
-  - name: Run hcp CLI to deploy hosted cluster
+  - name: Run hcp CLI to deploy hosted cluster (OCP <= 4.16)
     ansible.builtin.command: >-
       /usr/bin/hcp create cluster aws
         --name {{ _ocp4_workload_rhacm_hypershift_cluster_name }}

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/tasks/create_hypershift_cluster.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/tasks/create_hypershift_cluster.yml
@@ -28,84 +28,84 @@
 
 - name: Deploy hosted cluster (OCP >= 4.17) {{ _ocp4_workload_rhacm_hypershift_cluster_name }}
   when:
-  - r_hosted_cluster.resources | length == 0
-  - ocp4_installer_version is version('4.17', '>=')
+    - r_hosted_cluster.resources | length == 0
+    - ocp4_installer_version is version('4.17', '>=')
   block:
-  - name: Run hcp CLI to deploy hosted cluster (OCP >= 4.17)
-    environment:
-      AWS_ACCESS_KEY_ID: "{{ aws_access_key_id }}"
-      AWS_SECRET_ACCESS_KEY: "{{ aws_secret_access_key }}"
-      AWS_REGION: "{{ ocp4_workload_rhacm_hypershift_s3_bucket_region }}"
-    ansible.builtin.command: >-
-      /usr/bin/hcp create cluster aws
-        --auto-repair
-        --control-plane-availability-policy {{ _ocp4_workload_rhacm_hypershift_cluster_control_plane_availability }}
-        --etcd-storage-class {{ _ocp4_workload_rhacm_hypershift_cluster_etc_storage_class }}
-        --infra-availability-policy {{ _ocp4_workload_rhacm_hypershift_cluster_infra_availability }}
-        --infra-id {{ _ocp4_workload_rhacm_hypershift_cluster_infra_id }}
-        --instance-type {{ _ocp4_workload_rhacm_hypershift_cluster_worker_instance_type }}
-        --name {{ _ocp4_workload_rhacm_hypershift_cluster_name }}
-        --namespace local-cluster
-        --network-type {{ _ocp4_workload_rhacm_hypershift_cluster_network_type }}
-        --node-pool-replicas {{ _ocp4_workload_rhacm_hypershift_cluster_nodepool_replicas }}
-        --region {{ _ocp4_workload_rhacm_hypershift_cluster_region }}
-        --release-image quay.io/openshift-release-dev/ocp-release:{{ _ocp4_workload_rhacm_hypershift_cluster_ocp_release }}-x86_64
-        --root-volume-size {{ _ocp4_workload_rhacm_hypershift_cluster_root_volume_size }}
-        --root-volume-type {{ _ocp4_workload_rhacm_hypershift_cluster_root_volume_type }}
-        --zones {{ _ocp4_workload_rhacm_hypershift_cluster_zones | join(',') }}
-        --role-arn "{{ r_role_arn.stdout }}"
-        --sts-creds /tmp/sts-creds.json
-        --pull-secret /tmp/pull_secret.json
-        --base-domain "{{ subdomain_base_suffix | regex_replace('^\.', '') }}"
-        --endpoint-access=Public
-        --generate-ssh
-    register: r_hcp_create_cluster
-    ignore_errors: true
+    - name: Run hcp CLI to deploy hosted cluster (OCP >= 4.17)
+      environment:
+        AWS_ACCESS_KEY_ID: "{{ aws_access_key_id }}"
+        AWS_SECRET_ACCESS_KEY: "{{ aws_secret_access_key }}"
+        AWS_REGION: "{{ ocp4_workload_rhacm_hypershift_s3_bucket_region }}"
+      ansible.builtin.command: >-
+        /usr/bin/hcp create cluster aws
+          --auto-repair
+          --control-plane-availability-policy {{ _ocp4_workload_rhacm_hypershift_cluster_control_plane_availability }}
+          --etcd-storage-class {{ _ocp4_workload_rhacm_hypershift_cluster_etc_storage_class }}
+          --infra-availability-policy {{ _ocp4_workload_rhacm_hypershift_cluster_infra_availability }}
+          --infra-id {{ _ocp4_workload_rhacm_hypershift_cluster_infra_id }}
+          --instance-type {{ _ocp4_workload_rhacm_hypershift_cluster_worker_instance_type }}
+          --name {{ _ocp4_workload_rhacm_hypershift_cluster_name }}
+          --namespace local-cluster
+          --network-type {{ _ocp4_workload_rhacm_hypershift_cluster_network_type }}
+          --node-pool-replicas {{ _ocp4_workload_rhacm_hypershift_cluster_nodepool_replicas }}
+          --region {{ _ocp4_workload_rhacm_hypershift_cluster_region }}
+          --release-image quay.io/openshift-release-dev/ocp-release:{{ _ocp4_workload_rhacm_hypershift_cluster_ocp_release }}-x86_64
+          --root-volume-size {{ _ocp4_workload_rhacm_hypershift_cluster_root_volume_size }}
+          --root-volume-type {{ _ocp4_workload_rhacm_hypershift_cluster_root_volume_type }}
+          --zones {{ _ocp4_workload_rhacm_hypershift_cluster_zones | join(',') }}
+          --role-arn "{{ r_role_arn.stdout }}"
+          --sts-creds /tmp/sts-creds.json
+          --pull-secret /tmp/pull_secret.json
+          --base-domain "{{ subdomain_base_suffix | regex_replace('^\.', '') }}"
+          --endpoint-access=Public
+          --generate-ssh
+      register: r_hcp_create_cluster
+      ignore_errors: true
 
-  - name: Print hcp command output
-    ansible.builtin.debug:
-      msg: "{{ r_hcp_create_cluster.stdout }}"
+    - name: Print hcp command output
+      ansible.builtin.debug:
+        msg: "{{ r_hcp_create_cluster.stdout }}"
 
-  - name: Abort
-    when: r_hcp_create_cluster.rc > 0
-    ansible.builtin.fail:
-      msg: "Cluster creation failed. Aborting."
+    - name: Abort
+      when: r_hcp_create_cluster.rc > 0
+      ansible.builtin.fail:
+        msg: "Cluster creation failed. Aborting."
 
 - name: Deploy hosted cluster (OCP <= 4.16) {{ _ocp4_workload_rhacm_hypershift_cluster_name }}
   when:
-  - r_hosted_cluster.resources | length == 0
-  - ocp4_installer_version is version('4.17', '<')
+    - r_hosted_cluster.resources | length == 0
+    - ocp4_installer_version is version('4.17', '<')
   block:
-  - name: Run hcp CLI to deploy hosted cluster (OCP <= 4.16)
-    ansible.builtin.command: >-
-      /usr/bin/hcp create cluster aws
-        --name {{ _ocp4_workload_rhacm_hypershift_cluster_name }}
-        --infra-id {{ _ocp4_workload_rhacm_hypershift_cluster_infra_id }}
-        --region {{ _ocp4_workload_rhacm_hypershift_cluster_region }}
-        --zones {{ _ocp4_workload_rhacm_hypershift_cluster_zones | join(',') }}
-        --instance-type {{ _ocp4_workload_rhacm_hypershift_cluster_worker_instance_type }}
-        --root-volume-type {{ _ocp4_workload_rhacm_hypershift_cluster_root_volume_type }}
-        --root-volume-size {{ _ocp4_workload_rhacm_hypershift_cluster_root_volume_size }}
-        --etcd-storage-class {{ _ocp4_workload_rhacm_hypershift_cluster_etc_storage_class }}
-        --control-plane-availability-policy {{ _ocp4_workload_rhacm_hypershift_cluster_control_plane_availability }}
-        --infra-availability-policy {{ _ocp4_workload_rhacm_hypershift_cluster_infra_availability }}
-        --network-type {{ _ocp4_workload_rhacm_hypershift_cluster_network_type }}
-        --release-image quay.io/openshift-release-dev/ocp-release:{{ _ocp4_workload_rhacm_hypershift_cluster_ocp_release }}-x86_64
-        --node-pool-replicas {{ _ocp4_workload_rhacm_hypershift_cluster_nodepool_replicas }}
-        --namespace local-cluster
-        --secret-creds aws-credentials
-        --auto-repair
-    register: r_hcp_create_cluster
-    ignore_errors: true
+    - name: Run hcp CLI to deploy hosted cluster (OCP <= 4.16)
+      ansible.builtin.command: >-
+        /usr/bin/hcp create cluster aws
+          --name {{ _ocp4_workload_rhacm_hypershift_cluster_name }}
+          --infra-id {{ _ocp4_workload_rhacm_hypershift_cluster_infra_id }}
+          --region {{ _ocp4_workload_rhacm_hypershift_cluster_region }}
+          --zones {{ _ocp4_workload_rhacm_hypershift_cluster_zones | join(',') }}
+          --instance-type {{ _ocp4_workload_rhacm_hypershift_cluster_worker_instance_type }}
+          --root-volume-type {{ _ocp4_workload_rhacm_hypershift_cluster_root_volume_type }}
+          --root-volume-size {{ _ocp4_workload_rhacm_hypershift_cluster_root_volume_size }}
+          --etcd-storage-class {{ _ocp4_workload_rhacm_hypershift_cluster_etc_storage_class }}
+          --control-plane-availability-policy {{ _ocp4_workload_rhacm_hypershift_cluster_control_plane_availability }}
+          --infra-availability-policy {{ _ocp4_workload_rhacm_hypershift_cluster_infra_availability }}
+          --network-type {{ _ocp4_workload_rhacm_hypershift_cluster_network_type }}
+          --release-image quay.io/openshift-release-dev/ocp-release:{{ _ocp4_workload_rhacm_hypershift_cluster_ocp_release }}-x86_64
+          --node-pool-replicas {{ _ocp4_workload_rhacm_hypershift_cluster_nodepool_replicas }}
+          --namespace local-cluster
+          --secret-creds aws-credentials
+          --auto-repair
+      register: r_hcp_create_cluster
+      ignore_errors: true
 
-  - name: Print hcp command output
-    ansible.builtin.debug:
-      msg: "{{ r_hcp_create_cluster.stdout }}"
+    - name: Print hcp command output
+      ansible.builtin.debug:
+        msg: "{{ r_hcp_create_cluster.stdout }}"
 
-  - name: Abort
-    when: r_hcp_create_cluster.rc > 0
-    ansible.builtin.fail:
-      msg: "Cluster creation failed. Aborting."
+    - name: Abort
+      when: r_hcp_create_cluster.rc > 0
+      ansible.builtin.fail:
+        msg: "Cluster creation failed. Aborting."
 
 - name: Create managed cluster to add cluster to ACM
   kubernetes.core.k8s:

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/tasks/create_hypershift_cluster.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/tasks/create_hypershift_cluster.yml
@@ -30,12 +30,12 @@
   when:
   - r_hosted_cluster.resources | length == 0
   - ocp4_installer_version is version('4.17', '>=')
-  environment:
-    AWS_ACCESS_KEY_ID: "{{ aws_access_key_id }}"
-    AWS_SECRET_ACCESS_KEY: "{{ aws_secret_access_key }}"
-    AWS_REGION: "{{ ocp4_workload_rhacm_hypershift_s3_bucket_region }}"
   block:
   - name: Run hcp CLI to deploy hosted cluster (OCP >= 4.17)
+    environment:
+      AWS_ACCESS_KEY_ID: "{{ aws_access_key_id }}"
+      AWS_SECRET_ACCESS_KEY: "{{ aws_secret_access_key }}"
+      AWS_REGION: "{{ ocp4_workload_rhacm_hypershift_s3_bucket_region }}"
     ansible.builtin.command: >-
       /usr/bin/hcp create cluster aws
         --auto-repair
@@ -52,11 +52,11 @@
         --release-image quay.io/openshift-release-dev/ocp-release:{{ _ocp4_workload_rhacm_hypershift_cluster_ocp_release }}-x86_64
         --root-volume-size {{ _ocp4_workload_rhacm_hypershift_cluster_root_volume_size }}
         --root-volume-type {{ _ocp4_workload_rhacm_hypershift_cluster_root_volume_type }}
-        --secret-creds aws-credentials
         --zones {{ _ocp4_workload_rhacm_hypershift_cluster_zones | join(',') }}
-        --role-arn {{ r_role_arn.stdout }}
-        --sts-creds /tmp/sts-creds-default.json
-        --base-domain {{ subdomain_base }}
+        --role-arn "{{ r_role_arn.stdout }}"
+        --sts-creds /tmp/sts-creds.json
+        --pull-secret /tmp/pull_secret.json
+        --base-domain "{{ subdomain_base_suffix | regex_replace('^\.', '') }}"
         --endpoint-access=Public
         --generate-ssh
     register: r_hcp_create_cluster
@@ -72,7 +72,9 @@
       msg: "Cluster creation failed. Aborting."
 
 - name: Deploy hosted cluster (OCP <= 4.16) {{ _ocp4_workload_rhacm_hypershift_cluster_name }}
-  when: r_hosted_cluster.resources | length == 0
+  when:
+  - r_hosted_cluster.resources | length == 0
+  - ocp4_installer_version is version('4.17', '<')
   block:
   - name: Run hcp CLI to deploy hosted cluster (OCP <= 4.16)
     ansible.builtin.command: >-

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/tasks/prep_aws_roles.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/tasks/prep_aws_roles.yaml
@@ -1,0 +1,69 @@
+- name: Get ARN for hosted cluster user
+  environment:
+    AWS_ACCESS_KEY_ID: "{{ aws_access_key_id }}"
+    AWS_SECRET_ACCESS_KEY: "{{ aws_secret_access_key }}"
+    AWS_REGION: "{{ ocp4_workload_rhacm_hypershift_s3_bucket_region }}"
+  ansible.builtin.command:
+    cmd: >-
+      aws sts get-caller-identity --query "Arn"
+  register: r_arn
+
+- name: Debug r_arn
+  ansible.builtin.debug:
+    msg: "{{ r_arn.stdout }}"
+
+- name: Create trust-relationship.json
+  ansible.builtin.template:
+    src: trust-relationship.json.j2
+    dest: /tmp/trust-relationship.json
+    mode: "0664"
+
+- name: Apply trust-relationship.json
+  environment:
+    AWS_ACCESS_KEY_ID: "{{ aws_access_key_id }}"
+    AWS_SECRET_ACCESS_KEY: "{{ aws_secret_access_key }}"
+    AWS_REGION: "{{ ocp4_workload_rhacm_hypershift_s3_bucket_region }}"
+  ansible.builtin.command:
+    chdir: /tmp
+    cmd: >-
+      aws iam create-role
+        --role-name hcp-cli-role
+        --assume-role-policy-document file://trust-relationship.json
+        --query "Role.Arn"
+  register: r_role_arn
+  ignore_errors: true
+
+- name: Debug r_role_arn
+  ansible.builtin.debug:
+    msg: "{{ r_role_arn.stdout }}"
+
+- name: Create awspolicy-hcp-cli-role.json
+  ansible.builtin.template:
+    src: awspolicy-hcp-cli-role.json.j2
+    dest: /tmp/awspolicy-hcp-cli-role.json
+    mode: "0664"
+
+- name: Apply awspolicy-hcp-cli-role.json
+  environment:
+    AWS_ACCESS_KEY_ID: "{{ aws_access_key_id }}"
+    AWS_SECRET_ACCESS_KEY: "{{ aws_secret_access_key }}"
+    AWS_REGION: "{{ ocp4_workload_rhacm_hypershift_s3_bucket_region }}"
+  ansible.builtin.command:
+    chdir: /tmp
+    cmd: >-
+      aws iam put-role-policy
+       --role-name hcp-cli-role
+       --policy-name trust-relationship.json
+       --policy-document file://awspolicy-hcp-cli-role.json
+  ignore_errors: true
+
+- name: Get STS credentials
+  environment:
+    AWS_ACCESS_KEY_ID: "{{ aws_access_key_id }}"
+    AWS_SECRET_ACCESS_KEY: "{{ aws_secret_access_key }}"
+    AWS_REGION: "{{ ocp4_workload_rhacm_hypershift_s3_bucket_region }}"
+  ansible.builtin.shell:
+    chdir: /tmp
+    cmd: >-
+      aws sts get-session-token --output json > sts-creds-default.json
+  register: r_sts

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/tasks/prep_aws_roles.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/tasks/prep_aws_roles.yaml
@@ -30,6 +30,19 @@
         --role-name hcp-cli-role
         --assume-role-policy-document file://trust-relationship.json
         --query "Role.Arn"
+  ignore_errors: true
+
+- name: Get trust-relationship.json Arn
+  environment:
+    AWS_ACCESS_KEY_ID: "{{ aws_access_key_id }}"
+    AWS_SECRET_ACCESS_KEY: "{{ aws_secret_access_key }}"
+    AWS_REGION: "{{ ocp4_workload_rhacm_hypershift_s3_bucket_region }}"
+  ansible.builtin.command:
+    chdir: /tmp
+    cmd: >-
+      aws iam get-role
+        --role-name hcp-cli-role
+        --query "Role.Arn"
   register: r_role_arn
   ignore_errors: true
 
@@ -65,5 +78,10 @@
   ansible.builtin.shell:
     chdir: /tmp
     cmd: >-
-      aws sts get-session-token --output json > sts-creds-default.json
+      aws sts get-session-token --output json > sts-creds.json
   register: r_sts
+
+- name: Write pull secret to a file
+  ansible.builtin.copy:
+    content: "{{ ocp4_pull_secret }}"
+    dest: /tmp/pull_secret.json

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/tasks/remove_workload.yml
@@ -4,6 +4,45 @@
   ansible.builtin.debug:
     msg: "Removing workload for user ocp_username = {{ ocp_username }} - not implemented"
 
+- name: Remove role-policy hcp-cli-role, trust-relationship.json
+  environment:
+    AWS_ACCESS_KEY_ID: "{{ aws_access_key_id }}"
+    AWS_SECRET_ACCESS_KEY: "{{ aws_secret_access_key }}"
+    AWS_REGION: "{{ ocp4_workload_rhacm_hypershift_s3_bucket_region }}"
+  ansible.builtin.command:
+    chdir: /tmp
+    cmd: >-
+      aws iam delete-role-policy
+       --role-name hcp-cli-role
+       --policy-name trust-relationship.json
+  ignore_errors: true
+
+- name: Remove role hcp-cli-role
+  environment:
+    AWS_ACCESS_KEY_ID: "{{ aws_access_key_id }}"
+    AWS_SECRET_ACCESS_KEY: "{{ aws_secret_access_key }}"
+    AWS_REGION: "{{ ocp4_workload_rhacm_hypershift_s3_bucket_region }}"
+  ansible.builtin.command:
+    chdir: /tmp
+    cmd: >-
+      aws iam delete-role
+       --role-name hcp-cli-role
+  ignore_errors: true
+
+- name: Apply awspolicy-hcp-cli-role.json
+  environment:
+    AWS_ACCESS_KEY_ID: "{{ aws_access_key_id }}"
+    AWS_SECRET_ACCESS_KEY: "{{ aws_secret_access_key }}"
+    AWS_REGION: "{{ ocp4_workload_rhacm_hypershift_s3_bucket_region }}"
+  ansible.builtin.command:
+    chdir: /tmp
+    cmd: >-
+      aws iam delete-role-policy
+       --role-name hcp-cli-role
+       --policy-name trust-relationship.json
+       --policy-document file://awspolicy-hcp-cli-role.json
+  ignore_errors: true
+
 # Leave this as the last task in the playbook.
 - name: Remove_workload tasks complete
   when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/templates/awspolicy-hcp-cli-role.json.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/templates/awspolicy-hcp-cli-role.json.j2
@@ -1,0 +1,130 @@
+{
+        "Version": "2012-10-17",
+        "Statement": [
+           {
+               "Sid": "EC2",
+               "Effect": "Allow",
+               "Action": [
+                   "ec2:CreateDhcpOptions",
+                   "ec2:DeleteSubnet",
+                   "ec2:ReplaceRouteTableAssociation",
+                   "ec2:DescribeAddresses",
+                   "ec2:DescribeInstances",
+                   "ec2:DeleteVpcEndpoints",
+                   "ec2:CreateNatGateway",
+                   "ec2:CreateVpc",
+                   "ec2:DescribeDhcpOptions",
+                   "ec2:AttachInternetGateway",
+                   "ec2:DeleteVpcEndpointServiceConfigurations",
+                   "ec2:DeleteRouteTable",
+                   "ec2:AssociateRouteTable",
+                   "ec2:DescribeInternetGateways",
+                   "ec2:DescribeAvailabilityZones",
+                   "ec2:CreateRoute",
+                   "ec2:CreateInternetGateway",
+                   "ec2:RevokeSecurityGroupEgress",
+                   "ec2:ModifyVpcAttribute",
+                   "ec2:DeleteInternetGateway",
+                   "ec2:DescribeVpcEndpointConnections",
+                   "ec2:RejectVpcEndpointConnections",
+                   "ec2:DescribeRouteTables",
+                   "ec2:ReleaseAddress",
+                   "ec2:AssociateDhcpOptions",
+                   "ec2:TerminateInstances",
+                   "ec2:CreateTags",
+                   "ec2:DeleteRoute",
+                   "ec2:CreateRouteTable",
+                   "ec2:DetachInternetGateway",
+                   "ec2:DescribeVpcEndpointServiceConfigurations",
+                   "ec2:DescribeNatGateways",
+                   "ec2:DisassociateRouteTable",
+                   "ec2:AllocateAddress",
+                   "ec2:DescribeSecurityGroups",
+                   "ec2:RevokeSecurityGroupIngress",
+                   "ec2:CreateVpcEndpoint",
+                   "ec2:DescribeVpcs",
+                   "ec2:DeleteSecurityGroup",
+                   "ec2:DeleteDhcpOptions",
+                   "ec2:DeleteNatGateway",
+                   "ec2:DescribeVpcEndpoints",
+                   "ec2:DeleteVpc",
+                   "ec2:CreateSubnet",
+                   "ec2:DescribeSubnets"
+               ],
+               "Resource": "*"
+           },
+           {
+               "Sid": "ELB",
+               "Effect": "Allow",
+               "Action": [
+                   "elasticloadbalancing:DeleteLoadBalancer",
+                   "elasticloadbalancing:DescribeLoadBalancers",
+                   "elasticloadbalancing:DescribeTargetGroups",
+                   "elasticloadbalancing:DeleteTargetGroup"
+               ],
+               "Resource": "*"
+           },
+           {
+               "Sid": "IAMPassRole",
+               "Effect": "Allow",
+               "Action": "iam:PassRole",
+               "Resource": "arn:*:iam::*:role/*-worker-role",
+               "Condition": {
+                   "ForAnyValue:StringEqualsIfExists": {
+                       "iam:PassedToService": "ec2.amazonaws.com"
+                   }
+               }
+           },
+           {
+               "Sid": "IAM",
+               "Effect": "Allow",
+               "Action": [
+                   "iam:CreateInstanceProfile",
+                   "iam:DeleteInstanceProfile",
+                   "iam:GetRole",
+                   "iam:UpdateAssumeRolePolicy",
+                   "iam:GetInstanceProfile",
+                   "iam:TagRole",
+                   "iam:RemoveRoleFromInstanceProfile",
+                   "iam:CreateRole",
+                   "iam:DeleteRole",
+                   "iam:PutRolePolicy",
+                   "iam:AddRoleToInstanceProfile",
+                   "iam:CreateOpenIDConnectProvider",
+                   "iam:TagOpenIDConnectProvider",
+                   "iam:ListOpenIDConnectProviders",
+                   "iam:DeleteRolePolicy",
+                   "iam:UpdateRole",
+                   "iam:DeleteOpenIDConnectProvider",
+                   "iam:GetRolePolicy"
+               ],
+               "Resource": "*"
+           },
+           {
+               "Sid": "Route53",
+               "Effect": "Allow",
+               "Action": [
+                   "route53:ListHostedZonesByVPC",
+                   "route53:CreateHostedZone",
+                   "route53:ListHostedZones",
+                   "route53:ChangeResourceRecordSets",
+                   "route53:ListResourceRecordSets",
+                   "route53:DeleteHostedZone",
+                   "route53:AssociateVPCWithHostedZone",
+                   "route53:ListHostedZonesByName"
+               ],
+               "Resource": "*"
+           },
+           {
+               "Sid": "S3",
+               "Effect": "Allow",
+               "Action": [
+                   "s3:ListAllMyBuckets",
+                   "s3:ListBucket",
+                   "s3:DeleteObject",
+                   "s3:DeleteBucket"
+               ],
+               "Resource": "*"
+           }
+        ]
+}

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/templates/secret-aws-credentials.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/templates/secret-aws-credentials.yaml.j2
@@ -13,7 +13,7 @@ data:
   additionalTrustBundle: ""
   aws_secret_access_key: {{ aws_secret_access_key | b64encode }}
   aws_access_key_id: {{ aws_access_key_id | b64encode }}
-  baseDomain: {{ subdomain_base | b64encode }}
+  baseDomain: {{ subdomain_base_suffix | regex_replace('^\.', '') | b64encode }}
   httpProxy: ""
   httpsProxy: ""
   noProxy: ""

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/templates/trust-relationship.json.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/templates/trust-relationship.json.j2
@@ -1,0 +1,12 @@
+{
+        "Version": "2012-10-17",
+        "Statement": [
+           {
+               "Effect": "Allow",
+               "Principal": {
+                   "AWS": {{ r_arn.stdout }}
+               },
+               "Action": "sts:AssumeRole"
+           }
+        ]
+}


### PR DESCRIPTION
- Feature Pull Request

Added features to enable `hcp` from OCP 4.17, which uses new AWS Roles to control HCP deployments. 

ALSO tested against sandboxes-gpte/hol-ocp-plus development catalog item.  That prod tag can move without calamity.
