### PR TITLE
Add retries to nncp creation

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_network_config/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_network_config/tasks/workload.yml
@@ -19,3 +19,5 @@
   kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('file', 'nodenetworkconfigurationpolicy.yaml') | from_yaml }}"
+  retries: 20
+  delay: 10


### PR DESCRIPTION
##### SUMMARY

Needed to add retries to the creation of the NodeNetworkConfigurationPolicy to allow NMState operator to stabilize.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_virt_network_config