### PR TITLE
fix: use correct variable in argocd secret check

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_platform_engineering_workshop/tasks/openshift_gitops.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_platform_engineering_workshop/tasks/openshift_gitops.yml
@@ -100,8 +100,8 @@
   register: r_secret
   until:
     - r_secret is defined
-    - r_openshift_gitops.resources is defined
-    - r_openshift_gitops.resources | length == 1
+    - r_secret.resources is defined
+    - r_secret.resources | length == 1
   retries: 10
   delay: 30
   ignore_errors: true


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

Currently, the playbook can proceed even if this Secret check fails, due to it referencing the previously successful step's variable instead of the current `r_secret` variable.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

`ocp4_workload_platform_engineering_workshop`

##### ADDITIONAL INFORMATION

N/A