### PR TITLE
[host-ocp4-assisted-installer] Remove mountOptions

### DIFF
--- a/ansible/roles/host-ocp4-assisted-installer/files/etcd_disk.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/files/etcd_disk.yaml
@@ -16,9 +16,6 @@ spec:
       filesystems:
         - device: /dev/disk/by-partlabel/var-etcd
           format: xfs
-          mountOptions:
-            - defaults
-            - prjquota
           path: /var/lib/etcd
     systemd:
       units:


### PR DESCRIPTION
##### SUMMARY

Remove this option, is not needed and causing issues on compact installer

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
host-ocp4-assisted-installer role
