### PR TITLE
Add role host_workloads for minimal config

### DIFF
--- a/ansible/cloud_providers/multi_destroy_env.yml
+++ b/ansible/cloud_providers/multi_destroy_env.yml
@@ -1,0 +1,16 @@
+---
+- name: Step 001.1 Destroy Infrastructure
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  become: false
+  tags:
+    - step001
+    - step001.1
+    - deploy_infrastructure
+
+  tasks:
+
+    - name: Destroy multi cloud_provider debug task
+      ansible.builtin.debug:
+        msg: Destroy multi cloud_provider debug task

--- a/ansible/configs/minimal/default_vars.yml
+++ b/ansible/configs/minimal/default_vars.yml
@@ -9,6 +9,57 @@ output_dir: "/tmp/output_dir/{{ guid }}"      # Writable working scratch directo
 project_tag: "{{ env_type }}-{{ guid }}"      # This var is used to identify stack (cloudformation, azure resourcegroup, ...)
 agnosticd_inventory_exporter_enable: true     # Dump inventory in output_dir
 
+# Workloads should be specified in the appropriate var targeting the stage.
+# The format for each is a list with role name, hosts, and optional vars
+#
+# Workload roles use the ACTION var do determine whether they should
+# perform provision, start, stop, or destroy.
+#
+# If vars are included then those will be set with set_fact before the role
+# is called. This allows the same role to be called repeatedly on the same
+# or different hosts with different variables.
+#
+# Example:
+#
+# infra_workloads:
+# # Provsision a VM, add host to inventory
+# - name: mitzi_vm
+#   hosts: localhost
+#
+# # Configure software on bastion VM
+# software_workloads:
+# - name: mitzi_software
+#   hosts: bastion
+#
+# # Cleanup is just destroy the bastion
+# destroy_workloads:
+# - name: mitzi_vm
+#   hosts: localhost
+#
+# # Start the VM, then check software state
+# start_workloads:
+# - name: mitzi_vm
+#   hosts: localhost
+# - name: mitzi_software
+#   hosts: bastion
+#
+# # Shutdown the VM
+# stop_workloads:
+# - name: mitzi_vm
+#   hosts: localhost
+# - name: mitzi_software
+#   hosts: bastion
+#
+pre_infra_workloads: []
+infra_workloads: []
+post_infra_workloads: []
+pre_software_workloads: []
+software_workloads: []
+post_software_workloads: []
+destroy_workloads: []
+start_workloads: []
+stop_workloads: []
+
 email: "{{ env_type }}@opentlc.com"
 guid: "{{ env_type }}-01"
 uuid: "{{ guid }}"

--- a/ansible/configs/minimal/destroy_env.yml
+++ b/ansible/configs/minimal/destroy_env.yml
@@ -1,10 +1,27 @@
 ---
-
 - name: Import destroy workloads
-  ansible.builtin.import_playbook: workloads.yml
+  ansible.builtin.import_playbook: >-
+    {{ 'workloads.yml' if destroy_workloads is mapping else 'noop.yml' }}
+  when: destroy_workloads is defined
   vars:
     _workload_title_: "Pre Infra"
-    _workloads_: "{{ destroy_workloads | default([]) }}"
+    _workloads_: "{{ destroy_workloads }}"
+
+- name: Run host_workloads for destroy
+  hosts: all:localhost
+  gather_facts: false
+  tasks:
+  - name: Include host_workloads for destroy
+    when:
+    - destroy_workloads is iterable
+    - destroy_workloads is not mapping
+    - destroy_workloads is not string
+    vars:
+      agnosticd_stage: destroy
+      host_workloads: "{{ destroy_workloads }}"
+    ansible.builtin.include_role:
+      name: host_workloads
 
 - name: Import default cloud_provider destroy playbook
   ansible.builtin.import_playbook: ../../cloud_providers/{{ cloud_provider }}_destroy_env.yml
+...

--- a/ansible/configs/minimal/infra.yml
+++ b/ansible/configs/minimal/infra.yml
@@ -30,16 +30,16 @@
   hosts: all:localhost
   gather_facts: false
   tasks:
-  - debug:
-      msg: "{{ infra_workloads is mapping }}"
-  - name: Include host_workloads for infra
-    when:
-    - infra_workloads is iterable
-    - infra_workloads is not mapping
-    - infra_workloads is not string
-    vars:
-      agnosticd_stage: infra
-      host_workloads: "{{ infra_workloads }}"
-    ansible.builtin.include_role:
-      name: host_workloads
+    - debug:
+        msg: "{{ infra_workloads is mapping }}"
+    - name: Include host_workloads for infra
+      when:
+        - infra_workloads is iterable
+        - infra_workloads is not mapping
+        - infra_workloads is not string
+      vars:
+        agnosticd_stage: infra
+        host_workloads: "{{ infra_workloads }}"
+      ansible.builtin.include_role:
+        name: host_workloads
 ...

