### PR TITLE
[ocp4_workload_showroom] Allow SSH with different users (userX) to the bastion

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm.yaml
@@ -59,8 +59,8 @@
           autoSshToBastion: "{{ (true if ocp4_workload_showroom_wetty_ssh_bastion_login | bool else false) | bool | string | lower }}"
           sshAuth: password
           sshHost: "{{ _showroom_user_data.bastion_public_hostname }}"
-          sshUser: "{{ _showroom_user_data.bastion_ssh_user_name }}"
-          sshPass: "{{ _showroom_user_data.bastion_ssh_password }}"
+          sshUser: "{{ _showroom_user_data['users'][_showroom_user].bastion_ssh_user_name | default(_showroom_user_data.bastion_ssh_user_name) }}"
+          sshPass: "{{ _showroom_user_data['users'][_showroom_user].bastion_ssh_password | default(_showroom_user_data.bastion_ssh_password) }}"
           sshPort: "{{ _showroom_user_data.bastion_ssh_port | default(22) }}"
       novnc:
         setup: "{{ (true if ocp4_workload_showroom_novnc_enable | bool else false) | bool | string | lower }}"


### PR DESCRIPTION
##### SUMMARY

Currently all the showroom for users using wetty connect to the bastion with the default user (lab-user)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_showroom role
