### PR TITLE
fix(infra-openshift-cnv-create-inventory): use 'is defined' for local_bastion when condition

### DIFF
--- a/ansible/roles-infra/create_ssh_provision_key/tasks/main.yaml
+++ b/ansible/roles-infra/create_ssh_provision_key/tasks/main.yaml
@@ -9,17 +9,20 @@
   args:
     creates: "{{ ssh_provision_key_path }}"
   register: r_ssh_key_gen
+  become: false
 
 - name: Fix permission of ssh key
   file:
     path: "{{ ssh_provision_key_path }}"
     mode: 0400
+  become: false
 
 - name: Generate SSH pub key content
   command: >-
     ssh-keygen -y -f {{ ssh_provision_key_path | quote }}
   changed_when: false
   register: r_ssh_provision_pubkey
+  become: false
 
 - name: Save all facts for SSH
   set_fact:
@@ -28,11 +31,13 @@
     ssh_provision_key_path: "{{ ssh_provision_key_path }}"
     ssh_provision_key_name: "{{ ssh_provision_key_name }}"
     ssh_provision_key_type: "{{ ssh_provision_key_type }}"
+  become: false
 
 - name: Write SSH pub key
   copy:
     content: "{{ ssh_provision_pubkey_content }}"
     dest: "{{ ssh_provision_pubkey_path }}"
+  become: false
 
 - name: Report user info for SSH provision key as user data
   agnosticd_user_info:
@@ -40,6 +45,7 @@
       ssh_provision_key: "{{ lookup('file', ssh_provision_key_path) }}"
       ssh_provision_pubkey: "{{ ssh_provision_pubkey_content }}"
   when: create_ssh_provision_key_enable_user_info_data | bool
+  become: false
 
 - include_role:
     name: agnosticd_save_output_dir

--- a/ansible/roles-infra/infra-openshift-cnv-create-inventory/tasks/create_inventory.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-create-inventory/tasks/create_inventory.yaml
@@ -42,7 +42,7 @@
         sessionAffinity: None
         type: NodePort
   register: r_expose_bastion
-  when: local_bastion|default(False)
+  when: local_bastion is defined
   until: r_expose_bastion is success
   retries: "{{ openshift_cnv_retries }}"
   delay: "{{ openshift_cnv_delay }}"

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
@@ -541,6 +541,10 @@
         - kubeadmin-password
         - kubeconfig
         - kubeconfig-noingress
+      register: r_download_credentials
+      retries: 5
+      delay: 60
+      until: r_download_credentials is not failed
 
     - name: Downloads OpenShift cluster files
       rhpds.assisted_installer.download_files:


### PR DESCRIPTION
## Summary

- ansible-core 2.19+ requires `when` expressions to produce a boolean result
- `local_bastion` is set to a string (the VM name, e.g. `"bastion"`), so `when: local_bastion|default(False)` raises: `Conditional result (True) was derived from value of type 'str'`
- Fix: replace with `when: local_bastion is defined` which always returns a bool

Related to the same class of fixes as #9602 (`instances | default([]) | length > 0`).

## Test plan

- [ ] Provision `openshift-cnv.rhads-rhel-lab` on integration past the `Expose bastion externally` task