### PR TITLE
Make deployment more mature

### DIFF
--- a/ansible/configs/sap-hana-rhel9/pre_software.yml
+++ b/ansible/configs/sap-hana-rhel9/pre_software.yml
@@ -157,6 +157,14 @@
   hosts: hanas:s4hanas
   become: true
   tasks:
+    - name: DEBUG - Figure out current package/release versions of Network Manager and nmcli
+      ansible.builtin.shell: |
+        nmcli --version
+        nmcli con show
+        ip r show default
+        dnf list nmcli NetworkManager
+      changed_when: false
+      failed_when: false
     - name: Set 192.168.47.10 as default gw # noqa: no-changed-when
       ansible.builtin.command: "{{ item }}"
       loop:

--- a/ansible/configs/sap-hana-rhel9/pre_software.yml
+++ b/ansible/configs/sap-hana-rhel9/pre_software.yml
@@ -160,9 +160,16 @@
     - name: DEBUG - Figure out current package/release versions of Network Manager and nmcli
       ansible.builtin.shell: |
         nmcli --version
+        NetworkManager --version
         nmcli con show
         ip r show default
         dnf list nmcli NetworkManager
+      changed_when: false
+      failed_when: false
+    - name: Restart NetworkManager
+      ansible.builtin.service:
+        name: NetworkManager
+        state: restarted
       changed_when: false
       failed_when: false
     - name: Set 192.168.47.10 as default gw # noqa: no-changed-when


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

This change prohibits a failure due to an ald NetworkManager running.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
sap-hana-rhel9

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The previous version failed provisioning due to a wrong NetworkManager running:
```
Warning: nmcli (1.52.0) and NetworkManager (1.42.2) versions don't match. Restarting NetworkManager is advised.
Error: Failed to modify connection 'System eth0': connection.autoconnect-ports: unknown property
```
Additional debug information proves that 1.52.0 has been installed, but it is not always properly restarted. I forced a restart in the playbook to ensure the nmcli command passes

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below
TASK [DEBUG - Figure out current package/release versions of Network Manager and nmcli] ***
Monday 31 August 2026  15:19:03 +0000 (0:00:02.458)       0:16:58.060 ********* 
ok: [s4hana-bl7cq]
ok: [hana-bl7cq1]
ok: [hana-bl7cq2]
TASK [Restart NetworkManager] **************************************************
Monday 31 August 2026  15:19:08 +0000 (0:00:04.586)       0:17:02.647 ********* 
ok: [s4hana-bl7cq]
ok: [hana-bl7cq1]
ok: [hana-bl7cq2]

```
