### PR TITLE
setup_instructlab update CUDACXX location to variable

### DIFF
--- a/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_instructlab/tasks/40-instructlab-runtime-setup.yml
+++ b/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_instructlab/tasks/40-instructlab-runtime-setup.yml
@@ -37,7 +37,7 @@
             {{ setup_instructlab_home }}/venv/bin/pip install --force-reinstall 
             --no-cache-dir "llama-cpp-python[server]=={{ setup_instructlab_llama_cpp_python_version }}"
       environment:
-        CUDACXX: /usr/local/cuda-12/bin/nvcc 
+        CUDACXX: "{{ setup_instructlab_cuda_home | default('/usr/local/cuda-12') }}"/bin/nvcc 
         CMAKE_ARGS: "-DLLAMA_CUBLAS=on -DCMAKE_CUDA_ARCHITECTURES=all-major" 
         FORCE_CMAKE: 1 
 


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
This change creates a variable to specify the path of CUDACXX rather than hard coded.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
setup_instructlab

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
