### PR TITLE
install-command-line-tools  - Fix Helm CLI installer URL in main.yml

### DIFF
--- a/ansible/roles/install-command-line-tools/defaults/main.yml
+++ b/ansible/roles/install-command-line-tools/defaults/main.yml
@@ -37,4 +37,4 @@ install_cli_tools_openshift_cli_installer_url: >-
 # -------------------------------------------------
 install_cli_tools_helm_cli: true
 install_cli_tools_helm_cli_installer_url: >- 
-  https://mirror.openshift.com/pub/openshift-v4/clients//helm/latest/helm-linux-amd64.tar.gz
+  https://mirror.openshift.com/pub/openshift-v4/clients/helm/latest/helm-linux-amd64.tar.gz


### PR DESCRIPTION
This url is broken. Needs a single /