### PR TITLE
Parasol: NFD workload fixes + Deployment end check

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_nvidia_gpu_setup/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_nvidia_gpu_setup/defaults/main.yml
@@ -13,7 +13,7 @@ nfd_operator_use_catalog_snapshot: false
 nfd_operator_catalogsource_name: ""
 nfd_operator_catalog_snapshot_image: ""
 nfd_operator_catalog_snapshot_image_tag: ""
-nfd_operator_operand_image: "registry.redhat.io/openshift4/ose-node-feature-discovery-rhel9@sha256:b0f786e21798c27905c6fdf189bd91cae1f5ddd58ad101a28dbb8b5de92069ce"
+nfd_operator_operand_image: "registry.redhat.io/openshift4/ose-node-feature-discovery-rhel9:v4.17"
 
 # ------------------------------------------------
 # NVIDIA GPU Operator

--- a/ansible/roles_ocp_workloads/ocp4_workload_nvidia_gpu_setup/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_nvidia_gpu_setup/defaults/main.yml
@@ -13,6 +13,7 @@ nfd_operator_use_catalog_snapshot: false
 nfd_operator_catalogsource_name: ""
 nfd_operator_catalog_snapshot_image: ""
 nfd_operator_catalog_snapshot_image_tag: ""
+nfd_operator_operand_image: "registry.redhat.io/openshift4/ose-node-feature-discovery-rhel9@sha256:b0f786e21798c27905c6fdf189bd91cae1f5ddd58ad101a28dbb8b5de92069ce"
 
 # ------------------------------------------------
 # NVIDIA GPU Operator

--- a/ansible/roles_ocp_workloads/ocp4_workload_nvidia_gpu_setup/tasks/nfd_operator.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_nvidia_gpu_setup/tasks/nfd_operator.yml
@@ -21,7 +21,7 @@
 - name: Create NodeFeatureDiscovery Custom Resource
   kubernetes.core.k8s:
     state: present
-    definition: "{{ lookup('file', 'nodefeature_discovery_cr.yaml') | from_yaml }}"
+    definition: "{{ lookup('template', 'nodefeature_discovery_cr.yaml.j2') | from_yaml }}"
   register: result
   until: result is not failed
   retries: 30

--- a/ansible/roles_ocp_workloads/ocp4_workload_nvidia_gpu_setup/templates/nodefeature_discovery_cr.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_nvidia_gpu_setup/templates/nodefeature_discovery_cr.yaml.j2
@@ -14,7 +14,7 @@ spec:
       #      matchOn:
       #      - nodename: ["special-.*-node-.*"]
   operand:
-    image: 'registry.redhat.io/openshift4/ose-node-feature-discovery-rhel9@sha256:b0f786e21798c27905c6fdf189bd91cae1f5ddd58ad101a28dbb8b5de92069ce'
+    image: '{{ nfd_operator_operand_image }}'
     imagePullPolicy: IfNotPresent
     servicePort: 12000
   workerConfig:

--- a/ansible/roles_ocp_workloads/ocp4_workload_oai_parasol_insurance/tasks/workload.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_oai_parasol_insurance/tasks/workload.yaml
@@ -84,6 +84,32 @@
   command: "oc apply -f /tmp/ocp4_workload_oai_parasol_insurance_repo/{{ ocp4_workload_oai_parasol_insurance_yaml_file_path }}"
   when: git_clone.changed
 
+- name: Wait 30s for the Applications to be created
+  pause:
+    seconds: 30
+
+- name: Wait for ArgoCD Applications to be fully healthy
+  block:
+  - name: Check if all Applications are fully healthy
+    shell: |
+      if oc get applications.argoproj.io -n openshift-gitops \
+          -o jsonpath="{.items[*].status.health.status}" | grep -qvE '^(\s*Healthy\s*)+$'; then
+        exit 1
+      else
+        exit 0
+      fi
+    register: sync_check
+    retries: 360               # Retry for 360 attempts (15s * 360 = 1.5 hour)
+    delay: 15                  # Wait 15 seconds between retries
+    until: sync_check.rc == 0  # Continue retrying until all Applications are healthy
+    failed_when: sync_check.rc != 0
+    changed_when: false
+
+  - name: Fail if Applications did not sync within the timeout
+    fail:
+      msg: "Timeout reached! Not all Applications are healthy."
+    when: sync_check.rc != 0
+
 # Leave this as the last task in the playbook.
 - name: workload tasks complete
   debug:


### PR DESCRIPTION
##### SUMMARY

Two changes.
1) In the `ocp4_workload_nvidia_gpu_setup`, modify NFD deployment. The operand image version becomes a variable, with the default set at `registry.redhat.io/openshift4/ose-node-feature-discovery-rhel9:v4.17`
2) Parasol deployment workload modified to add an ArgoCD wait/check at the end. That way, the deployment is not finished until everything is properly deployed (no more sync wait time after you receive the go from the demo system).