### PR TITLE
Make bastion machine type for ocp4-cluster bastion variable and update to n2-standard-2

### DIFF
--- a/ansible/configs/ocp4-cluster/default_vars_gcp.yml
+++ b/ansible/configs/ocp4-cluster/default_vars_gcp.yml
@@ -47,6 +47,9 @@ master_instance_count: 3
 gcp_rhel_image_project: rhel-cloud
 gcp_rhel_image_family: rhel-9
 
+# Default type for GCP instances (bastion)
+gcp_default_machine_type: n2-standard-2
+
 # Machine Type for control plane (master) nodes
 master_instance_type: n2-standard-4
 

--- a/ansible/configs/ocp4-cluster/files/cloud_providers/gcp_cloud_template.j2
+++ b/ansible/configs/ocp4-cluster/files/cloud_providers/gcp_cloud_template.j2
@@ -41,7 +41,7 @@ resources:
   type: compute.v1.instance
   properties:
     zone: {{ gcp_zone }}
-    machineType: zones/{{ gcp_zone }}/machineTypes/n1-standard-2
+    machineType: zones/{{ gcp_zone }}/machineTypes/{{ gcp_default_machine_type }}
     metadata:
       items:
         - key: ssh-keys


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Make bastion machine type for ocp4-cluster bastion variable and update to n2-standard-2
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4-cluster

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
