### PR TITLE
[ocp4_workload_virt_network_config] Add "get" to verbs for clusterrole-list-nodenetworkconfigurationresources.yaml

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_network_config/files/clusterrole-list-nodenetworkconfigurationresources.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_network_config/files/clusterrole-list-nodenetworkconfigurationresources.yaml
@@ -10,3 +10,4 @@ rules:
       - nodenetworkconfigurationpolicies
     verbs:
       - list
+      - get


### PR DESCRIPTION
##### SUMMARY

Now is only allowing users to list but dont get the information


##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
ocp4_workload_virt_network_config role
