### PR TITLE
[host-ocp4-assisted-installer] Add functionality to add extra networks

### DIFF
--- a/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_masters_etcd.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_masters_etcd.yaml
@@ -1,4 +1,46 @@
 ---
+- name: Set default interfaces/networks variables
+  ansible.builtin.set_fact:
+    _instance_interfaces:
+      - masquerade: {}
+        model: virtio
+        name: default
+      - name: "{{ network }}"
+        macAddress: "{{ ai_masters_macs2[_index|int-1] }}"
+        bridge: {}
+    _instance_networks:
+      - name: default
+        pod:
+          vmNetworkCIDR: "{{ pod_network }}"
+      - name: "{{ network }}"
+        multus:
+          networkName: "{{ network_name }}"
+
+- name: Add attach masters networks if defined
+  vars:
+    _network_name: "{{ _network.split('/')[1] if '/' in _network else _network + guid }}"
+    _network_multusname: "{{ _network if '/' in _network else _network + guid }}"
+  when: ai_attach_masters_networks | default([]) | length > 0
+  ansible.builtin.set_fact:
+    _instance_interfaces: >-
+      {{
+        _instance_interfaces + [{
+          'name': _network_name,
+          'bridge': {},
+          'model': 'virtio',
+          'macAddress': ai_attach_masters_macs[_network][_index|int-1]
+        } ]
+      }}
+    _instance_networks: >-
+      {{ _instance_networks + [
+          {
+              'name': _network_name,
+              'multus': {'networkName': _network_multusname}
+          }] }}
+  loop: "{{ ai_attach_masters_networks }}"
+  loop_control:
+    loop_var: _network
+
 - name: Set default volumes/disks variables
   ansible.builtin.set_fact:
     _instance_volumes:
@@ -106,13 +148,7 @@
           model: host-passthrough
         devices:
           disks: {{ _instance_disks | replace('INSTANCENAME', vmname) }}
-          interfaces:
-            - masquerade: {}
-              model: virtio
-              name: default
-            - name: "{{ network }}"
-              macAddress: "{{ ai_masters_macs2[_index|int-1] }}"
-              bridge: {}
+          interfaces: {{ _instance_interfaces }}
           networkInterfaceMultiqueue: true
         machine:
           type: pc-q35-rhel8.6.0
@@ -128,13 +164,7 @@
           scheme: HTTPS
         initialDelaySeconds: 120
         periodSeconds: 1
-      networks:
-        - name: default
-          pod:
-            vmNetworkCIDR: "{{ pod_network }}"
-        - name: "{{ network }}"
-          multus:
-            networkName: "{{ network_name }}"
+      networks: {{ _instance_networks }}
       terminationGracePeriodSeconds: 180
       evictionStrategy: None
       volumes: {{ _instance_volumes | replace('INSTANCENAME', vmname) }}

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_workers.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_workers.yaml
@@ -1,4 +1,46 @@
 ---
+- name: Set default interfaces/networks variables
+  ansible.builtin.set_fact:
+    _instance_interfaces:
+      - masquerade: {}
+        model: virtio
+        name: default
+      - name: "{{ network }}"
+        macAddress: "{{ ai_workers_macs2[_index|int-1] }}"
+        bridge: {}
+    _instance_networks:
+      - name: default
+        pod:
+          vmNetworkCIDR: "{{ pod_network }}"
+      - name: "{{ network }}"
+        multus:
+          networkName: "{{ network_name }}"
+
+- name: Add attach workers networks if defined
+  vars:
+    _network_name: "{{ _network.split('/')[1] if '/' in _network else _network + guid }}"
+    _network_multusname: "{{ _network if '/' in _network else _network + guid }}"
+  when: ai_attach_workers_networks | default([]) | length > 0
+  ansible.builtin.set_fact:
+    _instance_interfaces: >-
+      {{
+        _instance_interfaces + [{
+          'name': _network_name,
+          'bridge': {},
+          'model': 'virtio',
+          'macAddress': ai_attach_workers_macs[_network][_index|int-1]
+        } ]
+      }}
+    _instance_networks: >-
+      {{ _instance_networks + [
+          {
+              'name': _network_name,
+              'multus': {'networkName': _network_multusname}
+          }] }}
+  loop: "{{ ai_attach_workers_networks }}"
+  loop_control:
+    loop_var: _network
+
 - name: Set default volumes/disks variables
   ansible.builtin.set_fact:
     _instance_volumes:
@@ -86,13 +128,7 @@
           model: host-passthrough
         devices:
           disks: {{ _instance_disks | replace('INSTANCENAME', vmname) }}
-          interfaces:
-            - masquerade: {}
-              model: virtio
-              name: default
-            - name: "{{ network_name }}"
-              macAddress: "{{ ai_workers_macs2[_index|int-1] }}"
-              bridge: {}
+          interfaces: {{ _instance_interfaces }}
           networkInterfaceMultiqueue: true
         machine:
           type: pc-q35-rhel8.6.0
