### PR TITLE
[ocp4_workload_metallb] Add IPAddressPool and L2Advertisement

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_metallb/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_metallb/defaults/main.yml
@@ -44,3 +44,16 @@ ocp4_workload_metallb_catalog_snapshot_image: quay.io/gpte-devops-automation/olm
 
 # Catalog snapshot image tag
 ocp4_workload_metallb_catalog_snapshot_image_tag: "v4.15_2024_05_27"
+
+# Configure IPAddressPool
+ocp4_workload_metallb_enable_ipaddresspool: false
+ocp4_workload_metallb_ipaddresspool_name: "ip-addresspool"
+ocp4_workload_metallb_ipaddresspool_addresses: 
+ - "10.10.10.200-10.10.10.210"
+
+# Configure L2Advertisement
+ocp4_workload_metallb_enable_l2advertisement: false
+ocp4_workload_metallb_l2advertisement_ipaddresspool: 
+ - "ip-addresspool"
+ocp4_workload_metallb_l2advertisement_interface: 
+ - "br-ex"

--- a/ansible/roles_ocp_workloads/ocp4_workload_metallb/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_metallb/defaults/main.yml
@@ -48,12 +48,12 @@ ocp4_workload_metallb_catalog_snapshot_image_tag: "v4.15_2024_05_27"
 # Configure IPAddressPool
 ocp4_workload_metallb_enable_ipaddresspool: false
 ocp4_workload_metallb_ipaddresspool_name: "ip-addresspool"
-ocp4_workload_metallb_ipaddresspool_addresses: 
- - "10.10.10.200-10.10.10.210"
+ocp4_workload_metallb_ipaddresspool_addresses:
+- "10.10.10.200-10.10.10.210"
 
 # Configure L2Advertisement
 ocp4_workload_metallb_enable_l2advertisement: false
-ocp4_workload_metallb_l2advertisement_ipaddresspool: 
- - "ip-addresspool"
+ocp4_workload_metallb_l2advertisement_ipaddresspool:
+- "ip-addresspool"
 ocp4_workload_metallb_l2advertisement_interface: 
- - "br-ex"
+- "br-ex"

--- a/ansible/roles_ocp_workloads/ocp4_workload_metallb/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_metallb/defaults/main.yml
@@ -55,5 +55,5 @@ ocp4_workload_metallb_ipaddresspool_addresses:
 ocp4_workload_metallb_enable_l2advertisement: false
 ocp4_workload_metallb_l2advertisement_ipaddresspool:
 - "ip-addresspool"
-ocp4_workload_metallb_l2advertisement_interface: 
+ocp4_workload_metallb_l2advertisement_interface:
 - "br-ex"

--- a/ansible/roles_ocp_workloads/ocp4_workload_metallb/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_metallb/tasks/workload.yml
@@ -41,6 +41,18 @@
     wait_sleep: 10
     wait_timeout: 600
 
+- name: Create the IPAddressPool instance
+  when: ocp4_workload_metallb_enable_ipaddresspool | default(false)
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('template', 'ipaddresspool.yaml.j2') }}"
+
+- name: Create the L2Advertisement instance
+  when: ocp4_workload_metallb_enable_l2advertisement | default(false)
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('template', 'l2advertisement.yaml.j2') }}"
+
 # Leave this as the last task in the playbook.
 - name: Workload tasks complete
   when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_metallb/templates/ipaddresspool.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_metallb/templates/ipaddresspool.yaml.j2
@@ -1,0 +1,9 @@
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: {{ ocp4_workload_metallb_ipaddresspool_name }}
+  namespace: metallb-system
+spec:
+  addresses: {{ ocp4_workload_metallb_ipaddresspool_addresses }}
+  autoAssign: true
+  avoidBuggyIPs: false

--- a/ansible/roles_ocp_workloads/ocp4_workload_metallb/templates/l2advertisement.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_metallb/templates/l2advertisement.yaml.j2
@@ -1,0 +1,8 @@
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: l2-adv
+  namespace: metallb-system
+spec:
+  ipAddressPools: "{{ ocp4_workload_metallb_l2advertisement_ipaddresspool }}"
+  interfaces: "{{ ocp4_workload_metallb_l2advertisement_interface }}"


### PR DESCRIPTION
##### SUMMARY

Current ocp4 workload just install operator and creates MetalLB object, this PR adds the functionality to add IPAddressPool and L2Advertisement records

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_metallb role

