### PR TITLE
Remove obsolete support for older rhelai

### DIFF
--- a/ansible/roles/user-create-ansible-service-account/templates/ssh_config.j2
+++ b/ansible/roles/user-create-ansible-service-account/templates/ssh_config.j2
@@ -1,6 +1,3 @@
-Host rhelai
-  User cloud-user
-
 Host *
 
 {% if cloud_provider == 'ec2' %}


### PR DESCRIPTION
##### SUMMARY

RHEL AI now has the correct ec2-user (it was cloud-user)

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME

roles/user-create-ansible-service-account

##### ADDITIONAL INFORMATION
