### PR TITLE
RH1 LAB01 (and ocp4_workload_rhacm_cloud_credentials) - fix pull secret in openshift secret

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm_cloud_credentials/templates/kubevirt_ns_and_secret.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm_cloud_credentials/templates/kubevirt_ns_and_secret.yaml.j2
@@ -15,7 +15,7 @@ metadata:
     cluster.open-cluster-management.io/type: kubevirt
 type: Opaque
 data:
-  pullSecret: {{ ocp4_token | string | b64encode }}
+  pullSecret: {{ ocp4_pull_secret | to_json | b64encode }}
   ssh-publickey: |
     {{ ocp4_workload_rhacm_cloud_credentials_kubevirt_pubkey |
        string | b64encode }}


### PR DESCRIPTION

- Bugfix Pull Request

Pull secrets in OpenShift secrets when used to deploy HCP clusters are strict about their json formatting.

This fixes the json formatting.