### PR TITLE
[host-ocp4-assisted-installer] Enable ipFowarding Global

### DIFF
--- a/ansible/roles/host-ocp4-assisted-installer/files/network_config.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/files/network_config.yaml
@@ -7,3 +7,4 @@ spec:
     ovnKubernetesConfig:
       gatewayConfig:
         routingViaHost: true
+        ipForwarding: Global


### PR DESCRIPTION
##### SUMMARY

For advanced networking on OCP on OCP (cnv) we require to enable ipFowarding to Global mode[1]

https://docs.openshift.com/container-platform/4.17/networking/networking_operators/cluster-network-operator.html#nw-cno-enable-ip-forwarding_cluster-network-operator

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
host-ocp4-assisted-installer role
