### PR TITLE
[infra-openshift-cnv-resources : Wait till VM is running -> Increase …

### DIFF
--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
@@ -170,7 +170,7 @@
     namespace: "{{ openshift_cnv_namespace }}"
   register: r_vm_status
   until: r_vm_status.resources[0].status.printableStatus | default('') == "Running"
-  retries: 30
+  retries: 60
   delay: 10
   loop: "{{ range(1, _instance.count | default(1) | int+1) | list }}"
   loop_control:


### PR DESCRIPTION
…retries

This task is failing sporadically in items such as `openshift-cnv.sap-e2e-demo-rhel9-cnv ` due to the fact that the VM does not have enough time to run.

Increasing retries to fix it.


