### PR TITLE
[ocp4_workload_metallb] RFE to add nodeselectors option to L2Advertisement

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_metallb/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_metallb/defaults/main.yml
@@ -57,3 +57,7 @@ ocp4_workload_metallb_l2advertisement_ipaddresspool:
 - "ip-addresspool"
 ocp4_workload_metallb_l2advertisement_interface:
 - "br-ex"
+
+# By default, MetalLB advertises in all nodes. This variable is used to specify in which nodes should be advertised
+
+ocp4_workload_metallb_node_selector: ""

--- a/ansible/roles_ocp_workloads/ocp4_workload_metallb/templates/l2advertisement.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_metallb/templates/l2advertisement.yaml.j2
@@ -6,3 +6,7 @@ metadata:
 spec:
   ipAddressPools: {{ ocp4_workload_metallb_l2advertisement_ipaddresspool | to_yaml }}
   interfaces: {{ ocp4_workload_metallb_l2advertisement_interface | to_yaml }}
+  {% if ocp4_workload_metallb_node_selector | default("") | length > 0 %}
+nodeSelectors:
+  {{ ocp4_workload_metallb_node_selector | to_yaml }}
+  {% endif %}


### PR DESCRIPTION
Add a new variable called **ocp4_workload_metallb_node_selector** to specify where the metallb should advertise, for example:

```
  ocp4_workload_metallb_node_selector: 
      - matchLabels:
         node-role.kubernetes.io/worker: "" 
```

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_metallb
