### PR TITLE
ocp4_workload_rhacm: allow ingresscontroller updates for wildcards

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm/defaults/main.yml
@@ -20,3 +20,7 @@ ocp4_workload_rhacm_automatic_install_plan_approval: true
 ocp4_workload_rhacm_mce_catalogsource_name: ""
 # This namespace cannot be changed due to multicluster-engine operator not able look elsewhere.
 ocp4_workload_rhacm_mce_catalogsource_namespace: openshift-marketplace
+
+# Required for Catalog Items that will deploy hosted clusters to the local-cluster
+# Enable Wildcards to allow access to HCP Hosted Clusters console, etc.
+ocp4_workload_rhacm_enable_wildcards: false

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/workload.yml
@@ -5,6 +5,19 @@
   ansible.builtin.debug:
     msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
 
+# oc patch ingresscontroller -n openshift-ingress-operator default --type=json -p '[{ "op": "add", "path": "/spec/routeAdmission", "value": {wildcardPolicy: "WildcardsAllowed"}}]'
+- name: Update Router for Wildcards for HCP Hosted Clusters
+  when: ocp4_workload_rhacm_enable_wildcards | bool
+  kubernetes.core.k8s_json_patch:
+    kind: IngressController
+    namespace: openshift-ingress-operator
+    name: default
+    patch:
+    - op: add
+      path: /spec/routeAdmission
+      value:
+        wildcardPolicy: WildcardsAllowed
+
 - name: Install RHACM operator
   ansible.builtin.include_role:
     name: install_operator


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

Required for Catalog Items that will deploy hosted clusters to the local-cluster
Enable Wildcards to allow access to HCP Hosted Clusters console, etc.


<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request
-
##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

ocp4_workload_rhacm

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
