### PR TITLE
[DevSecOps Roadshow] Add GitOps plugin var to set git reference to use …

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_devops_roadshow/templates/argocd-cr.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_devops_roadshow/templates/argocd-cr.yaml.j2
@@ -75,6 +75,8 @@ spec:
             value: {{ sub_domain }}
           - name: USERS
             value: "{{ num_users }}"
+          - name: GIT_REF
+            value: "{{ ocp4_workload_showroom_content_git_repo_ref }}"
         image: quay.io/gnunn/tools:latest
         imagePullPolicy: Always
         securityContext:


### PR DESCRIPTION
##### SUMMARY

This adds a new variable to the DevSecOps Roadshow in the GitOps Plugin. This is needed to enable gitea to clone the right refeerence depending on which environment is being used in RHDP, i.e. dev/test/prod

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
DevSecOps Roadshow