### PR TITLE
set a default num_users for ocp4_workload_showroom

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/prepare-variables.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/prepare-variables.yaml
@@ -9,6 +9,10 @@
     quiet: true
     fail_msg: Required variables not defined
 
+- name: Set a default num_users
+  ansible.builtin.set_fact:
+    num_users: "{{ num_users | default(1) }}"
+
 - name: Set a user.usernum
   agnosticd_user_info:
     data:


### PR DESCRIPTION
- Bugfix Pull Request

dedicated cluster orders were failing