### PR TITLE
ARO workshops: Fix dependency error for Rhel 9

### DIFF
--- a/ansible/configs/open-environment-azure/pre_software.yml
+++ b/ansible/configs/open-environment-azure/pre_software.yml
@@ -78,7 +78,7 @@
 
         - name: Add Azure CLI repository
           ansible.builtin.yum:
-            name: https://packages.microsoft.com/config/rhel/9/packages-microsoft-prod.rpm
+            name: https://packages.microsoft.com/config/rhel/9.0/packages-microsoft-prod.rpm
             state: present
 
         - name: Install Azure CLI package


### PR DESCRIPTION
This fix should fix the ongoing error with all ARO workshops.

For rhel 9 the correct repository is `https://packages.microsoft.com/config/rhel/9.0/packages-microsoft-prod.rpm` instead of the `https://packages.microsoft.com/config/rhel/9/packages-microsoft-prod.rpm` currently beig used which is causing a dependency error (Notice 9 vs 9.0)

This is explained in the Azure CLI installation documentation (Step 2 in [1])

[1] https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=dnf#install-azure-cli
