### PR TITLE
Add support for ovs-bridge

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_network_config/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_network_config/defaults/main.yml
@@ -6,3 +6,15 @@ ocp4_workload_virt_network_config_multi_user: false
 
 # Inherited from Assisted Installer
 ocp4_workload_virt_network_config_networks: "{{ ai_attach_workers_networks | default([]) }}"
+
+# Type of network bridge to create: ovs-bridge or linux-bridge
+ocp4_workload_virt_network_config_bridge_type: ovs-bridge
+
+# Name of Network bridge to create, e.g. br1 for ovs-bridge or br-flat for linux-bridge
+ocp4_workload_virt_network_config_bridge_name: br1
+
+# Port to attach the bridge
+ocp4_workload_virt_network_config_bridge_port: enp3s0
+
+# Local network to attach the bridge (for ovs-bridge)
+ocp4_workload_virt_network_config_bridge_network: localnet2

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_network_config/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_network_config/tasks/workload.yml
@@ -14,10 +14,22 @@
   loop_control:
     loop_var: resource
 
-- name: Create br-flat NNCP
-  when: ocp4_workload_virt_network_config_networks | default([]) | length > 0
+- name: Create NNCP (linux-bridge)
+  when:
+  - ocp4_workload_virt_network_config_networks | default([]) | length > 0
+  - ocp4_workload_virt_network_config_bridge_type == "linux-bridge"
   kubernetes.core.k8s:
     state: present
-    definition: "{{ lookup('file', 'nodenetworkconfigurationpolicy.yaml') | from_yaml }}"
+    definition: "{{ lookup('template', 'nodenetworkconfigurationpolicy-linux-bridge.yaml.j2') | from_yaml }}"
+  retries: 20
+  delay: 10
+
+- name: Create NNCP (ovs-bridge)
+  when:
+  - ocp4_workload_virt_network_config_networks | default([]) | length > 0
+  - ocp4_workload_virt_network_config_bridge_type == "ovs-bridge"
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('template', 'nodenetworkconfigurationpolicy-ovs-bridge.yaml.j2') | from_yaml }}"
   retries: 20
   delay: 10

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_network_config/templates/nodenetworkconfigurationpolicy-linux-bridge.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_network_config/templates/nodenetworkconfigurationpolicy-linux-bridge.yaml.j2
@@ -2,14 +2,14 @@
 apiVersion: nmstate.io/v1
 kind: NodeNetworkConfigurationPolicy
 metadata:
-  name: br-flat
+  name: {{ ocp4_workload_virt_network_config_bridge_name }}
 spec:
   nodeSelector:
     node-role.kubernetes.io/worker: ""
   desiredState:
     interfaces:
-    - name: br-flat
-      description: Linux bridge with enp3s0 as a port
+    - name: {{ ocp4_workload_virt_network_config_bridge_name }}
+      description: Linux bridge with {{ ocp4_workload_virt_network_config_bridge_port }} as a port
       type: linux-bridge
       state: up
       ipv4:
@@ -20,4 +20,4 @@ spec:
           stp:
             enabled: false
         port:
-        - name: enp3s0
+        - name: {{ ocp4_workload_virt_network_config_bridge_port }}

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_network_config/templates/nodenetworkconfigurationpolicy-ovs-bridge.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_network_config/templates/nodenetworkconfigurationpolicy-ovs-bridge.yaml.j2
@@ -1,0 +1,27 @@
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: {{ ocp4_workload_virt_network_config_bridge_name }}
+spec:
+  nodeSelector:
+    node-role.kubernetes.io/worker: ''
+  desiredState:
+    interfaces:
+    - bridge:
+        allow-extra-patch-ports: true
+        options:
+          stp: false
+        port:
+        - name: {{ ocp4_workload_virt_network_config_bridge_port }}
+      description: |-
+        A dedicated OVS bridge with {{ ocp4_workload_virt_network_config_bridge_port }} as a port
+        allowing all VLANs and untagged traffic
+      name: {{ ocp4_workload_virt_network_config_bridge_name }}
+      state: up
+      type: ovs-bridge
+    ovn:
+      bridge-mappings:
+      - bridge: {{ ocp4_workload_virt_network_config_bridge_name }}
+        localnet: {{ ocp4_workload_virt_network_config_bridge_network }}
+        state: present


### PR DESCRIPTION
##### SUMMARY

Change virt network workload to allow either linux-bridge or ovs-bridge. Make parameters to each bridge customizable.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_virt_network_config