### PR TITLE
[ocp4_workload_openshift_gitops] Add new variable ocp4_workload_openshift_gitops_api_version

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/defaults/main.yml
@@ -159,3 +159,6 @@ ocp4_workload_openshift_gitops_kustomize_plugin_image: quay.io/devfile/universal
 # Empty does not set anything.
 # https://argo-cd.readthedocs.io/en/latest/user-guide/resource_tracking/
 ocp4_workload_openshift_gitops_resourceTrackingMethod: ""
+
+# Define the api_version (i.e v1alpha1 or v1beta1
+ocp4_workload_openshift_gitops_api_version: "{{ _ocp4_workload_openshift_gitops_api_version }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/workload.yml
@@ -40,11 +40,11 @@
 
 - name: Debug version
   ansible.builtin.debug:
-    msg: "API Version: {{ ocp4_workload_openshift_gitops_api_version | default(_ocp4_workload_openshift_gitops_api_version) }}"
+    msg: "API Version: {{ ocp4_workload_openshift_gitops_api_version }}"
 
 - name: Wait until openshift-gitops ArgoCD instance has been created
   kubernetes.core.k8s_info:
-    api_version: "argoproj.io/{{ ocp4_workload_openshift_gitops_api_version | default(_ocp4_workload_openshift_gitops_api_version) }}"
+    api_version: "argoproj.io/{{ ocp4_workload_openshift_gitops_api_version }}"
     kind: ArgoCD
     name: openshift-gitops
     namespace: openshift-gitops

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_gitops/tasks/workload.yml
@@ -40,11 +40,11 @@
 
 - name: Debug version
   ansible.builtin.debug:
-    msg: "API Version: {{ _ocp4_workload_openshift_gitops_api_version }}"
+    msg: "API Version: {{ ocp4_workload_openshift_gitops_api_version | default(_ocp4_workload_openshift_gitops_api_version) }}"
 
 - name: Wait until openshift-gitops ArgoCD instance has been created
   kubernetes.core.k8s_info:
-    api_version: "argoproj.io/{{ _ocp4_workload_openshift_gitops_api_version }}"
+    api_version: "argoproj.io/{{ ocp4_workload_openshift_gitops_api_version | default(_ocp4_workload_openshift_gitops_api_version) }}"
     kind: ArgoCD
     name: openshift-gitops
     namespace: openshift-gitops


### PR DESCRIPTION
##### SUMMARY

Currently is difficult to specify directly the api_version, as you need to specify the internal variable (_ocp4_workload_openshift_gitops_api_version). This PR is to add a new variable called ocp4_workload_openshift_gitops_api_version and if doesnt exist it is using _ocp4_workload_openshift_gitops_api_version

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_openshift_gitops role
