### PR TITLE
[ocp4_workload_virt_roadshow_multi_user] Add the option to allow users to see cluster network configuration and create NaD

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_multi_user/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_multi_user/defaults/main.yml
@@ -6,3 +6,8 @@ silent: false
 # In the future once bug https://issues.redhat.com/browse/CNV-38284 is in the product
 # the namespace will need to change to openshift-cnv
 ocp4_workload_virt_roadshow_multi_user_configmap_namespace: default
+
+
+# Configure ClusterRole and RoleBinding to allow users to list network information
+# from the cluster and allow create Network Attach Definition
+ocp4_workload_virt_roadshow_multi_user_network_roles_configure: false

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_multi_user/files/clusterrole-list-nodenetworkconfigurationresources.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_multi_user/files/clusterrole-list-nodenetworkconfigurationresources.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: list-nodenetworkconfigurationresources
+rules:
+  - apiGroups:
+      - nmstate.io
+    resources:
+      - nodenetworkconfigurationenactments
+      - nodenetworkconfigurationpolicies
+    verbs:
+      - list

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_multi_user/files/clusterrole-list-nodenetworkstates.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_multi_user/files/clusterrole-list-nodenetworkstates.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: list-nodenetworkstates
+rules:
+  - apiGroups:
+      - nmstate.io
+    resources:
+      - nodenetworkstates
+    verbs:
+      - list

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_multi_user/files/clusterrole-network-attachment-admin.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_multi_user/files/clusterrole-network-attachment-admin.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: network-attachment-admin
+rules:
+  - apiGroups:
+      - "k8s.cni.cncf.io"
+    resources:
+      - network-attachment-definitions
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - delete
+      - update

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_multi_user/files/clusterrolebiding-network-attachment-admin.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_multi_user/files/clusterrolebiding-network-attachment-admin.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: network-attachment-admin-binding
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:authenticated'
+roleRef:
+  kind: ClusterRole
+  name: network-attachment-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_multi_user/files/clusterrolebinding-list-nodenetworkconfigurationresources.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_multi_user/files/clusterrolebinding-list-nodenetworkconfigurationresources.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: list-nodenetworkconfigurationresources-binding
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:authenticated'
+roleRef:
+  kind: ClusterRole
+  name: list-nodenetworkconfigurationresources
+  apiGroup: rbac.authorization.k8s.io

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_multi_user/files/clusterrolebinding-list-nodenetworkstates.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_multi_user/files/clusterrolebinding-list-nodenetworkstates.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: list-nodenetworkstates-binding
+  namespace: default
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:authenticated'
+roleRef:
+  kind: ClusterRole
+  name: list-nodenetworkstates
+  apiGroup: rbac.authorization.k8s.io

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_multi_user/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_multi_user/tasks/workload.yml
@@ -34,6 +34,21 @@
   loop_control:
     loop_var: resource
 
+- name: Set up users permissions to see node network configuration and allow create NaD
+  when: ocp4_workload_virt_roadshow_multi_user_network_roles_configure | default(false)
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('file', resource | from_yaml) }}"
+  loop:
+  - clusterrole-list-nodenetworkstates.yaml
+  - clusterrolebinding-list-nodenetworkstates.yaml
+  - clusterrole-list-nodenetworkconfigurationresources.yaml
+  - clusterrolebinding-list-nodenetworkconfigurationresources.yaml
+  - clusterrole-network-attachment-admin.yaml
+  - clusterrolebiding-network-attachment-admin.yaml
+  loop_control:
+    loop_var: resource
+
 # Leave this as the last task in the playbook.
 - name: Workload tasks complete
   when: not silent|bool


### PR DESCRIPTION
##### SUMMARY

Allow authenticated users to list network details from the cluster (such as interfaces, bridges, bonds), the NNCP configs and allow users to create NaD (network attach definition)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_virt_roadshow_multi_user role
