### PR TITLE
Fix InstallPlan task - Zero SSL

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/defaults/main.yml
@@ -81,7 +81,7 @@ ocp4_workload_cert_manager_azure_tenant_id: "{{ azure_tenant }}"
 # ---------------------------------------------------------------
 # Operator settings
 # ---------------------------------------------------------------
-ocp4_workload_cert_manager_channel: stable-v1.14
+ocp4_workload_cert_manager_channel: stable-v1
 ocp4_workload_cert_manager_starting_csv: ""
 # ocp4_workload_cert_manager_starting_csv: cert-manager-operator.v1.13.0
 ocp4_workload_cert_manager_automatic_install_plan_approval: true


### PR DESCRIPTION
Task is failing due to the available channel being stable-v1:

```
[lab-user@bastion ~]$ oc get packagemanifests openshift-cert-manager-operator -o jsonpath='{.status.channels[].name}{"\n"}'
stable-v1
```