### PR TITLE
fix: add retries to pe workshop argocd patch

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_platform_engineering_workshop/tasks/openshift_gitops.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_platform_engineering_workshop/tasks/openshift_gitops.yml
@@ -45,6 +45,8 @@
 
 - name: Update resources for openshift-gitops ArgoCD instance
   when: ocp4_workload_platform_engineering_workshop_openshift_gitops_update_resources | bool
+  retries: 10
+  delay: 30
   kubernetes.core.k8s:
     state: patched
     definition: "{{ lookup('template', 'openshift-gitops/openshift-gitops.yaml.j2') | from_yaml }}"


### PR DESCRIPTION

##### SUMMARY

This step fails occasionally. Adding retries to reduce deployment failures.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ocp4_workload_platform_engineering_workshop

##### ADDITIONAL INFORMATION

The error that occurs is below. Perhaps Argo CD is not ready in time for the request? 

```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: Value of unknown type: <class 'urllib3.exceptions.NewConnectionError'>, <urllib3.connection.HTTPSConnection object at 0x7f97948ab1f0>: Failed to establish a new connection: [Errno 111] Connection refused
```