### PR TITLE
Add multi-platform support for execution environment

### DIFF
--- a/.github/workflows/build-ee.yml
+++ b/.github/workflows/build-ee.yml
@@ -32,6 +32,16 @@ jobs:
 
       - uses: actions/setup-python@v4
 
+      - name: Setup QEMU for multi-platform builds
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: all
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu binfmt-support
+
       - name: Buildah Action
         uses: redhat-actions/buildah-build@v2
         id: build-image

--- a/.github/workflows/build-ee.yml
+++ b/.github/workflows/build-ee.yml
@@ -32,15 +32,15 @@ jobs:
 
       - uses: actions/setup-python@v4
 
-      - name: Setup QEMU for multi-platform builds
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y qemu binfmt-support
+
+      - name: Setup QEMU for multi-platform builds
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: all
 
       - name: Buildah Action
         uses: redhat-actions/buildah-build@v2

--- a/.github/workflows/build-ee.yml
+++ b/.github/workflows/build-ee.yml
@@ -39,6 +39,7 @@ jobs:
           image: ee-multicloud
           tags: ${{inputs.tag}} ${{ github.sha }}
           labels: ${{ inputs.labels }}
+          platforms: linux/amd64,linux/arm64
           context: tools/execution_environments/ee-multicloud-public
           containerfiles: |-
             tools/execution_environments/ee-multicloud-public/Containerfile

--- a/.github/workflows/build-ee.yml
+++ b/.github/workflows/build-ee.yml
@@ -42,6 +42,14 @@ jobs:
         with:
           platforms: all
 
+      - name: Cache Buildah layers
+        uses: actions/cache@v4
+        with:
+          path: /var/lib/containers/storage
+          key: ${{ runner.os }}-buildah-cache-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildah-cache-
+
       - name: Buildah Action
         uses: redhat-actions/buildah-build@v2
         id: build-image
@@ -53,6 +61,7 @@ jobs:
           context: tools/execution_environments/ee-multicloud-public
           containerfiles: |-
             tools/execution_environments/ee-multicloud-public/Containerfile
+          layers: true
 
       -  name: Push To quay.io
          id: push-to-quay

--- a/tools/execution_environments/ee-multicloud-public/install_binaries.sh
+++ b/tools/execution_environments/ee-multicloud-public/install_binaries.sh
@@ -3,19 +3,32 @@ set -ue
 
 cd /tmp
 
-# OC
+# initArch discovers the architecture for this system.
+ARCH=$(uname -m)
+case $ARCH in
+    armv5*) ARCH="armv5";;
+    armv6*) ARCH="armv6";;
+    armv7*) ARCH="arm";;
+    aarch64) ARCH="arm64";;
+    x86) ARCH="386";;
+    x86_64) ARCH="amd64";;
+    i686) ARCH="386";;
+    i386) ARCH="386";;
+esac
 
+# OC
+# Install rhel8 version of oc
+# https://access.redhat.com/solutions/7077895
 version=stable
-arch=x86_64
-tarball=openshift-client-linux.tar.gz
-url="https://mirror.openshift.com/pub/openshift-v4/${arch}/clients/ocp/${version}/${tarball}"
+tarball=openshift-client-linux-${ARCH}-rhel8.tar.gz
+url="https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/${version}/${tarball}"
 curl -s -L "${url}" -o ${tarball}
 tar xzf ${tarball}
 install -t /usr/bin oc kubectl
 rm ${tarball}
 
 # Bitwarden
-
+# DISCLAIMER: BW doesn't support ARM64 yet, so this is just a placeholder
 url="https://vault.bitwarden.com/download/?app=cli&platform=linux"
 curl -s -L "${url}" -o bw.zip
 unzip bw.zip
@@ -24,9 +37,8 @@ rm bw bw.zip
 
 
 # AWS CLI
-
 aws_version=2.4.23
-curl -s -L "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${aws_version}.zip" \
+curl -s -L "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${aws_version}.zip" \
     -o "awscliv2.zip"
 unzip awscliv2.zip
 ./aws/install


### PR DESCRIPTION
##### SUMMARY

- Updated `install_binaries.sh` to dynamically detect system architecture (`ARCH`)
- Modified OpenShift CLI (`oc`) installation to use RHEL 8 version with architecture-specific tarballs.
- Adjusted AWS CLI download URL to include architecture detection.
- Added placeholder for Bitwarden CLI installation, as it does not support ARM64 yet.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ee-multicloud-public
