### PR TITLE
Remove need for 8443 on satellite HA

### DIFF
--- a/ansible/roles/set-repositories/tasks/satellite-repos.yml
+++ b/ansible/roles/set-repositories/tasks/satellite-repos.yml
@@ -137,7 +137,7 @@
     state: present
     consumer_name: "{{ set_repositories_subscription_hostname }}"
     server_hostname: "{{ set_repositories_satellite_hostname }}"
-    server_port: "8443"
+    server_port: "443"
     server_prefix: /rhsm
     rhsm_baseurl: "https://{{ set_repositories_satellite_hostname }}/pulp/repos"
     activationkey: "{{ set_repositories_satellite_activationkey }}"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Remove need for 8443 on satellite HA
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
set-repositories
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
