### PR TITLE
ocp4_workload_showroom: add usernum to user_data.user dict

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/prepare-variables.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/prepare-variables.yaml
@@ -9,6 +9,15 @@
     quiet: true
     fail_msg: Required variables not defined
 
+- name: Set a user.usernum
+  agnosticd_user_info:
+    data:
+      usernum: "{{ n }}"
+    user: "user{{ n }}"
+  loop: "{{ range(1, num_users | int + 1) | list }}"
+  loop_control:
+    loop_var: n
+
 - name: Set passthrough variables to per-user data, if desired
   when:
   - agnosticd_passthrough_user_data is defined


### PR DESCRIPTION
We never actually gave lab instructions authors simply the integer of the user in a multi-user environment.

This adds that.

Gerald Nunn wanted it.