### PR TITLE
[host-ocp4-assisted-installer] Add the option to add extra disks to masters and/or workers

### DIFF
--- a/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_masters_etcd.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_masters_etcd.yaml
@@ -39,7 +39,7 @@
             'dataVolume': {'name': _disk.metadata.name}
         }
     ] }}"
-  loop: "{{ _instance.ai_masters_extra_disks | default([]) | list }}"
+  loop: "{{ ai_masters_extra_disks | default([]) | list }}"
   loop_control:
     loop_var: _disk
 
@@ -51,7 +51,7 @@
     validate_certs: false
     name: "{{ vmname }}"
     namespace: "{{ namespace }}"
-    data_volume_templates: "{{ _datavolume + _instance.ai_masters_extra_disks }}"
+    data_volume_templates: "{{ _datavolume + ai_masters_extra_disks }}"
     running: true
     wait: false
     annotations:

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_masters_etcd.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_masters_etcd.yaml
@@ -51,7 +51,7 @@
     validate_certs: false
     name: "{{ vmname }}"
     namespace: "{{ namespace }}"
-    data_volume_templates: "{{ _datavolume + ai_masters_extra_disks }}"
+    data_volume_templates: "{{ _datavolume + (ai_masters_extra_disks | default([]) | to_json | replace('INSTANCENAME', vmname) | from_json ) }}"
     running: true
     wait: false
     annotations:

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_masters_etcd.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_masters_etcd.yaml
@@ -1,4 +1,48 @@
 ---
+- name: Set default volumes/disks variables
+  ansible.builtin.set_fact:
+    _instance_volumes:
+      - dataVolume:
+          name: "{{ vmname }}"
+        name: rootdisk
+      - dataVolume:
+          name: "{{ vmname }}-installation-cdrom"
+        name: installation-cdrom
+      - dataVolume:
+          name: "{{ vmname }}-etcd"
+        name: etcd
+    _instance_disks:
+      - bootOrder: 1
+        disk:
+          bus: virtio
+        name: rootdisk
+      - bootOrder: 3
+        disk:
+          bus: virtio
+        name: etcd
+      - bootOrder: 2
+        cdrom:
+          bus: sata
+        name: installation-cdrom
+
+- name: Set the instances disks
+  ansible.builtin.set_fact:
+    _instance_disks: "{{ _instance_disks | from_yaml + [
+    {
+        'name': _disk.metadata.name,
+        'disk': {'bus': _instance.disk_type | default('virtio')}
+    }
+    ] }}"
+    _instance_volumes: "{{ _instance_volumes | from_yaml + [
+        {
+            'name': _disk.metadata.name,
+            'dataVolume': {'name': _disk.metadata.name}
+        }
+    ] }}"
+  loop: "{{ _instance.ai_masters_extra_disks | default([]) | list }}"
+  loop_control:
+    loop_var: _disk
+
 - name: Create Master virtual machine
   kubevirt.core.kubevirt_vm:
     api_version: kubevirt.io/v1
@@ -7,7 +51,17 @@
     validate_certs: false
     name: "{{ vmname }}"
     namespace: "{{ namespace }}"
-    data_volume_templates:
+    data_volume_templates: "{{ _datavolume + _instance.ai_masters_extra_disks }}"
+    running: true
+    wait: false
+    annotations:
+      vm.kubevirt.io/os: rhel8
+    labels:
+      kubevirt.io/domain: "{{ vmname }}"
+      role: control-plane
+    spec: "{{ _spec | from_yaml }}"
+  vars:
+    _datavolume:
       - metadata:
           name: "{{ vmname }}-installation-cdrom"
         spec:
@@ -43,16 +97,6 @@
                 storage: 30Gi
             storageClassName: "{{ ai_local_storageclass }}"
             volumeMode: Filesystem
-
-    running: true
-    wait: false
-    annotations:
-      vm.kubevirt.io/os: rhel8
-    labels:
-      kubevirt.io/domain: "{{ vmname }}"
-      role: control-plane
-    spec: "{{ _spec | from_yaml }}"
-  vars:
     _spec: |
       domain:
         cpu:
