### PR TITLE
Clean up tab handling in showroom for codeserver

### DIFF
--- a/ansible/roles/showroom/templates/service_double_tty/tablink_double_tty.j2
+++ b/ansible/roles/showroom/templates/service_double_tty/tablink_double_tty.j2
@@ -1,1 +1,1 @@
-					<button class="tablinks" onclick="openTerminal(event, 'terminal_tab')" id="defaultOpen" tabindex="0">Terminals</button>
+					<button class="tablinks" onclick="openTerminal(event, 'terminal_tab')">Terminals</button>

--- a/ansible/roles/showroom/templates/service_web1/tablink_web1.j2
+++ b/ansible/roles/showroom/templates/service_web1/tablink_web1.j2
@@ -1,1 +1,1 @@
-          <button class="tablinks" onclick="openTerminal(event, 'web1_tab')"{% if loop.first %} id="defaultOpen" tabindex="0"{% endif %}>{{ showroom_tab_web1_name }}</button>
+          <button class="tablinks" onclick="openTerminal(event, 'web1_tab')" id="defaultOpen" tabindex="0">{{ showroom_tab_web1_name }}</button>


### PR DESCRIPTION

##### SUMMARY

Clean up tab handling in showroom fixing clash between web_1 and doube_tty (which doesn't need it)

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME

roles/showroom

##### ADDITIONAL INFORMATION
