### PR TITLE
[DEVOPS_ROADSHOW] Add subdomain var to userdata

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_devops_roadshow/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_devops_roadshow/tasks/workload.yml
@@ -168,6 +168,7 @@
       user: "user{{ n }}"
       usernum: "{{ n }}"
       password: "{{ ocp4_workload_authentication_htpasswd_user_password }}"
+      subdomain: "{{ sub_domain }}"
   loop: "{{ range(1, num_users | int + 1) | list }}"
   loop_control:
     loop_var: n


### PR DESCRIPTION
##### SUMMARY

This adds the subdomain of the cluster to the showroom variables to support substituting it in when creating a pipelinerun in the workshop instead of it being hard coded and requiring the instructor to manually update it.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
DEVOPS_ROADSHOW

