### PR TITLE
[host-ocp4-assisted-installer] Allow the option to install OCP in a existing network

### DIFF
--- a/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
@@ -255,6 +255,7 @@
           delay: 30
 
     - name: Create OVN secondary network
+      when: not ai_install_use_network | default(false)
       kubernetes.core.k8s:
         definition: "{{ lookup('ansible.builtin.template', 'templates/net-attach-def.yaml') }}"
         wait: true
@@ -421,7 +422,7 @@
         namespace: "{{ ai_ocp_namespace }}"
         storageclass: "{{ ai_storage_class }}"
         network: "{{ cluster_name }}-openshift"
-        network_name: "{{ cluster_name }}-openshift"
+        network_name: "{{ ai_install_use_network | default(cluster_name + '-openshift') }}"
         pod_network: "192.168.{{ _index }}.0/24"
       loop: "{{ range(1,master_instance_count|int+1)|list }}"
       loop_control:
@@ -435,7 +436,7 @@
         namespace: "{{ ai_ocp_namespace }}"
         storageclass: "{{ ai_storage_class }}"
         network: "{{ cluster_name}}-openshift"
-        network_name: "{{ cluster_name }}-openshift"
+        network_name: "{{ ai_install_use_network | default(cluster_name + '-openshift') }}"
         pod_network: "192.168.1{{ _index }}.0/24"
       loop: "{{ range(1,worker_instance_count|int+1)|list }}"
       loop_control:

--- a/ansible/roles/host-ocp4-assisted-installer/vars/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/vars/main.yaml
@@ -19,6 +19,7 @@ ai_local_storageclass: "hostpath-csi"
 ai_network_prefix: "10.10.10"
 ai_service_network_cidr: "172.31.0.0/16"
 ai_cluster_network_cidr: "10.132.0.0/14"
+ai_install_use_network: false
 ai_network_mtu: 1500
 ai_masters_macs: []
 ai_workers_macs: []


### PR DESCRIPTION
##### SUMMARY

In some cases we would like to install OCP using AI in a existing network. Use case: we want to connect bastion to the same network as the OCP cluster (machine)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
host-ocp4-assisted-installer role
