### PR TITLE
Role: Showroom, add new network definition for ZT items

### DIFF
--- a/ansible/roles/showroom/tasks/40-showroom-render.yml
+++ b/ansible/roles/showroom/tasks/40-showroom-render.yml
@@ -82,7 +82,7 @@
         state: directory
         owner: "root"
         group: "root"
-        mode: "0755"
+        mode: "u=rwx,g=rx,o=rx"
 
     - name: Create containers.conf file to specify rootless network
       ansible.builtin.lineinfile:

--- a/ansible/roles/showroom/tasks/40-showroom-render.yml
+++ b/ansible/roles/showroom/tasks/40-showroom-render.yml
@@ -75,3 +75,15 @@
         mode: "u=rw,g=r,o=r"
         remote_src: true
         # state: link
+
+    - name: Create containers.conf file to specify rootless network
+      ansible.builtin.lineinfile:
+        path: "/etc/containers/containers.conf"
+        owner: "root"
+        group: "root"
+        state: present
+        create: true
+        mode: "u=rwx,g=rx,o=rx"
+        line: |
+          [network]
+          default_rootless_network_cmd = "slirp4netns"

--- a/ansible/roles/showroom/tasks/40-showroom-render.yml
+++ b/ansible/roles/showroom/tasks/40-showroom-render.yml
@@ -76,6 +76,14 @@
         remote_src: true
         # state: link
 
+    - name: Ensure /etc/containers directory exists
+      ansible.builtin.file:
+        path: "/etc/containers"
+        state: directory
+        owner: "root"
+        group: "root"
+        mode: "0755"
+
     - name: Create containers.conf file to specify rootless network
       ansible.builtin.lineinfile:
         path: "/etc/containers/containers.conf"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
This change is to fix the issue with podman-5.2.2 where the default rootless network definition changed.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
Role: showroom
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
