### PR TITLE
Add support for RHEL95 and RHELAI 1.2 AMIs

### DIFF
--- a/ansible/roles-infra/infra-images/defaults/main.yaml
+++ b/ansible/roles-infra/infra-images/defaults/main.yaml
@@ -4,17 +4,34 @@ infra_images_instances: "{{ instances | default([]) }}"
 
 # Predefined search dicts for commonly used images
 infra_images_redhat_owner_id: 309956199498
+#TODO: Do we want AI images owned by 309956199498?
+infra_ai_images_redhat_owner_id: 809721187735
 
 _infra_images_arch: "{{ ocp4_architecture_cluster | default(infra_images_arch) | default('x86_64') }}"
 
 infra_images_predefined:
+
+  RHELAI12:
+    owner: "{{ infra_ai_images_redhat_owner_id  | default(infra_images_redhat_owner_id) }}"
+    name: rhel-ai-nvidia-1.2*
+    architecture: "{{ _infra_images_arch }}"
+    aws_filters:
+      is-public: false
+
+  RHEL95GOLD-latest:
+    owner: "{{ infra_images_redhat_owner_id }}"
+    name: RHEL-9.5.*_HVM-*Access*
+    architecture: "{{ _infra_images_arch }}"
+    aws_filters:
+      is-public: false
+
   RHEL94GOLD-latest:
     owner: "{{ infra_images_redhat_owner_id }}"
     name: RHEL-9.4.*_HVM-*Access*
     architecture: "{{ _infra_images_arch }}"
     aws_filters:
       is-public: false
-      
+
   RHEL93GOLD-latest:
     owner: "{{ infra_images_redhat_owner_id }}"
     name: RHEL-9.3.*_HVM-*Access*


### PR DESCRIPTION
##### SUMMARY

Extend AgnosticD to support RHEL 95 and RHEL AI 1.2 AMIs

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME

roles-infra/infra-images

##### ADDITIONAL INFORMATION

