### PR TITLE
[install_operator] Add option install_operator_skip_operatorgroup to skip create operatorgroup

### DIFF
--- a/ansible/roles/install_operator/defaults/main.yml
+++ b/ansible/roles/install_operator/defaults/main.yml
@@ -89,3 +89,6 @@ install_operator_catalogsource_pullsecrets: []
 # Accepted values: true , false
 # Default value: false
 install_operator_install_csv_ignore_error: false
+
+# If your operator doesnt need to create a OperatorGroup, because it already exists, set to true
+install_operator_skip_operatorgroup: false

--- a/ansible/roles/install_operator/tasks/install.yml
+++ b/ansible/roles/install_operator/tasks/install.yml
@@ -16,6 +16,7 @@
       name: "{{ install_operator_namespace }}"
 
   - name: "Ensure OperatorGroup exists ({{ install_operator_name }})"
+    when: install_operator_skip_operatorgroup | default(false) | bool == false
     kubernetes.core.k8s:
       state: present
       definition: "{{ lookup('template', 'operatorgroup.yaml.j2') | from_yaml }}"


### PR DESCRIPTION
##### SUMMARY

In some cases we want to still an operator inside a namespace where OperatorGroup exists, this PR is to avoid create the OperatorGroup as if it has different name causes issues.

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
install_operator role