--- a/ansible/configs/minimal/infra.yml
+++ b/ansible/configs/minimal/infra.yml
@@ -20,9 +20,26 @@
 # ----------------------------------------------------------------------
 
 - name: Import infra workloads
-  ansible.builtin.import_playbook: workloads.yml
+  ansible.builtin.import_playbook: >-
+    {{ 'workloads.yml' if infra_workloads is mapping else 'noop.yml' }}
   vars:
     _workload_title_: "Infra"
-    _workloads_: "{{ infra_workloads | default([]) }}"
+    _workloads_: "{{ infra_workloads }}"
 
+- name: Run host_workloads for infra_workloads
+  hosts: all:localhost
+  gather_facts: false
+  tasks:
+  - debug:
+      msg: "{{ infra_workloads is mapping }}"
+  - name: Include host_workloads for infra
+    when:
+    - infra_workloads is iterable
+    - infra_workloads is not mapping
+    - infra_workloads is not string
+    vars:
+      agnosticd_stage: infra
+      host_workloads: "{{ infra_workloads }}"
+    ansible.builtin.include_role:
+      name: host_workloads
 ...

--- a/ansible/configs/minimal/noop.yml
+++ b/ansible/configs/minimal/noop.yml
@@ -1,0 +1,4 @@
+---
+# Stand-in to implement no-op for workloads import_playbook compatibility
+- name: Workloads not configured as mapping for {{ _workload_title_ }}
+  hosts: localhost

--- a/ansible/configs/minimal/post_infra.yml
+++ b/ansible/configs/minimal/post_infra.yml
@@ -29,14 +29,14 @@
   hosts: all:localhost
   gather_facts: false
   tasks:
-  - name: Include host_workloads for post_infra
-    when:
-    - post_infra_workloads is iterable
-    - post_infra_workloads is not mapping
-    - post_infra_workloads is not string
-    vars:
-      agnosticd_stage: post_infra
-      host_workloads: "{{ post_infra_workloads }}"
-    ansible.builtin.include_role:
-      name: host_workloads
+    - name: Include host_workloads for post_infra
+      when:
+        - post_infra_workloads is iterable
+        - post_infra_workloads is not mapping
+        - post_infra_workloads is not string
+      vars:
+        agnosticd_stage: post_infra
+        host_workloads: "{{ post_infra_workloads }}"
+      ansible.builtin.include_role:
+        name: host_workloads
 ...

--- a/ansible/configs/minimal/post_infra.yml
+++ b/ansible/configs/minimal/post_infra.yml
@@ -19,7 +19,24 @@
 # ----------------------------------------------------------------------
 
 - name: Import post_infra workloads
-  ansible.builtin.import_playbook: workloads.yml
+  ansible.builtin.import_playbook: >-
+    {{ 'workloads.yml' if post_infra_workloads is mapping else 'noop.yml' }}
   vars:
     _workload_title_: "Post Infra"
-    _workloads_: "{{ post_infra_workloads | default([]) }}"
+    _workloads_: "{{ post_infra_workloads }}"
+
+- name: Run host_workloads for post_infra_workloads
+  hosts: all:localhost
+  gather_facts: false
+  tasks:
+  - name: Include host_workloads for post_infra
+    when:
+    - post_infra_workloads is iterable
+    - post_infra_workloads is not mapping
+    - post_infra_workloads is not string
+    vars:
+      agnosticd_stage: post_infra
+      host_workloads: "{{ post_infra_workloads }}"
+    ansible.builtin.include_role:
+      name: host_workloads
+...

--- a/ansible/configs/minimal/post_software.yml
+++ b/ansible/configs/minimal/post_software.yml
@@ -25,14 +25,14 @@
   hosts: all:localhost
   gather_facts: false
   tasks:
-  - name: Include host_workloads for post_software
-    when:
-    - post_software_workloads is iterable
-    - post_software_workloads is not mapping
-    - post_software_workloads is not string
-    vars:
-      agnosticd_stage: post_software
-      host_workloads: "{{ post_software_workloads }}"
-    ansible.builtin.include_role:
-      name: host_workloads
+    - name: Include host_workloads for post_software
+      when:
+        - post_software_workloads is iterable
+        - post_software_workloads is not mapping
+        - post_software_workloads is not string
+      vars:
+        agnosticd_stage: post_software
+        host_workloads: "{{ post_software_workloads }}"
+      ansible.builtin.include_role:
+        name: host_workloads
 ...

