### PR TITLE
Update role OCP4_QUARKUS_SUPER_HEROES_DEMO to use RHBQ 3.15

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/defaults/main.yml
@@ -19,7 +19,7 @@ ocp4_workload_quarkus_super_heroes_demo_install_prometheus: true
 ocp4_workload_quarkus_super_heroes_demo_install_grafana: false
 
 ocp4_workload_quarkus_super_heroes_demo_temp_dir: /tmp/quarkus_superheroes
-ocp4_workload_quarkus_super_heroes_demo_release_tag: rhbq-3.8
+ocp4_workload_quarkus_super_heroes_demo_release_tag: rhbq-3.15
 ocp4_workload_quarkus_super_heroes_demo_project_name: quarkus-superheroes
 
 # yamllint disable-line rule:line-length


### PR DESCRIPTION
This updates the Quarkus superheroes demo catalog item to Red Hat Build of Quarkus 3.15