### PR TITLE
ocp4_workload_nginxplus - Update workload.yml

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_nginxplus/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_nginxplus/tasks/workload.yml
@@ -116,9 +116,9 @@
     timeout: "{{ ocp4_workload_nginxplus_wait_time | int }}"
 
 ### Start: This fixes an issue where the ingress controller pod does not start in some clusters
-- name: Get {{ ocp4_workload_nginxplus_ic_instance_name }} pod output
+- name: Get {{ ocp4_workload_nginxplus_ic_instance_name }} nginxingress output
   # yamllint disable-line rule:line-length
-  shell: oc get pods -n "{{ ocp4_workload_nginxplus_namespace }}" --no-headers=true | grep "{{ ocp4_workload_nginxplus_ic_instance_name }}"
+  shell: oc get nginxingress -n "{{ ocp4_workload_nginxplus_namespace }}" --no-headers=true | grep "{{ ocp4_workload_nginxplus_ic_instance_name }}"
   register: pod_output
   changed_when: false
 


### PR DESCRIPTION
This item is failing as there is no pod defined as `my-nginx-ingress` [1]. The right reference is probably the NginxIngres here [2].

Changing and testing.

[1] https://github.com/redhat-cop/agnosticd/blob/2fd579f61a4adeeb3301f02ddfad0a93f4bb68c6/ansible/roles_ocp_workloads/ocp4_workload_nginxplus/defaults/main.yml#L22

[2] https://github.com/redhat-cop/agnosticd/blob/2fd579f61a4adeeb3301f02ddfad0a93f4bb68c6/ansible/roles_ocp_workloads/ocp4_workload_nginxplus/templates/nginx-ingress-controller.j2#L4