--- a/ansible/configs/minimal/post_software.yml
+++ b/ansible/configs/minimal/post_software.yml
@@ -15,7 +15,24 @@
 # ----------------------------------------------------------------------
 
 - name: Import Post-software workloads
-  ansible.builtin.import_playbook: workloads.yml
+  ansible.builtin.import_playbook: >-
+    {{ 'workloads.yml' if post_software_workloads is mapping else 'noop.yml' }}
   vars:
     _workload_title_: "Post Software"
-    _workloads_: "{{ post_software_workloads | default([]) }}"
+    _workloads_: "{{ post_software_workloads }}"
+
+- name: Run host_workloads for post_software_workloads
+  hosts: all:localhost
+  gather_facts: false
+  tasks:
+  - name: Include host_workloads for post_software
+    when:
+    - post_software_workloads is iterable
+    - post_software_workloads is not mapping
+    - post_software_workloads is not string
+    vars:
+      agnosticd_stage: post_software
+      host_workloads: "{{ post_software_workloads }}"
+    ansible.builtin.include_role:
+      name: host_workloads
+...

--- a/ansible/configs/minimal/pre_infra.yml
+++ b/ansible/configs/minimal/pre_infra.yml
@@ -30,14 +30,14 @@
   hosts: all:localhost
   gather_facts: false
   tasks:
-  - name: Include host_workloads for pre_infra
-    when:
-    - infra_workloads is iterable
-    - pre_infra_workloads is not mapping
-    - pre_infra_workloads is not string
-    vars:
-      agnosticd_stage: pre_infra
-      host_workloads: "{{ pre_infra_workloads }}"
-    ansible.builtin.include_role:
-      name: host_workloads
+    - name: Include host_workloads for pre_infra
+      when:
+        - infra_workloads is iterable
+        - pre_infra_workloads is not mapping
+        - pre_infra_workloads is not string
+      vars:
+        agnosticd_stage: pre_infra
+        host_workloads: "{{ pre_infra_workloads }}"
+      ansible.builtin.include_role:
+        name: host_workloads
 ...

--- a/ansible/configs/minimal/pre_infra.yml
+++ b/ansible/configs/minimal/pre_infra.yml
@@ -20,7 +20,24 @@
 # ----------------------------------------------------------------------
 
 - name: Import pre_infra workloads
-  ansible.builtin.import_playbook: workloads.yml
+  ansible.builtin.import_playbook: >-
+    {{ 'workloads.yml' if pre_infra_workloads is mapping else 'noop.yml' }}
   vars:
     _workload_title_: "Pre Infra"
-    _workloads_: "{{ pre_infra_workloads | default([]) }}"
+    _workloads_: "{{ pre_infra_workloads }}"
+
+- name: Run host_workloads for pre_infra_workloads
+  hosts: all:localhost
+  gather_facts: false
+  tasks:
+  - name: Include host_workloads for pre_infra
+    when:
+    - infra_workloads is iterable
+    - pre_infra_workloads is not mapping
+    - pre_infra_workloads is not string
+    vars:
+      agnosticd_stage: pre_infra
+      host_workloads: "{{ pre_infra_workloads }}"
+    ansible.builtin.include_role:
+      name: host_workloads
+...

--- a/ansible/configs/minimal/pre_software.yml
+++ b/ansible/configs/minimal/pre_software.yml
@@ -18,7 +18,24 @@
 # ----------------------------------------------------------------------
 
 - name: Import Pre-software workloads
-  ansible.builtin.import_playbook: workloads.yml
+  ansible.builtin.import_playbook: >-
+    {{ 'workloads.yml' if pre_software_workloads is mapping else 'noop.yml' }}
   vars:
     _workload_title_: "Pre Software"
-    _workloads_: "{{ pre_software_workloads | default([]) }}"
+    _workloads_: "{{ pre_software_workloads }}"
+
+- name: Run host_workloads for pre_software_workloads
+  hosts: all:localhost
+  gather_facts: false
+  tasks:
+  - name: Include host_workloads for pre_software
+    when:
+    - software_workloads is iterable
+    - pre_software_workloads is not mapping
+    - pre_software_workloads is not string
+    vars:
+      agnosticd_stage: pre_software
+      host_workloads: "{{ pre_software_workloads }}"
+    ansible.builtin.include_role:
+      name: host_workloads
+...