@@ -107,13 +143,7 @@
         initialDelaySeconds: 120
         periodSeconds: 5
       evictionStrategy: LiveMigrate
-      networks:
-        - name: default
-          pod:
-            vmNetworkCIDR: "{{ pod_network }}"
-        - name: "{{ network_name }}"
-          multus:
-            networkName: "{{ network_name }}"
+      networks: {{ _instance_networks }}
       terminationGracePeriodSeconds: 180
       volumes: {{ _instance_volumes | replace('INSTANCENAME', vmname) }}
 

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
@@ -340,6 +340,22 @@
       loop_control:
         loop_var: _index
 
+    - name: Generate MAC addresses for control plane for attached networks
+      ansible.builtin.set_fact:
+        ai_attach_masters_macs: >-
+          {{
+            ai_attach_masters_macs | combine({
+              item.1: (ai_attach_masters_macs[item.1] | default([])) + [
+                'f6' | community.general.random_mac(
+                  ai_ocp_namespace + cluster_name + item.0|string + item.1
+                )
+              ]
+            })
+          }}
+      loop: "{{ range(1, master_instance_count | int + 1) | list | product(ai_attach_masters_networks) | list }}"
+      loop_control:
+        loop_var: item
+
     - name: Generate mac addresses for workers
       ansible.builtin.set_fact:
         ai_workers_macs: >
@@ -351,6 +367,23 @@
       loop: "{{ range(1,worker_instance_count|int+1)|list }}"
       loop_control:
         loop_var: _index
+
+    - name: Generate MAC addresses for workers for attached networks
+      ansible.builtin.set_fact:
+        ai_attach_workers_macs: >-
+          {{
+            ai_attach_workers_macs | combine({
+              item.1: (ai_attach_workers_macs[item.1] | default([])) + [
+                'f6' | community.general.random_mac(
+                  ai_ocp_namespace + cluster_name + item.0|string + item.1
+                )
+              ]
+            })
+          }}
+      loop: "{{ range(1, worker_instance_count | int + 1) | list | product(ai_attach_workers_networks) | list }}"
+      loop_control:
+        loop_var: item
+
 
     - name: Set static_network_config variable
       ansible.builtin.set_fact:

--- a/ansible/roles/host-ocp4-assisted-installer/templates/static_network_config_full.j2
+++ b/ansible/roles/host-ocp4-assisted-installer/templates/static_network_config_full.j2
@@ -16,6 +16,14 @@
       name: enp2s0
       state: up
       type: ethernet
+{% for _network in ai_attach_masters_networks %}
+    - ipv4:
+        dhcp: false
+        enabled: false
+      name: enp{{ loop.index+2 }}s0
+      state: up
+      type: ethernet
+{% endfor %}
     routes:
       config:
       - destination: 0.0.0.0/0
@@ -27,6 +35,10 @@
       logical_nic_name: "enp1s0"
     - mac_address: "{{ ai_masters_macs2[index] }}"
       logical_nic_name: "enp2s0"
+{% for _network in ai_attach_masters_networks %}
+    - mac_address: "{{ ai_attach_masters_macs[_network][loop.index0] }}"
+      logical_nic_name: "enp{{ loop.index+2 }}s0"
+{% endfor %}
 {% endfor %}
 {% for index in range(0,worker_instance_count|int) %} 
 - network_yaml: |
@@ -46,6 +58,14 @@
       name: enp2s0
       state: up
       type: ethernet
+{% for _network in ai_attach_workers_networks %}
+    - ipv4:
+        dhcp: false
+        enabled: false
+      name: enp{{ loop.index+2 }}s0
+      state: up
+      type: ethernet
+{% endfor %}
     routes:
       config:
       - destination: 0.0.0.0/0
@@ -57,5 +77,9 @@
       logical_nic_name: "enp1s0"
     - mac_address: "{{ ai_workers_macs2[index] }}"
       logical_nic_name: "enp2s0"
+{% for _network in ai_attach_workers_networks %}
+    - mac_address: "{{ ai_attach_workers_macs[_network][loop.index0] }}"
+      logical_nic_name: "enp{{ loop.index+2 }}s0"
+{% endfor %}
 {% endfor %}
 

--- a/ansible/roles/host-ocp4-assisted-installer/vars/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/vars/main.yaml
@@ -24,6 +24,10 @@ ai_masters_macs: []
 ai_workers_macs: []
 ai_masters_macs2: []
 ai_workers_macs2: []
+ai_attach_masters_networks: []
+ai_attach_workers_networks: []
+ai_attach_masters_macs: {}
+ai_attach_workers_macs: {}
 
 ai_masters_extra_disks: []
 ai_workers_extra_disks: []


### PR DESCRIPTION
##### SUMMARY

This PR allows to use the variables ai_attach_masters_networks and ai_attach_workers_networks to attach the nodes to an existing network

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
host-ocp4-assisted-installer role
