### PR TITLE
[GPTEINFRA-17836] Add rosa_channel_group support for EUS versions

### DIFF
--- a/ansible/configs/rosa-consolidated/default_vars.yml
+++ b/ansible/configs/rosa-consolidated/default_vars.yml
@@ -69,6 +69,11 @@ rosa_version: default
 # version that has available_upgrades set (use 'rosa list versions -o json' for examples)
 rosa_version_base: "openshift-v4.22"
 
+# ROSA channel group to use when creating the cluster.
+# Options: stable, eus, fast, candidate
+# EUS versions (e.g. 4.18) require 'eus' after their stable channel is removed.
+rosa_channel_group: stable
+
 # ROSA CLI version
 rosa_installer_version: latest
 

--- a/ansible/configs/rosa-consolidated/install_rosa_common_pre.yml
+++ b/ansible/configs/rosa-consolidated/install_rosa_common_pre.yml
@@ -18,6 +18,7 @@
 - name: Get available ROSA versions
   ansible.builtin.command: >-
     {{ rosa_binary_path }}/rosa list versions --output json
+    --channel-group {{ rosa_channel_group }}
     {% if rosa_deploy_hcp | bool %}--hosted-cp{% endif %}
   register: r_rosa_versions
 
@@ -100,3 +101,4 @@
   - "ROSA Version available to be upgraded to: {{ _rosa_version_next | default('not set') }}"
   - "OCP CLI to be installed: {{ _rosa_ocp_cli_version}}"
   - "Cloud Tags to be added: {{ cloud_tags_list }}"
+  - "ROSA Channel Group: {{ rosa_channel_group }}"

--- a/ansible/configs/rosa-consolidated/install_rosa_hcp.yml
+++ b/ansible/configs/rosa-consolidated/install_rosa_hcp.yml
@@ -110,6 +110,7 @@
       --oidc-config-id {{ rosa_oidc_id }}
       --subnet-ids {{ rosa_subnets }}
       --tags "{{ cloud_tags_list }}"
+      --channel-group {{ rosa_channel_group }}
       {% if _rosa_version_to_install | default("") | length > 0 %}--version {{ _rosa_version_to_install }}{% endif %}
       {% if rosa_compute_machine_type is defined %}--compute-machine-type {{ rosa_compute_machine_type }}{% endif %}
       {% if rosa_compute_worker_disk_size is defined %}--worker-disk-size {{ rosa_compute_worker_disk_size }}{% endif %}

--- a/ansible/configs/rosa-consolidated/install_rosa_sts.yml
+++ b/ansible/configs/rosa-consolidated/install_rosa_sts.yml
@@ -16,6 +16,7 @@
     --mode auto
     --yes
     --tags "{{ cloud_tags_list }}"
+    --channel-group {{ rosa_channel_group }}
     {% if _rosa_version_to_install | default("") | length > 0 %}--version {{ _rosa_version_to_install }}{% endif %}
     {% if rosa_compute_machine_type is defined %}--compute-machine-type {{ rosa_compute_machine_type }}{% endif %}
     {% if rosa_compute_worker_disk_size is defined %}--worker-disk-size {{ rosa_compute_worker_disk_size }}{% endif %}


### PR DESCRIPTION
## Summary

- Add `rosa_channel_group` variable (default: `stable`) to `default_vars.yml`
- Wire `--channel-group {{ rosa_channel_group }}` into `rosa list versions` (version discovery), `rosa create cluster` for HCP, and `rosa create cluster` for classic STS
- Backwards-compatible: existing catalog items on 4.19+ are unaffected (default `stable` works)
- Catalog items pinned to 4.18 override to `rosa_channel_group: eus` in AgnosticV

## Root Cause

ROSA removed the `stable-4.18` channel after OCP 4.18 Maintenance Support ended (2026-08-25). Only `eus-4.18` remains. Without `--channel-group`, both `rosa list versions` and `rosa create cluster` default to `stable`, causing all 4.18 deployments to fail with:

> Channel 'stable-4.18' is not available for this cluster version.

## Files Changed

| File | Change |
|------|--------|
| `default_vars.yml` | Added `rosa_channel_group: stable` with documentation |
| `install_rosa_common_pre.yml` | Added `--channel-group {{ rosa_channel_group }}` to `rosa list versions` + debug output |
| `install_rosa_hcp.yml` | Added `--channel-group {{ rosa_channel_group }}` to `rosa create cluster` |
| `install_rosa_sts.yml` | Added `--channel-group {{ rosa_channel_group }}` to `rosa create cluster` |

## Test plan

- [ ] Deploy a ROSA HCP cluster with `rosa_channel_group: eus` and `rosa_version_base: openshift-v4.18` — should resolve and create successfully
- [ ] Deploy a ROSA HCP cluster with default `rosa_channel_group: stable` and `rosa_version_base: openshift-v4.22` — should work as before (no regression)
- [ ] Verify `rosa list versions --channel-group eus --hosted-cp` returns 4.18.x versions

Jira: https://redhat.atlassian.net/browse/GPTEINFRA-17836