### PR TITLE
[ocp4-cluster] Allow the option to speciy userdata and networkdata to the bastion (cnv)

### DIFF
--- a/ansible/configs/ocp4-cluster/default_vars_openshift_cnv.yml
+++ b/ansible/configs/ocp4-cluster/default_vars_openshift_cnv.yml
@@ -46,6 +46,8 @@ instances:
   cores: "{{ bastion_cores }}"
   image_size: "{{ bastion_rootfs_size }}"
   image: "{{ bastion_instance_image }}"
+  networkdata: "{{ bastion_networkdata | default(omit) }}"
+  userdata: "{{ bastion_userdata | default(omit) }}"
   metadata:
   - AnsibleGroup: "bastions"
   - function: bastion


### PR DESCRIPTION
##### SUMMARY

For CNV (OpenShift virtualization) we use a layer2 network for the OCP. For advanced networking we require to use the bastion as a gateway. this PR is to allow configure the userdata (i.e. enable ip_forward and masquerade) and the networkdata (to set a static ip) with the variables bastion_userdata and bastion_metadata

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
ocp4-cluster config