### PR TITLE
add kueue and modelregistry configuration to DSC template

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_ai/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_ai/defaults/main.yml
@@ -31,7 +31,9 @@ ocp4_workload_openshift_ai_codeflare: Removed
 ocp4_workload_openshift_ai_dashboard: Managed
 ocp4_workload_openshift_ai_datasciencepipelines: Managed
 ocp4_workload_openshift_ai_kserve: Removed
+ocp4_workload_openshift_ai_kueue: Removed
 ocp4_workload_openshift_ai_modelmeshserving: Managed
+ocp4_workload_openshift_ai_modelregistry: Removed
 ocp4_workload_openshift_ai_ray: Removed
 ocp4_workload_openshift_ai_trustyai: Removed
 ocp4_workload_openshift_ai_workbenches: Managed

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_ai/templates/redhat-datasciencecluster.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_ai/templates/redhat-datasciencecluster.yaml.j2
@@ -13,8 +13,12 @@ spec:
       managementState: {{ ocp4_workload_openshift_ai_datasciencepipelines }}
     kserve:
       {{ ocp4_workload_openshift_ai_kserve_config | to_yaml | indent(6) }}
+    kueue:
+      managementState: {{ ocp4_workload_openshift_ai_kueue }}
     modelmeshserving:
       managementState: {{ ocp4_workload_openshift_ai_modelmeshserving }}
+    modelregistry:
+      managementState: {{ ocp4_workload_openshift_ai_modelregistry }}
     ray:
       managementState: {{ ocp4_workload_openshift_ai_ray }}
     trustyai:


### PR DESCRIPTION
##### SUMMARY

The new release of OpenShift AI (stable) introduced new components that can be activated: Kueue and Model Registry.
This PR adds them to the available parameter of `ocp4_workload_openshift_ai`.
Defaults are set to "Removed" so that they are not installed by default in other pre-existing deployments.

##### COMPONENT NAME
`ocp4_workload_openshift_ai`