### PR TITLE
Add cloud_provider to AgnosticD User Info for ocp4-cluster

### DIFF
--- a/ansible/configs/ocp4-cluster/post_infra.yml
+++ b/ansible/configs/ocp4-cluster/post_infra.yml
@@ -12,6 +12,7 @@
     agnosticd_user_info:
       data:
         guid: "{{ guid }}"
+        cloud_provider: "{{ cloud_provider | default('none') }}"
 
   - name: OpenStack Post Infrastructure
     when: cloud_provider is match("osp")


### PR DESCRIPTION
##### SUMMARY

For RH1 with two clouds for each catalog item it may be necessary to adapt the showroom instructions based on the cloud provider selected.

This PR adds the `cloud_provider` variable to the AgnosticD user data so that in showroom some ifdef's can be written depending on which cloud the catalog item was deployed.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4-cluster