### PR TITLE
fix: retry kubeconfig download on KubeVirt timing race in host-ocp4-assisted-installer

### DIFF
--- a/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
@@ -541,6 +541,10 @@
         - kubeadmin-password
         - kubeconfig
         - kubeconfig-noingress
+      register: r_download_credentials
+      retries: 5
+      delay: 60
+      until: r_download_credentials is not failed
 
     - name: Downloads OpenShift cluster files
       rhpds.assisted_installer.download_files:


### PR DESCRIPTION
## Summary

On KubeVirt deployments, the AI API returns an empty body for the full `kubeconfig` if the ingress CA hasn't been generated by the ingress operator yet. This causes a JSON decode error in the **Downloads OpenShift cluster credentials** task, failing the play even though `kubeadmin-password` and `kubeconfig-noingress` both succeed.

Fix: add `retries: 5, delay: 60, until: not failed` to the download_credentials task. This gives the ingress operator up to 5 minutes to generate the CA before giving up.

Observed on: `rhcos-layer-rsyslog` partner provision (KubeVirt cluster)
Job: https://aap2-partner0-prod-us-east-2.aap.infra.partner.demo.redhat.com/#/jobs/playbook/168859/output

## Test plan
- [ ] Re-provision `rhcos-layer-rsyslog` on partner integration and confirm kubeconfig download no longer fails
- [ ] Verify `kubeadmin-password` and `kubeconfig-noingress` still download on first try (no extra delay)