### PR TITLE
Update create_instances.yaml

### DIFF
--- a/ansible/roles-infra/infra-equinix-metal-resources/tasks/create_instances.yaml
+++ b/ansible/roles-infra/infra-equinix-metal-resources/tasks/create_instances.yaml
@@ -20,7 +20,7 @@
     operating_system: "{{ _instance.os | default(equinix_metal_default_os) }}"
     plan: "{{ _instance.type }}"
     # facility: "{{ omit if _instance.facility == 'any' else _instance.facility }}"
-    provisioning_wait_seconds: "{{ equinix_metal_provisioning_wait_seconds | default(300) }}"
+    provisioning_wait_seconds: "{{ equinix_metal_provisioning_wait_seconds | default(500) }}"
     metro: "{{ _instance.metro | default(equinix_metal_metro) | default('any') }}"
     tags: >-
       {{ cloud_tags_final


### PR DESCRIPTION
This task is failing for larger instances such as n3.xlarge as it is deployed but not ready by the time the current timeout expires. Increased timeout - this task is working fine for smaller instances.

