### PR TITLE
Improvements to test-empty-config user data vars

### DIFF
--- a/ansible/configs/test-empty-config/default_vars.yml
+++ b/ansible/configs/test-empty-config/default_vars.yml
@@ -8,6 +8,12 @@ bookbag_deploy: false
 test_empty_config_multi_user: false
 test_empty_config_user_count: "{{ user_count | default(num_users) | default(10) }}"
 
+# Request config set agnosticd_user_data at top level or per user
+#test_empty_config_passthrough_user_data:
+#  foo: bar
+#test_empty_config_passthrough_per_user_data:
+#  foo: bar
+
 # Variables to request the test empty config to fail on specific actions
 fail_infra: false
 fail_infra_percentage: 0

--- a/ansible/configs/test-empty-config/post_software.yml
+++ b/ansible/configs/test-empty-config/post_software.yml
@@ -25,6 +25,7 @@
       seconds: "{{ test_empty_config_pause_post_software_seconds | default(30) }}"
 
   - name: Test agnosticd_user_info from post_software with random string
+    when: test_empty_config_passthrough_user_data is undefined
     agnosticd_user_info:
       msg: Some random string {{ random_string }}
       data:
@@ -44,6 +45,7 @@
   - when: test_empty_config_multi_user | bool
     block:
     - name: Test set agnosticd_user_info for users
+      when: test_empty_config_passthrough_per_user_data is undefined
       agnosticd_user_info:
         user: student{{ n }}
         msg: student{{ n }} password is {{ random_string }}
@@ -55,6 +57,18 @@
       vars:
         random_string: >-
           {{ lookup('password', '/dev/null length=15 chars=ascii_letters') }}
+
+    - name: Pass-through agnosticd_user_info data for users
+      when: test_empty_config_passthrough_per_user_data is defined
+      agnosticd_user_info:
+        user: student{{ n }}
+        data: >-
+         {{ test_empty_config_passthrough_per_user_data | from_yaml
+         if test_empty_config_passthrough_per_user_data is string
+         else test_empty_config_passthrough_per_user_data }}
+      loop: "{{ range(1, 1 + test_empty_config_user_count | int) | list }}"
+      loop_control:
+        loop_var: n
 
     - name: Test add agnosticd_user_info for users
       agnosticd_user_info:


### PR DESCRIPTION
##### SUMMARY

- Disable random_string when test_empty_config_passthrough_user_data is provided.
- Add test_empty_config_passthrough_per_user_data to allow setting user data for a range of simulated users.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Config test-empty-config