--- a/ansible/configs/minimal/pre_software.yml
+++ b/ansible/configs/minimal/pre_software.yml
@@ -28,14 +28,14 @@
   hosts: all:localhost
   gather_facts: false
   tasks:
-  - name: Include host_workloads for pre_software
-    when:
-    - software_workloads is iterable
-    - pre_software_workloads is not mapping
-    - pre_software_workloads is not string
-    vars:
-      agnosticd_stage: pre_software
-      host_workloads: "{{ pre_software_workloads }}"
-    ansible.builtin.include_role:
-      name: host_workloads
+    - name: Include host_workloads for pre_software
+      when:
+        - software_workloads is iterable
+        - pre_software_workloads is not mapping
+        - pre_software_workloads is not string
+      vars:
+        agnosticd_stage: pre_software
+        host_workloads: "{{ pre_software_workloads }}"
+      ansible.builtin.include_role:
+        name: host_workloads
 ...

--- a/ansible/configs/minimal/software.yml
+++ b/ansible/configs/minimal/software.yml
@@ -20,7 +20,24 @@
 # ----------------------------------------------------------------------
 
 - name: Import Software workloads
-  ansible.builtin.import_playbook: workloads.yml
+  ansible.builtin.import_playbook: >-
+    {{ 'workloads.yml' if software_workloads is mapping else 'noop.yml' }}
   vars:
     _workload_title_: "Software"
-    _workloads_: "{{ software_workloads | default([]) }}"
+    _workloads_: "{{ software_workloads }}"
+
+- name: Run host_workloads for software_workloads
+  hosts: all:localhost
+  gather_facts: false
+  tasks:
+  - name: Include host_workloads for software
+    when:
+    - software_workloads is iterable
+    - software_workloads is not mapping
+    - software_workloads is not string
+    vars:
+      agnosticd_stage: software
+      host_workloads: "{{ software_workloads }}"
+    ansible.builtin.include_role:
+      name: host_workloads
+...

--- a/ansible/configs/minimal/software.yml
+++ b/ansible/configs/minimal/software.yml
@@ -30,14 +30,14 @@
   hosts: all:localhost
   gather_facts: false
   tasks:
-  - name: Include host_workloads for software
-    when:
-    - software_workloads is iterable
-    - software_workloads is not mapping
-    - software_workloads is not string
-    vars:
-      agnosticd_stage: software
-      host_workloads: "{{ software_workloads }}"
-    ansible.builtin.include_role:
-      name: host_workloads
+    - name: Include host_workloads for software
+      when:
+        - software_workloads is iterable
+        - software_workloads is not mapping
+        - software_workloads is not string
+      vars:
+        agnosticd_stage: software
+        host_workloads: "{{ software_workloads }}"
+      ansible.builtin.include_role:
+        name: host_workloads
 ...

--- a/ansible/configs/minimal/start.yml
+++ b/ansible/configs/minimal/start.yml
@@ -4,17 +4,33 @@
   gather_facts: false
   become: false
   tasks:
-
-    - name: Start Playbook
-      ansible.builtin.debug:
-        msg: "Start Playbook Running"
+  - name: Start Playbook
+    ansible.builtin.debug:
+      msg: "Start Playbook Running"
 
 # ----------------------------------------------------------------------
 # Start Workloads as role
 # ----------------------------------------------------------------------
 
 - name: Import start workloads
-  ansible.builtin.import_playbook: workloads.yml
+  ansible.builtin.import_playbook: >-
+    {{ 'workloads.yml' if start_workloads is mapping else 'noop.yml' }}
   vars:
     _workload_title_: "Start"
-    _workloads_: "{{ start_workloads | default([]) }}"
+    _workloads_: "{{ start_workloads }}"
+
+- name: Run host_workloads for start
+  hosts: all:localhost
+  gather_facts: false
+  tasks:
+  - name: Include host_workloads for start
+    when:
+    - start_workloads is iterable
+    - start_workloads is not mapping
+    - start_workloads is not string
+    vars:
+      agnosticd_stage: start
+      host_workloads: "{{ start_workloads }}"
+    ansible.builtin.include_role:
+      name: host_workloads
+...

--- a/ansible/configs/minimal/stop.yml
+++ b/ansible/configs/minimal/stop.yml
@@ -4,17 +4,33 @@
   gather_facts: false
   become: false
   tasks:
-
-    - name: Stop Playbook
-      ansible.builtin.debug:
-        msg: "Stop Playbook Running"
+  - name: Stop Playbook
+    ansible.builtin.debug:
+      msg: "Stop Playbook Running"
 
 # ----------------------------------------------------------------------
 # Stop Workloads as role
 # ----------------------------------------------------------------------
 
 - name: Import stop workloads
-  ansible.builtin.import_playbook: workloads.yml
+  ansible.builtin.import_playbook: >-
+    {{ 'workloads.yml' if stop_workloads is mapping else 'noop.yml' }}
   vars:
     _workload_title_: "Stop"
-    _workloads_: "{{ stop_workloads | default([]) }}"
+    _workloads_: "{{ stop_workloads }}"
+
+- name: Run host_workloads for stop
+  hosts: all:localhost
+  gather_facts: false
+  tasks:
+  - name: Include host_workloads for stop
+    when:
+    - stop_workloads is iterable
+    - stop_workloads is not mapping
+    - stop_workloads is not string
+    vars:
+      agnosticd_stage: stop
+      host_workloads: "{{ stop_workloads }}"
+    ansible.builtin.include_role:
+      name: host_workloads
+...

--- a/ansible/roles/host_workloads/README.adoc
+++ b/ansible/roles/host_workloads/README.adoc
@@ -1,0 +1,46 @@
+:role: host_workloads
+:author1: Johnathan Kupferer <jkupfere@redhat.com>
+:team: Red Hat Demo Platform
+
+
+Role: {role}
+============
+
+The role {role} runs workloads roles on hosts using hosts selector.
+
+Variables
+------------
+
+* This role requires only `host_workloads` variable to be set.
+
+* The reference implementation of calling this role is found in the minimal config.
+
+Example:
+
+----
+- name: Run host_workloads for infra_workloads
+  hosts: all:localhost
+  gather_facts: false
+  tasks:
+  - debug:
+      msg: "{{ infra_workloads is mapping }}"
+  - name: Include host_workloads for infra
+    when:
+    - infra_workloads is iterable
+    - infra_workloads is not mapping
+    - infra_workloads is not string
+    vars:
+      agnosticd_stage: infra
+      host_workloads: "{{ infra_workloads }}"
+    include_role:
+      name: host_workloads
+----
+
+Author Information
+------------------
+
+* Author/owner:
+** {author1}
+
+* Team:
+** {team}

--- a/ansible/roles/host_workloads/defaults/main.yml
+++ b/ansible/roles/host_workloads/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+# List of dictionaries describing what roles to run on which hosts.
+# Each entry must have `name`, should have `hosts`, and may also set `vars`.
+host_workloads: []
+...

--- a/ansible/roles/host_workloads/tasks/main.yml
+++ b/ansible/roles/host_workloads/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+- name: Check workloads set hosts and names
+  loop: "{{ host_workloads }}"
+  loop_control:
+    loop_var: __workload
+    label: "{{ __workload.name }}"
+  ansible.builtin.assert:
+    that:
+    - __workload is defined
+    - __workload is mapping
+    - __workload.name is defined
+    - __workload.name is string
+    - __workload.hosts is defined
+    - __workload.hosts is string
+
+- name: Run workloads
+  loop: "{{ host_workloads }}"
+  loop_control:
+    loop_var: __workload
+    label: "{{ __workload.name }}"
+  vars:
+    # Default hosts to localhost in infra and all during software
+    __default_hosts: >-
+      {{
+        'localhost' if agnosticd_stage.endswith('infra') else 'all'
+      }}
+  when:
+  - inventory_hostname in lookup('inventory_hostnames', __workload.hosts | default(__default_hosts))
+  ansible.builtin.include_tasks:
+    file: run_workload.yml
+...

--- a/ansible/roles/host_workloads/tasks/run_workload.yml
+++ b/ansible/roles/host_workloads/tasks/run_workload.yml
@@ -1,0 +1,13 @@
+- name: Set vars for host workload {{ __workload.name }}
+  when: __workload.vars is defined
+  loop: >-
+    {{ __workload.vars | dict2items }}
+  loop_control:
+    loop_var: __var
+    label: "{{ __var.key }}"
+  ansible.builtin.set_fact:
+    "{{ __var.key }}": "{{ __var.value }}"
+
+- name: Run workload {{ __workload.name }}
+  ansible.builtin.include_role:
+    name: "{{ __workload.name }}"


### PR DESCRIPTION
##### SUMMARY

Add `host_workloads` role and call from minimal config to allow more powerful configuration of roles and targeting of hosts.

Maintain compatibility with existing configs.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Role host_workloads
Config minimal