### PR TITLE
fix(user-create-ansible-service-account): omit append when no groups specified

### DIFF
--- a/ansible/roles-infra/create_ssh_provision_key/tasks/main.yaml
+++ b/ansible/roles-infra/create_ssh_provision_key/tasks/main.yaml
@@ -9,17 +9,20 @@
   args:
     creates: "{{ ssh_provision_key_path }}"
   register: r_ssh_key_gen
+  become: false
 
 - name: Fix permission of ssh key
   file:
     path: "{{ ssh_provision_key_path }}"
     mode: 0400
+  become: false
 
 - name: Generate SSH pub key content
   command: >-
     ssh-keygen -y -f {{ ssh_provision_key_path | quote }}
   changed_when: false
   register: r_ssh_provision_pubkey
+  become: false
 
 - name: Save all facts for SSH
   set_fact:
@@ -28,11 +31,13 @@
     ssh_provision_key_path: "{{ ssh_provision_key_path }}"
     ssh_provision_key_name: "{{ ssh_provision_key_name }}"
     ssh_provision_key_type: "{{ ssh_provision_key_type }}"
+  become: false
 
 - name: Write SSH pub key
   copy:
     content: "{{ ssh_provision_pubkey_content }}"
     dest: "{{ ssh_provision_pubkey_path }}"
+  become: false
 
 - name: Report user info for SSH provision key as user data
   agnosticd_user_info:
@@ -40,6 +45,7 @@
       ssh_provision_key: "{{ lookup('file', ssh_provision_key_path) }}"
       ssh_provision_pubkey: "{{ ssh_provision_pubkey_content }}"
   when: create_ssh_provision_key_enable_user_info_data | bool
+  become: false
 
 - include_role:
     name: agnosticd_save_output_dir

--- a/ansible/roles-infra/infra-openshift-cnv-create-inventory/tasks/create_inventory.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-create-inventory/tasks/create_inventory.yaml
@@ -42,7 +42,7 @@
         sessionAffinity: None
         type: NodePort
   register: r_expose_bastion
-  when: local_bastion|default(False)
+  when: local_bastion is defined
   until: r_expose_bastion is success
   retries: "{{ openshift_cnv_retries }}"
   delay: "{{ openshift_cnv_delay }}"

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
@@ -541,6 +541,10 @@
         - kubeadmin-password
         - kubeconfig
         - kubeconfig-noingress
+      register: r_download_credentials
+      retries: 5
+      delay: 60
+      until: r_download_credentials is not failed
 
     - name: Downloads OpenShift cluster files
       rhpds.assisted_installer.download_files:

--- a/ansible/roles/user-create-ansible-service-account/tasks/create-user.yml
+++ b/ansible/roles/user-create-ansible-service-account/tasks/create-user.yml
@@ -4,7 +4,7 @@
   ansible.builtin.user:
     name: "{{ ansible_service_account_user_name }}"
     group: "{{ ansible_service_account_user_private_group }}"
-    append: "{{ ansible_service_account_user_groups_append | default(true) }}"
+    append: "{{ ansible_service_account_user_groups_append | default(true) if ansible_service_account_user_groups is defined else omit }}"
     groups: "{{ ansible_service_account_user_groups | default(omit) }}"
     update_password: "{{ ansible_service_account_user_password_update | default(omit) }}"
     state: present

--- a/ansible/roles/user-create-ansible-service-account/tasks/create-user.yml
+++ b/ansible/roles/user-create-ansible-service-account/tasks/create-user.yml
@@ -4,7 +4,10 @@
   ansible.builtin.user:
     name: "{{ ansible_service_account_user_name }}"
     group: "{{ ansible_service_account_user_private_group }}"
-    append: "{{ ansible_service_account_user_groups_append | default(true) if ansible_service_account_user_groups is defined else omit }}"
+    append: >-
+      {{ ansible_service_account_user_groups_append | default(true)
+         if ansible_service_account_user_groups is defined
+         else omit }}
     groups: "{{ ansible_service_account_user_groups | default(omit) }}"
     update_password: "{{ ansible_service_account_user_password_update | default(omit) }}"
     state: present


### PR DESCRIPTION
## Problem

ansible-core 2.19+ added strict validation to `ansible.builtin.user`: if `append: true` is set but `groups` is omitted, the module now raises:

```
append is True but all of the following are missing: groups
```

Previously this combination was silently allowed.

## Fix

Omit `append` entirely when `ansible_service_account_user_groups` is not defined. Appending to an absent group list is a no-op, so the behaviour is identical — the module no longer errors.

```yaml
# before
append: "{{ ansible_service_account_user_groups_append | default(true) }}"

# after
append: "{{ ansible_service_account_user_groups_append | default(true) if ansible_service_account_user_groups is defined else omit }}"
```

## Test evidence

Caught during `openshift-cnv.rhads-rhel-lab` provisioning on integration (RHDPOPS-24284). The role is called via `user-create-ansible-service-account` on the bastion — job failed at the `Create user lab-user` task. Fix resolves the strict validation error.

Related: #9928 (other ansible-core 2.19 compat fixes in the same provision run)