### PR TITLE
[infra-openshift-cnv-resources] Change default mtu to 1500 for secondary networks

### DIFF
--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
@@ -10,7 +10,7 @@
       spec:
         config: "{{ config | to_json }}"
   vars:
-    config: "{'cniVersion':'0.3.1','type':'ovn-k8s-cni-overlay','topology':'layer2','name': '{{ _network.name }}{{ guid }}', 'netAttachDefName': '{{ openshift_cnv_namespace }}/{{ _network.name }}{{ guid }}', 'mtu': { _network.mtu | default(1500) }}}"
+    config: "{'cniVersion':'0.3.1','type':'ovn-k8s-cni-overlay','topology':'layer2','name': '{{ _network.name }}{{ guid }}', 'netAttachDefName': '{{ openshift_cnv_namespace }}/{{ _network.name }}{{ guid }}', 'mtu': {{ _network.mtu | default(1500) }}}"
   register: r_createnetwork
   until: r_createnetwork is success
   retries: "{{ openshift_cnv_retries }}"

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
@@ -10,7 +10,7 @@
       spec:
         config: "{{ config | to_json }}"
   vars:
-    config: "{'cniVersion':'0.3.1','type':'ovn-k8s-cni-overlay','topology':'layer2','name': '{{ _network.name }}{{ guid }}', 'netAttachDefName': '{{ openshift_cnv_namespace }}/{{ _network.name }}{{ guid }}', 'mtu': 9000}"
+    config: "{'cniVersion':'0.3.1','type':'ovn-k8s-cni-overlay','topology':'layer2','name': '{{ _network.name }}{{ guid }}', 'netAttachDefName': '{{ openshift_cnv_namespace }}/{{ _network.name }}{{ guid }}', 'mtu': { _network.mtu | default(1500) }}}"
   register: r_createnetwork
   until: r_createnetwork is success
   retries: "{{ openshift_cnv_retries }}"


### PR DESCRIPTION

##### SUMMARY

Currently default value is 9000. Changed to 1500. This PR allows to specify another value for the mtu too


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
infra-openshift-cnv-resources role
