### PR TITLE
Showroom role, allow user to specify where ansible is executed by the service

### DIFF
--- a/ansible/roles/showroom/templates/showroom.service.j2
+++ b/ansible/roles/showroom/templates/showroom.service.j2
@@ -9,7 +9,7 @@ User={{ showroom_user | default('showroom') }}
 Group={{ showroom_user_group | default('showroom') }}
 Environment=PODMAN_SYSTEMD_UNIT=%n
 {% if showroom_frontend_service == "traefik" %}
-ExecStart=/usr/bin/ansible-playbook /usr/local/bin/showroom-user-socket.yml
+ExecStart="{{ showroom_preffered_python_exec | default('/usr/bin/ansible-playbook') }}" /usr/local/bin/showroom-user-socket.yml
 {% endif %}
 ExecStart=/usr/local/bin/showroom-start.sh
 ExecStop=/usr/local/bin/showroom-stop.sh

--- a/ansible/roles/showroom/templates/showroom.service.j2
+++ b/ansible/roles/showroom/templates/showroom.service.j2
@@ -9,7 +9,7 @@ User={{ showroom_user | default('showroom') }}
 Group={{ showroom_user_group | default('showroom') }}
 Environment=PODMAN_SYSTEMD_UNIT=%n
 {% if showroom_frontend_service == "traefik" %}
-ExecStart="{{ showroom_preffered_python_exec | default('/usr/bin/ansible-playbook') }}" /usr/local/bin/showroom-user-socket.yml
+ExecStart={{ showroom_preffered_ansible_exec | default('/usr/bin/ansible-playbook') }} /usr/local/bin/showroom-user-socket.yml
 {% endif %}
 ExecStart=/usr/local/bin/showroom-start.sh
 ExecStop=/usr/local/bin/showroom-stop.sh


### PR DESCRIPTION
…wroom.service

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
showroom
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
