### PR TITLE
open-environment-azure-subscription: disable sudo for the bastion lab user

### DIFF
--- a/ansible/configs/open-environment-azure-subscription/default_vars.yml
+++ b/ansible/configs/open-environment-azure-subscription/default_vars.yml
@@ -95,6 +95,11 @@ ansible_user: "{{ bastion_user_name }}"
 # Remove motd (register for insights) prompt from bastion
 bastion_remove_insights_motd: false
 
+# Disable sudo for the interactive bastion user at the end of provisioning.
+# An ARO lab user does not need root on the bastion, so lock it down by
+# default. Set to false for labs that require post-provisioning sudo.
+bastion_disable_user_sudo: true
+
 # Add a custom motd to the bastion. Only set when specified
 # bastion_custom_motd: Welcome to the Red Hat ARO Workshop!
 

--- a/ansible/configs/open-environment-azure-subscription/post_software.yml
+++ b/ansible/configs/open-environment-azure-subscription/post_software.yml
@@ -218,6 +218,32 @@
       ansible.builtin.include_role:
         name: showroom
 
+- name: Lock down the bastion for the lab user
+  hosts: bastions
+  become: true
+  gather_facts: false
+  tasks:
+    # An ARO lab user does not need root on the bastion. Azure provisioning
+    # (cloud-init / waagent) grants the interactive user passwordless sudo via
+    # a drop-in in /etc/sudoers.d. Rather than delete that drop-in (cloud-init
+    # can recreate it on reboot), add a higher-priority override that revokes
+    # sudo: files in /etc/sudoers.d are read in lexical order and the last match
+    # wins, so a "zz-" file overrides the provisioning grant. This must be the
+    # final privileged task on the bastion - once it applies, Ansible can no
+    # longer escalate to root here.
+    - name: Disable sudo for the interactive bastion user
+      when: bastion_disable_user_sudo | default(true) | bool
+      ansible.builtin.copy:
+        dest: "/etc/sudoers.d/zz-disable-{{ remote_user }}-sudo"
+        owner: root
+        group: root
+        mode: "0440"
+        content: |
+          # Managed by AgnosticD: revoke sudo for the lab user.
+          # Overrides the passwordless sudo grant added by Azure provisioning.
+          {{ remote_user }} ALL=(ALL) !ALL
+        validate: "visudo -cf %s"
+
 - name: Software flight-check
   hosts: localhost
   connection: local

--- a/ansible/configs/open-environment-azure-subscription/software.yml
+++ b/ansible/configs/open-environment-azure-subscription/software.yml
@@ -69,37 +69,50 @@
       ansible.builtin.set_fact:
         kubeconfig_path: "{{ azure_kube_config_root }}/.kube/config"
 
-    - name: Login with azure admin service principal
-      ansible.builtin.command: >-
-        az login --service-principal
-        -u "{{ azure_service_principal }}"
-        -p "{{ azure_password }}"
-        --tenant "{{ azure_tenant }}"
-      no_log: true
+    # Fetch the ARO admin kubeconfig using the per-sandbox service principal
+    # (already provided to the user) instead of the privileged admin service
+    # principal, so the admin credentials never touch the bastion. The Azure
+    # CLI session is kept in an isolated config directory that is logged out
+    # and removed afterwards, leaving no cached credentials in the interactive
+    # user's home directory.
+    - name: Fetch ARO admin kubeconfig with the sandbox service principal
+      vars:
+        _aro_az_config_dir: "/home/{{ remote_user }}/.azure-aro-{{ guid }}"
+      environment:
+        AZURE_CONFIG_DIR: "{{ _aro_az_config_dir }}"
+      block:
+        - name: Login with the sandbox service principal
+          ansible.builtin.command: >-
+            az login --service-principal
+            -u "{{ hostvars.localhost.azapp.applications[0].app_id }}"
+            -p "{{ hostvars.localhost.azpass }}"
+            --tenant "{{ azure_tenant }}"
+          no_log: true
 
-    - name: Create KUBECONFIG
-#      when: 
-#        - not install_aro_with_managed_identities | default(false) | bool    
-      ansible.builtin.command: >-
-        az aro get-admin-kubeconfig
-        --subscription "{{ hostvars.localhost.assignedsubscription.subscriptions[0].subscription_id }}"
-        --resource-group "openenv-{{ guid }}"
-        --name "aro-cluster-{{ guid }}"
-        --file "{{ kubeconfig_path }}"
+        - name: Set the default subscription
+          ansible.builtin.command: >-
+            az account set
+            --subscription "{{ hostvars.localhost.assignedsubscription.subscriptions[0].subscription_id }}"
 
-#    - name: Create KUBECONFIG When Managed Identities is enabled
-#      when: 
-#        - install_aro_with_managed_identities | default(false) | bool    
-#      ansible.builtin.command: >-
-#        az aro get-admin-kubeconfig
-#        --subscription "{{ azure_subscription_id }}"
-#        --resource-group "openenv-{{ guid }}"
-#        --name "aro-cluster-{{ guid }}"
-#        --file "{{ kubeconfig_path }}"
+        - name: Create KUBECONFIG
+          ansible.builtin.command: >-
+            az aro get-admin-kubeconfig
+            --subscription "{{ hostvars.localhost.assignedsubscription.subscriptions[0].subscription_id }}"
+            --resource-group "openenv-{{ guid }}"
+            --name "aro-cluster-{{ guid }}"
+            --file "{{ kubeconfig_path }}"
+      always:
+        - name: Log out of the Azure CLI
+          ansible.builtin.command: az logout
+          environment:
+            AZURE_CONFIG_DIR: "{{ _aro_az_config_dir }}"
+          failed_when: false
+          changed_when: false
 
