### PR TITLE
Add AgD kasten_storageclass variable

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_kasten_k10/tasks/workload.yml
@@ -53,6 +53,7 @@
     agnosticd_user_info:
       data:
         kasten_dashboard: "https://{{ r_kasten_route.resources[0].spec.host }}/k10/"
+        kasten_storageclass: "{{ ocp4_workload_kasten_k10_storageclasses[0] | default('ocs-storagecluster-ceph-rbd-virtualization') }}"
 
   # Jinja templates handle single/multi-user deployment
   - name: Set up Demo environment


### PR DESCRIPTION
##### SUMMARY

Supporting multiple cloud providers (CNV/GCP) requires slightly different storage classes.
Adding a data point to AgD user info to provide the actual storage class to showroom.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_kasten_k10