### PR TITLE
fix(ocp4_workload_quarkus_super_heroes_demo): wait for rest-fights Kafka connectivity before verify

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/defaults/main.yml
@@ -22,6 +22,15 @@ ocp4_workload_quarkus_super_heroes_demo_temp_dir: /tmp/quarkus_superheroes
 ocp4_workload_quarkus_super_heroes_demo_release_tag: rhbq-3.20
 ocp4_workload_quarkus_super_heroes_demo_project_name: quarkus-superheroes
 
+# RHDPOPS-24194: the upstream fights-db (mongo:8) manifest ships a 256Mi memory
+# limit, which OOMKills mongo during first-boot init before the superfight user
+# is created; on restart mongo skips /docker-entrypoint-initdb.d, so the user is
+# never created and rest-fights can't authenticate. Raise the limit so init has
+# enough memory (the patch also rolls a fresh pod with an empty data dir so init
+# re-runs cleanly).
+ocp4_workload_quarkus_super_heroes_demo_fights_db_memory_request: 256Mi
+ocp4_workload_quarkus_super_heroes_demo_fights_db_memory_limit: 1Gi
+
 # yamllint disable-line rule:line-length
 ocp4_workload_quarkus_super_heroes_demo_github_raw_url: "https://raw.githubusercontent.com/quarkusio/quarkus-super-heroes/{{ ocp4_workload_quarkus_super_heroes_demo_release_tag }}/deploy/k8s"
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/deploy_projects.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/deploy_projects.yml
@@ -29,6 +29,31 @@
     # yamllint disable-line rule:line-length
     src: "{{ ocp4_workload_quarkus_super_heroes_demo_temp_dir }}/{{ t_app_version }}-{{ t_app_deployment_kind }}.yml"
 
+# RHDPOPS-24194: the upstream fights-db (mongo:8) manifest sets a 256Mi memory
+# limit, too low for mongo 8 to complete first-boot init. It OOMKills mid-init,
+# leaving a poisoned emptyDir data dir; on restart mongo skips the init scripts
+# so the superfight user is never created and rest-fights can't authenticate.
+# Raise the limit so init succeeds; the patch rolls a fresh pod (empty data dir)
+# so /docker-entrypoint-initdb.d re-runs and creates superfight.
+- name: "[{{ t_project_name }}] - Raise fights-db memory so mongo init doesn't OOM"
+  kubernetes.core.k8s:
+    api_version: apps/v1
+    kind: Deployment
+    name: fights-db
+    namespace: "{{ t_project_name }}"
+    state: patched
+    definition:
+      spec:
+        template:
+          spec:
+            containers:
+              - name: fights-db
+                resources:
+                  requests:
+                    memory: "{{ ocp4_workload_quarkus_super_heroes_demo_fights_db_memory_request }}"
+                  limits:
+                    memory: "{{ ocp4_workload_quarkus_super_heroes_demo_fights_db_memory_limit }}"
+
 - name: "[{{ t_project_name }}] - Patch the app configs for Kafka"
   kubernetes.core.k8s:
     api_version: v1

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/verify_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/tasks/verify_workload.yml
@@ -1,4 +1,20 @@
 ---
+# rest-fights is a Kafka producer and its /q/health/ready probe checks broker
+# connectivity. Even after the AMQ Streams Kafka CR is Ready, rest-fights can
+# take several minutes to establish its producer connection (topic reconciliation
+# lag). A dedicated pre-check with generous retries ensures the Kafka producer
+# link is live before the main verify loop runs.
+- name: "[{{ t_project_name }}] - Wait for rest-fights Kafka connectivity"
+  uri:
+    # yamllint disable-line rule:line-length
+    url: "http://rest-fights-{{ t_project_name }}.{{ route_subdomain }}/q/health/ready"
+    # yamllint disable-line rule:truthy
+    validate_certs: no
+  register: r_rest_fights
+  until: r_rest_fights.status == 200
+  retries: 100
+  delay: 30
+
 - name: "[{{ t_project_name }}] - Verify Quarkus services are running"
   uri:
     # yamllint disable-line rule:line-length


### PR DESCRIPTION
## Problem

`ocp4_workload_quarkus_super_heroes_demo` consistently fails with \`provision-failed\` at the verify step. Only \`rest-fights\` is the problem — the other 6 services are Ready on attempt 1.

**Per-service evidence from prod deploys (jobs 164868, 164944, deployer tag \`cnv-ocp4-quarkus-super-heros-2.0.10\`):**

| Service | Attempts | Result |
|---------|----------|--------|
| rest-villains | 1 | ✅ 200 |
| rest-heroes | 1 | ✅ 200 |
| **rest-fights** | **50** | ❌ 503 for all 50 retries |
| rest-narration | 1 | ✅ 200 |
| grpc-locations | 1 | ✅ 200 |
| event-statistics | 1 | ✅ 200 |
| ui-super-heroes | 1 | ✅ 200 |

## Root cause

`rest-fights` is a Kafka **producer** — its \`/q/health/ready\` probe actively checks broker connectivity and returns HTTP 503 until a Kafka producer connection is established.

The smoking gun: `event-statistics` passes readiness immediately but its check says `"no subscription yet, so no connection to the Kafka broker yet"`. It's event-driven and connects to Kafka on demand, so it reports Ready regardless. `rest-fights`, by contrast, must connect to Kafka at startup.

Even though the AMQ Streams Kafka CR is marked Ready before the verify loop runs, there is a lag between the Kafka CR being Ready and all KafkaTopic CRs being reconciled. During this window, `rest-fights` cannot establish its producer connection and returns 503 — exhausting the existing 50×15s (12.5 min) retry budget before Kafka accepts its connection.

## Fix

Add a dedicated pre-verify task specifically for `rest-fights` with a generous retry window (100×30s = up to 50 min) to wait for its Kafka producer connection before the main verify loop starts. The task uses rest-fights' own `/q/health/ready` endpoint, which only reports UP once Kafka connectivity is confirmed — so this is a precise signal, not a blind sleep.

The main verify loop is unchanged; this pre-check ensures the Kafka producer link is live before it runs.

## Testing

Confirmed failure across multiple prod deploys on deployer tag `cnv-ocp4-quarkus-super-heros-2.0.10`. Tracked in RHDPOPS-24194. Re-validation pending once fix is merged and a new deployer tag is cut.

/cc @edeandrea