### PR TITLE
ocp4_workload_rhacm_hypershift: use multi-arch release, not x86

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/tasks/create_hypershift_cluster.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm_hypershift/tasks/create_hypershift_cluster.yml
@@ -49,7 +49,7 @@
           --network-type {{ _ocp4_workload_rhacm_hypershift_cluster_network_type }}
           --node-pool-replicas {{ _ocp4_workload_rhacm_hypershift_cluster_nodepool_replicas }}
           --region {{ _ocp4_workload_rhacm_hypershift_cluster_region }}
-          --release-image quay.io/openshift-release-dev/ocp-release:{{ _ocp4_workload_rhacm_hypershift_cluster_ocp_release }}-x86_64
+          --release-image quay.io/openshift-release-dev/ocp-release:{{ _ocp4_workload_rhacm_hypershift_cluster_ocp_release }}-multi
           --root-volume-size {{ _ocp4_workload_rhacm_hypershift_cluster_root_volume_size }}
           --root-volume-type {{ _ocp4_workload_rhacm_hypershift_cluster_root_volume_type }}
           --zones {{ _ocp4_workload_rhacm_hypershift_cluster_zones | join(',') }}


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
