### PR TITLE
removing xorg package as dependeny not available

### DIFF
--- a/ansible/roles/rhel-graphical/tasks/main.yml
+++ b/ansible/roles/rhel-graphical/tasks/main.yml
@@ -78,7 +78,6 @@
       yum:
         name:
         - tigervnc-server
-        - "xorg-*"
         - coreutils
         - wget
     when: ansible_distribution == 'RedHat' and ansible_distribution_major_version == '8'
@@ -96,7 +95,6 @@
       yum:
         name:
         - tigervnc-server
-        - "xorg-*"
         - coreutils
         - wget
     when: ansible_distribution == 'RedHat' and ansible_distribution_major_version == '9'


### PR DESCRIPTION
TASK [rhel-graphical : Install VNC packages on RHEL 8] *************************
Monday 10 February 2025  06:55:07 +0000 (0:04:58.181)       0:13:32.887 ******* 
fatal: [bastion.xlfrz.internal]: FAILED! => {"changed": false, "failures": [], "msg": "Depsolve Error occurred: \n Problem: conflicting requests\n  - nothing provides x2goserver >= 4.1.0.4 needed by xorg-x11-server-x2gokdrive-0.0.0.2-2.el8.x86_64", "rc": 1, "results": []}

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
