### PR TITLE
[WIP] Allow adding extra networks to the bastion for ocp4-cluster config

### DIFF
--- a/ansible/configs/ocp4-cluster/default_vars_openshift_cnv.yml
+++ b/ansible/configs/ocp4-cluster/default_vars_openshift_cnv.yml
@@ -34,6 +34,8 @@ bastion_instance_image: rhel-8.2
 bastion_cores: 2
 bastion_memory: 2G
 bastion_rootfs_size: 30Gi
+bastion_extra_networks: []
+bastion_networks: "{{ ['default'] + bastion_extra_networks }}"
 
 instances:
 - name: bastion
@@ -58,5 +60,4 @@ instances:
     value: "linux"
   - key: "instance_filter"
     value: "{{ env_type }}-{{ guid }}"
-  networks:
-  - default
+  networks: "{{ bastion_networks }}"

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
@@ -17,7 +17,7 @@
     _instance_interfaces: >-
       {{
         _instance_interfaces + [{
-          'name': _network,
+          'name': _network.split('/')[1] if '/' in _network else _network + guid,
           'macAddress': _instance.fixed_macs[_network] | default('2c:c2:60' | random_mac),
           'bridge': {},
           'model': 'e1000e',
@@ -34,7 +34,7 @@
     _instance_networks: >-
       {{ _instance_networks + [
           {
-              'name': _network,
+              'name': _network.split('/')[1] if '/' in _network else _network + guid,
               'multus': {'networkName': _network + guid}
           }
           if _network != 'default'

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
@@ -35,7 +35,7 @@
       {{ _instance_networks + [
           {
               'name': _network.split('/')[1] if '/' in _network else _network + guid,
-              'multus': {'networkName': _network + guid}
+              'multus': {'networkName':  _network if '/' in _network else _network + guid}
           }
           if _network != 'default'
           else {


### PR DESCRIPTION
##### SUMMARY

For the use case of running OCP attached to a second network (i.e. flat network), is useful to have the bastion connected to that network. 

The variable **bastion_extra_networks** of type list, adds that functionality for cnv (ocp virt)

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME
ocp4-cluster config