@@ -61,19 +105,7 @@
           threads: 1
           model: host-passthrough
         devices:
-          disks:
-            - bootOrder: 1
-              disk:
-                bus: virtio
-              name: rootdisk
-            - bootOrder: 3
-              disk:
-                bus: virtio
-              name: etcd
-            - bootOrder: 2
-              cdrom:
-                bus: sata
-              name: installation-cdrom
+          disks: {{ _instance_disks | replace('INSTANCENAME', vmname) }}
           interfaces:
             - masquerade: {}
               model: virtio
@@ -105,16 +137,7 @@
             networkName: "{{ network_name }}"
       terminationGracePeriodSeconds: 180
       evictionStrategy: None
-      volumes:
-        - dataVolume:
-            name: "{{ vmname }}"
-          name: rootdisk
-        - dataVolume:
-            name: "{{ vmname }}-installation-cdrom"
-          name: installation-cdrom
-        - dataVolume:
-            name: "{{ vmname }}-etcd"
-          name: etcd
+      volumes: {{ _instance_volumes | replace('INSTANCENAME', vmname) }}
 
 - name: Wait till VM is running
   kubernetes.core.k8s_info:

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_workers.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_workers.yaml
@@ -51,7 +51,7 @@
     validate_certs: false
     name: "{{ vmname }}"
     namespace: "{{ namespace }}"
-    data_volume_templates: "{{ _datavolume + ai_workers_extra_disks }}"
+    data_volume_templates: "{{ _datavolume + (ai_workers_extra_disks | default([]) | to_json | replace('INSTANCENAME', vmname) | from_json ) }}"
     running: true
     wait: false
     annotations:

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_workers.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_workers.yaml
@@ -8,18 +8,11 @@
       - dataVolume:
           name: "{{ vmname }}-installation-cdrom"
         name: installation-cdrom
-      - dataVolume:
-          name: "{{ vmname }}-etcd"
-        name: etcd
     _instance_disks:
       - bootOrder: 1
         disk:
           bus: virtio
         name: rootdisk
-      - bootOrder: 3
-        disk:
-          bus: virtio
-        name: etcd
       - bootOrder: 2
         cdrom:
           bus: sata
@@ -84,20 +77,6 @@
               requests:
                 storage: 100Gi
             storageClassName: "{{ storageclass }}"
-
-      - metadata:
-          name: "{{ vmname }}-etcd"
-        spec:
-          preallocation: false
-          source:
-            blank: {}
-          storage:
-            resources:
-              requests:
-                storage: 30Gi
-            storageClassName: "{{ ai_local_storageclass }}"
-            volumeMode: Filesystem
-
     _spec: |
       domain:
         cpu:
@@ -111,7 +90,7 @@
             - masquerade: {}
               model: virtio
               name: default
-            - name: "{{ network }}"
+            - name: "{{ network_name }}"
               macAddress: "{{ ai_workers_macs2[_index|int-1] }}"
               bridge: {}
           networkInterfaceMultiqueue: true

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_workers.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_workers.yaml
@@ -1,4 +1,48 @@
 ---
+- name: Set default volumes/disks variables
+  ansible.builtin.set_fact:
+    _instance_volumes:
+      - dataVolume:
+          name: "{{ vmname }}"
+        name: rootdisk
+      - dataVolume:
+          name: "{{ vmname }}-installation-cdrom"
+        name: installation-cdrom
+      - dataVolume:
+          name: "{{ vmname }}-etcd"
+        name: etcd
+    _instance_disks:
+      - bootOrder: 1
+        disk:
+          bus: virtio
+        name: rootdisk
+      - bootOrder: 3
+        disk:
+          bus: virtio
+        name: etcd
+      - bootOrder: 2
+        cdrom:
+          bus: sata
+        name: installation-cdrom
+
+- name: Set the instances disks
+  ansible.builtin.set_fact:
+    _instance_disks: "{{ _instance_disks | from_yaml + [
+    {
+        'name': _disk.metadata.name,
+        'disk': {'bus': _instance.disk_type | default('virtio')}
+    }
+    ] }}"
+    _instance_volumes: "{{ _instance_volumes | from_yaml + [
+        {
+            'name': _disk.metadata.name,
+            'dataVolume': {'name': _disk.metadata.name}
+        }
+    ] }}"
+  loop: "{{ ai_workers_extra_disks | default([]) | list }}"
+  loop_control:
+    loop_var: _disk
+
 - name: Create Worker virtual machine
   kubevirt.core.kubevirt_vm:
     api_version: kubevirt.io/v1