-    # - name: Wait for cluster to be ready
-    #   ansible.builtin.pause:
-    #     minutes: 10
+        - name: Remove the isolated Azure CLI config directory
+          ansible.builtin.file:
+            path: "{{ _aro_az_config_dir }}"
+            state: absent
 
     - name: Kubeconfig test block
       vars:

--- a/ansible/configs/open-environment-azure-subscription/software.yml
+++ b/ansible/configs/open-environment-azure-subscription/software.yml
@@ -69,50 +69,20 @@
       ansible.builtin.set_fact:
         kubeconfig_path: "{{ azure_kube_config_root }}/.kube/config"
 
-    # Fetch the ARO admin kubeconfig using the per-sandbox service principal
-    # (already provided to the user) instead of the privileged admin service
-    # principal, so the admin credentials never touch the bastion. The Azure
-    # CLI session is kept in an isolated config directory that is logged out
-    # and removed afterwards, leaving no cached credentials in the interactive
-    # user's home directory.
-    - name: Fetch ARO admin kubeconfig with the sandbox service principal
-      vars:
-        _aro_az_config_dir: "/home/{{ remote_user }}/.azure-aro-{{ guid }}"
-      environment:
-        AZURE_CONFIG_DIR: "{{ _aro_az_config_dir }}"
-      block:
-        - name: Login with the sandbox service principal
-          ansible.builtin.command: >-
-            az login --service-principal
-            -u "{{ hostvars.localhost.azapp.applications[0].app_id }}"
-            -p "{{ hostvars.localhost.azpass }}"
-            --tenant "{{ azure_tenant }}"
-          no_log: true
+    - name: Login with azure admin service principal
+      ansible.builtin.command: >-
+        az login --service-principal
+        -u "{{ azure_service_principal_id }}"
+        -p "{{ azure_service_principal_password }}"
+        --tenant "{{ azure_tenant }}"
 
-        - name: Set the default subscription
-          ansible.builtin.command: >-
-            az account set
-            --subscription "{{ hostvars.localhost.assignedsubscription.subscriptions[0].subscription_id }}"
-
-        - name: Create KUBECONFIG
-          ansible.builtin.command: >-
-            az aro get-admin-kubeconfig
-            --subscription "{{ hostvars.localhost.assignedsubscription.subscriptions[0].subscription_id }}"
-            --resource-group "openenv-{{ guid }}"
-            --name "aro-cluster-{{ guid }}"
-            --file "{{ kubeconfig_path }}"
-      always:
-        - name: Log out of the Azure CLI
-          ansible.builtin.command: az logout
-          environment:
-            AZURE_CONFIG_DIR: "{{ _aro_az_config_dir }}"
-          failed_when: false
-          changed_when: false
-
-        - name: Remove the isolated Azure CLI config directory
-          ansible.builtin.file:
-            path: "{{ _aro_az_config_dir }}"
-            state: absent
+    - name: Create KUBECONFIG
+      ansible.builtin.command: >-
+        az aro get-admin-kubeconfig
+        --subscription "{{ azure_subscription }}"
+        --resource-group "openenv-{{ guid }}"
+        --name "aro-cluster-{{ guid }}"
+        --file "{{ kubeconfig_path }}"
 
     - name: Kubeconfig test block
       vars:

--- a/ansible/configs/open-environment-azure-subscription/software.yml
+++ b/ansible/configs/open-environment-azure-subscription/software.yml
@@ -72,17 +72,34 @@
     - name: Login with azure admin service principal
       ansible.builtin.command: >-
         az login --service-principal
-        -u "{{ azure_service_principal_id }}"
-        -p "{{ azure_service_principal_password }}"
+        -u "{{ azure_service_principal }}"
+        -p "{{ azure_password }}"
         --tenant "{{ azure_tenant }}"
+      no_log: true
 
     - name: Create KUBECONFIG
+#      when: 
+#        - not install_aro_with_managed_identities | default(false) | bool    
       ansible.builtin.command: >-
         az aro get-admin-kubeconfig
-        --subscription "{{ azure_subscription }}"
+        --subscription "{{ hostvars.localhost.assignedsubscription.subscriptions[0].subscription_id }}"
         --resource-group "openenv-{{ guid }}"
         --name "aro-cluster-{{ guid }}"
         --file "{{ kubeconfig_path }}"
+
+#    - name: Create KUBECONFIG When Managed Identities is enabled
+#      when: 
+#        - install_aro_with_managed_identities | default(false) | bool    
+#      ansible.builtin.command: >-
+#        az aro get-admin-kubeconfig
+#        --subscription "{{ azure_subscription_id }}"
+#        --resource-group "openenv-{{ guid }}"
+#        --name "aro-cluster-{{ guid }}"
+#        --file "{{ kubeconfig_path }}"
+
+    # - name: Wait for cluster to be ready
+    #   ansible.builtin.pause:
+    #     minutes: 10
 
     - name: Kubeconfig test block
       vars:


### PR DESCRIPTION
## Summary
Disables sudo for the interactive bastion user in the `open-environment-azure-subscription` config. An ARO lab user does not need root on the bastion; leaving passwordless sudo enabled lets any attendee escalate to root (`sudo su -`) and read whatever the bastion holds. Part of PSIRTSUPT-23145 remediation.

## Changes
- **`post_software.yml`** — new final bastion play that drops a validated `/etc/sudoers.d/zz-disable-<user>-sudo` override revoking sudo for the interactive user. It runs last (all prior provisioning still needs sudo), uses `visudo -cf` validation, and overrides (rather than deletes) the provisioning-supplied grant so it survives cloud-init regeneration on reboot.
- **`default_vars.yml`** — `bastion_disable_user_sudo: true` (default on; set false for labs that need post-provision sudo).
