### PR TITLE
Add a flag to portworx workload to not install the operator if so desired

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_portworx/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_portworx/defaults/main.yml
@@ -5,6 +5,7 @@ ocp_username: "system:admin"
 ocp4_workload_portworx_namespace: portworx
 
 # Define operator metadata
+ocp4_workload_portworx_install_operator: true
 ocp4_workload_portworx_channel: stable
 ocp4_workload_portworx_installplan: Automatic
 ocp4_workload_portworx_sub_name: portworx-certified

--- a/ansible/roles_ocp_workloads/ocp4_workload_portworx/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_portworx/tasks/workload.yml
@@ -114,6 +114,7 @@
     state: present
 
 - name: Install Portworx operator
+  when: ocp4_workload_portworx_install_operator | bool
   ansible.builtin.include_role:
     name: install_operator
   vars:
@@ -130,7 +131,9 @@
     install_operator_catalogsource_setup: false
 
 - name: Deploy StorageCluster
-  when: ocp4_workload_portworx_deploy_storagecluster | bool
+  when:
+  - ocp4_workload_portworx_install_operator | bool
+  - ocp4_workload_portworx_deploy_storagecluster | bool
   block:
   - name: Create StorageCluster
     kubernetes.core.k8s:


### PR DESCRIPTION
##### SUMMARY

For RH1 Labs add a flag to the portworx workload to not pre-install the operator - yet still create the AWS policy.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_portworx