### PR TITLE
remove generic usernum from showroom

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/prepare-variables.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/prepare-variables.yaml
@@ -29,18 +29,6 @@
   ansible.builtin.set_fact:
     _user_count: "{{ _showroom_user_data['users'] | length }}"
 
-- name: Set a user.usernum
-  when:
-  - _user_count is defined
-  - _user_count | int > 0
-  agnosticd_user_info:
-    data:
-      usernum: "{{ n }}"
-    user: "user{{ n }}"
-  loop: "{{ range(1, _user_count | int + 1) | list }}"
-  loop_control:
-    loop_var: n
-
 - name: Read user-info.yaml
   delegate_to: localhost
   ansible.builtin.slurp:


### PR DESCRIPTION
It was creating unwanted user_data.users.userX dictionaries

- Bugfix Pull Request
