### PR TITLE
QuayClair: Fix default psql size

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/defaults/main.yml
@@ -83,6 +83,7 @@ ocp4_workload_quay_operator_registry_admin_password_length: 20
 
 # Quay Registry Features
 ocp4_workload_quay_operator_registry_enable_clair: true
+ocp4_workload_quay_operator_registry_clair_volume_size: 100Gi
 ocp4_workload_quay_operator_registry_enable_hpa: false
 ocp4_workload_quay_operator_registry_enable_mirror: false
 ocp4_workload_quay_operator_registry_enable_monitoring: false

--- a/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/templates/quay_registry.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quay_operator/templates/quay_registry.yaml.j2
@@ -19,6 +19,10 @@ spec:
     managed: true
   - kind: clair
     managed: {{ ocp4_workload_quay_operator_registry_enable_clair }}
+{% if ocp4_workload_quay_operator_registry_enable_clair | bool %}
+    overrides:
+      volumeSize: {{ ocp4_workload_quay_operator_registry_clair_volume_size }}
+{% endif %}
   - kind: horizontalpodautoscaler
     managed: {{ ocp4_workload_quay_operator_registry_enable_hpa }}
   - kind: mirror


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

Default quay clair psql is insufficient.  Need to increase default size if enabled.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