@@ -7,7 +51,17 @@
     validate_certs: false
     name: "{{ vmname }}"
     namespace: "{{ namespace }}"
-    data_volume_templates:
+    data_volume_templates: "{{ _datavolume + ai_workers_extra_disks }}"
+    running: true
+    wait: false
+    annotations:
+      vm.kubevirt.io/os: rhel8
+    labels:
+      kubevirt.io/domain: "{{ vmname }}"
+      role: worker
+    spec: "{{ _spec | from_yaml }}"
+  vars:
+    _datavolume:
       - metadata:
           name: "{{ vmname }}-installation-cdrom"
         spec:
@@ -18,7 +72,7 @@
           storage:
             resources:
               requests:
-                storage: 2Gi
+                storage: 1Gi
       - metadata:
           name: "{{ vmname }}"
         spec:
@@ -30,15 +84,20 @@
               requests:
                 storage: 100Gi
             storageClassName: "{{ storageclass }}"
-    running: true
-    wait: false
-    annotations:
-      vm.kubevirt.io/os: rhel8
-    labels:
-      kubevirt.io/domain: "{{ vmname }}"
-      role: worker
-    spec: "{{ _spec | from_yaml }}"
-  vars:
+
+      - metadata:
+          name: "{{ vmname }}-etcd"
+        spec:
+          preallocation: false
+          source:
+            blank: {}
+          storage:
+            resources:
+              requests:
+                storage: 30Gi
+            storageClassName: "{{ ai_local_storageclass }}"
+            volumeMode: Filesystem
+
     _spec: |
       domain:
         cpu:
@@ -47,20 +106,12 @@
           threads: 1
           model: host-passthrough
         devices:
-          disks:
-            - bootOrder: 1
-              disk:
-                bus: virtio
-              name: rootdisk
-            - bootOrder: 2
-              cdrom:
-                bus: sata
-              name: installation-cdrom
+          disks: {{ _instance_disks | replace('INSTANCENAME', vmname) }}
           interfaces:
             - masquerade: {}
               model: virtio
               name: default
-            - name: "{{ network_name }}"
+            - name: "{{ network }}"
               macAddress: "{{ ai_workers_macs2[_index|int-1] }}"
               bridge: {}
           networkInterfaceMultiqueue: true
@@ -85,13 +136,7 @@
           multus:
             networkName: "{{ network_name }}"
       terminationGracePeriodSeconds: 180
-      volumes:
-        - dataVolume:
-            name: "{{ vmname }}"
-          name: rootdisk
-        - dataVolume:
-            name: "{{ vmname }}-installation-cdrom"
-          name: installation-cdrom
+      volumes: {{ _instance_volumes | replace('INSTANCENAME', vmname) }}
 
 - name: Wait till VM is running
   kubernetes.core.k8s_info:

--- a/ansible/roles/host-ocp4-assisted-installer/vars/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/vars/main.yaml
@@ -22,5 +22,8 @@ ai_workers_macs: []
 ai_masters_macs2: []
 ai_workers_macs2: []
 
+ai_masters_extra_disks: []
+ai_workers_extra_disks: []
+
 # This variable is used to configure the role and the installation disk
 ai_configure_hosts: []


### PR DESCRIPTION
##### SUMMARY

Two new variables are added:

ai_masters_extra_disks: []
ai_workers_extra_disks: []

INSTANCENAME text will be replaced with the name of the instance, to avoid duplicate names

Example:
```
ai_workers_extra_disks:
  - metadata:
      name: "extradiskINSTANCENAME"
    spec:
      source:
        blank: {}
      pvc:
        accessModes:
          - ReadWriteMany
        volumeMode: Block
        resources:
          requests:
            storage: "20Gi"
```


##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
host-ocp4-assisted-installer role
