### PR TITLE
[ocp4_workload_summit_2024_cloud_native_camel] Disable devfile check as it requires authentication

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_summit_2024_cloud_native_camel/tasks/install_devspaces.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_summit_2024_cloud_native_camel/tasks/install_devspaces.yml
@@ -88,18 +88,18 @@
   delay: 10
   until: r_devspace_pod.resources | list | length == 1
 
-- name: Check DevSpaces plugin-registry devfile endpoint readiness
-  ansible.builtin.uri:
-    validate_certs: '{{ verify_tls }}'
-    url: https://devspaces.{{ route_subdomain }}/plugin-registry/v3/plugins/che-incubator/che-code/latest/devfile.yaml
-    method: GET
-    return_content: false
-    status_code: 200
-    timeout: 3
-  register: api_response
-  retries: 120
-  delay: 10
-  until: api_response.status == 200
+#- name: Check DevSpaces plugin-registry devfile endpoint readiness
+#  ansible.builtin.uri:
+#    validate_certs: '{{ verify_tls }}'
+#    url: https://devspaces.{{ route_subdomain }}/plugin-registry/v3/plugins/che-incubator/che-code/latest/devfile.yaml
+#    method: GET
+#    return_content: false
+#    status_code: 200
+#    timeout: 3
+#  register: api_response
+#  retries: 120
+#  delay: 10
+#  until: api_response.status == 200
 
 - name: Wait DevSpaces container-build scc
   kubernetes.core.k8s_info:


### PR DESCRIPTION
##### SUMMARY

Tested manually the installation, devspaces works perfectly, so this check is not mandatory

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
ocp4_workload_summit_2024_cloud_native_camel role

